### PR TITLE
Provides instructions how to build Ditto from within a Maven Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You have now running:
 
 #### Build from within Docker image
 
-If you do not have the right Maven and JDK version available, you can also use a Maven Docker image as build environment:
+If you do not have the right Maven and JDK version available, you can also use a Maven Docker image as build environment. On a Linux or macOS host, you can expose the docker socket to Maven like this:
 
 ```bash
 # Start up the docker image with maven:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ You have now running:
 * an nginx acting as a reverse proxy performing a simple "basic authentication" listening on port `8080`
    * including some static HTTP + API documentation on [http://localhost:8080](http://localhost:8080)
 
+#### Build from within Docker image
+
+If you do not have the right Maven and JDK version available, you can also use a Maven Docker image as build environment:
+
+```bash
+# Start up the docker image with maven:
+docker run -it --rm --name mvn-ditto \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven \
+    -u root \
+    maven:3.5.0-jdk-8 \
+    /bin/bash
+# From within the docker image, build the docker images:
+mvn clean install -Pdocker-build-image \
+    -Ddocker.daemon.url=unix:///var/run/docker.sock
+# Docker images are now available on your Docker host
+```
+
 ### Try it out
 
 Have a look at the [Getting Started](documentation/getting-started/README.md)


### PR DESCRIPTION
For those that do not have an up-to-date Maven and JDK environment available, it might be helpful to use a Docker-based build environment instead. Since this is non-trivial, I provided some instructions how this can be achieved. This might also be a temporary solution for issue #5 .

Signed-off-by: Christian Renz <crenz@web42.com>