### PR TITLE
calculate "read subjects" for events in advance

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -293,6 +293,10 @@
                 <version>${kamon.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>io.kamon</groupId>
+                        <artifactId>kamon-akka-2.4_${scala.version}</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>com.typesafe.akka</groupId>
                         <artifactId>akka-remote_${scala.version}</artifactId>
                     </exclusion>

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -284,7 +284,7 @@ public final class WebsocketRoute {
         return jsonObject.toString();
     }
 
-    private static boolean isLiveSignal(final WithDittoHeaders<?> signal) {
+    private static boolean isLiveSignal(final Signal<?> signal) {
         return signal.getDittoHeaders().getChannel().filter(TopicPath.Channel.LIVE.getName()::equals).isPresent();
     }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -255,7 +255,7 @@ public final class WebsocketRoute {
     private String jsonifiableToString(final String connectionCorrelationId,
             final Jsonifiable.WithPredicate<JsonObject, JsonField> jsonifiable) {
         final Adaptable adaptable;
-        if (jsonifiable instanceof Signal && isLiveSignal((WithDittoHeaders<?>) jsonifiable)) {
+        if (jsonifiable instanceof Signal && isLiveSignal((Signal<?>) jsonifiable)) {
             adaptable = jsonifiableToAdaptable(jsonifiable, TopicPath.Channel.LIVE);
         } else {
             adaptable = jsonifiableToAdaptable(jsonifiable, TopicPath.Channel.TWIN);

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractProxyActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractProxyActor.java
@@ -18,7 +18,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.protocoladapter.TopicPath;
@@ -202,7 +201,7 @@ public abstract class AbstractProxyActor extends AbstractActor {
         return forwardToEnforcerLookup(enforcerLookup, ReadConsistency.MAJORITY);
     }
 
-    static boolean isLiveSignal(final WithDittoHeaders<?> signal) {
+    static boolean isLiveSignal(final Signal<?> signal) {
         return signal.getDittoHeaders().getChannel().filter(TopicPath.Channel.LIVE.getName()::equals).isPresent();
     }
 

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
@@ -22,7 +22,6 @@ import java.util.function.Supplier;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.messages.MessageSendNotAllowedException;
 import org.eclipse.ditto.model.policies.PoliciesModelFactory;
 import org.eclipse.ditto.model.policies.PoliciesResourceType;
@@ -83,7 +82,7 @@ public abstract class AbstractThingPolicyEnforcerActor extends AbstractPolicyEnf
 
                 /* Live Signals */
                 .match(Signal.class, AbstractPolicyEnforcerActor::isLiveSignal, liveSignal -> {
-                    final WithDittoHeaders enrichedSignal =
+                    final Signal enrichedSignal =
                             enrichDittoHeaders(liveSignal, liveSignal.getResourcePath(), liveSignal.getResourceType());
                     getSender().tell(enrichedSignal, getSelf());
                 })

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
@@ -41,7 +41,6 @@ import org.eclipse.ditto.signals.commands.things.exceptions.ThingNotModifiableEx
 import org.eclipse.ditto.signals.commands.things.modify.CreateThing;
 import org.eclipse.ditto.signals.commands.things.modify.ThingModifyCommand;
 import org.eclipse.ditto.signals.commands.things.query.ThingQueryCommand;
-import org.eclipse.ditto.signals.events.things.ThingEvent;
 
 import akka.actor.ActorRef;
 import akka.japi.pf.ReceiveBuilder;
@@ -97,8 +96,7 @@ public abstract class AbstractThingPolicyEnforcerActor extends AbstractPolicyEnf
                 .match(ThingQueryCommand.class, this::isAuthorized, this::forwardThingQueryCommand)
                 .match(ThingQueryCommand.class, this::unauthorized)
 
-                /* ThingEvents */
-                .match(ThingEvent.class, this::publishEvent);
+                ;
     }
 
     private void forwardThingSudoCommand(final SudoCommand command) {

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/actors/handlers/AbstractThingHandlerActorTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/actors/handlers/AbstractThingHandlerActorTest.java
@@ -12,6 +12,7 @@
 package org.eclipse.ditto.services.gateway.proxy.actors.handlers;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
@@ -44,6 +45,9 @@ public class AbstractThingHandlerActorTest {
 
     protected static final DittoHeaders defaultHeaders = DittoHeaders.newBuilder()
             .authorizationSubjects(defaultSubject.getId().toString())
+            .readSubjects(
+                    Collections.singleton(defaultSubject.getId().toString())
+            )
             .build();
     protected static final String defaultEnforcerId = "default:enforcerShardId";
 

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/actors/handlers/ModifyThingHandlerActorTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/actors/handlers/ModifyThingHandlerActorTest.java
@@ -479,8 +479,9 @@ public class ModifyThingHandlerActorTest extends AbstractThingHandlerActorTest {
             final String subjectId = "subject:" + UUID.randomUUID();
             final Policy policy = Policy.newBuilder(thingId)
                     .forLabel("dummylabel")
-                    .setSubject(Subject.newInstance(SubjectIssuer.GOOGLE_URL, subjectId, SubjectType.JWT))
+                    .setSubject(defaultSubject)
                     .setGrantedPermissions("policy", "/", "WRITE", "EAT")
+                    .setGrantedPermissions("thing", "/", "READ")
                     .build();
             final Thing thing = ThingsModelFactory.newThingBuilder().setId(thingId).build();
             final ModifyThing modifyThing = ModifyThing.of(thingId, thing, policy.toJson(), defaultHeaders);
@@ -514,13 +515,15 @@ public class ModifyThingHandlerActorTest extends AbstractThingHandlerActorTest {
             final String subjectId = "subject:" + UUID.randomUUID();
             final Policy policy = Policy.newBuilder(thingId)
                     .forLabel("dummylabel")
-                    .setSubject(Subject.newInstance(SubjectIssuer.GOOGLE_URL, subjectId, SubjectType.JWT))
+                    .setSubject(defaultSubject)
                     .setGrantedPermissions("policy", "/", "WRITE", "EAT")
+                    .setGrantedPermissions("thing", "/", "READ")
                     .build();
             final Thing thing =
                     ThingsModelFactory.newThingBuilder().setId(thingId).setPolicyId(thingId).build();
             final ModifyThing modifyThing =
-                    ModifyThing.of(thingId, thing, policy.toJson().remove("policyId"), defaultHeaders);
+                    ModifyThing.of(thingId, thing, policy.toJson().remove("policyId"),
+                            defaultHeaders);
             underTest.tell(modifyThing, getRef());
 
             // verifies nonexistence of policy

--- a/services/gateway/starter/src/main/resources/gateway-dev.conf
+++ b/services/gateway/starter/src/main/resources/gateway-dev.conf
@@ -7,7 +7,7 @@ ditto {
     }
 
     mongo {
-      hostname = "192.168.56.11"
+      hostname = "localhost"
       hostname = ${?DOCKER_HOST}
       hostname = ${?MONGO_HOSTNAME}
       port = 27017

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingType.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingType.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.signals.events.things.ThingEvent;
  */
 public enum StreamingType {
 
-    EVENTS(ThingEvent.TYPE_PREFIX_EXTERNAL),
+    EVENTS(ThingEvent.TYPE_PREFIX),
     MESSAGES(MessageCommand.TYPE_PREFIX),
     LIVE_COMMANDS("things-live-commands"),
     LIVE_EVENTS("things-live-events");

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/EventAndResponsePublisher.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/EventAndResponsePublisher.java
@@ -19,7 +19,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
 import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.gateway.streaming.Connect;
@@ -164,7 +163,7 @@ public final class EventAndResponsePublisher
                 .build();
     }
 
-    private static boolean isLiveSignal(final WithDittoHeaders<?> signal) {
+    private static boolean isLiveSignal(final Signal<?> signal) {
         return signal.getDittoHeaders().getChannel().filter(TopicPath.Channel.LIVE.getName()::equals).isPresent();
     }
 

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
@@ -211,8 +211,7 @@ final class StreamingSessionActor extends AbstractActor {
                     } else {
                         final Set<String> readSubjects = dittoHeaders.getReadSubjects();
                         // check if this session is "allowed" to receive the event
-                        if (readSubjects != null && authorizationSubjects != null &&
-                                !Collections.disjoint(readSubjects, authorizationSubjects)) {
+                        if (authorizationSubjects != null && !Collections.disjoint(readSubjects, authorizationSubjects)) {
                             logger.debug(
                                     "Got 'Event' message in <{}> session, telling eventAndResponsePublisher about it: {}",
                                     type, event);

--- a/services/policies/starter/src/main/resources/policies-dev.conf
+++ b/services/policies/starter/src/main/resources/policies-dev.conf
@@ -14,7 +14,7 @@ ditto {
     }
 
     mongo {
-      hostname = "192.168.56.11"
+      hostname = "localhost"
       hostname = ${?DOCKER_HOST}
       hostname = ${?MONGO_HOSTNAME}
       port = 27017

--- a/services/things/starter/src/main/resources/things-dev.conf
+++ b/services/things/starter/src/main/resources/things-dev.conf
@@ -15,7 +15,7 @@ ditto {
     }
 
     mongo {
-      hostname = "192.168.56.11"
+      hostname = "localhost"
       hostname = ${?DOCKER_HOST}
       hostname = ${?MONGO_HOSTNAME}
       port = 27017

--- a/services/thingsearch/starter/src/main/resources/things-search-dev.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search-dev.conf
@@ -6,7 +6,7 @@ ditto {
     }
 
     mongodb {
-      hostname = "192.168.56.11"
+      hostname = "localhost"
       hostname = ${?MONGO_HOSTNAME}
       port = 27017
       database = "searchDB"

--- a/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/Event.java
+++ b/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/Event.java
@@ -35,11 +35,6 @@ public interface Event<T extends Event> extends Signal<T>, WithOptionalEntity {
     String TYPE_QUALIFIER = "events";
 
     /**
-     * External suffix for events.
-     */
-    String EXTERNAL = "external";
-
-    /**
      * Revision of not yet persisted events.
      */
     long DEFAULT_REVISION = 0;
@@ -51,13 +46,6 @@ public interface Event<T extends Event> extends Signal<T>, WithOptionalEntity {
      */
     @Override
     String getType();
-
-    /**
-     * Returns the external type prefix of this event.
-     *
-     * @return the prefix.
-     */
-    String getExternalTypePrefix();
 
     @Override
     default JsonSchemaVersion getImplementedSchemaVersion() {

--- a/signals/events/batch/src/main/java/org/eclipse/ditto/signals/events/batch/BatchEvent.java
+++ b/signals/events/batch/src/main/java/org/eclipse/ditto/signals/events/batch/BatchEvent.java
@@ -36,12 +36,6 @@ public interface BatchEvent<T extends BatchEvent> extends Event<T> {
     String TYPE_PREFIX = "batch." + TYPE_QUALIFIER + ":";
 
     /**
-     * Type Prefix of external Batch events.
-     *
-     */
-    String TYPE_PREFIX_EXTERNAL = "batch." + TYPE_QUALIFIER + "." + EXTERNAL + ":";
-
-    /**
      * Batch resource type.
      */
     String RESOURCE_TYPE = "batch";
@@ -75,11 +69,6 @@ public interface BatchEvent<T extends BatchEvent> extends Event<T> {
     @Override
     default String getResourceType() {
         return RESOURCE_TYPE;
-    }
-
-    @Override
-    default String getExternalTypePrefix() {
-        return TYPE_PREFIX_EXTERNAL;
     }
 
     /**

--- a/signals/events/policies/src/main/java/org/eclipse/ditto/signals/events/policies/PolicyEvent.java
+++ b/signals/events/policies/src/main/java/org/eclipse/ditto/signals/events/policies/PolicyEvent.java
@@ -33,12 +33,6 @@ public interface PolicyEvent<T extends PolicyEvent> extends Event<T> {
     String TYPE_PREFIX = "policies." + TYPE_QUALIFIER + ":";
 
     /**
-     * Type Prefix of external Policy events.
-     *
-     */
-    String TYPE_PREFIX_EXTERNAL = "policies." + TYPE_QUALIFIER + "." + EXTERNAL + ":";
-
-    /**
      * Policy resource type.
      */
     String RESOURCE_TYPE = "policy";
@@ -68,11 +62,6 @@ public interface PolicyEvent<T extends PolicyEvent> extends Event<T> {
     @Override
     default String getResourceType() {
         return RESOURCE_TYPE;
-    }
-
-    @Override
-    default String getExternalTypePrefix() {
-        return TYPE_PREFIX_EXTERNAL;
     }
 
     @Override

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingEvent.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingEvent.java
@@ -33,11 +33,6 @@ public interface ThingEvent<T extends ThingEvent> extends Event<T>, WithThingId 
      * Type Prefix of Thing events.
      */
     String TYPE_PREFIX = "things." + TYPE_QUALIFIER + ":";
-    /**
-     * Type Prefix of external Thing events.
-     *
-     */
-    String TYPE_PREFIX_EXTERNAL = "things." + TYPE_QUALIFIER + "." + EXTERNAL + ":";
 
     /**
      * Thing resource type.
@@ -59,11 +54,6 @@ public interface ThingEvent<T extends ThingEvent> extends Event<T>, WithThingId 
     @Override
     default String getResourceType() {
         return RESOURCE_TYPE;
-    }
-
-    @Override
-    default String getExternalTypePrefix() {
-        return TYPE_PREFIX_EXTERNAL;
     }
 
     @Override


### PR DESCRIPTION
... when processing commands:

* got rid of "external" types and therefore events
* changed "-dev" profiles to connect to mongoDb on localhost instead of 192.168.56.11

Signed-off-by: Thomas Jaeckle <thomas.jaeckle@bosch-si.com>