### PR TITLE
Optimize json conversion of ditto headers

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -154,10 +154,10 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
 
     private Class<?> getTypeForKey(final CharSequence key) {
         return getSpecificDefinitionByKey(key)
-                .map(Optional::of)
-                .orElseGet(() -> DittoHeaderDefinition.forKey(key))
                 .map(HeaderDefinition::getJavaType)
-                .orElse(String.class);
+                .orElseGet(() -> DittoHeaderDefinition.forKey(key)
+                        .map(HeaderDefinition::getJavaType)
+                        .orElse(String.class));
     }
 
     @Override

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -17,10 +17,8 @@ import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -148,21 +146,9 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
     }
 
     private Class<?> getTypeForKey(final CharSequence key) {
-        final Collection<HeaderDefinition> definitions = getDefinitions();
-
-        return definitions.parallelStream()
-                .filter(definition -> Objects.equals(definition.getKey(), key))
-                .map(HeaderDefinition::getJavaType)
-                .findAny()
+        return DittoHeaderDefinition.forKey(key)
+                .map(DittoHeaderDefinition::getJavaType)
                 .orElse(String.class);
-    }
-
-    private Collection<HeaderDefinition> getDefinitions() {
-        final Collection<HeaderDefinition> result = new LinkedHashSet<>();
-        Collections.addAll(result, DittoHeaderDefinition.values());
-        result.addAll(getSpecificDefinitions());
-
-        return result;
     }
 
     @Override

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
@@ -11,9 +11,11 @@
  */
 package org.eclipse.ditto.model.base.headers;
 
-import java.util.Objects;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Stream;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -88,10 +90,16 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
      */
     CHANNEL("channel", String.class);
 
+    /**
+     * Map to speed up lookup of header definition by key.
+     */
+    private static final Map<CharSequence, DittoHeaderDefinition> VALUES_BY_KEY = Arrays.stream(values())
+            .collect(Collectors.toMap(DittoHeaderDefinition::getKey, Function.identity()));
+
     private final String key;
     private final Class<?> type;
 
-    private DittoHeaderDefinition(final String theKey, final Class<?> theType) {
+    DittoHeaderDefinition(final String theKey, final Class<?> theType) {
         key = theKey;
         type = theType;
     }
@@ -103,9 +111,7 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
      * @return the DittoHeaderKey or an empty Optional.
      */
     public static Optional<DittoHeaderDefinition> forKey(@Nullable final CharSequence key) {
-        return Stream.of(values())
-                .filter(dittoHeaderKey -> Objects.equals(dittoHeaderKey.key, String.valueOf(key)))
-                .findAny();
+        return Optional.ofNullable(VALUES_BY_KEY.get(key));
     }
 
     @Override

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
@@ -110,7 +110,7 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
      * @param key the key to look up.
      * @return the DittoHeaderKey or an empty Optional.
      */
-    public static Optional<DittoHeaderDefinition> forKey(@Nullable final CharSequence key) {
+    public static Optional<HeaderDefinition> forKey(@Nullable final CharSequence key) {
         return Optional.ofNullable(VALUES_BY_KEY.get(key));
     }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeaders.java
@@ -11,9 +11,8 @@
  */
 package org.eclipse.ditto.model.base.headers;
 
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -39,8 +38,10 @@ final class ImmutableDittoHeaders extends AbstractDittoHeaders implements DittoH
     }
 
     @Override
-    protected Collection<HeaderDefinition> getSpecificDefinitions() {
-        return Arrays.asList(DittoHeaderDefinition.values());
+    protected Optional<HeaderDefinition> getSpecificDefinitionByKey(final CharSequence key) {
+        // there is no specific header defined for this class; all headers are already defined
+        // in the enum DittoHeaderDefinition for AbstractDittoHeaders.
+        return Optional.empty();
     }
 
     @Override

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/ImmutableMessageHeaders.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/ImmutableMessageHeaders.java
@@ -110,8 +110,8 @@ final class ImmutableMessageHeaders extends AbstractDittoHeaders implements Mess
     }
 
     @Override
-    protected Collection<HeaderDefinition> getSpecificDefinitions() {
-        return Arrays.asList(MessageHeaderDefinition.values());
+    protected Optional<HeaderDefinition> getSpecificDefinitionByKey(final CharSequence key) {
+        return MessageHeaderDefinition.forKey(key);
     }
 
     @Override

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
@@ -15,8 +15,12 @@ import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -141,24 +145,28 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
     static final String SUBJECT_REGEX =
             "(([a-zA-Z][0-9a-zA-Z+\\-\\.]*:)?/{0,2}[0-9a-zA-Z;/?:@&=+$\\.\\-_!~*'()%]+)?(#[0-9a-zA-Z;/?:@&=+$\\.\\-_!~*'()%]+)?";
 
+    /**
+     * Map to speed up lookup of header definition by key.
+     */
+    private static final Map<CharSequence, MessageHeaderDefinition> VALUES_BY_KEY = Arrays.stream(values())
+            .collect(Collectors.toMap(MessageHeaderDefinition::getKey, Function.identity()));
+
     private final String key;
     private final Class<?> type;
 
-    private MessageHeaderDefinition(final String theKey, final Class<?> theType) {
+    MessageHeaderDefinition(final String theKey, final Class<?> theType) {
         key = theKey;
         type = theType;
     }
 
     /**
-     * Finds an appropriate {@code MessageHeaderKey} for the specified key.
+     * Finds an appropriate {@code MessageHeaderDefinition} for the specified key.
      *
      * @param key the key to look up.
-     * @return the MessageHeaderKey or an empty Optional.
+     * @return the MessageHeaderDefinition or an empty Optional.
      */
-    public static Optional<MessageHeaderDefinition> forKey(@Nullable final CharSequence key) {
-        return Stream.of(values())
-                .filter(dittoHeaderKey -> Objects.equals(dittoHeaderKey.key, String.valueOf(key)))
-                .findAny();
+    public static Optional<HeaderDefinition> forKey(@Nullable final CharSequence key) {
+        return Optional.ofNullable(VALUES_BY_KEY.get(key));
     }
 
     @Override

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
@@ -17,11 +17,9 @@ import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
@@ -99,6 +99,20 @@ public final class ImmutableMessageHeadersTest {
     }
 
     @Test
+    public void timeoutIsSerializedAsInteger() {
+        final long timeout = Long.MAX_VALUE;
+
+        final MessageHeaders underTest = MessageHeadersBuilder.newInstance(DIRECTION, THING_ID, SUBJECT)
+                .timeout(timeout)
+                .build();
+
+        final JsonObject jsonObject = underTest.toJson();
+
+        assertThat(jsonObject.getValue(MessageHeaderDefinition.TIMEOUT.getKey()))
+                .contains(JsonFactory.newValue(timeout));
+    }
+
+    @Test
     public void createInstanceOfValidHeaderMapWorksAsExpected() {
         final Map<String, String> initialHeaders = createMapContainingAllKnownHeaders();
 


### PR DESCRIPTION
`AbstractDittoHeaders.toJson` spends a lot of time in the method `getTypeForKey` iterating over all possible values of `DittoHeaderDefinition`. This commit creates a static index for Ditto header definition values for a faster class lookup during JSON serialization.