### PR TITLE
added generation of sitemap.xml + fixed mobile layout for doc

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -23,6 +23,7 @@ Use that if you are on a UNIX system (or have the Ubuntu bash subsystem for Wind
 ```bash
 sudo apt-get install build-essential ruby-dev
 sudo gem install --http-proxy http://localhost:3128 jekyll
+sudo gem install --http-proxy http://localhost:3128 jekyll-sitemap
 ```
 
 Watch all resources and start local server serving the Jekyll content at [http://localhost:4000](http://localhost:4000):

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -47,6 +47,12 @@
             </dependency>
             <dependency>
                 <groupId>rubygems</groupId>
+                <artifactId>jekyll-sitemap</artifactId>
+                <version>1.1.1</version>
+                <type>gem</type>
+            </dependency>
+            <dependency>
+                <groupId>rubygems</groupId>
                 <artifactId>addressable</artifactId>
                 <version>2.5.2</version>
                 <type>gem</type>
@@ -246,6 +252,12 @@
                     <type>gem</type>
                     <optional>true</optional>
                 </dependency>
+                <dependency>
+                    <groupId>rubygems</groupId>
+                    <artifactId>jekyll-sitemap</artifactId>
+                    <type>gem</type>
+                    <optional>true</optional>
+                </dependency>
             </dependencies>
         </profile>
 
@@ -259,7 +271,7 @@
                         <artifactId>exec-maven-plugin</artifactId>
                         <configuration>
                             <supportNative>true</supportNative>
-                            <jrubyVersion>9.0.5.0</jrubyVersion>
+                            <jrubyVersion>9.1.12.0</jrubyVersion>
                             <addProjectClasspath>true</addProjectClasspath>
                             <jrubyVerbose>false</jrubyVerbose>
                         </configuration>

--- a/documentation/src/main/resources/_config.yml
+++ b/documentation/src/main/resources/_config.yml
@@ -101,4 +101,7 @@ description: "Eclipse Ditto Blog"
 # the description is used in the feed.xml file
 
 # needed for sitemap.xml file only
-url:
+url: https://www.eclipse.org/ditto
+
+plugins:
+  - jekyll-sitemap

--- a/documentation/src/main/resources/_data/topnav.yml
+++ b/documentation/src/main/resources/_data/topnav.yml
@@ -10,6 +10,8 @@ topnav:
       url: /http-api-doc.html
     - title: GitHub
       external_url: https://github.com/eclipse/ditto
+    - title: GitHub examples
+      external_url: https://github.com/eclipse/ditto-examples
 
 #Topnav dropdowns
 topnav_dropdowns:

--- a/documentation/src/main/resources/js/customscripts.js
+++ b/documentation/src/main/resources/js/customscripts.js
@@ -1,6 +1,4 @@
 $(function () {
-    $('#mysidebar').height($(".nav").height());
-
     //this script says, if the height of the viewport is greater than 800px, then insert affix class, which makes the
     // nav bar float in a fixed position as your scroll. if you have a lot of nav items, this height may not work for
     // you. var h = $(window).height(); console.log (h); if (h > 800) { $( "#mysidebar" ).attr("class", "nav affix"); }


### PR DESCRIPTION
The documentation in the mobile layout (small screen width) is broken in the way that the navigation is overlayed into the content.

sitemap.xml is required to render google search results "as a block" for our project site