### PR TITLE
Improve ThingUpdater

### DIFF
--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdaterTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdaterTest.java
@@ -851,9 +851,8 @@ public final class ThingUpdaterTest {
         final ActorRef thingUpdater = createUninitializedThingUpdaterActor(thingsShardProbe.ref(),
                 policiesShardProbe.ref(), thingsTimeout, thingCacheFacade, policyCacheFacade);
 
-        expectShardedSudoRetrieveThing(thingsShardProbe, THING_ID);
-        thingUpdater.tell(SudoRetrieveThingResponse.of(initialThing, FieldType.regularOrSpecial(),
-                DittoHeaders.empty()), thingsShardProbe.ref());
+        final ThingCreated thingCreated = ThingCreated.of(initialThing, 0L, DittoHeaders.empty());
+        thingUpdater.tell(thingCreated, thingsShardProbe.ref());
 
         // wait until actor becomes `awaitingSyncResult` and is ready to stash & process other messages
         waitUntil().insertOrUpdate(any(), anyLong(), anyLong());


### PR DESCRIPTION
Bugs fixed:
1. ThingUpdater state was modified in a future.
2. ThingUpdater stayed in initial behavior forever if the first retrieve-cache-entry roundtrip did not complete.

Improvements:
1. Removed retrieve-cache-entry messages. Its response is not handled during synchronization, and it is not necessary during initialization.
2. Streamlined shortcuts for CreateThing and ModifyThing events.
3. Made the special handling of the first TagThing message more explicit. Removed unnecessary actor state checkThingTagOnly.