### PR TITLE
#53 Fix message serialization of empty raw messages payloads

### DIFF
--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageAdaptableHelper.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageAdaptableHelper.java
@@ -20,7 +20,6 @@ import java.util.regex.Pattern;
 
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonParseException;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
@@ -146,11 +145,9 @@ final class MessageAdaptableHelper {
                 value.ifPresent(jsonValue -> messageBuilder.payload((T) jsonValue));
             }
         } else {
-            final byte[] messagePayloadBytes = value
-                    .map(jsonValue -> jsonValue.isString() ? jsonValue.asString() : jsonValue.toString())
+            value.map(jsonValue -> jsonValue.isString() ? jsonValue.asString() : jsonValue.toString())
                     .map(payloadString -> payloadString.getBytes(charset))
-                    .orElseThrow(() -> JsonParseException.newBuilder().build());
-            messageBuilder.rawPayload(ByteBuffer.wrap(tryToDecode(messagePayloadBytes)));
+                    .ifPresent(bytes -> messageBuilder.rawPayload(ByteBuffer.wrap(tryToDecode(bytes))));
         }
         return messageBuilder.build();
     }

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommand.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommand.java
@@ -13,9 +13,6 @@ package org.eclipse.ditto.signals.commands.messages;
 
 import static java.util.Objects.requireNonNull;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -64,12 +61,6 @@ abstract class AbstractMessageCommand<T, C extends AbstractMessageCommand> exten
      */
     public static final String THING_ID_REGEX = THING_NAMESPACE_PREFIX_REGEX + "\\:" + THING_ID_NON_NAMESPACE_REGEX;
 
-    private static final String TEXT_PLAIN = "text/plain";
-    private static final String APPLICATION_JSON = "application/json";
-
-    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
-    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
-
     private final String thingId;
     private final Message<T> message;
 
@@ -109,29 +100,7 @@ abstract class AbstractMessageCommand<T, C extends AbstractMessageCommand> exten
         final JsonObject headersObject = message.getHeaders().toJson();
         messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_HEADERS, headersObject, predicate);
 
-        final Optional<T> payloadOptional = message.getPayload();
-        if (payloadOptional.isPresent()) {
-            final T payload = payloadOptional.get();
-            if (payload instanceof JsonValue) {
-                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, (JsonValue) payload, predicate);
-            } else {
-                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(payload.toString()),
-                        predicate);
-            }
-        } else {
-            final String encodedString;
-            if (shouldBeInterpretedAsText(message.getContentType().orElse(""))) {
-                encodedString = message.getRawPayload()
-                        .map(payload -> new String(payload.array()))
-                        .orElse("");
-            } else {
-                encodedString = message.getRawPayload()
-                        .map(BASE64_ENCODER::encode)
-                        .map(base64Encoded -> new String(base64Encoded.array(), StandardCharsets.UTF_8))
-                        .orElse("");
-            }
-            messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(encodedString), predicate);
-        }
+        MessagePayloadSerializer.serialize(message, messageBuilder, predicate);
 
         final JsonObject messageObject = messageBuilder.build();
         jsonObjectBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE, messageObject, predicate);
@@ -148,26 +117,14 @@ abstract class AbstractMessageCommand<T, C extends AbstractMessageCommand> exten
         final JsonObject messageObject = jsonObject.getValueOrThrow(MessageCommand.JsonFields.JSON_MESSAGE);
         final JsonObject messageHeadersObject =
                 messageObject.getValueOrThrow(MessageCommand.JsonFields.JSON_MESSAGE_HEADERS);
-        final JsonValue messagePayloadValue =
-                messageObject.getValueOrThrow(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD);
+        final Optional<JsonValue> messagePayloadOptional =
+                messageObject.getValue(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD);
 
         final MessageHeaders messageHeaders = MessageHeaders.of(messageHeadersObject);
-
         final MessageBuilder<T> messageBuilder = Message.newBuilder(messageHeaders);
-        final String payloadStr = messagePayloadValue.isString()
-                ? messagePayloadValue.asString()
-                : messagePayloadValue.toString();
-        final byte[] payloadBytes = payloadStr.getBytes(StandardCharsets.UTF_8);
-        if (shouldBeInterpretedAsText(messageHeaders.getContentType().orElse(""))) {
-            messageBuilder.rawPayload(ByteBuffer.wrap(payloadBytes));
-        } else {
-            messageBuilder.rawPayload(ByteBuffer.wrap(BASE64_DECODER.decode(payloadBytes)));
-        }
+        MessagePayloadSerializer.deserialize(messagePayloadOptional, messageBuilder,
+                messageHeaders.getContentType().orElse(""));
         return messageBuilder.build();
-    }
-
-    private static boolean shouldBeInterpretedAsText(final String contentType) {
-        return contentType.startsWith(TEXT_PLAIN) || contentType.startsWith(APPLICATION_JSON);
     }
 
     @Override

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommandResponse.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommandResponse.java
@@ -13,9 +13,6 @@ package org.eclipse.ditto.signals.commands.messages;
 
 import static java.util.Objects.requireNonNull;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -44,12 +41,6 @@ import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
  */
 abstract class AbstractMessageCommandResponse<T, C extends AbstractMessageCommandResponse>
         extends AbstractCommandResponse<C> implements MessageCommandResponse<T, C> {
-
-    private static final String TEXT_PLAIN = "text/plain";
-    private static final String APPLICATION_JSON = "application/json";
-
-    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
-    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
 
     private final String thingId;
     private final Message<T> message;
@@ -85,29 +76,7 @@ abstract class AbstractMessageCommandResponse<T, C extends AbstractMessageComman
         final JsonObject messageHeadersObject = message.getHeaders().toJson();
         messageBuilder.set(MessageCommandResponse.JsonFields.JSON_MESSAGE_HEADERS, messageHeadersObject, predicate);
 
-        final Optional<T> payloadOptional = message.getPayload();
-        if (payloadOptional.isPresent()) {
-            final T payload = payloadOptional.get();
-            if (payload instanceof JsonValue) {
-                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, (JsonValue) payload, predicate);
-            } else {
-                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(payload.toString()),
-                        predicate);
-            }
-        } else {
-            final String encodedString;
-            if (shouldBeInterpretedAsText(message.getContentType().orElse(""))) {
-                encodedString = message.getRawPayload()
-                        .map(payload -> new String(payload.array()))
-                        .orElse("");
-            } else {
-                encodedString = message.getRawPayload()
-                        .map(BASE64_ENCODER::encode)
-                        .map(base64Encoded -> new String(base64Encoded.array(), StandardCharsets.UTF_8))
-                        .orElse("");
-            }
-            messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(encodedString), predicate);
-        }
+        MessagePayloadSerializer.serialize(message, messageBuilder, predicate);
 
         final JsonObject messageObject = messageBuilder.build();
         jsonObjectBuilder.set(MessageCommandResponse.JsonFields.JSON_MESSAGE, messageObject, predicate);
@@ -130,27 +99,15 @@ abstract class AbstractMessageCommandResponse<T, C extends AbstractMessageComman
                                 .fieldName(
                                         MessageCommandResponse.JsonFields.JSON_MESSAGE_HEADERS.getPointer().toString())
                                 .build());
-        final JsonValue messagePayloadValue = messageObject.getValue(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD)
-                .orElseThrow(() -> JsonMissingFieldException.newBuilder()
-                        .fieldName(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD.getPointer().toString()).build());
+        final Optional<JsonValue> messagePayloadOptional =
+                messageObject.getValue(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD);
 
         final MessageHeaders messageHeaders = MessageHeaders.of(messageHeadersObject);
 
         final MessageBuilder<T> messageBuilder = Message.<T>newBuilder(messageHeaders);
-        final String payloadStr = messagePayloadValue.isString()
-                ? messagePayloadValue.asString()
-                : messagePayloadValue.toString();
-        final byte[] payloadBytes = payloadStr.getBytes(StandardCharsets.UTF_8);
-        if (shouldBeInterpretedAsText(messageHeaders.getContentType().orElse(""))) {
-            messageBuilder.rawPayload(ByteBuffer.wrap(payloadBytes));
-        } else {
-            messageBuilder.rawPayload(ByteBuffer.wrap(BASE64_DECODER.decode(payloadBytes)));
-        }
+        final String contentType = messageHeaders.getContentType().orElse("");
+        MessagePayloadSerializer.deserialize(messagePayloadOptional, messageBuilder, contentType);
         return messageBuilder.build();
-    }
-
-    private static boolean shouldBeInterpretedAsText(final String contentType) {
-        return contentType.startsWith(TEXT_PLAIN) || contentType.startsWith(APPLICATION_JSON);
     }
 
     @Override

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessagePayloadSerializer.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessagePayloadSerializer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.signals.commands.messages;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.messages.Message;
+import org.eclipse.ditto.model.messages.MessageBuilder;
+
+/**
+ * (De-)Serializes message payloads of {@code MessageCommand}s and {@code MessageCommandResponse}s.
+ */
+public class MessagePayloadSerializer {
+
+    private static final String TEXT_PLAIN = "text/plain";
+    private static final String APPLICATION_JSON = "application/json";
+
+    private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
+    private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+
+    private MessagePayloadSerializer() {
+    }
+
+    static <T> void serialize(final Message<T> message, final JsonObjectBuilder messageBuilder,
+            final Predicate<JsonField> predicate) {
+
+        final Optional<T> payloadOptional = message.getPayload();
+        final Optional<ByteBuffer> rawPayloadOptional = message.getRawPayload();
+
+        if (payloadOptional.isPresent()) {
+            final T payload = payloadOptional.get();
+            if (payload instanceof JsonValue) {
+                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, (JsonValue) payload, predicate);
+            } else {
+                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(payload.toString()),
+                        predicate);
+            }
+        } else {
+            if (rawPayloadOptional.isPresent()) {
+                final ByteBuffer rawPayload = rawPayloadOptional.get();
+                final String encodedString;
+                if (shouldBeInterpretedAsText(message.getContentType().orElse(""))) {
+                    encodedString = new String(rawPayload.array());
+                } else {
+                    final ByteBuffer base64Encoded = BASE64_ENCODER.encode(rawPayload);
+                    encodedString = new String(base64Encoded.array(), StandardCharsets.UTF_8);
+                }
+                messageBuilder.set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonValue.of(encodedString),
+                        predicate);
+            }
+        }
+    }
+
+    static <T> void deserialize(final Optional<JsonValue> messagePayloadOptional,
+            final MessageBuilder<T> messageBuilder, final String contentType) {
+        if (messagePayloadOptional.isPresent()) {
+            final JsonValue messagePayloadValue = messagePayloadOptional.get();
+            final String payloadStr = messagePayloadValue.isString()
+                    ? messagePayloadValue.asString()
+                    : messagePayloadValue.toString();
+            final byte[] payloadBytes = payloadStr.getBytes(StandardCharsets.UTF_8);
+            if (shouldBeInterpretedAsText(contentType)) {
+                messageBuilder.rawPayload(ByteBuffer.wrap(payloadBytes));
+            } else {
+                messageBuilder.rawPayload(ByteBuffer.wrap(BASE64_DECODER.decode(payloadBytes)));
+            }
+        }
+    }
+
+    private static boolean shouldBeInterpretedAsText(final String contentType) {
+        return contentType.startsWith(TEXT_PLAIN) || contentType.startsWith(APPLICATION_JSON);
+    }
+}

--- a/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/SendThingMessageTest.java
+++ b/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/SendThingMessageTest.java
@@ -61,6 +61,12 @@ public final class SendThingMessageTest {
             .rawPayload(ByteBuffer.wrap(KNOWN_RAW_PAYLOAD_BYTES))
             .build();
 
+    private static final Message<?> MESSAGE_EMPTY_PAYLOAD = MessagesModelFactory.newMessageBuilder(
+            MessageHeaders.newBuilder(MessageDirection.TO, THING_ID, SUBJECT)
+                    .contentType(CONTENT_TYPE)
+                    .build())
+            .build();
+
     private static final JsonObject KNOWN_MESSAGE_AS_JSON = JsonFactory.newObjectBuilder()
             .set(MessageCommand.JsonFields.JSON_MESSAGE_HEADERS, MESSAGE.getHeaders().toJson())
             .set(MessageCommand.JsonFields.JSON_MESSAGE_PAYLOAD, JsonFactory.newValue(new String(Base64.getEncoder()
@@ -68,11 +74,22 @@ public final class SendThingMessageTest {
             )
             .build();
 
+    private static final JsonObject KNOWN_EMPTY_PAYLOAD_MESSAGE_AS_JSON = JsonFactory.newObjectBuilder()
+            .set(MessageCommand.JsonFields.JSON_MESSAGE_HEADERS, MESSAGE.getHeaders().toJson())
+            .build();
+
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(Command.JsonFields.TYPE, SendThingMessage.TYPE)
             .set(MessageCommand.JsonFields.JSON_THING_ID, THING_ID)
             .set(MessageCommand.JsonFields.JSON_MESSAGE, KNOWN_MESSAGE_AS_JSON)
             .build();
+
+    private static final JsonObject KNOWN_JSON_WITH_EMPTY_PAYLOAD = JsonFactory.newObjectBuilder()
+            .set(Command.JsonFields.TYPE, SendThingMessage.TYPE)
+            .set(MessageCommand.JsonFields.JSON_THING_ID, THING_ID)
+            .set(MessageCommand.JsonFields.JSON_MESSAGE, KNOWN_EMPTY_PAYLOAD_MESSAGE_AS_JSON)
+            .build();
+
 
     @Test
     public void assertImmutability() {
@@ -123,6 +140,18 @@ public final class SendThingMessageTest {
     }
 
     @Test
+    public void toJsonWithEmptyPayloadReturnsExpected() {
+        final SendThingMessage<?> underTest =
+                SendThingMessage.of(THING_ID, MESSAGE_EMPTY_PAYLOAD, TestConstants.EMPTY_DITTO_HEADERS);
+        final JsonObject actualJson = underTest.toJson(FieldType.regularOrSpecial());
+
+        System.out.println(actualJson.toString());
+        System.out.println(KNOWN_JSON_WITH_EMPTY_PAYLOAD.toString());
+
+        assertThat(actualJson).isEqualTo(KNOWN_JSON_WITH_EMPTY_PAYLOAD);
+    }
+
+    @Test
     public void createInstanceFromValidJson() {
         final SendThingMessage<?> underTest =
                 SendThingMessage.fromJson(KNOWN_JSON.toString(), TestConstants.EMPTY_DITTO_HEADERS);
@@ -131,6 +160,19 @@ public final class SendThingMessageTest {
         assertThat(underTest.getThingId()).isEqualTo(THING_ID);
         assertThat(underTest.getMessageType()).isEqualTo(SendThingMessage.NAME);
         assertThat(underTest.getMessage()).isEqualTo(MESSAGE);
+    }
+
+    @Test
+    public void createInstanceFromValidJsonWithEmptyPayload() {
+        final SendThingMessage<?> underTest =
+                SendThingMessage.fromJson(KNOWN_JSON_WITH_EMPTY_PAYLOAD, TestConstants.EMPTY_DITTO_HEADERS);
+
+        assertThat(underTest).isNotNull();
+        assertThat(underTest.getThingId()).isEqualTo(THING_ID);
+        assertThat(underTest.getMessageType()).isEqualTo(SendThingMessage.NAME);
+        assertThat(underTest.getMessage()).isEqualTo(MESSAGE_EMPTY_PAYLOAD);
+        assertThat(underTest.getMessage().getPayload()).isEmpty();
+        assertThat(underTest.getMessage().getRawPayload()).isEmpty();
     }
 
 


### PR DESCRIPTION
- do not (de-)serialize payload field if payload is empty
- added tests
- extract MessagePayloadSerializer to reduce code duplication

Signed-off-by: Dominik Guggemos <dominik.guggemos@bosch-si.com>