### PR TITLE
acknowledge subscriptions for events, messages, live commands/events …

### DIFF
--- a/documentation/src/main/resources/jsonschema/protocol-envelope.json
+++ b/documentation/src/main/resources/jsonschema/protocol-envelope.json
@@ -39,11 +39,11 @@
     },
     "fields": {
       "type": "string",
-      "description": "The fields of a Thing that are included in the response.\nExample: `thingId,attributes(location)`"
+      "description": "The fields that should be included in the response.\nExample: `thingId,attributes(location)`"
     },
     "value": {
-      "type": "object",
-      "description": "The `value` field contains the actual payload e.g. a sensor value. The content must follow the *Things Model Schema*."
+      "type": ["object","string","number","array","boolean"],
+      "description": "The `value` field contains the actual payload e.g. a sensor value."
     }
   },
   "required": [ "topic", "headers", "path", "value" ]

--- a/documentation/src/main/resources/jsonschema/protocol-response.json
+++ b/documentation/src/main/resources/jsonschema/protocol-response.json
@@ -30,8 +30,8 @@
       "description": "A Path that references a part of a Thing which is affected by this message.\nExamples:\n * `/feature/location/properties/longitude` (a single sensor value)\n * `/` (the whole Thing)"
     },
     "value": {
-      "type": "object",
-      "description": "The _value_ field contains the actual payload e.g. a sensor value. The content must follow the *Things Model Schema*."
+      "type": ["object","string","number","array","boolean"],
+      "description": "The _value_ field contains the actual payload e.g. a sensor value."
     },
     "status": {
       "type": "integer",

--- a/documentation/src/main/resources/pages/ditto/protocol-bindings-websocket.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-bindings-websocket.md
@@ -33,7 +33,7 @@ Please find examples of commands and their response pattern at [Protocol example
 
 ### Request receiving events/change notifications
 
-Additionally to the response, which Ditto addresses directly to the instance which was sending the command, an event 
+In addition to the response, which Ditto addresses directly to the instance which was sending the command, an event 
 is generated. <br/>
 This will be delivered to all other clients with read permissions for the respective thing, feature change, etc. 
 
@@ -58,7 +58,7 @@ subscribing/unsubscribing for receiving live commands and events.
 
 ## WebSocket endpoint
 
-The WebSocket endpoint is accessible at these URLs (depdening on which API version to use):
+The WebSocket endpoint is accessible at these URLs (depending on which API version to use):
 
 ```
 ws://localhost:8080/ws/1
@@ -77,15 +77,15 @@ See [Authenticate](basic-auth.html) for more details.
 
 ## WebSocket protocol format
 
-As in the [Protocol specification](protocol-specification.html) defined a Ditto Protocol message consists of different
-information. These information are combined into a single JSON message for the WebSocket endpoint:
+As defined in the [Protocol specification](protocol-specification.html) a Ditto Protocol message consists of different
+information. This information is combined into a single JSON message for the WebSocket endpoint:
 * [topic](protocol-specification.html#topic): JSON string with key `topic`
 * [headers](protocol-specification.html#headers): JSON object with key `headers`
 * [path](protocol-specification.html#path): JSON string with key `path`
 * [value](protocol-specification.html#value): JSON value (e.g. JSON object, string, array, ...) with key `value`
 * [status](protocol-specification.html#status) (for responses): JSON number with key `status`
 
-The schema in for Ditto Protocol message via WebSocket:
+The schema for Ditto Protocol message via WebSocket:
 
 ```json
 {
@@ -124,9 +124,9 @@ This message is acknowledged by Ditto by sending back:
 START-SEND-EVENTS:ACK
 ``` 
 
-From this point on the WebSocket session will receive all change notifications it is entitled to see.
+From then on the WebSocket session will receive all change notifications it is entitled to see.
 
-In order to stop receiving change notifications, following text message has to be sent to the backend:
+In order to stop receiving change notifications, the following text message has to be sent to the backend:
                                                
 ```
 STOP-SEND-EVENTS
@@ -140,9 +140,9 @@ STOP-SEND-EVENTS:ACK
 
 ### Request messages
 
-In order to subscribe for [messages](basic-messages.html) which can be sent from WebSocket session to other WebSocket 
-session or from the [HTTP API](httpapi-overview.html) to a WebSocket session, following text message has to be sent to 
-the backend:
+In order to subscribe for [messages](basic-messages.html) which can be sent from a WebSocket session to another 
+WebSocket session or from the [HTTP API](httpapi-overview.html) to a WebSocket session, the following text message has 
+to be sent to the backend:
 
 ```
 START-SEND-MESSAGES
@@ -154,9 +154,9 @@ This message is acknowledged by Ditto by sending back:
 START-SEND-MESSAGES:ACK
 ``` 
 
-From this point on the WebSocket session will receive all messages it is entitled to see.
+From then on the WebSocket session will receive all messages it is entitled to see.
 
-In order to stop receiving messages, following text message has to be sent to the backend:
+In order to stop receiving messages, the following text message has to be sent to the backend:
                                                
 ```
 STOP-SEND-MESSAGES
@@ -170,8 +170,8 @@ STOP-SEND-MESSAGES:ACK
 
 ### Request live commands
 
-In order to subscribe for [live commands](protocol-twinlive.html) which can be sent from WebSocket session to other 
-WebSocket session, following text message has to be sent to the backend:
+In order to subscribe for [live commands](protocol-twinlive.html) which can be sent from a WebSocket session to another 
+WebSocket session, the following text message has to be sent to the backend:
 
 ```
 START-SEND-LIVE-COMMANDS
@@ -183,9 +183,9 @@ This message is acknowledged by Ditto by sending back:
 START-SEND-LIVE-COMMANDS:ACK
 ``` 
 
-From this point on the WebSocket session will receive all live commands it is entitled to see.
+From then on the WebSocket session will receive all live commands it is entitled to see.
 
-In order to stop receiving live commands, following text message has to be sent to the backend:
+In order to stop receiving live commands, the following text message has to be sent to the backend:
                                                
 ```
 STOP-SEND-LIVE-COMMANDS
@@ -199,8 +199,8 @@ STOP-SEND-LIVE-COMMANDS:ACK
 
 ### Request live events
 
-In order to subscribe for [live events](protocol-twinlive.html) which can be sent from WebSocket session to other 
-WebSocket session, following text message has to be sent to the backend:
+In order to subscribe for [live events](protocol-twinlive.html) which can be sent from a WebSocket session to another 
+WebSocket session, the following text message has to be sent to the backend:
 
 ```
 START-SEND-LIVE-EVENTS
@@ -212,9 +212,9 @@ This message is acknowledged by Ditto by sending back:
 START-SEND-LIVE-EVENTS:ACK
 ``` 
 
-From this point on the WebSocket session will receive all live events it is entitled to see.
+From then on the WebSocket session will receive all live events it is entitled to see.
 
-In order to stop receiving live events, following text message has to be sent to the backend:
+In order to stop receiving live events, the following text message has to be sent to the backend:
                                                
 ```
 STOP-SEND-LIVE-EVENTS

--- a/documentation/src/main/resources/pages/ditto/protocol-bindings-websocket.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-bindings-websocket.md
@@ -8,15 +8,64 @@ permalink: protocol-bindings-websocket.html
 The Ditto Protocol message can be sent *as is* as [WebSocket](https://tools.ietf.org/html/rfc6455) message.
 The Ditto Protocol JSON must be sent as `UTF-8` encoded String payload.
 
-## Ditto WebSocket endpoint
 
-The WebSocket endpoint is accessible at this URL:
+## WebSocket features
+
+The WebSocket provides an alternative to the [HTTP API](httpapi-overview.html) in order to manage your Digital Twins.
+
+The benefits of the WebSocket compared to HTTP are multiple ones:
+* a single connection (socket like) is established and for commands to Digital Twins no further HTTP overhead 
+  (e.g. HTTP headers, HTTP connection establishment) is produced which means you can get more commands/seconds 
+  through the WebSocket compared to the HTTP endpoint
+* as the WebSocket is a duplex connection, [change notifications](basic-changenotifications.html) can be sent via the
+  WebSocket for changes to entities done in Ditto
+* additionally, [messages](basic-messages.html) and [live commands/events](protocol-twinlive.html) can be exchanged 
+  (sending and receiving) via multiple connected WebSocket sessions 
+
+### Send commands and get responses
+   
+When sending a command via WebSocket you will receive a corresponding response (the response can be related to the 
+request by the `correlation-id` header). <br/>
+The response indicates the success or the failure of the command and, depending on the command type, contains the result
+payload.
+
+Please find examples of commands and their response pattern at [Protocol examples](protocol-examples.html).
+
+### Request receiving events/change notifications
+
+Additionally to the response, which Ditto addresses directly to the instance which was sending the command, an event 
+is generated. <br/>
+This will be delivered to all other clients with read permissions for the respective thing, feature change, etc. 
+
+See [request events](#request-events) for subscribing/unsubscribing for receiving change notifications.
+
+### Request receiving messages
+
+[Messages](basic-messages.html) can be sent both via the [HTTP API](httpapi-overview.html) and the WebSocket. Receiving
+messages and answering to them however can only be done via the WebSocket.
+
+See [request messages](#request-messages) for subscribing/unsubscribing for receiving messages.
+
+### Request receiving live commands + events
+
+In order to receive [live commands and events](protocol-twinlive.html), the WebSocket API can be used. The Ditto Protocol
+messages are the same as for the "twin" channel, only with *live* as channel in the 
+[topic](protocol-specification-topic.html).
+
+See [request live commands](#request-live-commands) and [request live events](#request-live-events) for 
+subscribing/unsubscribing for receiving live commands and events.
+
+
+## WebSocket endpoint
+
+The WebSocket endpoint is accessible at these URLs (depdening on which API version to use):
 
 ```
 ws://localhost:8080/ws/1
+ws://localhost:8080/ws/2
 ```
 
-## Authenticate
+### Authentication
 
 A user who connects to the WebSocket endpoint can be authenticated by using
 
@@ -26,22 +75,153 @@ A user who connects to the WebSocket endpoint can be authenticated by using
 See [Authenticate](basic-auth.html) for more details.
 
 
-## Send commands and get responses
-   
-When sending a command via WebSocket you will receive a corresponding response (the response can be related to the 
-request by the `correlation-id` header).
-The response indicates the success or the failure of the command and, depending on the command type, contains the result
-payload.
+## WebSocket protocol format
 
-Please find examples of commands and their response pattern at [Protocol examples.](protocol-examples.html)
+As in the [Protocol specification](protocol-specification.html) defined a Ditto Protocol message consists of different
+information. These information are combined into a single JSON message for the WebSocket endpoint:
+* [topic](protocol-specification.html#topic): JSON string with key `topic`
+* [headers](protocol-specification.html#headers): JSON object with key `headers`
+* [path](protocol-specification.html#path): JSON string with key `path`
+* [value](protocol-specification.html#value): JSON value (e.g. JSON object, string, array, ...) with key `value`
+* [status](protocol-specification.html#status) (for responses): JSON number with key `status`
+
+The schema in for Ditto Protocol message via WebSocket:
+
+```json
+{
+  "topic": "<the topic>",
+  "headers": {
+    "correlation-id": "<a correlation-id>",
+    "a-header": "<header value>"
+  },
+  "path": "<the path>",
+  "value": {
+    
+  }
+}
+```
 
 
-## Request events/change notifications
+## WebSocket binding specific messages
 
-Additionally to the response, which Ditto addresses directly to the instance which was sending the command, an event 
-is generated. 
-This will be delivered to all other clients with read permissions for the respective thing, feature change, etc. 
-Thus in order to receive such events (triggered by commands of a 3rd-party) you will need to send a `START-SEND-EVENTS`
-WebSocket message literally.
+The WebSocket binding defines several specific messages which are not defined in the Ditto Protocol specification.
 
-To close the events subscription, send a `STOP-SEND-EVENTS` message.
+Those are also not defined as JSON messages, but as plain text messages. All of those declare a demand for some kind
+of information from the backend to be pushed into the WebSocket session.
+
+### Request events
+
+In order to subscribe for [events/change notifications](basic-changenotifications.html) for entities (e.g. Things), 
+following text message has to be sent to the backend:
+
+```
+START-SEND-EVENTS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+START-SEND-EVENTS:ACK
+``` 
+
+From this point on the WebSocket session will receive all change notifications it is entitled to see.
+
+In order to stop receiving change notifications, following text message has to be sent to the backend:
+                                               
+```
+STOP-SEND-EVENTS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+STOP-SEND-EVENTS:ACK
+``` 
+
+### Request messages
+
+In order to subscribe for [messages](basic-messages.html) which can be sent from WebSocket session to other WebSocket 
+session or from the [HTTP API](httpapi-overview.html) to a WebSocket session, following text message has to be sent to 
+the backend:
+
+```
+START-SEND-MESSAGES
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+START-SEND-MESSAGES:ACK
+``` 
+
+From this point on the WebSocket session will receive all messages it is entitled to see.
+
+In order to stop receiving messages, following text message has to be sent to the backend:
+                                               
+```
+STOP-SEND-MESSAGES
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+STOP-SEND-MESSAGES:ACK
+``` 
+
+### Request live commands
+
+In order to subscribe for [live commands](protocol-twinlive.html) which can be sent from WebSocket session to other 
+WebSocket session, following text message has to be sent to the backend:
+
+```
+START-SEND-LIVE-COMMANDS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+START-SEND-LIVE-COMMANDS:ACK
+``` 
+
+From this point on the WebSocket session will receive all live commands it is entitled to see.
+
+In order to stop receiving live commands, following text message has to be sent to the backend:
+                                               
+```
+STOP-SEND-LIVE-COMMANDS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+STOP-SEND-LIVE-COMMANDS:ACK
+``` 
+
+### Request live events
+
+In order to subscribe for [live events](protocol-twinlive.html) which can be sent from WebSocket session to other 
+WebSocket session, following text message has to be sent to the backend:
+
+```
+START-SEND-LIVE-EVENTS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+START-SEND-LIVE-EVENTS:ACK
+``` 
+
+From this point on the WebSocket session will receive all live events it is entitled to see.
+
+In order to stop receiving live events, following text message has to be sent to the backend:
+                                               
+```
+STOP-SEND-LIVE-EVENTS
+``` 
+
+This message is acknowledged by Ditto by sending back:
+
+```
+STOP-SEND-LIVE-EVENTS:ACK
+``` 

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StopStreaming.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StopStreaming.java
@@ -33,8 +33,7 @@ public final class StopStreaming {
     }
 
     /**
-     *
-     * @return
+     * @return the Streaming type of what streaming to stop.
      */
     public StreamingType getStreamingType() {
         return streamingType;

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingAck.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingAck.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.gateway.streaming;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nonnull;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.model.base.json.FieldType;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.base.json.Jsonifiable;
+
+/**
+ * Send for acknowledging that a subscription in the cluster for a {@link StreamingType} was either subscribed to
+ * ({@link #subscribed} is {@code true}) or unsubscribed from ({@link #subscribed} is {@code false}).
+ */
+public final class StreamingAck implements Jsonifiable.WithPredicate<JsonObject, JsonField> {
+
+    private static final JsonFieldDefinition<String> JSON_STREAMING_TYPE =
+            JsonFactory.newStringFieldDefinition("streamingType", FieldType.REGULAR, JsonSchemaVersion.V_1,
+                    JsonSchemaVersion.V_2);
+    private static final JsonFieldDefinition<Boolean> JSON_SUBSCRIBED =
+            JsonFactory.newBooleanFieldDefinition("subscribed", FieldType.REGULAR, JsonSchemaVersion.V_1,
+                    JsonSchemaVersion.V_2);
+
+    private final StreamingType streamingType;
+    private final boolean subscribed;
+
+    /**
+     * Constructs a new acknowledge for when a subscription in the cluster was added/removed.
+     *
+     * @param streamingType the StreamingType of this StreamingAck message.
+     * @param subscribed whether it is acknowledged if a subscription was added ({@link #subscribed} is {@code true}) or
+     * removed ({@link #subscribed} is {@code false}).
+     */
+    public StreamingAck(final StreamingType streamingType, final boolean subscribed) {
+        this.streamingType = streamingType;
+        this.subscribed = subscribed;
+    }
+
+    /**
+     * @return the StreamingType of this StreamingAck message.
+     */
+    public StreamingType getStreamingType() {
+        return streamingType;
+    }
+
+    /**
+     * @return whether it is acknowledged if a subscription was added ({@link #subscribed} is {@code true}) or removed
+     * ({@link #subscribed} is {@code false}).
+     */
+    public boolean isSubscribed() {
+        return subscribed;
+    }
+
+    /**
+     * Creates a new {@code StreamingAck} message from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the StreamingAck is to be created.
+     * @return the StreamingAck message.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static StreamingAck fromJson(final JsonObject jsonObject) {
+        final String streamingType = jsonObject.getValueOrThrow(JSON_STREAMING_TYPE);
+        final boolean subscribed = jsonObject.getValueOrThrow(JSON_SUBSCRIBED);
+
+        return new StreamingAck(StreamingType.fromTopic(streamingType), subscribed);
+    }
+
+    @Override
+    @Nonnull
+    public JsonObject toJson() {
+        return toJson(FieldType.notHidden());
+    }
+
+    @Override
+    @Nonnull
+    public JsonObject toJson(@Nonnull final JsonSchemaVersion schemaVersion,
+            @Nonnull final Predicate<JsonField> thePredicate) {
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+
+        final JsonObjectBuilder jsonObjectBuilder = JsonObject.newBuilder();
+        jsonObjectBuilder.set(JSON_STREAMING_TYPE, streamingType.getDistributedPubSubTopic(), predicate);
+        jsonObjectBuilder.set(JSON_SUBSCRIBED, subscribed, predicate);
+        return jsonObjectBuilder.build();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof StreamingAck)) {
+            return false;
+        }
+        final StreamingAck that = (StreamingAck) o;
+        return subscribed == that.subscribed && streamingType == that.streamingType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(streamingType, subscribed);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "streamingType=" + streamingType +
+                ", subscribed=" + subscribed +
+                "]";
+    }
+}

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingType.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StreamingType.java
@@ -54,4 +54,6 @@ public enum StreamingType {
                         () -> new IllegalStateException("Unknown distributedPubSubTopic: " + distributedPubSubTopic));
     }
 
+
+
 }

--- a/services/gateway/util/pom.xml
+++ b/services/gateway/util/pom.xml
@@ -25,6 +25,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>ditto-services-gateway-streaming</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-json</artifactId>
         </dependency>

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/starter/service/util/GatewayMappingStrategy.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/starter/service/util/GatewayMappingStrategy.java
@@ -18,6 +18,7 @@ import java.util.function.BiFunction;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
+import org.eclipse.ditto.services.gateway.streaming.StreamingAck;
 import org.eclipse.ditto.services.models.policies.PoliciesMappingStrategy;
 import org.eclipse.ditto.services.models.things.ThingsMappingStrategy;
 import org.eclipse.ditto.services.models.thingsearch.ThingSearchMappingStrategy;
@@ -59,6 +60,9 @@ public final class GatewayMappingStrategy implements MappingStrategy {
 
         builder.add(BaseCacheEntry.class,
                 jsonObject -> BaseCacheEntry.fromJson(jsonObject)); // do not replace with lambda!
+
+        builder.add(StreamingAck.class,
+                jsonObject -> StreamingAck.fromJson(jsonObject)); // do not replace with lambda!
 
         addMessagesStrategies(builder);
         addDevOpsStrategies(builder);

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
@@ -2537,7 +2537,7 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
         }
 
         private void logInfoAboutIncomingMessage(final String messageType) {
-            log.info("<{}> got <{}>.", thingId, messageType);
+            log.debug("<{}> got <{}>.", thingId, messageType);
         }
 
     }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/Command.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/Command.java
@@ -93,12 +93,6 @@ public interface Command<T extends Command> extends Signal<T> {
                 JsonFactory.newStringFieldDefinition("type", FieldType.REGULAR, JsonSchemaVersion.V_2);
 
         /**
-         * JSON field containing the command's payload as {@link JsonObject}.
-         */
-        public static final JsonFieldDefinition<JsonObject> PAYLOAD = JsonFactory.newJsonObjectFieldDefinition
-                ("payload", FieldType.REGULAR, JsonSchemaVersion.V_1, JsonSchemaVersion.V_2);
-
-        /**
          * Constructs a new {@code JsonFields} object.
          */
         protected JsonFields() {


### PR DESCRIPTION
…at WebSocket

* for each "START-SEND-..." message an "START-SEND-...:ACK" response is sent onto the WS once the backend is confident that the subscription is established
* works with a max. timeout of 2,5 seconds in the backend - if any events are received earlier, the ACK is sent back as early as possible