### PR TITLE
CI-friendly maven versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .checkstyle
 .classpath
+.flattened-pom.xml
 .idea
 *.iml
 .project

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,30 +1,23 @@
 #!groovy
 node {
   // Need to replace the '%2F' used by Jenkins to deal with / in the path (e.g. story/...)
-    String theBranch = "${env.BRANCH_NAME}".replace('%2F', '-').replace('/','-');
+  String theBranch = "${env.BRANCH_NAME}".replace('%2F', '-').replace('/','-')
+  String theVersion = "0-${theBranch}-SNAPSHOT"
   String theMvnRepo = "$WORKSPACE/../feature-repository-${theBranch}";
 
   stage('Checkout') {
     checkout scm
   }
 
-  stage('set version to ${theBranch}') {
-    withMaven(
-      maven: 'maven-3.5.2',
-      mavenLocalRepo: theMvnRepo) {
-
-      sh "mvn versions:set -DnewVersion=0-${theBranch}-SNAPSHOT"
-    }
-  }
-
   stage('Build') {
     withMaven(
-      maven: 'maven-3.5.2',
+      maven: 'maven-3.3.9',
       mavenLocalRepo: theMvnRepo) {
 
       sh "mvn clean deploy javadoc:jar source:jar-no-fork" +
               " -T16 --batch-mode --errors" +
-              " -Pbuild-documentation,internal-repos -DcreateJavadoc=true"
+              " -Pbuild-documentation,internal-repos -DcreateJavadoc=true" +
+              " -Drevision=${theVersion}"
     }
   }
 }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-bom</artifactId>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-documentation</artifactId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 

--- a/model/amqp-bridge/pom.xml
+++ b/model/amqp-bridge/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-amqp-bridge</artifactId>

--- a/model/base/pom.xml
+++ b/model/base/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-base</artifactId>

--- a/model/devops/pom.xml
+++ b/model/devops/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-devops</artifactId>

--- a/model/messages/pom.xml
+++ b/model/messages/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-messages</artifactId>

--- a/model/policies-enforcers/pom.xml
+++ b/model/policies-enforcers/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-policies-enforcers</artifactId>

--- a/model/policies/pom.xml
+++ b/model/policies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-policies</artifactId>

--- a/model/pom.xml
+++ b/model/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 

--- a/model/things/pom.xml
+++ b/model/things/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-things</artifactId>

--- a/model/thingsearch-parser/pom.xml
+++ b/model/thingsearch-parser/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-thingsearch-parser</artifactId>

--- a/model/thingsearch/pom.xml
+++ b/model/thingsearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-model</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-model-thingsearch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <groupId>org.eclipse.ditto</groupId>
     <artifactId>ditto</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <name>Eclipse Ditto</name>
     <description>Eclipse Ditto is a framework for creating and managing digital twins in the IoT.</description>
@@ -164,6 +164,8 @@
     </modules>
 
     <properties>
+        <revision>0.1.0-SNAPSHOT</revision>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -489,6 +491,33 @@
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <version>1.0.1</version>
+                <configuration>
+                    <flattenMode>oss</flattenMode>
+                    <updatePomFile>true</updatePomFile>
+                </configuration>
+                <executions>
+                    <!-- enable flattening -->
+                    <execution>
+                        <id>flatten</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                    <!-- ensure proper cleanup -->
+                    <execution>
+                        <id>flatten.clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/protocol-adapter/pom.xml
+++ b/protocol-adapter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 

--- a/services/amqp-bridge/messaging/pom.xml
+++ b/services/amqp-bridge/messaging/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-amqpbridge</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-amqpbridge-messaging</artifactId>

--- a/services/amqp-bridge/pom.xml
+++ b/services/amqp-bridge/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-amqpbridge</artifactId>

--- a/services/amqp-bridge/starter/pom.xml
+++ b/services/amqp-bridge/starter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-amqpbridge</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-amqpbridge-starter</artifactId>

--- a/services/amqp-bridge/util/pom.xml
+++ b/services/amqp-bridge/util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-amqpbridge</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-amqpbridge-util</artifactId>

--- a/services/gateway/endpoints/pom.xml
+++ b/services/gateway/endpoints/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-endpoints</artifactId>

--- a/services/gateway/health/pom.xml
+++ b/services/gateway/health/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-health</artifactId>

--- a/services/gateway/pom.xml
+++ b/services/gateway/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway</artifactId>

--- a/services/gateway/proxy/pom.xml
+++ b/services/gateway/proxy/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-proxy</artifactId>

--- a/services/gateway/security/pom.xml
+++ b/services/gateway/security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-security</artifactId>

--- a/services/gateway/starter/pom.xml
+++ b/services/gateway/starter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-starter</artifactId>

--- a/services/gateway/streaming/pom.xml
+++ b/services/gateway/streaming/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-streaming</artifactId>

--- a/services/gateway/util/pom.xml
+++ b/services/gateway/util/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-gateway</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-gateway-util</artifactId>

--- a/services/models/amqp-bridge/pom.xml
+++ b/services/models/amqp-bridge/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-models</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
 

--- a/services/models/policies/pom.xml
+++ b/services/models/policies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-models</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-models-policies</artifactId>

--- a/services/models/pom.xml
+++ b/services/models/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-models</artifactId>

--- a/services/models/things/pom.xml
+++ b/services/models/things/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-models</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-models-things</artifactId>

--- a/services/models/thingsearch/pom.xml
+++ b/services/models/thingsearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-models</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-models-thingsearch</artifactId>

--- a/services/policies/persistence/pom.xml
+++ b/services/policies/persistence/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-policies</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-policies-persistence</artifactId>

--- a/services/policies/pom.xml
+++ b/services/policies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-policies</artifactId>

--- a/services/policies/starter/pom.xml
+++ b/services/policies/starter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-policies</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-policies-starter</artifactId>

--- a/services/policies/util/pom.xml
+++ b/services/policies/util/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-policies</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-policies-util</artifactId>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 

--- a/services/things/persistence/pom.xml
+++ b/services/things/persistence/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-things</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-things-persistence</artifactId>

--- a/services/things/pom.xml
+++ b/services/things/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-things</artifactId>

--- a/services/things/starter/pom.xml
+++ b/services/things/starter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-things</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-things-starter</artifactId>

--- a/services/things/util/pom.xml
+++ b/services/things/util/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-things</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-things-util</artifactId>

--- a/services/thingsearch/common/pom.xml
+++ b/services/thingsearch/common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-common</artifactId>

--- a/services/thingsearch/persistence/pom.xml
+++ b/services/thingsearch/persistence/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-persistence</artifactId>

--- a/services/thingsearch/pom.xml
+++ b/services/thingsearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch</artifactId>

--- a/services/thingsearch/query-model/pom.xml
+++ b/services/thingsearch/query-model/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-query-model</artifactId>

--- a/services/thingsearch/query/pom.xml
+++ b/services/thingsearch/query/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-query</artifactId>

--- a/services/thingsearch/starter/pom.xml
+++ b/services/thingsearch/starter/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-starter</artifactId>

--- a/services/thingsearch/updater-actors/pom.xml
+++ b/services/thingsearch/updater-actors/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-thingsearch</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-thingsearch-updater-actors</artifactId>

--- a/services/utils/akka-persistence-mongo-addons/pom.xml
+++ b/services/utils/akka-persistence-mongo-addons/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-akka-persistence-mongo-addons</artifactId>

--- a/services/utils/akka/pom.xml
+++ b/services/utils/akka/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-akka</artifactId>

--- a/services/utils/cluster/pom.xml
+++ b/services/utils/cluster/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-cluster</artifactId>

--- a/services/utils/config/pom.xml
+++ b/services/utils/config/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-config</artifactId>

--- a/services/utils/devops/pom.xml
+++ b/services/utils/devops/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-devops</artifactId>

--- a/services/utils/distributed-cache/actors/pom.xml
+++ b/services/utils/distributed-cache/actors/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils-distributed-cache</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-distributed-cache-actors</artifactId>

--- a/services/utils/distributed-cache/model/pom.xml
+++ b/services/utils/distributed-cache/model/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils-distributed-cache</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-distributed-cache-model</artifactId>

--- a/services/utils/distributed-cache/pom.xml
+++ b/services/utils/distributed-cache/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-distributed-cache</artifactId>

--- a/services/utils/health/pom.xml
+++ b/services/utils/health/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-health</artifactId>

--- a/services/utils/persistence/pom.xml
+++ b/services/utils/persistence/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-persistence</artifactId>

--- a/services/utils/pom.xml
+++ b/services/utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils</artifactId>

--- a/services/utils/test/pom.xml
+++ b/services/utils/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-services-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-services-utils-test</artifactId>

--- a/signals/base/pom.xml
+++ b/signals/base/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-base</artifactId>

--- a/signals/commands/amqp-bridge/pom.xml
+++ b/signals/commands/amqp-bridge/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-amqp-bridge</artifactId>

--- a/signals/commands/base/pom.xml
+++ b/signals/commands/base/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-base</artifactId>

--- a/signals/commands/batch/pom.xml
+++ b/signals/commands/batch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-batch</artifactId>

--- a/signals/commands/devops/pom.xml
+++ b/signals/commands/devops/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-devops</artifactId>

--- a/signals/commands/live/pom.xml
+++ b/signals/commands/live/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-live</artifactId>

--- a/signals/commands/messages/pom.xml
+++ b/signals/commands/messages/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-messages</artifactId>

--- a/signals/commands/policies/pom.xml
+++ b/signals/commands/policies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-policies</artifactId>

--- a/signals/commands/pom.xml
+++ b/signals/commands/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands</artifactId>

--- a/signals/commands/things/pom.xml
+++ b/signals/commands/things/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-things</artifactId>

--- a/signals/commands/thingsearch/pom.xml
+++ b/signals/commands/thingsearch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-commands</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-commands-thingsearch</artifactId>

--- a/signals/events/amqp-bridge/pom.xml
+++ b/signals/events/amqp-bridge/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-events</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events-amqp-bridge</artifactId>

--- a/signals/events/base/pom.xml
+++ b/signals/events/base/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-events</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events-base</artifactId>

--- a/signals/events/batch/pom.xml
+++ b/signals/events/batch/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-events</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events-batch</artifactId>

--- a/signals/events/policies/pom.xml
+++ b/signals/events/policies/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-events</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events-policies</artifactId>

--- a/signals/events/pom.xml
+++ b/signals/events/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events</artifactId>

--- a/signals/events/things/pom.xml
+++ b/signals/events/things/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-signals-events</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-signals-events-things</artifactId>

--- a/signals/pom.xml
+++ b/signals/pom.xml
@@ -17,13 +17,13 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 
     <artifactId>ditto-signals</artifactId>
     <packaging>pom</packaging>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>${revision}</version>
 
     <name>Eclipse Ditto :: Signals</name>
 

--- a/utils/jsr305/pom.xml
+++ b/utils/jsr305/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-utils</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>ditto-utils-jsr305</artifactId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ditto</groupId>
         <artifactId>ditto-bom</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>${revision}</version>
         <relativePath>../bom</relativePath>
     </parent>
 


### PR DESCRIPTION
Changes:
- Set version of parent by the speicial maven property 'revision'.
- Flattened poms are deployed to work around maven bug MNG-5576.
- Swtich to maven 3.3.9 to deploy in parallel because maven 3.5.2 deadlocks.

References:
https://www.igorkromin.net/index.php/2017/06/16/multi-module-builds-with-maven-35-and-the-parent-child-pom-version-management/
https://maven.apache.org/maven-ci-friendly.html
https://issues.apache.org/jira/browse/MNG-5576