### PR TITLE
Deploy BOM with dynamically resolved version properties

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -728,5 +728,22 @@
         </dependencies>
     </dependencyManagement>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <configuration>
+                    <!-- instead of flattenMode=bom, set the pom-element <dependencyManagement/> explicitly without
+                         <properties/> so that dynamic version properties are resolved in deployed bom. -->
+                    <flattenMode>oss</flattenMode>
+                    <pomElements>
+                        <dependencyManagement/>
+                    </pomElements>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>
 


### PR DESCRIPTION
Configure flatten-maven-plugin to create a POM with the element `<dependencyManagement>` such that the versions of all dependencies are fully resolved.