### PR TITLE
Introduce synchronization sessions in ThingUpdater

### DIFF
--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdaterTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdaterTest.java
@@ -36,6 +36,8 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
@@ -867,12 +869,13 @@ public final class ThingUpdaterTest {
                 underTest.tell(thingTag, ref());
 
                 // WHEN: synchronization is unsuccessful, thing updater will retry two times
+                final HttpStatusCode teapot = HttpStatusCode.IM_A_TEAPOT;
                 expectShardedSudoRetrieveThing(thingsShardProbe, THING_ID);
-                underTest.tell(new AskTimeoutException("forced timeout for testing"), ActorRef.noSender());
+                underTest.tell(DittoRuntimeException.newBuilder("dummy 1", teapot).build(), ActorRef.noSender());
                 expectShardedSudoRetrieveThing(thingsShardProbe, THING_ID);
-                underTest.tell(new AskTimeoutException("forced timeout for testing"), ActorRef.noSender());
+                underTest.tell(DittoRuntimeException.newBuilder("dummy 2", teapot).build(), ActorRef.noSender());
                 expectShardedSudoRetrieveThing(thingsShardProbe, THING_ID);
-                underTest.tell(new AskTimeoutException("forced timeout for testing"), ActorRef.noSender());
+                underTest.tell(DittoRuntimeException.newBuilder("dummy 3", teapot).build(), ActorRef.noSender());
 
                 // THEN: failure is acknowledged
                 expectMsgEquals(StreamAck.failure(thingTag.asIdentifierString()));


### PR DESCRIPTION
Changes:
- Each synchronization cycle is identified by a unique ID; ThingUpdater no longer reacts to timeout messages from previous sync cycles.
- Fixed an assignment to mutable field ThingUpdater.syncAttempt inside a future.
- Reduced logging during normal operation.