### PR TITLE
made it possible to connect to sandbox via basic auth

### DIFF
--- a/docker/sandbox/docker-compose.yml
+++ b/docker/sandbox/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - TZ=Europe/Berlin
       - INSTANCE_INDEX=1
       - BIND_HOSTNAME=0.0.0.0
-      - ENABLE_DUMMY_AUTH=false
+      - ENABLE_DUMMY_AUTH=true
       - _JAVA_OPTIONS=-Xms512m -Xmx512m -Xss512k -XX:MaxMetaspaceSize=128m -XX:+ExitOnOutOfMemoryError
       - STATSD_PORT_8125_UDP_ADDR=graphite
       - STATSD_PORT_8125_UDP_PORT=8125
@@ -148,6 +148,7 @@ services:
     image: docker.io/nginx:1.13-alpine
     volumes:
        - ./nginx.conf:/etc/nginx/nginx.conf:ro
+       - ./nginx.htpasswd:/etc/nginx/nginx.htpasswd:ro
        - ./nginx-devops.htpasswd:/etc/nginx/nginx-devops.htpasswd:ro
        - ./html:/etc/nginx/html
        - ../nginx-cors.conf:/etc/nginx/nginx-cors.conf:ro

--- a/docker/sandbox/nginx.conf
+++ b/docker/sandbox/nginx.conf
@@ -18,12 +18,71 @@ http {
 
   merge_slashes off; # allow multiple slashes
 
+  map $http_authorization $authentication {
+    default "Authentication required";
+    "~Bearer" "off";
+    # the above means: if we get a request containing an "Authorization: Bearer ..." header, set "off" to $authentication
+  }
+
+  map $http_authorization $dittodummyuser {
+    default "nginx:${remote_user}";
+    "~Bearer" "";
+  }
+
   server {
-    listen 80;
-    listen [::]:80;
+    listen         80;
+    listen         [::]:80;
+    server_name    ditto.eclipse.org;
+
+    location / {  # the default location redirects to https
+      return       301 https://$server_name$request_uri;
+    }
+
+    # api - also accessible via plain HTTP (in order to connect from "weak IoT devices")
+    location /api {
+      include nginx-cors.conf;
+
+      auth_basic                    $authentication;
+      auth_basic_user_file          nginx.htpasswd;
+
+      proxy_pass                    http://gateway:8080/api;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwared-User     $remote_user;
+      proxy_set_header              x-ditto-dummy-auth  $dittodummyuser;
+
+      proxy_set_header Connection  '';
+      chunked_transfer_encoding    off;
+      proxy_buffering              off;
+      proxy_cache                  off;
+    }
+
+    # ws - also accessible via plain HTTP (in order to connect from "weak IoT devices")
+    location /ws {
+      auth_basic                    $authentication;
+      auth_basic_user_file          nginx.htpasswd;
+
+      proxy_pass                    http://gateway:8080/ws;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwared-User     $remote_user;
+      proxy_set_header              x-ditto-dummy-auth  $dittodummyuser;
+
+      proxy_set_header              Upgrade             $http_upgrade;
+      proxy_set_header              Connection          "upgrade";
+      proxy_read_timeout            1d;
+      proxy_send_timeout            1d;
+    }
+  }
+
+  server {
     listen 443 default_server ssl;
     listen [::]:443 ssl;
-    server_name ditto.eclise.org;
+    server_name ditto.eclipse.org;
 
     server_tokens off;
 
@@ -62,12 +121,16 @@ http {
     location /api {
       include nginx-cors.conf;
 
+      auth_basic                    $authentication;
+      auth_basic_user_file          nginx.htpasswd;
+
       proxy_pass                    http://gateway:8080/api;
       proxy_http_version            1.1;
       proxy_set_header              Host                $http_host;
       proxy_set_header              X-Real-IP           $remote_addr;
       proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_set_header              X-Forwared-User     $remote_user;
+      proxy_set_header              x-ditto-dummy-auth  $dittodummyuser;
 
       proxy_set_header Connection  '';
       chunked_transfer_encoding    off;
@@ -77,12 +140,16 @@ http {
 
     # ws
     location /ws {
+      auth_basic                    $authentication;
+      auth_basic_user_file          nginx.htpasswd;
+
       proxy_pass                    http://gateway:8080/ws;
       proxy_http_version            1.1;
       proxy_set_header              Host                $http_host;
       proxy_set_header              X-Real-IP           $remote_addr;
       proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
       proxy_set_header              X-Forwared-User     $remote_user;
+      proxy_set_header              x-ditto-dummy-auth  $dittodummyuser;
 
       proxy_set_header              Upgrade             $http_upgrade;
       proxy_set_header              Connection          "upgrade";

--- a/docker/sandbox/nginx.htpasswd
+++ b/docker/sandbox/nginx.htpasswd
@@ -1,0 +1,15 @@
+# this file contains sample users and their hashed password
+ditto:A6BgmB8IEtPTs
+# the demoX users have password: demo
+demo1:X4kTj/GB0pf4c
+demo2:X4kTj/GB0pf4c
+demo3:X4kTj/GB0pf4c
+demo4:X4kTj/GB0pf4c
+demo5:X4kTj/GB0pf4c
+demo6:X4kTj/GB0pf4c
+demo7:X4kTj/GB0pf4c
+demo8:X4kTj/GB0pf4c
+demo9:X4kTj/GB0pf4c
+# some more users:
+alice:o9S8dqdxXR7WY
+bob:n4I9IRPkdvQKo


### PR DESCRIPTION
* support both HTTP+HTTPS for /api and /ws
* redirect all other resources on ditto sandbox to HTTPS
* still be able to use google auth