### PR TITLE
Improve logging of search-updater

### DIFF
--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/MongoThingsSearchUpdaterPersistenceIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/MongoThingsSearchUpdaterPersistenceIT.java
@@ -1447,21 +1447,6 @@ public final class MongoThingsSearchUpdaterPersistenceIT extends AbstractThingSe
         }
 
         @Test
-        public void updatePolicyForThingIllegalArguments() {
-            final Thing thing = createThing(KNOWN_THING_ID, VALUE1, isV2);
-
-            insertBlockingAndResetMocks(isV2, thing, 1L, -1L, policyEnforcer);
-            final Policy policy = createPolicy1();
-
-            Assertions.assertThat(runBlockingWithReturn(
-                    writePersistence.updatePolicy(null, PolicyEnforcers.defaultEvaluator(policy)))).isFalse();
-            Assertions.assertThat(runBlockingWithReturn(
-                    writePersistence.updatePolicy(thing, null)))
-                    .isFalse();
-        }
-
-
-        @Test
         public void getThingIdsForPolicy() {
             final String policyId = "any-ns:testPolicyId";
             final Thing thing1 = createThing("test:id1", "val1", isV2).setPolicyId(policyId);

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
@@ -991,7 +991,10 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
                     if (null != throwable) {
                         log.error(throwable, "Failed to update policy because of an exception!");
                     } else if (!isPolicyUpdated) {
-                        log.error("Failed to update policy because of an unknown reason!");
+                        log.debug("The update operation for the policy of Thing <{}> did not have an effect, " +
+                                "probably because it does not contain fine-grained policies!", thingId);
+                    } else {
+                        log.debug("Successfully updated policy.");
                     }
                 }));
     }

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
@@ -335,7 +335,7 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         cancelSyncTimeoutAndResetSessionId();
         super.postStop();
     }
-    
+
     private void cancelActivityCheck() {
         if (activityChecker != null) {
             activityChecker.cancel();
@@ -573,8 +573,10 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         gatheredEvents.add(thingEvent);
     }
 
-    private static boolean needToReloadPolicy(final ThingEvent thingEvent) {
-        return thingEvent instanceof PolicyIdCreated || thingEvent instanceof PolicyIdModified;
+    private boolean needToReloadPolicy(final ThingEvent thingEvent) {
+        return thingEvent instanceof PolicyIdCreated || thingEvent instanceof PolicyIdModified
+                // check if Thing has a policy but the policy enforcer is not instantiated
+                || (schemaVersionHasPolicy(thingEvent.getImplementedSchemaVersion()) && Objects.isNull(policyEnforcer));
     }
 
     /**
@@ -1095,7 +1097,7 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         private SyncSuccess() {
             // no-op
         }
-        
+
     }
 
     private static final class SyncFailure {
@@ -1105,7 +1107,7 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         private SyncFailure() {
             // no-op
         }
-        
+
     }
 
     private static class ActorInitializationComplete {
@@ -1115,7 +1117,7 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         private ActorInitializationComplete() {
             // no-op
         }
-        
+
     }
 
     private static final class SyncMetadata {
@@ -1155,5 +1157,5 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
             return StreamAck.failure(thingIdentifier);
         }
     }
-    
+
 }

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
@@ -353,6 +353,7 @@ public final class DefaultStreamSupervisor<E> extends AbstractActor {
     }
 
     private void scheduleStream(final Duration duration) {
+        log.info("Schedule Stream in: {}", duration);
         if (activityCheck != null) {
             activityCheck.cancel();
         }

--- a/services/utils/akka/src/test/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisorTest.java
+++ b/services/utils/akka/src/test/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisorTest.java
@@ -40,6 +40,7 @@ import org.mockito.verification.VerificationWithTimeout;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
@@ -89,7 +90,7 @@ public class DefaultStreamSupervisorTest {
         when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd(any(Instant.class)))
                 .thenAnswer(unused -> KNOWN_LAST_SYNC);
         when(searchSyncPersistence.updateLastSuccessfulStreamEnd(any(Instant.class)))
-                .thenReturn(Source.empty());
+                .thenReturn(Source.single(NotUsed.getInstance()));
     }
 
     /** */


### PR DESCRIPTION
- make sure that the policy has been loaded before handling ThingEvents (errors caused by missing policy could be recovered by the update mechanism, but made it a bit inefficient and produced confusing log messages)
- add debug logs to MongoThingsSearchUpdaterPersistence
- log an INFO whenever a stream (i.e. sync) is scheduled