### PR TITLE
refine documentation on PUT things/{thingId}/policyId 

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -328,13 +328,14 @@ paths:
         - name: policyId
           in: body
           description: >-
-            The Policy ID used for controlling access to this Thing. Managed by
+            The Policy ID (as JSON String) used for controlling access to this Thing. Managed by
             resource `/policies/{policyId}`.
 
               * contain the mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
               * conform to RFC-2396 (URI)
           schema:
             type: string
+            example: "any.namespace:any.policy"
           required: true
       responses:
         '201':


### PR DESCRIPTION
to clarify that an id formatted as JSON has to be used as content body.

Signed-off-by: Florian Fendt <Florian.Fendt@bosch-si.com>