### PR TITLE
Removed inconsistencies between API versions when modifying a Thing

### DIFF
--- a/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.model.things;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -25,8 +26,8 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 
 /**
- * This exception indicates that a {@link org.eclipse.ditto.model.things.Thing}'s {@link org.eclipse.ditto.model.base.json.JsonSchemaVersion} requires a
- * policyId.
+ * This exception indicates that a {@link org.eclipse.ditto.model.things.Thing}'s
+ * {@link org.eclipse.ditto.model.base.json.JsonSchemaVersion} requires a policyId.
  */
 @Immutable
 public final class PolicyIdMissingException extends DittoRuntimeException implements ThingException {
@@ -34,7 +35,7 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
     /**
      * Error code of this exception.
      */
-    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policy.missing";
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policy.id.missing";
 
 
     private static final String MESSAGE_TEMPLATE =
@@ -48,8 +49,8 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
 
     private static final long serialVersionUID = -2640894758584381867L;
 
-    private PolicyIdMissingException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private PolicyIdMissingException(final DittoHeaders dittoHeaders, @Nullable final String message,
+            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -61,23 +62,23 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
      * @return the new PolicyIdMissingException.
      */
     public static PolicyIdMissingException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
     /**
      * Constructs a new {@code PolicyIdMissingException} object with the given exception message.
      *
-     * @param thingId the identifier of the Thing.
+     * @param thingId the ID of the Thing.
      * @param dittoHeaders the headers of the command which resulted in this exception.
      * @return the new PolicyIdMissingException.
      */
     public static PolicyIdMissingException fromThingId(final String thingId, final DittoHeaders dittoHeaders) {
         final JsonSchemaVersion schemaVersion = dittoHeaders.getSchemaVersion().orElse(JsonSchemaVersion.LATEST);
-        return new Builder(thingId, schemaVersion) //
-                .dittoHeaders(dittoHeaders) //
+        return new Builder(thingId, schemaVersion)
+                .dittoHeaders(dittoHeaders)
                 .build();
     }
 
@@ -85,10 +86,12 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
      * Constructs a new {@code PolicyIdMissingException} object with the exception message extracted from the given JSON
      * object.
      *
-     * @param jsonObject the JSON to read the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param jsonObject the JSON to read the
+     * {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
      * @param dittoHeaders the headers of the command which resulted in this exception.
      * @return the new PolicyIdMissingException.
-     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the
+     * {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static PolicyIdMissingException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return fromMessage(readMessage(jsonObject), dittoHeaders);
@@ -115,8 +118,8 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
         }
 
         @Override
-        protected PolicyIdMissingException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyIdMissingException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
+                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
             return new PolicyIdMissingException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.model.things;
+
+import java.net.URI;
+import java.text.MessageFormat;
+
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+
+/**
+ * This exception indicates that a {@link org.eclipse.ditto.model.things.Thing}'s {@link org.eclipse.ditto.model.base.json.JsonSchemaVersion} requires a
+ * policyId.
+ */
+@Immutable
+public final class PolicyIdMissingException extends DittoRuntimeException implements ThingException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policy.missing";
+
+
+    private static final String MESSAGE_TEMPLATE =
+            "The schema version of the Thing with ID ''{0}'' does not allow an update on schema version ''{1}'' without" +
+                    " providing a policy id";
+
+    private static final String DEFAULT_DESCRIPTION =
+            "When updating a schema version 1 Thing using a higher schema version API, you need to add a policyId. " +
+                    "Be aware that this will convert the Thing to the higher schema version, thus removing all ACL " +
+                    "information from it.";
+
+    private static final long serialVersionUID = -2640894758584381867L;
+
+    private PolicyIdMissingException(final DittoHeaders dittoHeaders, final String message, final String description,
+            final Throwable cause, final URI href) {
+        super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * Constructs a new {@code PolicyIdMissingException} object with the given exception message.
+     *
+     * @param message the Message.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyIdMissingException.
+     */
+    public static PolicyIdMissingException fromMessage(final String message, final DittoHeaders dittoHeaders) {
+        return new Builder() //
+                .dittoHeaders(dittoHeaders) //
+                .message(message) //
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code PolicyIdMissingException} object with the given exception message.
+     *
+     * @param thingId the identifier of the Thing.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyIdMissingException.
+     */
+    public static PolicyIdMissingException fromThingId(final String thingId, final DittoHeaders dittoHeaders) {
+        final JsonSchemaVersion schemaVersion = dittoHeaders.getSchemaVersion().orElse(JsonSchemaVersion.LATEST);
+        return new Builder(thingId, schemaVersion) //
+                .dittoHeaders(dittoHeaders) //
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code PolicyIdMissingException} object with the exception message extracted from the given JSON
+     * object.
+     *
+     * @param jsonObject the JSON to read the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyIdMissingException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
+     */
+    public static PolicyIdMissingException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return fromMessage(readMessage(jsonObject), dittoHeaders);
+    }
+
+    @Override
+    public JsonSchemaVersion[] getSupportedSchemaVersions() {
+        return new JsonSchemaVersion[]{JsonSchemaVersion.V_1};
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link PolicyIdMissingException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyIdMissingException> {
+
+        private Builder() {
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        private Builder(final String thingId, final JsonSchemaVersion version) {
+            this();
+            message(MessageFormat.format(MESSAGE_TEMPLATE, thingId, version.toInt()));
+        }
+
+        @Override
+        protected PolicyIdMissingException doBuild(final DittoHeaders dittoHeaders, final String message,
+                final String description, final Throwable cause, final URI href) {
+            return new PolicyIdMissingException(dittoHeaders, message, description, cause, href);
+        }
+    }
+
+}

--- a/model/things/src/test/java/org/eclipse/ditto/model/things/PolicyIdMissingExceptionTest.java
+++ b/model/things/src/test/java/org/eclipse/ditto/model/things/PolicyIdMissingExceptionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.model.things;
+
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.net.URI;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.junit.Test;
+
+public class PolicyIdMissingExceptionTest {
+
+    private static final String KNOWN_MESSAGE = "any Message";
+    private static final String KNOWN_THING_ID = "org.eclipse.ditto:a.thing";
+    private static final String KNOWN_DESCRIPTION = "any description";
+    private static final URI KNOWN_HREF = URI.create("any://href");
+    private static final String KNOWN_ERROR_CODE = PolicyIdMissingException.ERROR_CODE;
+    private static final HttpStatusCode KNOWN_STATUS = HttpStatusCode.NOT_FOUND;
+
+
+    private static final DittoHeaders KNOWN_HEADERS = DittoHeaders.newBuilder()
+            .schemaVersion(JsonSchemaVersion.V_1)
+            .correlationId("any")
+            .build();
+
+    private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
+            .set(DittoRuntimeException.JsonFields.STATUS, KNOWN_STATUS.toInt())
+            .set(DittoRuntimeException.JsonFields.ERROR_CODE, KNOWN_ERROR_CODE)
+            .set(DittoRuntimeException.JsonFields.MESSAGE, KNOWN_MESSAGE)
+            .set(DittoRuntimeException.JsonFields.DESCRIPTION, KNOWN_DESCRIPTION)
+            .set(DittoRuntimeException.JsonFields.HREF, KNOWN_HREF.toString())
+            .build();
+
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(PolicyIdMissingException.class, areImmutable());
+    }
+
+    @Test
+    public void fromMessage() {
+        final PolicyIdMissingException exception =  PolicyIdMissingException.fromMessage(KNOWN_MESSAGE, KNOWN_HEADERS);
+        Assertions.assertThat(exception.getMessage()).isEqualTo(KNOWN_MESSAGE);
+    }
+
+    @Test
+    public void fromJson() {
+        final PolicyIdMissingException exception = PolicyIdMissingException.fromJson(KNOWN_JSON, KNOWN_HEADERS);
+        Assertions.assertThat(exception.getMessage()).isEqualTo(KNOWN_MESSAGE);
+    }
+
+    @Test
+    public void fromThingId() {
+        final PolicyIdMissingException exception = PolicyIdMissingException.fromThingId(KNOWN_THING_ID, KNOWN_HEADERS);
+        Assertions.assertThat(exception.getMessage()).contains(KNOWN_THING_ID);
+    }
+}

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/examples/JsonExamplesProducer.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/examples/JsonExamplesProducer.java
@@ -70,6 +70,7 @@ import org.eclipse.ditto.model.things.Feature;
 import org.eclipse.ditto.model.things.FeatureProperties;
 import org.eclipse.ditto.model.things.Features;
 import org.eclipse.ditto.model.things.Permission;
+import org.eclipse.ditto.model.things.PolicyIdMissingException;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.model.things.ThingLifecycle;
@@ -1178,6 +1179,10 @@ class JsonExamplesProducer {
                 .dittoHeaders(DITTO_HEADERS)
                 .build();
         writeJson(exceptionsDir.resolve(Paths.get("thingIdInvalidException.json")), thingIdInvalidException);
+
+        final PolicyIdMissingException policyIdMissingException = PolicyIdMissingException
+                .fromThingId(THING_ID, DITTO_HEADERS);
+        writeJson(exceptionsDir.resolve(Paths.get("policyIdMissingException.json")), policyIdMissingException);
 
         final AttributesNotAccessibleException attributesNotAccessibleException =
                 AttributesNotAccessibleException.newBuilder(THING_ID)

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
@@ -76,10 +76,6 @@ public abstract class AbstractThingPolicyEnforcerActor extends AbstractPolicyEnf
 
                 /* MessageCommands */
                 .match(SendClaimMessage.class, this::publishMessageCommand)
-                .match(MessageCommand.class, this::isEnforcerNull, command -> {
-                    doStash();
-                    synchronizePolicy();
-                })
                 .match(MessageCommand.class, this::isAuthorized, this::publishMessageCommand)
                 .match(MessageCommand.class, this::unauthorized)
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
@@ -1273,8 +1273,12 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
         private void handleModifyExistingV2WithV1Command(final ModifyThing command) {
             // remove any acl information from command and add the current policy Id
             final Thing thingWithoutAcl = removeACL(copyPolicyId(thing, command.getThing()));
+            // set version of ThingModified event to the version of the thing
+            final DittoHeaders newHeaders = command.getDittoHeaders().toBuilder()
+                    .schemaVersion(thing.getImplementedSchemaVersion())
+                    .build();
             final ThingModified thingModified =
-                    ThingModified.of(thingWithoutAcl, nextRevision(), eventTimestamp(), command.getDittoHeaders());
+                    ThingModified.of(thingWithoutAcl, nextRevision(), eventTimestamp(), newHeaders);
             persistAndApplyEvent(thingModified,
                     event -> notifySender(ModifyThingResponse.modified(thingId, command.getDittoHeaders())));
         }

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/PersistenceActorTestBase.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/PersistenceActorTestBase.java
@@ -130,10 +130,16 @@ public abstract class PersistenceActorTestBase {
     }
 
     protected ActorRef createPersistenceActorFor(final String thingId) {
-        return actorSystem.actorOf(getPropsOfThingPersistenceActor(thingId));
+        return createPersistenceActorWithPubSubFor(thingId, pubSubMediator);
+    }
+    protected ActorRef createPersistenceActorWithPubSubFor(final String thingId, final ActorRef pubSubMediator) {
+        return actorSystem.actorOf(getPropsOfThingPersistenceActor(thingId, pubSubMediator));
     }
 
     private Props getPropsOfThingPersistenceActor(final String thingId) {
+        return getPropsOfThingPersistenceActor(thingId, pubSubMediator);
+    }
+    private Props getPropsOfThingPersistenceActor(final String thingId, final ActorRef pubSubMediator) {
         return ThingPersistenceActor.props(thingId, pubSubMediator, thingCacheFacade);
     }
 

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
@@ -17,7 +17,9 @@ import static org.eclipse.ditto.model.things.assertions.DittoThingsAssertions.as
 
 import java.time.Instant;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
+import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
@@ -40,7 +42,9 @@ import org.eclipse.ditto.model.things.Attributes;
 import org.eclipse.ditto.model.things.Feature;
 import org.eclipse.ditto.model.things.Features;
 import org.eclipse.ditto.model.things.Permissions;
+import org.eclipse.ditto.model.things.PolicyIdMissingException;
 import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingBuilder;
 import org.eclipse.ditto.model.things.ThingLifecycle;
 import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.things.ThingCommand;
@@ -80,6 +84,10 @@ import org.eclipse.ditto.signals.commands.things.query.RetrieveThing;
 import org.eclipse.ditto.signals.commands.things.query.RetrieveThingResponse;
 import org.eclipse.ditto.signals.commands.things.query.RetrieveThings;
 import org.eclipse.ditto.signals.commands.things.query.ThingQueryCommandResponse;
+import org.eclipse.ditto.signals.events.base.Event;
+import org.eclipse.ditto.signals.events.things.ThingCreated;
+import org.eclipse.ditto.signals.events.things.ThingEvent;
+import org.eclipse.ditto.signals.events.things.ThingModified;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -89,7 +97,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
-import akka.testkit.JavaTestKit;
+import akka.cluster.pubsub.DistributedPubSubMediator;
 import akka.testkit.TestActorRef;
 import akka.testkit.javadsl.TestKit;
 import scala.PartialFunction;
@@ -120,7 +128,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void unavailableExpectedIfPersistenceActorTerminates() throws Exception {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final String thingId = thing.getId().orElse(null);
@@ -178,7 +186,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                         .dittoHeaders(dittoHeadersV1)
                         .build();
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thingId);
 
@@ -200,7 +208,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final String thingId = "test.ns:23420815";
         final ThingCommand retrieveThingCommand = RetrieveThing.of(thingId, dittoHeadersV2);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thingId);
                 thingPersistenceActor.tell(retrieveThingCommand, getRef());
@@ -235,7 +243,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void createThingV2() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final ActorRef underTest = createPersistenceActorFor(thing);
@@ -251,6 +259,32 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
     /** */
     @Test
+    public void modifyThingV1() {
+        final Thing thing = createThingV1WithRandomId();
+
+        final Thing modifiedThing = thing.setAttribute(JsonFactory.newPointer("foo/bar"), JsonFactory.newValue("baz"));
+        final ModifyThing modifyThingCommand =
+                ModifyThing.of(thing.getId().orElse(null), modifiedThing, null, dittoHeadersV1);
+
+        new TestKit(actorSystem) {
+            {
+                final ActorRef underTest = createPersistenceActorFor(thing);
+
+                final CreateThing createThing = CreateThing.of(thing, null, dittoHeadersV1);
+                underTest.tell(createThing, getRef());
+
+                final CreateThingResponse createThingResponse = expectMsgClass(CreateThingResponse.class);
+                assertThingInResponse(createThingResponse.getThingCreated().orElse(null), thing);
+
+                underTest.tell(modifyThingCommand, getRef());
+
+                expectMsgEquals(ModifyThingResponse.modified(thing.getId().orElse(null), dittoHeadersV1));
+            }
+        };
+    }
+
+    /** */
+    @Test
     public void modifyThingV2() {
         final Thing thing = createThingV2WithRandomId();
 
@@ -258,7 +292,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final ModifyThing modifyThingCommand =
                 ModifyThing.of(thing.getId().orElse(null), modifiedThing, null, dittoHeadersV2);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -284,7 +318,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                 RetrieveThingResponse.of(thing.getId().orElse(null), thing.toJson(),
                         retrieveThingCommand.getDittoHeaders());
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -307,7 +341,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
         final RetrieveThings retrieveThingsCommand = RetrieveThings.getBuilder("foo", "bar").build();
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -326,7 +360,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void deleteThingV1() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thing);
@@ -346,7 +380,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void deleteThingV2() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final ActorRef underTest = createPersistenceActorFor(thing);
@@ -367,7 +401,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void modifyFeatures() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final DittoHeaders headersMockWithOtherAuth =
                         createDittoHeadersMock(JsonSchemaVersion.V_2, AUTH_SUBJECT);
@@ -407,7 +441,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void modifyAttributes() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final DittoHeaders headersMockWithOtherAuth =
                         createDittoHeadersMock(JsonSchemaVersion.V_2, AUTH_SUBJECT);
@@ -467,7 +501,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
         final String thingId = thing.getId().orElse(null);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -503,7 +537,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
         final String thingId = thing.getId().orElse(null);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -538,7 +572,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
         final String thingId = thing.getId().orElse(null);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -563,7 +597,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final DeleteThing deleteThingCommand = DeleteThing.of(thing.getId().orElse(null), dittoHeadersV2);
         final RetrieveThing retrieveThingCommand = RetrieveThing.of(thing.getId().orElse(null), dittoHeadersV2);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thing);
 
@@ -585,7 +619,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void recoverThingCreated() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final String thingId = thing.getId().orElse(null);
@@ -619,7 +653,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void recoverThingDeleted() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final String thingId = thing.getId().orElse(null);
@@ -654,7 +688,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void recoverAclModified() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thingV1 = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thingV1);
@@ -691,7 +725,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void recoverAclEntryModified() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thingV1 = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thingV1);
@@ -729,7 +763,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void recoverAclEntryDeleted() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thingV1 = createThingV1WithRandomId();
                 final AclEntry aclEntry = newAclEntry(AUTHORIZATION_SUBJECT, PERMISSIONS);
@@ -769,7 +803,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void ensureSequenceNumberCorrectness() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final String thingId = thing.getId().orElse(null);
@@ -810,7 +844,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void ensureSequenceNumberCorrectnessAfterRecovery() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV2WithRandomId();
                 final String thingId = thing.getId().orElse(null);
@@ -877,7 +911,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final RetrieveThingResponse retrieveThingResponseV1 =
                 RetrieveThingResponse.of(thingIdOfActor, thingV1, dittoHeadersV1);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thingV1);
                 underTest.tell(createThingV1, getRef());
@@ -918,7 +952,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final RetrieveThingResponse retrieveThingResponseV2 =
                 RetrieveThingResponse.of(thingIdOfActor, thingV1, dittoHeadersV2);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thingV1);
                 underTest.tell(createThingV1, getRef());
@@ -966,7 +1000,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final RetrieveThingResponse retrieveThingResponseV2 = RetrieveThingResponse.of(thingId, thingV2WithPolicy,
                 dittoHeadersV2);
 
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createPersistenceActorFor(thingV1);
 
@@ -986,7 +1020,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void responsesDuringInitializationAreSentWithDittoHeaders() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final String thingId = "org.eclipse.ditto:myThing";
                 final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
@@ -1013,7 +1047,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void ensureModifiedCorrectnessAfterCreation() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thing);
@@ -1045,7 +1079,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void ensureModifiedCorrectnessAfterModification() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thing);
@@ -1094,7 +1128,7 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     /** */
     @Test
     public void ensureModifiedCorrectnessAfterRecovery() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final Thing thing = createThingV1WithRandomId();
                 final ActorRef thingPersistenceActor = createPersistenceActorFor(thing);
@@ -1169,6 +1203,190 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         }};
     }
 
+
+    /**
+     */
+    @Test
+    public void createThingInV1AndUpdateWithV2WithoutPolicyId() {
+        final String thingId = "test.ns.v1:createThingInV1AndUpdateWithV2WithoutPolicyId";
+        final Thing thingV1 = buildThing(thingId, JsonSchemaVersion.V_1);
+        final Thing thingV2WithoutPolicyId = buildThing(thingId, JsonSchemaVersion.V_2)
+                .toBuilder()
+                .removePolicyId()
+                .build();
+        new TestKit(actorSystem) {{
+            final DittoHeaders headersUsed =
+                    testCreateAndModify(thingV1,
+                            JsonSchemaVersion.V_1,
+                            thingV2WithoutPolicyId,
+                            JsonSchemaVersion.V_2,
+                            this,
+                            modifyThing -> PolicyIdMissingException.fromThingId(thingId, modifyThing.getDittoHeaders()));
+            expectNoMsg();
+        }};
+    }
+
+    /**
+     */
+    @Test
+    public void createThingInV1AndUpdateWithV2WithPolicyId() {
+        final String thingId = "test.ns.v1:createThingInV1AndUpdateWithV2WithPolicyId";
+        final Thing thingV1 = buildThing(thingId, JsonSchemaVersion.V_1);
+        final Thing thingV2 = buildThing(thingId, JsonSchemaVersion.V_2)
+                .toBuilder()
+                .setPolicyId("test.ns.v1:createThingInV1AndUpdateWithV2WithPolicyId.OTHER.POLICY.ID")
+                .build();
+        new TestKit(actorSystem) {{
+            final DittoHeaders headersUsed =
+                    testCreateAndModify(thingV1,
+                            JsonSchemaVersion.V_1,
+                            thingV2,
+                            JsonSchemaVersion.V_2,
+                            this,
+                            modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
+            assertPublishEvent(this, ThingModified.of(thingV2, 2L, headersUsed));
+        }};
+    }
+
+    /**
+     */
+    @Test
+    public void createThingInV2AndUpdateWithV1() {
+        final String thingId = "test.ns.v1:createThingInV2AndUpdateWithV1";
+        final Thing thingV2 = buildThing(thingId, JsonSchemaVersion.V_2);
+        final Thing thingV1WithoutACL = buildThing(thingId, JsonSchemaVersion.V_1)
+                .toBuilder()
+                .removeAllPermissions()
+                .build();
+        final Thing expected = thingV1WithoutACL.toBuilder()
+                .setPolicyId(thingV2.getPolicyId().get())
+                .build();
+
+        new TestKit(actorSystem) {{
+            final DittoHeaders headersUsed =
+                    testCreateAndModify(thingV2,
+                            JsonSchemaVersion.V_2,
+                            thingV1WithoutACL,
+                            JsonSchemaVersion.V_1,
+                            this,
+                            modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
+            assertPublishEvent(this, ThingModified.of(expected, 2L, headersUsed));
+        }};
+    }
+
+    /**
+     */
+    @Test
+    public void createThingInV2AndUpdateWithV1WithACL() {
+        final String thingId = "test.ns.v1:createThingInV2AndUpdateWithV1WithACL";
+        final Thing thingV2 = buildThing(thingId, JsonSchemaVersion.V_2);
+        final Thing thingV1 = buildThing(thingId, JsonSchemaVersion.V_1);
+        final Thing expected = thingV1.toBuilder()
+                .setPolicyId(thingV2.getPolicyId().get())
+                .removeAllPermissions()
+                .build();
+
+        new TestKit(actorSystem) {{
+            final DittoHeaders headersUsed =
+                    testCreateAndModify(thingV2,
+                            JsonSchemaVersion.V_2,
+                            thingV1,
+                            JsonSchemaVersion.V_1,
+                            this,
+                            modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
+            assertPublishEvent(this, ThingModified.of(expected, 2L, headersUsed));
+        }};
+    }
+
+    /**
+     */
+    @Test
+    public void createThingInV2AndUpdateWithV2AndChangedPolicyId() {
+        final String thingId = "test.ns.v1:createThingInV2AndUpdateWithV2AndChangedPolicyId";
+        final Thing thingV2 = buildThing(thingId, JsonSchemaVersion.V_2);
+        final Thing thingV2_2 =
+                buildThing(thingId, JsonSchemaVersion.V_2).setPolicyId(thingId + ".ANY.OTHER.NAMESPACE");
+
+        new TestKit(actorSystem) {{
+            final DittoHeaders headersUsed =
+                    testCreateAndModify(thingV2,
+                            JsonSchemaVersion.V_2,
+                            thingV2_2,
+                            JsonSchemaVersion.V_2,
+                            this,
+                            modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
+            assertPublishEvent(this, ThingModified.of(thingV2_2, 2L, headersUsed));
+        }};
+    }
+
+    private DittoHeaders testCreateAndModify(final Thing toCreate,
+            final JsonSchemaVersion createVersion,
+            final Thing toModify,
+            final JsonSchemaVersion modifyVersion,
+            final TestKit pubSubMediator,
+            final Function<ModifyThing, Object> expectedMessage) {
+        final CreateThing createThing = createThing(toCreate, createVersion);
+        final ModifyThing modifyThing = modifyThing(toModify, modifyVersion);
+
+        new TestKit(actorSystem) {{
+            final ActorRef underTest =
+                    createPersistenceActorWithPubSubFor(createThing.getThing(), pubSubMediator.getRef());
+
+            underTest.tell(createThing, getRef());
+            final CreateThingResponse createThingResponse = expectMsgClass(CreateThingResponse.class);
+            assertThingInResponse(createThingResponse.getThingCreated().orElse(null), createThing.getThing());
+            assertPublishEvent(pubSubMediator, ThingCreated.of(toCreate, 1L, createThing.getDittoHeaders()));
+
+            underTest.tell(modifyThing, getRef());
+            expectMsgEquals(expectedMessage.apply(modifyThing));
+        }};
+        return modifyThing.getDittoHeaders();
+    }
+
+    private void assertPublishEvent(final TestKit pubSubMediator, final ThingEvent event) {
+        final DistributedPubSubMediator.Publish result =
+                pubSubMediator.expectMsgClass(DistributedPubSubMediator.Publish.class);
+        final ThingEvent msg = (ThingEvent) result.msg();
+        Assertions.assertThat(msg.toJson())
+                .isEqualTo(event.toJson().set(msg.toJson().getField(Event.JsonFields.TIMESTAMP.getPointer()).get()));
+    }
+
+    private Thing buildThing(final String thingId, final JsonSchemaVersion schemaVersion) {
+        final ThingBuilder.FromScratch builder = ThingsModelFactory.newThingBuilder()
+                .setLifecycle(ThingLifecycle.ACTIVE)
+                .setAttributes(THING_ATTRIBUTES)
+                .setRevision(1)
+                .setId(thingId);
+        if (JsonSchemaVersion.V_1.equals(schemaVersion)) {
+            return builder.setPermissions(AUTHORIZED_SUBJECT, AccessControlListModelFactory.allPermissions())
+                    .build();
+        } else {
+            return builder.setPolicyId(thingId)
+                    .build();
+        }
+    }
+
+
+    private CreateThing createThing(final Thing thing, final JsonSchemaVersion version) {
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .schemaVersion(version)
+                .authorizationSubjects(AUTH_SUBJECT)
+                .build();
+
+        return CreateThing.of(thing, null, dittoHeaders);
+    }
+
+    private ModifyThing modifyThing(final Thing thing, final JsonSchemaVersion version) {
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
+                .schemaVersion(version)
+                .authorizationSubjects(AUTH_SUBJECT)
+                .build();
+        return ModifyThing.of(thing.getId().orElseThrow(() -> new IllegalStateException("[test]")),
+                thing,
+                null,
+                dittoHeaders);
+    }
+
     private static void assertThingInResponse(final Thing actualThing, final Thing expectedThing) {
         // Policy entries are ignored by things-persistence.
         assertThat(actualThing).hasEqualJson(expectedThing, FieldType.notHidden()
@@ -1188,6 +1406,10 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
 
     private ActorRef createPersistenceActorFor(final Thing thing) {
         return createPersistenceActorFor(thing.getId().orElse(null));
+    }
+
+    private ActorRef createPersistenceActorWithPubSubFor(final Thing thing, final ActorRef pubSubMediator) {
+        return createPersistenceActorWithPubSubFor(thing.getId().orElse(null), pubSubMediator);
     }
 
 }

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
@@ -1244,7 +1244,8 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                             JsonSchemaVersion.V_2,
                             this,
                             modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
-            assertPublishEvent(this, ThingModified.of(thingV2, 2L, headersUsed));
+            assertPublishEvent(this, ThingModified.of(thingV2, 2L,
+                    headersUsed.toBuilder().schemaVersion(JsonSchemaVersion.V_1).build()));
         }};
     }
 

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
@@ -1270,7 +1270,8 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                             JsonSchemaVersion.V_1,
                             this,
                             modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
-            assertPublishEvent(this, ThingModified.of(expected, 2L, headersUsed));
+            final DittoHeaders headersV2 = headersUsed.toBuilder().schemaVersion(JsonSchemaVersion.V_2).build();
+            assertPublishEvent(this, ThingModified.of(expected, 2L, headersV2));
         }};
     }
 
@@ -1294,7 +1295,8 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                             JsonSchemaVersion.V_1,
                             this,
                             modifyThing -> ModifyThingResponse.modified(thingId, modifyThing.getDittoHeaders()));
-            assertPublishEvent(this, ThingModified.of(expected, 2L, headersUsed));
+            final DittoHeaders headersV2 = headersUsed.toBuilder().schemaVersion(JsonSchemaVersion.V_2).build();
+            assertPublishEvent(this, ThingModified.of(expected, 2L, headersV2));
         }};
     }
 
@@ -1349,6 +1351,8 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
         final ThingEvent msg = (ThingEvent) result.msg();
         Assertions.assertThat(msg.toJson())
                 .isEqualTo(event.toJson().set(msg.toJson().getField(Event.JsonFields.TIMESTAMP.getPointer()).get()));
+        Assertions.assertThat(msg.getDittoHeaders().getSchemaVersion())
+                .isEqualTo(event.getDittoHeaders().getSchemaVersion());
     }
 
     private Thing buildThing(final String thingId, final JsonSchemaVersion schemaVersion) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -31,7 +32,7 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
     /**
      * Error code of this exception.
      */
-    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policyId.notallowed";
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policy.id.notallowed";
 
     private static final String MESSAGE_TEMPLATE =
             "The Thing with ID ''{0}'' could not be modified as it contained an inline Policy with an ID or a Policy " +
@@ -43,8 +44,8 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
 
     private static final long serialVersionUID = 4511420390758955872L;
 
-    private PolicyIdNotAllowedException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyIdNotAllowedException(final DittoHeaders dittoHeaders, @Nullable final String message,
+            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -103,8 +104,8 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
         }
 
         @Override
-        protected PolicyIdNotAllowedException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyIdNotAllowedException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
+                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
             return new PolicyIdNotAllowedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
@@ -22,6 +22,7 @@ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.things.AclEntryInvalidException;
 import org.eclipse.ditto.model.things.AclInvalidException;
 import org.eclipse.ditto.model.things.AclNotAllowedException;
+import org.eclipse.ditto.model.things.PolicyIdMissingException;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.signals.base.AbstractErrorRegistry;
 import org.eclipse.ditto.signals.base.JsonParsable;
@@ -81,6 +82,7 @@ public final class ThingErrorRegistry extends AbstractErrorRegistry<DittoRuntime
         parseStrategies.put(PolicyIdNotModifiableException.ERROR_CODE, PolicyIdNotModifiableException::fromJson);
         parseStrategies.put(PolicyIdNotAllowedException.ERROR_CODE, PolicyIdNotAllowedException::fromJson);
         parseStrategies.put(PolicyNotAllowedException.ERROR_CODE, PolicyNotAllowedException::fromJson);
+        parseStrategies.put(PolicyIdMissingException.ERROR_CODE, PolicyIdMissingException::fromJson);
         parseStrategies.put(ThingUnavailableException.ERROR_CODE, ThingUnavailableException::fromJson);
         parseStrategies.put(ThingTooManyModifyingRequestsException.ERROR_CODE,
                 ThingTooManyModifyingRequestsException::fromJson);

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/examplejson/JsonExamplesProducer.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/examplejson/JsonExamplesProducer.java
@@ -40,6 +40,7 @@ import org.eclipse.ditto.model.things.Feature;
 import org.eclipse.ditto.model.things.FeatureProperties;
 import org.eclipse.ditto.model.things.Features;
 import org.eclipse.ditto.model.things.Permission;
+import org.eclipse.ditto.model.things.PolicyIdMissingException;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.model.things.ThingLifecycle;
@@ -524,6 +525,10 @@ public class JsonExamplesProducer {
                 .dittoHeaders(DITTO_HEADERS)
                 .build();
         writeJson(exceptionsDir.resolve(Paths.get("thingIdInvalidException.json")), thingIdInvalidException);
+
+        final PolicyIdMissingException policyIdMissingException = PolicyIdMissingException
+                .fromThingId(THING_ID, DITTO_HEADERS);
+        writeJson(exceptionsDir.resolve(Paths.get("policyIdMissingException.json")), policyIdMissingException);
 
         final AttributesNotAccessibleException attributesNotAccessibleException =
                 AttributesNotAccessibleException.newBuilder(THING_ID)

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingDeleted.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingDeleted.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.signals.events.things;
 import java.time.Instant;
 import java.util.function.Predicate;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonFactory;
@@ -41,7 +42,7 @@ public final class ThingDeleted extends AbstractThingEvent<ThingDeleted> impleme
      */
     public static final String TYPE = TYPE_PREFIX + NAME;
 
-    private ThingDeleted(final String thingId, final long revision, final Instant timestamp,
+    private ThingDeleted(final String thingId, final long revision, @Nullable final Instant timestamp,
             final DittoHeaders dittoHeaders) {
         super(TYPE, thingId, revision, timestamp, dittoHeaders);
     }
@@ -69,7 +70,7 @@ public final class ThingDeleted extends AbstractThingEvent<ThingDeleted> impleme
      * @return the ThingDeleted created.
      * @throws NullPointerException if {@code thing} is {@code null}.
      */
-    public static ThingDeleted of(final String thingId, final long revision, final Instant timestamp,
+    public static ThingDeleted of(final String thingId, final long revision, @Nullable final Instant timestamp,
             final DittoHeaders dittoHeaders) {
         return new ThingDeleted(thingId, revision, timestamp, dittoHeaders);
     }
@@ -113,12 +114,12 @@ public final class ThingDeleted extends AbstractThingEvent<ThingDeleted> impleme
 
     @Override
     public ThingDeleted setRevision(final long revision) {
-        return of(getThingId(), revision, getDittoHeaders());
+        return of(getThingId(), revision, getTimestamp().orElse(null), getDittoHeaders());
     }
 
     @Override
     public ThingDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return of(getThingId(), getRevision(), dittoHeaders);
+        return of(getThingId(), getRevision(), getTimestamp().orElse(null), dittoHeaders);
     }
 
     @Override
@@ -129,7 +130,7 @@ public final class ThingDeleted extends AbstractThingEvent<ThingDeleted> impleme
     }
 
     @Override
-    protected boolean canEqual(final Object other) {
+    protected boolean canEqual(@Nullable final Object other) {
         return (other instanceof ThingDeleted);
     }
 


### PR DESCRIPTION
This pull request fixes issue #110 through different changes:
* a ModifyThing command from a schema version 1 request may only contain an ACL
* a ModifyThing command from a schema version 2 request may only contain a policyId
* things-service will add acl/policyId to the ThingModified event that is distributed to the cluster via PubSub so that any receiving service receives the correct authorization information