### PR TITLE
Reject all message commands in the absence of policy enforcer

### DIFF
--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractThingPolicyEnforcerActor.java
@@ -76,10 +76,6 @@ public abstract class AbstractThingPolicyEnforcerActor extends AbstractPolicyEnf
 
                 /* MessageCommands */
                 .match(SendClaimMessage.class, this::publishMessageCommand)
-                .match(MessageCommand.class, this::isEnforcerNull, command -> {
-                    doStash();
-                    synchronizePolicy();
-                })
                 .match(MessageCommand.class, this::isAuthorized, this::publishMessageCommand)
                 .match(MessageCommand.class, this::unauthorized)
 


### PR DESCRIPTION
This prevents policy enforcer actor from looping.