### PR TITLE
adapt response code for fire and forget messages

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-1.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-1.yml
@@ -1508,7 +1508,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: >-
             The message was sent but not necessarly received by the Thing (fire
             and forget).
@@ -1566,7 +1566,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: The message was sent (fire and forget).
         '400':
           description: |-
@@ -1624,7 +1624,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: >-
             The message was sent but not necessarly received by the Feature
             (fire and forget).
@@ -1683,7 +1683,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: The message was sent (fire and forget).
         '400':
           description: |-

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -1380,7 +1380,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: >-
             The message was sent but not necessarly received by the Thing (fire
             and forget).
@@ -1438,7 +1438,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: The message was sent (fire and forget).
         '400':
           description: |-
@@ -1496,7 +1496,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: >-
             The message was sent but not necessarly received by the Feature
             (fire and forget).
@@ -1555,7 +1555,7 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '202':
           description: The message was sent (fire and forget).
         '400':
           description: |-


### PR DESCRIPTION
Changes response code for fire and forget messages in swagger docu to 202 - ACCEPTED.
