### PR TITLE
Always include `TYPE` when serializing events

### DIFF
--- a/signals/events/amqp-bridge/src/main/java/org/eclipse/ditto/signals/events/amqpbridge/AbstractAmqpBridgeEvent.java
+++ b/signals/events/amqp-bridge/src/main/java/org/eclipse/ditto/signals/events/amqpbridge/AbstractAmqpBridgeEvent.java
@@ -97,9 +97,10 @@ public abstract class AbstractAmqpBridgeEvent<T extends AbstractAmqpBridgeEvent>
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         final JsonObjectBuilder jsonObjectBuilder = JsonFactory.newObjectBuilder();
 
+        // TYPE is included unconditionally
+        jsonObjectBuilder.set(Event.JsonFields.TYPE, type);
         getTimestamp().ifPresent(timestampPresent ->
                 jsonObjectBuilder.set(Event.JsonFields.TIMESTAMP, timestampPresent.toString(), predicate));
-        jsonObjectBuilder.set(Event.JsonFields.TYPE, type, predicate);
         jsonObjectBuilder.set(JsonFields.CONNECTION_ID, connectionId);
 
         appendPayloadAndBuild(jsonObjectBuilder, schemaVersion, thePredicate);

--- a/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/Event.java
+++ b/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/Event.java
@@ -92,14 +92,14 @@ public interface Event<T extends Event> extends Signal<T>, WithOptionalEntity {
         /**
          * JSON field containing the event's identifier - was used in SchemaVersion 1 instead of "type".
          */
+        @Deprecated
         public static final JsonFieldDefinition<String> ID =
                 JsonFactory.newStringFieldDefinition("event", FieldType.REGULAR, JsonSchemaVersion.V_1);
 
         /**
-         * JSON field containing the event's type.
+         * JSON field containing the event's type. Always included in new events.
          */
-        public static final JsonFieldDefinition<String> TYPE =
-                JsonFactory.newStringFieldDefinition("type", FieldType.REGULAR, JsonSchemaVersion.V_2);
+        public static final JsonFieldDefinition<String> TYPE = JsonFactory.newStringFieldDefinition("type");
 
         /**
          * JSON field containing the event's revision.

--- a/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/EventJsonDeserializer.java
+++ b/signals/events/base/src/main/java/org/eclipse/ditto/signals/events/base/EventJsonDeserializer.java
@@ -17,7 +17,6 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 import java.text.MessageFormat;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
-import java.util.Optional;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -90,7 +89,8 @@ public final class EventJsonDeserializer<T extends Event> {
      * @param factoryMethodFunction creates the actual {@code Event} object.
      * @return the created event.
      * @throws NullPointerException if {@code factoryMethodFunction} is {@code null}.
-     * @throws org.eclipse.ditto.json.JsonParseException if the JSON is invalid or if the event TYPE differs from the expected one.
+     * @throws org.eclipse.ditto.json.JsonParseException if the JSON is invalid or if the event TYPE differs from the
+     * expected one.
      */
     public T deserialize(final FactoryMethodFunction<T> factoryMethodFunction) {
         checkNotNull(factoryMethodFunction, "method for creating an event object");
@@ -109,11 +109,11 @@ public final class EventJsonDeserializer<T extends Event> {
     }
 
     private void validateEventType() {
-        final Optional<String> eventOpt = jsonObject.getValue(Event.JsonFields.ID);
         final String type = jsonObject.getValue(Event.JsonFields.TYPE)
                 .orElseGet(() -> // if type was not present (was included in V2)
                         // take event instead and transform to V2 format, fail if "event" is not present, too
-                        eventOpt.map(event -> eventTypePrefix + ':' + event)
+                        jsonObject.getValue(Event.JsonFields.ID)
+                                .map(event -> eventTypePrefix + ':' + event)
                                 .orElseThrow(() -> new JsonMissingFieldException(Event.JsonFields.TYPE.getPointer()))
                 );
 

--- a/signals/events/batch/src/main/java/org/eclipse/ditto/signals/events/batch/AbstractBatchEvent.java
+++ b/signals/events/batch/src/main/java/org/eclipse/ditto/signals/events/batch/AbstractBatchEvent.java
@@ -49,8 +49,8 @@ public abstract class AbstractBatchEvent<T extends AbstractBatchEvent> implement
      * @param type the type of this event.
      * @param batchId the identifier of the batch.
      * @param timestamp the timestamp of the event.
-     * @param dittoHeaders the headers of the command which was the cause of this event.   @throws
-     * NullPointerException if any argument is {@code null}.
+     * @param dittoHeaders the headers of the command which was the cause of this event.   @throws NullPointerException
+     * if any argument is {@code null}.
      */
     protected AbstractBatchEvent(final String type,
             final String batchId,
@@ -93,8 +93,9 @@ public abstract class AbstractBatchEvent<T extends AbstractBatchEvent> implement
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         final JsonObjectBuilder jsonObjectBuilder = JsonFactory.newObjectBuilder()
-                .set(Event.JsonFields.TIMESTAMP, getTimestamp().map(Instant::toString).orElse(null), predicate)
-                .set(Event.JsonFields.TYPE, type, predicate);
+                // TYPE is included unconditionally
+                .set(Event.JsonFields.TYPE, type)
+                .set(Event.JsonFields.TIMESTAMP, getTimestamp().map(Instant::toString).orElse(null), predicate);
 
         appendPayloadAndBuild(jsonObjectBuilder, schemaVersion, thePredicate);
 

--- a/signals/events/policies/src/main/java/org/eclipse/ditto/signals/events/policies/AbstractPolicyEvent.java
+++ b/signals/events/policies/src/main/java/org/eclipse/ditto/signals/events/policies/AbstractPolicyEvent.java
@@ -102,8 +102,9 @@ public abstract class AbstractPolicyEvent<T extends AbstractPolicyEvent> impleme
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         final JsonObjectBuilder jsonObjectBuilder = JsonFactory.newObjectBuilder()
+                // TYPE is included unconditionally
+                .set(Event.JsonFields.TYPE, type)
                 .set(Event.JsonFields.TIMESTAMP, getTimestamp().map(Instant::toString).orElse(null), predicate)
-                .set(Event.JsonFields.TYPE, type, predicate)
                 .set(Event.JsonFields.REVISION, revision, predicate)
                 .set(JsonFields.POLICY_ID, policyId, predicate);
 

--- a/signals/events/policies/src/test/java/org/eclipse/ditto/signals/events/policies/PolicyEntriesModifiedTest.java
+++ b/signals/events/policies/src/test/java/org/eclipse/ditto/signals/events/policies/PolicyEntriesModifiedTest.java
@@ -11,7 +11,7 @@
  */
 package org.eclipse.ditto.signals.events.policies;
 
-import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assertThat;
+import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
@@ -83,7 +83,7 @@ public final class PolicyEntriesModifiedTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(FieldType.regularOrSpecial());
 
-        assertThat(actualJson.toString()).isEqualTo(KNOWN_JSON.toString());
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON);
     }
 
 

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/AbstractThingEvent.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/AbstractThingEvent.java
@@ -108,9 +108,9 @@ public abstract class AbstractThingEvent<T extends AbstractThingEvent> implement
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         final JsonObjectBuilder jsonObjectBuilder = JsonFactory.newObjectBuilder()
+                // TYPE is included unconditionally
+                .set(Event.JsonFields.TYPE, type)
                 .set(Event.JsonFields.TIMESTAMP, getTimestamp().map(Instant::toString).orElse(null), predicate)
-                .set(Event.JsonFields.ID, type.replace(TYPE_PREFIX, ""), predicate) // backward compatibility to V1!
-                .set(Event.JsonFields.TYPE, type, predicate)
                 .set(Event.JsonFields.REVISION, revision, predicate)
                 .set(JsonFields.THING_ID, thingId);
 

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryCreatedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryCreatedTest.java
@@ -76,10 +76,12 @@ public final class AclEntryCreatedTest {
     public void toJsonReturnsExpected() {
         final AclEntryCreated underTest =
                 AclEntryCreated.of(TestConstants.Thing.THING_ID, TestConstants.Authorization.ACL_ENTRY_OLDMAN,
-                1, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
+                        1, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(JsonSchemaVersion.V_1, FieldType.regularOrSpecial());
 
-        assertThat(actualJson).isEqualTo(KNOWN_JSON);
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON
+                .remove(Event.JsonFields.ID.getPointer())
+                .set(Event.JsonFields.TYPE, AclEntryCreated.TYPE));
     }
 
     @Test

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryDeletedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryDeletedTest.java
@@ -64,6 +64,7 @@ public final class AclEntryDeletedTest {
         AclEntryDeleted.of(TestConstants.Thing.THING_ID, null, TestConstants.Thing.REVISION_NUMBER,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
+
     @Test
     public void createInstanceFromValidJson() {
         final AclEntryDeleted underTest =
@@ -76,10 +77,12 @@ public final class AclEntryDeletedTest {
     public void toJsonReturnsExpected() {
         final AclEntryDeleted underTest =
                 AclEntryDeleted.of(TestConstants.Thing.THING_ID, TestConstants.Authorization.AUTH_SUBJECT_GRIMES,
-                2, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
+                        2, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(JsonSchemaVersion.V_1, FieldType.regularOrSpecial());
 
-        assertThat(actualJson).isEqualTo(KNOWN_JSON);
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON
+                .remove(Event.JsonFields.ID.getPointer())
+                .set(Event.JsonFields.TYPE, AclEntryDeleted.TYPE));
     }
 
 }

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryModifiedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclEntryModifiedTest.java
@@ -76,10 +76,12 @@ public final class AclEntryModifiedTest {
     public void toJsonReturnsExpected() {
         final AclEntryModified underTest =
                 AclEntryModified.of(TestConstants.Thing.THING_ID, TestConstants.Authorization.ACL_ENTRY_OLDMAN,
-                2, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
+                        2, TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(JsonSchemaVersion.V_1, FieldType.regularOrSpecial());
 
-        assertThat(actualJson).isEqualTo(KNOWN_JSON);
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON
+                .remove(Event.JsonFields.ID.getPointer())
+                .set(Event.JsonFields.TYPE, AclEntryModified.TYPE));
     }
 
     @Test

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclModifiedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/AclModifiedTest.java
@@ -84,7 +84,9 @@ public final class AclModifiedTest {
                         TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(JsonSchemaVersion.V_1, FieldType.regularOrSpecial());
 
-        assertThat(actualJson).isEqualTo(KNOWN_JSON);
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON
+                .remove(Event.JsonFields.ID.getPointer())
+                .set(Event.JsonFields.TYPE, AclModified.TYPE));
     }
 
 

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/FeatureDefinitionModifiedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/FeatureDefinitionModifiedTest.java
@@ -95,9 +95,9 @@ public final class FeatureDefinitionModifiedTest {
                 FeatureDefinitionModified.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
                         TestConstants.Feature.FLUX_CAPACITOR_DEFINITION, TestConstants.Thing.REVISION_NUMBER,
                         TestConstants.TIMESTAMP, TestConstants.EMPTY_DITTO_HEADERS);
-        final String actualJsonString = underTest.toJson(FieldType.regularOrSpecial()).toString();
+        final JsonObject actualJson = underTest.toJson(FieldType.regularOrSpecial());
 
-        assertThat(actualJsonString).isEqualTo(KNOWN_JSON.toString());
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON);
     }
 
     @Test

--- a/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/FeaturePropertiesModifiedTest.java
+++ b/signals/events/things/src/test/java/org/eclipse/ditto/signals/events/things/FeaturePropertiesModifiedTest.java
@@ -91,9 +91,9 @@ public final class FeaturePropertiesModifiedTest {
                         TestConstants.Feature.FLUX_CAPACITOR_PROPERTIES,
                         TestConstants.Thing.REVISION_NUMBER, TestConstants.TIMESTAMP,
                         TestConstants.EMPTY_DITTO_HEADERS);
-        final String actualJsonString = underTest.toJson(FieldType.regularOrSpecial()).toString();
+        final JsonObject actualJson = underTest.toJson(FieldType.regularOrSpecial());
 
-        assertThat(actualJsonString).isEqualTo(KNOWN_JSON.toString());
+        assertThat(actualJson).isEqualToIgnoringFieldDefinitions(KNOWN_JSON);
     }
 
 


### PR DESCRIPTION
When deserializing an event from JSON, `AbstractEventRegistry` expect the field `Event.JsonFields.TYPE` to be present, but events do not write the 'TYPE' field when serialized under `JsonSchemaVersion.V_1`.

This patch makes the `Event.JsonFields.TYPE` field the standard place to hold event type names. All events include the `TYPE` field when converted to JSON. The field `Event.JsonFields.ID` becomes deprecated. It is used to parse very old events from the persistence. No new event writes the field `Event.JsonFields.ID`.

Changes:
- `Event.JsonFields.ID` is deprecated.
- `Event.JsonFields.TYPE` is included in `toJson` methods regardless of the predicate.