### PR TITLE
Include bulk update size in search-update-metrics

### DIFF
--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
@@ -619,6 +619,7 @@ final class ThingUpdater extends AbstractActorWithDiscardOldStash
         if (!thingEvents.isEmpty()) {
             transactionActive = true;
             final TraceContext traceContext = Kamon.tracer().newContext(TRACE_THING_BULK_UPDATE);
+            traceContext.addMetadata("count", String.valueOf(thingEvents.size()));
             circuitBreaker.callWithCircuitBreakerCS(() -> searchUpdaterPersistence
                     .executeCombinedWrites(thingId, thingEvents, policyEnforcer, targetRevision)
                     .via(finishTrace(traceContext))


### PR DESCRIPTION
Include bulk update size in search-update-metrics.

Signed-off-by: Daniel Fesenmeyer <daniel.fesenmeyer@bosch-si.com>