### PR TITLE
monitor last successful search-sync end-timestamp in /status/health endpoint

### DIFF
--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
@@ -67,7 +67,7 @@ public final class StatisticsActor extends AbstractActor {
     private static final String THINGS_ROOT = "/user/thingsRoot";
     private static final String POLICIES_ROOT = "/user/policiesRoot";
     private static final String GATEWAY_ROOT = "/user/gatewayRoot";
-    private static final String SEARCH_UPDATER_ROOT = "/user/searchUpdaterRoot";
+    private static final String SEARCH_UPDATER_ROOT = "/user/thingsSearchRoot/searchUpdaterRoot";
 
     /**
      * The wait time in milliseconds to gather all statistics from the cluster nodes.

--- a/services/policies/starter/src/main/java/org/eclipse/ditto/services/policies/starter/PoliciesRootActor.java
+++ b/services/policies/starter/src/main/java/org/eclipse/ditto/services/policies/starter/PoliciesRootActor.java
@@ -164,8 +164,10 @@ public final class PoliciesRootActor extends AbstractActor {
         }
 
         final HealthCheckingActorOptions healthCheckingActorOptions = hcBuilder.build();
-        final Props healthCheckingActorProps = DefaultHealthCheckingActorFactory.props(healthCheckingActorOptions, mongoClient);
-        final ActorRef healthCheckingActor = startChildActor(DefaultHealthCheckingActorFactory.ACTOR_NAME, healthCheckingActorProps);
+        final Props healthCheckingActorProps =
+                DefaultHealthCheckingActorFactory.props(healthCheckingActorOptions, mongoClient);
+        final ActorRef healthCheckingActor =
+                startChildActor(DefaultHealthCheckingActorFactory.ACTOR_NAME, healthCheckingActorProps);
 
         String hostname = config.getString(ConfigKeys.HTTP_HOSTNAME);
         if (hostname.isEmpty()) {

--- a/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
+++ b/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
@@ -130,6 +130,12 @@ public final class ConfigKeys {
     public static final String THINGS_SYNCER_OUTDATED_WARNING_OFFSET = SYNC_THINGS_PREFIX + "outdated-warning-offset";
 
     /**
+     * Things-Sync: if a query-start is more than this offset in the past, an errir will be logged and health
+     * endpoint shows "DOWN".
+     */
+    public static final String THINGS_SYNCER_OUTDATED_ERROR_OFFSET = SYNC_THINGS_PREFIX + "outdated-error-offset";
+
+    /**
      * Things-Sync: The maximum idle time of the syncer (as a Duration).
      */
     public static final String THINGS_SYNCER_MAX_IDLE_TIME = SYNC_THINGS_PREFIX + "max-idle-time";
@@ -176,6 +182,13 @@ public final class ConfigKeys {
      */
     public static final String POLICIES_SYNCER_OUTDATED_WARNING_OFFSET =
             SYNC_POLICIES_PREFIX + "outdated-warning-offset";
+
+    /**
+     * Policies-Sync: if a query-start is more than this offset in the past, an error will be logged and the health
+     * endpoint shows "DOWN".
+     */
+    public static final String POLICIES_SYNCER_OUTDATED_ERROR_OFFSET =
+            SYNC_POLICIES_PREFIX + "outdated-error-offset";
 
     /**
      * Policies-Sync: The maximum idle time of the syncer (as a Duration).

--- a/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/RootSupervisorStrategyFactory.java
+++ b/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/RootSupervisorStrategyFactory.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.common.util;
+
+import java.net.ConnectException;
+import java.util.NoSuchElementException;
+
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+
+import akka.actor.ActorKilledException;
+import akka.actor.InvalidActorNameException;
+import akka.actor.OneForOneStrategy;
+import akka.actor.SupervisorStrategy;
+import akka.event.LoggingAdapter;
+import akka.japi.pf.DeciderBuilder;
+import akka.pattern.AskTimeoutException;
+
+/**
+ * Creates a {@link OneForOneStrategy} which can be used as Supervisor-Strategy for Root Actors, especially when they
+ * have many different children.
+ */
+public final class RootSupervisorStrategyFactory {
+
+    private static final String RESTARTING_CHILD_MSG = "Restarting child...";
+
+    private RootSupervisorStrategyFactory() {
+        throw new AssertionError();
+    }
+
+    public static OneForOneStrategy createStrategy(final LoggingAdapter log) {
+        return new OneForOneStrategy(true, DeciderBuilder
+                .match(NullPointerException.class, e -> {
+                    log.error(e, "NullPointer in child actor: {}", e.getMessage());
+                    log.info(RESTARTING_CHILD_MSG);
+                    return SupervisorStrategy.restart();
+                }).match(IllegalArgumentException.class, e -> {
+                    log.warning("Illegal Argument in child actor: {}", e.getMessage());
+                    return SupervisorStrategy.resume();
+                }).match(IllegalStateException.class, e -> {
+                    log.warning("Illegal State in child actor: {}", e.getMessage());
+                    return SupervisorStrategy.resume();
+                }).match(NoSuchElementException.class, e -> {
+                    log.warning("NoSuchElement in child actor: {}", e.getMessage());
+                    return SupervisorStrategy.resume();
+                }).match(AskTimeoutException.class, e -> {
+                    log.warning("AskTimeoutException in child actor: {}", e.getMessage());
+                    return SupervisorStrategy.resume();
+                }).match(ConnectException.class, e -> {
+                    log.warning("ConnectException in child actor: {}", e.getMessage());
+                    log.info(RESTARTING_CHILD_MSG);
+                    return SupervisorStrategy.restart();
+                }).match(InvalidActorNameException.class, e -> {
+                    log.warning("InvalidActorNameException in child actor: {}", e.getMessage());
+                    return SupervisorStrategy.resume();
+                }).match(ActorKilledException.class, e -> {
+                    log.error(e, "ActorKilledException in child actor: {}", e.message());
+                    log.info(RESTARTING_CHILD_MSG);
+                    return SupervisorStrategy.restart();
+                }).match(DittoRuntimeException.class, e -> {
+                    log.error(e,
+                            "DittoRuntimeException '{}' should not be escalated to RootActor. Simply resuming Actor.",
+                            e.getErrorCode());
+                    return SupervisorStrategy.resume();
+                }).match(Throwable.class, e -> {
+                    log.error(e, "Escalating above root actor!");
+                    return SupervisorStrategy.escalate();
+                }).matchAny(e -> {
+                    log.error("Unknown message:'{}'! Escalating above root actor!", e);
+                    return SupervisorStrategy.escalate();
+                }).build());
+    }
+}

--- a/services/thingsearch/starter/pom.xml
+++ b/services/thingsearch/starter/pom.xml
@@ -138,6 +138,12 @@
             <groupId>io.kamon</groupId>
             <artifactId>kamon-statsd_${scala.version}</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/SearchService.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/SearchService.java
@@ -11,15 +11,11 @@
  */
 package org.eclipse.ditto.services.thingsearch.starter;
 
-import java.util.Collection;
-import java.util.Collections;
-
 import org.eclipse.ditto.services.base.BaseConfigKey;
 import org.eclipse.ditto.services.base.BaseConfigKeys;
 import org.eclipse.ditto.services.base.DittoService;
 import org.eclipse.ditto.services.thingsearch.common.util.ConfigKeys;
 import org.eclipse.ditto.services.thingsearch.starter.actors.SearchRootActor;
-import org.eclipse.ditto.services.thingsearch.updater.actors.SearchUpdaterRootActor;
 import org.eclipse.ditto.utils.jsr305.annotations.AllParametersAndReturnValuesAreNonnullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,9 +46,9 @@ public final class SearchService extends DittoService {
 
     private SearchService() {
         super(LOGGER, SERVICE_NAME, SearchRootActor.ACTOR_NAME, BaseConfigKeys.getBuilder()
-            .put(BaseConfigKey.Cluster.MAJORITY_CHECK_ENABLED, ConfigKeys.CLUSTER_MAJORITY_CHECK_ENABLED)
-            .put(BaseConfigKey.Cluster.MAJORITY_CHECK_DELAY, ConfigKeys.CLUSTER_MAJORITY_CHECK_DELAY)
-            .build());
+                .put(BaseConfigKey.Cluster.MAJORITY_CHECK_ENABLED, ConfigKeys.CLUSTER_MAJORITY_CHECK_ENABLED)
+                .put(BaseConfigKey.Cluster.MAJORITY_CHECK_DELAY, ConfigKeys.CLUSTER_MAJORITY_CHECK_DELAY)
+                .build());
     }
 
     /**
@@ -71,14 +67,4 @@ public final class SearchService extends DittoService {
 
         return SearchRootActor.props(config, pubSubMediator, materializer);
     }
-
-    @Override
-    protected Collection<DittoService.RootActorInformation> getAdditionalRootActorsInformation(final Config config,
-            final ActorRef pubSubMediator, final ActorMaterializer actorMaterializer) {
-
-        return Collections.singleton(
-                RootActorInformation.getInstance(SearchUpdaterRootActor.props(config, pubSubMediator),
-                        SearchUpdaterRootActor.ACTOR_NAME));
-    }
-
 }

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/MongoReactiveHealthCheckActor.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/MongoReactiveHealthCheckActor.java
@@ -11,19 +11,18 @@
  */
 package org.eclipse.ditto.services.thingsearch.starter.actors;
 
+import org.eclipse.ditto.services.thingsearch.persistence.MongoHealthCheck;
+import org.eclipse.ditto.services.thingsearch.persistence.PersistenceHealthCheck;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.health.mongo.RetrieveMongoStatus;
 import org.eclipse.ditto.services.utils.health.mongo.RetrieveMongoStatusResponse;
+import org.eclipse.ditto.services.utils.persistence.mongo.MongoClientWrapper;
 
 import akka.actor.AbstractActor;
 import akka.actor.Props;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.japi.Creator;
 import akka.japi.pf.ReceiveBuilder;
-
-import org.eclipse.ditto.services.thingsearch.persistence.MongoHealthCheck;
-import org.eclipse.ditto.services.thingsearch.persistence.PersistenceHealthCheck;
-import org.eclipse.ditto.services.utils.persistence.mongo.MongoClientWrapper;
 
 /**
  * Actor encapsulating {@link MongoHealthCheck} and reacting on {@link RetrieveMongoStatus} messages.
@@ -46,7 +45,7 @@ public final class MongoReactiveHealthCheckActor extends AbstractActor {
             private static final long serialVersionUID = 1L;
 
             @Override
-            public MongoReactiveHealthCheckActor create() throws Exception {
+            public MongoReactiveHealthCheckActor create() {
                 return new MongoReactiveHealthCheckActor(mongoClientWrapper);
             }
         });

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActor.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActor.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.starter.actors.health;
+
+import static java.text.MessageFormat.format;
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.eclipse.ditto.services.utils.akka.streaming.StreamMetadataPersistence;
+import org.eclipse.ditto.services.utils.health.AbstractHealthCheckingActor;
+import org.eclipse.ditto.services.utils.health.StatusDetailMessage;
+import org.eclipse.ditto.services.utils.health.StatusInfo;
+
+import akka.actor.AbstractActor;
+import akka.actor.Props;
+import akka.japi.Creator;
+
+/**
+ * Actor for checking if the duration since the last synchronization is acceptable low.
+ */
+public class LastSuccessfulStreamCheckingActor extends AbstractHealthCheckingActor {
+
+    /**
+     * Indicates whether the sync stream is enabled or not. If not the health status will always be unknown.
+     */
+    private final boolean syncEnabled;
+
+    /**
+     * Used to determine the time stamp of the last successful stream.
+     */
+    private final StreamMetadataPersistence streamMetadataPersistence;
+
+    /**
+     * Defines the maximum duration that is allowed without a successful stream. If this duration is exceeded, the
+     * health check will set the status to {@link StatusInfo.Status#DOWN}.
+     */
+    private final Duration syncOutdatedErrorOffset;
+
+    /**
+     * Defines the maximum duration that is allowed without a
+     * successful stream. If this duration is exceeded, the health check will show a warning.
+     */
+    private final Duration syncOutdatedWarningOffset;
+
+    static final String NO_SUCCESSFUL_STREAM_YET_MESSAGE = "No successful stream, yet.";
+
+    static final String SYNC_DISABLED_MESSAGE = "Sync is currently disabled. No status will be retrieved";
+
+    /**
+     * Constructs a {@code HealthCheckingActor}.
+     *
+     * @param syncEnabled indicates whether the sync is enabled. If not the health status will always be
+     * {@link org.eclipse.ditto.services.utils.health.StatusInfo.Status#UNKNOWN}.
+     * @param streamMetadataPersistence Used to determine the time stamp of the last successful stream.
+     * @param syncOutdatedWarningOffset Defines the maximum duration that is allowed without a
+     * successful stream. If this duration is exceeded, the health check will show a warning.
+     * @param syncOutdatedErrorOffset Defines the maximum duration that is allowed without a
+     * successful stream. If this duration is exceeded, the health check will set the status to
+     * {@link org.eclipse.ditto.services.utils.health.StatusInfo.Status#DOWN}.
+     */
+    private LastSuccessfulStreamCheckingActor(final boolean syncEnabled,
+            final StreamMetadataPersistence streamMetadataPersistence, final Duration syncOutdatedWarningOffset,
+            final Duration syncOutdatedErrorOffset) {
+        this.syncEnabled = syncEnabled;
+        this.streamMetadataPersistence = requireNonNull(streamMetadataPersistence);
+        this.syncOutdatedWarningOffset = requireNonNull(syncOutdatedWarningOffset);
+        this.syncOutdatedErrorOffset = requireNonNull(syncOutdatedErrorOffset);
+    }
+
+    /**
+     * Creates Akka configuration object Props for this {@link LastSuccessfulStreamCheckingActor}.
+     *
+     * @param streamHealthCheckConfigurationProperties Holds the configuration properties of this health check.
+     * @return the Akka configuration Props object.
+     */
+    public static Props props(
+            final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties) {
+        return Props.create(LastSuccessfulStreamCheckingActor.class, new Creator<LastSuccessfulStreamCheckingActor>() {
+            private static final long serialVersionUID = 1L;
+
+            @Override
+            public LastSuccessfulStreamCheckingActor create() {
+                return new LastSuccessfulStreamCheckingActor(
+                        streamHealthCheckConfigurationProperties.isSyncEnabled(),
+                        streamHealthCheckConfigurationProperties.getStreamMetadataPersistence(),
+                        streamHealthCheckConfigurationProperties.getWarningOffset(),
+                        streamHealthCheckConfigurationProperties.getErrorOffset());
+            }
+        });
+    }
+
+    @Override
+    protected Receive matchCustomMessages() {
+        return AbstractActor.emptyBehavior();
+    }
+
+    @Override
+    protected void triggerHealthRetrieval() {
+        StatusInfo statusInfo;
+
+        try {
+            if (this.syncEnabled) {
+                statusInfo = this.getStatusInfo();
+            } else {
+                statusInfo = createStatusInfo(StatusInfo.Status.UNKNOWN, StatusDetailMessage.Level.WARN,
+                        SYNC_DISABLED_MESSAGE);
+            }
+        } catch (final RuntimeException e) {
+            final String message = buildRetrievalErrorMessage(e);
+            log.error(e, message);
+
+            statusInfo = createStatusInfo(StatusDetailMessage.Level.ERROR, message);
+        }
+
+        updateHealth(statusInfo);
+    }
+
+    private StatusInfo getStatusInfo() {
+        final Optional<Instant> instantOfLastSuccessfulStreamOptional =
+                this.streamMetadataPersistence.retrieveLastSuccessfulStreamEnd();
+
+        final StatusInfo statusInfo;
+
+        if (instantOfLastSuccessfulStreamOptional.isPresent()) {
+            final Duration durationSinceLastSuccessfulStream =
+                    calculateDurationSinceLastSuccessfulStream(instantOfLastSuccessfulStreamOptional.get());
+
+            if (syncErrorOffsetExceeded(durationSinceLastSuccessfulStream)) {
+                final String message = buildSyncErrorOffsetExceededErrorMessage(durationSinceLastSuccessfulStream);
+                statusInfo = createStatusInfo(StatusDetailMessage.Level.ERROR, message);
+            } else if (syncWarningOffsetExceeded(durationSinceLastSuccessfulStream)) {
+                final String message = buildSyncWarningOffsetExceededErrorMessage(durationSinceLastSuccessfulStream);
+                statusInfo = createStatusInfo(StatusDetailMessage.Level.WARN, message);
+            } else {
+                final String message =
+                        buildInformationAboutLastSuccessfulStreamMessage(durationSinceLastSuccessfulStream);
+                statusInfo = createStatusInfo(StatusDetailMessage.Level.INFO, message);
+            }
+        } else {
+            statusInfo = createStatusInfo(StatusDetailMessage.Level.WARN, NO_SUCCESSFUL_STREAM_YET_MESSAGE);
+        }
+        return statusInfo;
+    }
+
+    private StatusInfo createStatusInfo(final StatusDetailMessage.Level level, final String message) {
+        return StatusInfo.fromDetail(StatusDetailMessage.of(level, message));
+    }
+
+    private StatusInfo createStatusInfo(final StatusInfo.Status status, final StatusDetailMessage.Level level,
+            final String message) {
+        return StatusInfo.fromStatus(status, Collections.singleton(StatusDetailMessage.of(level, message)));
+    }
+
+    private Duration calculateDurationSinceLastSuccessfulStream(final Instant instantOfLastSuccessfulStream) {
+        final Instant now = Instant.now();
+
+        return Duration.between(instantOfLastSuccessfulStream, now);
+    }
+
+    private boolean syncErrorOffsetExceeded(final Duration durationSinceLastSuccessfulStream) {
+        return durationSinceLastSuccessfulStream.compareTo(syncOutdatedErrorOffset) > 0;
+    }
+
+    private boolean syncWarningOffsetExceeded(final Duration durationSinceLastSuccessfulStream) {
+        return durationSinceLastSuccessfulStream.compareTo(syncOutdatedWarningOffset) > 0;
+    }
+
+    private String buildSyncErrorOffsetExceededErrorMessage(final Duration durationSinceLastSuccessfulStream) {
+        return format("{0} Maximum duration before showing this error is <{1}>.",
+                buildInformationAboutLastSuccessfulStreamMessage(durationSinceLastSuccessfulStream),
+                this.syncOutdatedErrorOffset);
+    }
+
+    private String buildSyncWarningOffsetExceededErrorMessage(final Duration durationSinceLastSuccessfulStream) {
+        return format("{0} Maximum duration before showing this warning is <{1}>.",
+                buildInformationAboutLastSuccessfulStreamMessage(durationSinceLastSuccessfulStream),
+                this.syncOutdatedWarningOffset);
+    }
+
+    private String buildInformationAboutLastSuccessfulStreamMessage(final Duration durationSinceLastSuccessfulStream) {
+        return format("End timestamp of last successful sync is about <{0}> minutes ago.",
+                durationSinceLastSuccessfulStream.toMinutes());
+    }
+
+    private String buildRetrievalErrorMessage(final Throwable reason) {
+        return format("An error occurred when asking for the end timestamp of last successful sync. Reason: <{0}>.",
+                reason);
+    }
+}

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActorConfigurationProperties.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActorConfigurationProperties.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.starter.actors.health;
+
+import static java.util.Objects.requireNonNull;
+
+import java.time.Duration;
+
+import org.eclipse.ditto.services.thingsearch.common.util.ConfigKeys;
+import org.eclipse.ditto.services.utils.akka.streaming.StreamMetadataPersistence;
+
+import com.typesafe.config.Config;
+
+/**
+ * Holds the configuration properties for a new instance of
+ * {@link org.eclipse.ditto.services.thingsearch.starter.actors.health.LastSuccessfulStreamCheckingActor}.
+ */
+final class LastSuccessfulStreamCheckingActorConfigurationProperties {
+
+    private final boolean syncEnabled;
+    private final Duration warningOffset;
+    private final Duration errorOffset;
+    private final StreamMetadataPersistence streamMetadataPersistence;
+
+    LastSuccessfulStreamCheckingActorConfigurationProperties(final boolean syncEnabled,
+            final Duration warningOffset,
+            final Duration errorOffset, final StreamMetadataPersistence streamMetadataPersistence) {
+
+        if (errorOffset.compareTo(warningOffset) <= 0) {
+            throw new IllegalArgumentException("Warning offset must be shorter than error offset.");
+        }
+        requireNonNull(streamMetadataPersistence);
+
+        this.syncEnabled = syncEnabled;
+        this.warningOffset = warningOffset;
+        this.errorOffset = errorOffset;
+        this.streamMetadataPersistence = streamMetadataPersistence;
+    }
+
+    /**
+     * Creates properties for the policies sync health check.
+     *
+     * @param config The application config.
+     * @param policiesSyncPersistence The persistence that should be used to retrieve time of last successful
+     * policies stream.
+     * @return The properties.
+     */
+    public static LastSuccessfulStreamCheckingActorConfigurationProperties policiesSync(final Config config,
+            final StreamMetadataPersistence policiesSyncPersistence) {
+        final boolean policiesSynchronizationActive = config.getBoolean(ConfigKeys.POLICIES_SYNCER_ACTIVE);
+        final Duration policiesSyncerOutdatedWarningOffset =
+                config.getDuration(ConfigKeys.POLICIES_SYNCER_OUTDATED_WARNING_OFFSET);
+        final Duration policiesSyncerOutdatedErrorOffset =
+                config.getDuration(ConfigKeys.POLICIES_SYNCER_OUTDATED_ERROR_OFFSET);
+
+        return new LastSuccessfulStreamCheckingActorConfigurationProperties(policiesSynchronizationActive,
+                policiesSyncerOutdatedWarningOffset,
+                policiesSyncerOutdatedErrorOffset, policiesSyncPersistence);
+    }
+
+    /**
+     * Creates properties for the things sync health check.
+     *
+     * @param config The application config.
+     * @param thingsSyncPersistence The persistence that should be used to retrieve time of last successful
+     * things stream.
+     * @return The properties.
+     */
+    public static LastSuccessfulStreamCheckingActorConfigurationProperties thingsSync(final Config config,
+            final StreamMetadataPersistence thingsSyncPersistence) {
+        final boolean policiesSynchronizationActive = config.getBoolean(ConfigKeys.THINGS_SYNCER_ACTIVE);
+        final Duration policiesSyncerOutdatedWarningOffset =
+                config.getDuration(ConfigKeys.THINGS_SYNCER_OUTDATED_WARNING_OFFSET);
+        final Duration policiesSyncerOutdatedErrorOffset =
+                config.getDuration(ConfigKeys.THINGS_SYNCER_OUTDATED_ERROR_OFFSET);
+
+        return new LastSuccessfulStreamCheckingActorConfigurationProperties(policiesSynchronizationActive,
+                policiesSyncerOutdatedWarningOffset,
+                policiesSyncerOutdatedErrorOffset, thingsSyncPersistence);
+    }
+
+    /**
+     * Provides information whether the health check is enabled or not.
+     *
+     * @return True if enabled false if not
+     */
+    public boolean isSyncEnabled() {
+        return syncEnabled;
+    }
+
+    /**
+     * Returns the configured warning offset.
+     *
+     * @return The duration if {@link #isSyncEnabled()} is true. Null if not.
+     */
+    public Duration getWarningOffset() {
+        return warningOffset;
+    }
+
+    /**
+     * Returns the configured error offset.
+     *
+     * @return The duration if {@link #isSyncEnabled()} is true. Null if not.
+     */
+    public Duration getErrorOffset() {
+        return errorOffset;
+    }
+
+    /**
+     * Returns the configured persistence.
+     *
+     * @return The persistence if {@link #isSyncEnabled()} is true. Null if not.
+     */
+    public StreamMetadataPersistence getStreamMetadataPersistence() {
+        return streamMetadataPersistence;
+    }
+}

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/SearchHealthCheckingActorFactory.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/SearchHealthCheckingActorFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.starter.actors.health;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+
+import org.eclipse.ditto.services.thingsearch.common.util.ConfigKeys;
+import org.eclipse.ditto.services.utils.akka.streaming.StreamMetadataPersistence;
+import org.eclipse.ditto.services.utils.health.AbstractHealthCheckingActor;
+import org.eclipse.ditto.services.utils.health.CompositeCachingHealthCheckingActor;
+import org.eclipse.ditto.services.utils.health.PersistenceHealthCheckingActor;
+
+import com.typesafe.config.Config;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+
+/**
+ * Provides an actor for checking and caching the health of the search service.
+ */
+public class SearchHealthCheckingActorFactory {
+
+    /**
+     * The required name of the Actor to be created in the ActorSystem.
+     */
+    public static final String ACTOR_NAME = AbstractHealthCheckingActor.ACTOR_NAME;
+
+    private static final String PERSISTENCE_LABEL = "persistence";
+
+    private static final String THINGS_SYNC_LABEL = "thingsSync";
+
+    private static final String POLICIES_SYNC_LABEL = "policiesSync";
+
+    private SearchHealthCheckingActorFactory() {}
+
+    /**
+     * Creates Akka configuration object Props for a health checking actor.
+     *
+     * @param config the configuration settings.
+     * @param mongoClientActor the actor handling mongodb calls.
+     * @param thingsSyncPersistence the things sync persistence to determine time of last successful things-sync.
+     * @param policiesSyncPersistence the policies sync persistence to determine time of last successful policies-sync.
+     * @return the Akka configuration Props object.
+     */
+    public static Props props(final Config config, final ActorRef mongoClientActor,
+            final StreamMetadataPersistence thingsSyncPersistence,
+            final StreamMetadataPersistence policiesSyncPersistence) {
+
+        final LinkedHashMap<String, Props> childActorProps = new LinkedHashMap<>();
+
+        final boolean enablePersistenceCheck = config.getBoolean(ConfigKeys.HEALTH_CHECK_PERSISTENCE_ENABLED);
+        if (enablePersistenceCheck) {
+            childActorProps.put(PERSISTENCE_LABEL, PersistenceHealthCheckingActor.props(mongoClientActor));
+        }
+
+        childActorProps.put(THINGS_SYNC_LABEL,
+                LastSuccessfulStreamCheckingActor.props(
+                        LastSuccessfulStreamCheckingActorConfigurationProperties.thingsSync(config,
+                                thingsSyncPersistence)));
+
+        childActorProps.put(POLICIES_SYNC_LABEL,
+                LastSuccessfulStreamCheckingActor.props(
+                        LastSuccessfulStreamCheckingActorConfigurationProperties.policiesSync(config,
+                                policiesSyncPersistence)));
+
+        final boolean healthCheckEnabled = config.getBoolean(ConfigKeys.HEALTH_CHECK_ENABLED);
+        final Duration healthCheckInterval = config.getDuration(ConfigKeys.HEALTH_CHECK_INTERVAL);
+        return CompositeCachingHealthCheckingActor.props(childActorProps, healthCheckInterval, healthCheckEnabled);
+    }
+}

--- a/services/thingsearch/starter/src/main/resources/kamon.conf
+++ b/services/thingsearch/starter/src/main/resources/kamon.conf
@@ -8,9 +8,7 @@ kamon {
       akka-actor {
         includes = [
           "ditto-cluster/user/thingsSearchRoot",
-          "ditto-cluster/user/thingsSearchRoot/**",
-          "ditto-cluster/user/searchUpdaterRoot",
-          "ditto-cluster/user/searchUpdaterRoot/**"
+          "ditto-cluster/user/thingsSearchRoot/**"
         ]
         excludes = [
           "ditto-cluster/system/**"

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -111,8 +111,10 @@ ditto {
           initial-start-offset = ${?THINGS_SYNCHRONIZATION_INITIAL_START_OFFSET}
           stream-interval = 5m
           stream-interval = ${?THINGS_SYNCHRONIZATION_STREAM_INTERVAL}
-          outdated-warning-offset = 12h
+          outdated-warning-offset = 3h
           outdated-warning-offset = ${?THINGS_SYNCHRONIZATION_OUTDATED_WARNING_OFFSET}
+          outdated-error-offset = 4h
+          outdated-error-offset = ${?THINGS_SYNCHRONIZATION_OUTDATED_ERROR_OFFSET}
           max-idle-time = 1m
           max-idle-time = ${?THINGS_SYNCHRONIZATION_MAX_IDLE_TIME}
           streaming-actor-timeout = 5m
@@ -130,8 +132,10 @@ ditto {
           initial-start-offset = ${?POLICIES_SYNCHRONIZATION_INITIAL_START_OFFSET}
           stream-interval = 5m
           stream-interval = ${?POLICIES_SYNCHRONIZATION_STREAM_INTERVAL}
-          outdated-warning-offset = 12h
+          outdated-warning-offset = 3h
           outdated-warning-offset = ${?POLICIES_SYNCHRONIZATION_OUTDATED_WARNING_OFFSET}
+          outdated-error-offset = 4h
+          outdated-error-offset = ${?POLICIES_SYNCHRONIZATION_OUTDATED_ERROR_OFFSET}
           max-idle-time = 1m
           max-idle-time = ${?POLICIES_SYNCHRONIZATION_MAX_IDLE_TIME}
           // streaming actor timeout is set generouslyl because each policy tag may trigger updates at many things.

--- a/services/thingsearch/starter/src/test/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActorTest.java
+++ b/services/thingsearch/starter/src/test/java/org/eclipse/ditto/services/thingsearch/starter/actors/health/LastSuccessfulStreamCheckingActorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.starter.actors.health;
+
+import static java.time.Instant.now;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.thingsearch.starter.actors.health.LastSuccessfulStreamCheckingActor.SYNC_DISABLED_MESSAGE;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.eclipse.ditto.services.utils.akka.streaming.StreamMetadataPersistence;
+import org.eclipse.ditto.services.utils.health.RetrieveHealth;
+import org.eclipse.ditto.services.utils.health.StatusDetailMessage;
+import org.eclipse.ditto.services.utils.health.StatusInfo;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LastSuccessfulStreamCheckingActorTest {
+
+    private static ActorSystem actorSystem;
+    private static Duration syncErrorOffset;
+    private static Duration syncWarningOffset;
+
+    private TestKit testKit;
+    private ActorRef underTest;
+
+    @Mock
+    private StreamMetadataPersistence searchSyncPersistence;
+
+    @BeforeClass
+    public static void setupOnce() {
+        actorSystem = ActorSystem.create("AkkaTestSystem");
+        syncErrorOffset = Duration.ofMinutes(30);
+        syncWarningOffset = Duration.ofMinutes(20);
+    }
+
+    @AfterClass
+    public static void teardown() {
+        TestKit.shutdownActorSystem(actorSystem);
+        actorSystem = null;
+    }
+
+    @Before
+    public void setup() {
+        testKit = new TestKit(actorSystem);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithNoSuccessfulStream() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(true, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd()).thenReturn(Optional.empty());
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo = createStatusInfo(StatusDetailMessage.Level.WARN,
+                LastSuccessfulStreamCheckingActor.NO_SUCCESSFUL_STREAM_YET_MESSAGE);
+        expectStatusInfo(expectedStatusInfo);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithExceededErrorOffset() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(true, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+        Instant lastSuccessfulStream = now().minusSeconds(syncErrorOffset.getSeconds() + 60);
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd()).thenReturn(Optional.of(lastSuccessfulStream));
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo =
+                createStatusInfo(StatusDetailMessage.Level.ERROR,
+                        "End timestamp of last successful sync is about <31> " +
+                        "minutes ago. Maximum duration before showing this error is <PT30M>.");
+        expectStatusInfo(expectedStatusInfo);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithExceededWarningOffset() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(true, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+        Instant lastSuccessfulStream = now().minusSeconds(syncWarningOffset.getSeconds() + 60);
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd()).thenReturn(Optional.of(lastSuccessfulStream));
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo =
+                createStatusInfo(StatusDetailMessage.Level.WARN,
+                        "End timestamp of last successful sync is about <21> " +
+                        "minutes ago. Maximum duration before showing this warning is <PT20M>.");
+        expectStatusInfo(expectedStatusInfo);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithExceptionWhenAskingForLastSyncTime() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(true, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+        final IllegalStateException mockedEx = new IllegalStateException("Something happened");
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd()).thenThrow(mockedEx);
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo =
+                createStatusInfo(StatusDetailMessage.Level.ERROR, "An error occurred when asking for the end " +
+                        "timestamp of last successful sync. Reason: <" + mockedEx.toString() + ">.");
+        expectStatusInfo(expectedStatusInfo);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithSuccessfulStreamInTime() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(true, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+        Instant lastSuccessfulStream = now().minusSeconds(syncWarningOffset.getSeconds() - 10);
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd()).thenReturn(Optional.of(lastSuccessfulStream));
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo = createStatusInfo(StatusDetailMessage.Level.INFO,
+                "End timestamp of last successful sync is about <19> minutes ago.");
+        expectStatusInfo(expectedStatusInfo);
+    }
+
+    @Test
+    public void triggerHealthRetrievalWithDisabledSync() {
+        final LastSuccessfulStreamCheckingActorConfigurationProperties streamHealthCheckConfigurationProperties =
+                buildConfigProperties(false, searchSyncPersistence, syncWarningOffset, syncErrorOffset);
+        underTest =
+                actorSystem.actorOf(LastSuccessfulStreamCheckingActor.props(streamHealthCheckConfigurationProperties));
+
+        sendRetrieveHealth();
+
+        final StatusInfo expectedStatusInfo =
+                createStatusInfo(StatusInfo.Status.UNKNOWN, StatusDetailMessage.Level.WARN,
+                        SYNC_DISABLED_MESSAGE);
+        expectStatusInfo(expectedStatusInfo);
+        verify(searchSyncPersistence, never()).retrieveLastSuccessfulStreamEnd();
+    }
+
+    private static LastSuccessfulStreamCheckingActorConfigurationProperties buildConfigProperties(
+            final boolean syncEnabled, final StreamMetadataPersistence streamMetadataPersistence,
+            final Duration syncWarningOffset, final Duration syncErrorOffset) {
+
+        return new LastSuccessfulStreamCheckingActorConfigurationProperties(syncEnabled, syncWarningOffset,
+                syncErrorOffset, streamMetadataPersistence);
+    }
+
+    private void sendRetrieveHealth() {
+        underTest.tell(RetrieveHealth.newInstance(), testKit.getRef());
+    }
+
+    private StatusInfo createStatusInfo(final StatusDetailMessage.Level level, final String message) {
+        return StatusInfo.fromDetail(StatusDetailMessage.of(level, message));
+    }
+
+    private StatusInfo createStatusInfo(final StatusInfo.Status status, final StatusDetailMessage.Level level,
+            final String message) {
+        return StatusInfo.fromStatus(status, Collections.singleton(StatusDetailMessage.of(level, message)));
+    }
+
+    private void expectStatusInfo(final StatusInfo expectedStatusInfo) {
+        final StatusInfo statusInfo = testKit.expectMsgClass(StatusInfo.class);
+        assertThat(statusInfo).isEqualTo(expectedStatusInfo);
+    }
+}

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdater.java
@@ -129,7 +129,7 @@ final class ThingsUpdater extends AbstractActor {
             private static final long serialVersionUID = 1L;
 
             @Override
-            public ThingsUpdater create() throws Exception {
+            public ThingsUpdater create() {
                 return new ThingsUpdater(numberOfShards, shardRegionFactory, searchUpdaterPersistence, circuitBreaker,
                         eventProcessingActive, thingUpdaterActivityCheckInterval, maxBulkSize, thingCacheFacade,
                         policyCacheFacade);

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
@@ -19,6 +19,7 @@ import static org.eclipse.ditto.services.utils.akka.streaming.StreamConstants.ST
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -315,8 +316,9 @@ public final class DefaultStreamSupervisor<E> extends AbstractActor {
             // the initial start ts is only used when no sync has been run yet (i.e. no timestamp has been persisted)
             final Instant initialStartTsWithoutStandardOffset =
                     now.minus(streamConsumerSettings.getInitialStartOffset());
-
-            queryStart = streamMetadataPersistence.retrieveLastSuccessfulStreamEnd(initialStartTsWithoutStandardOffset);
+            final Optional<Instant> instant = streamMetadataPersistence.retrieveLastSuccessfulStreamEnd();
+            queryStart = instant.orElse
+                    (initialStartTsWithoutStandardOffset);
         }
 
         final Duration offsetFromNow = Duration.between(queryStart, now);

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/StreamMetadataPersistence.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/StreamMetadataPersistence.java
@@ -12,6 +12,7 @@
 package org.eclipse.ditto.services.utils.akka.streaming;
 
 import java.time.Instant;
+import java.util.Optional;
 
 import akka.NotUsed;
 import akka.stream.javadsl.Source;
@@ -30,11 +31,10 @@ public interface StreamMetadataPersistence {
     Source<NotUsed, NotUsed> updateLastSuccessfulStreamEnd(Instant timestamp);
 
     /**
-     * <strong>Blocking:</strong> Retrieves the end timestamp of the last successful stream or the provided
-     * {@code defaultTimestamp}, if a timestamp has not yet been persisted.
+     * <strong>Blocking:</strong> Retrieves the end timestamp of the last successful stream.
      *
-     * @param defaultTimestamp The default timestamp to be returned if a timestamp has not yet been persisted.
-     * @return a {@link Source} holding the publisher to execute the operation.
+     * @return An {@link java.util.Optional} of the {@link Instant} of the last successful stream.
+     * Optional will be empty if a timestamp has not yet been persisted.
      */
-    Instant retrieveLastSuccessfulStreamEnd(Instant defaultTimestamp);
+    Optional<Instant> retrieveLastSuccessfulStreamEnd();
 }

--- a/services/utils/akka/src/test/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisorTest.java
+++ b/services/utils/akka/src/test/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisorTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -87,8 +88,8 @@ public class DefaultStreamSupervisorTest {
         forwardTo = TestProbe.apply(actorSystem);
         provider = TestProbe.apply(actorSystem);
 
-        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd(any(Instant.class)))
-                .thenAnswer(unused -> KNOWN_LAST_SYNC);
+        when(searchSyncPersistence.retrieveLastSuccessfulStreamEnd())
+                .thenAnswer(unused -> Optional.of(KNOWN_LAST_SYNC));
         when(searchSyncPersistence.updateLastSuccessfulStreamEnd(any(Instant.class)))
                 .thenReturn(Source.single(NotUsed.getInstance()));
     }
@@ -117,7 +118,7 @@ public class DefaultStreamSupervisorTest {
             expectStreamTriggerMsg(expectedQueryEnd);
 
             // verify that last query end has been retrieved from persistence
-            verify(searchSyncPersistence).retrieveLastSuccessfulStreamEnd(any(Instant.class));
+            verify(searchSyncPersistence).retrieveLastSuccessfulStreamEnd();
 
             getForwarderActor(streamSupervisor).tell(STREAM_STARTED, ActorRef.noSender());
             sendMessageToForwarderAndExpectTerminated(this, streamSupervisor, STREAM_COMPLETED);
@@ -141,7 +142,7 @@ public class DefaultStreamSupervisorTest {
             expectStreamTriggerMsg(expectedQueryEnd);
 
             // verify that last query end has been retrieved from persistence
-            verify(searchSyncPersistence).retrieveLastSuccessfulStreamEnd(any(Instant.class));
+            verify(searchSyncPersistence).retrieveLastSuccessfulStreamEnd();
 
             when(searchSyncPersistence.updateLastSuccessfulStreamEnd(any(Instant.class)))
                     .thenReturn(Source.failed(new IllegalStateException("mocked stream-metadata-persistence error")));

--- a/services/utils/health/pom.xml
+++ b/services/utils/health/pom.xml
@@ -56,6 +56,19 @@
             <scope>provided</scope>
             <!-- HealthRouteFunction needs akka-http .. if a service uses the class, it must provide akka-http itself -->
         </dependency>
+        <!-- for testing purpose -->
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_2.12</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractHealthCheckingActor.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractHealthCheckingActor.java
@@ -26,6 +26,11 @@ import akka.japi.pf.ReceiveBuilder;
  */
 public abstract class AbstractHealthCheckingActor extends AbstractActor {
 
+    /**
+     * The required actor name of the Actor to be created in the ActorSystem.
+     */
+    public static final String ACTOR_NAME = "healthCheckingActor";
+
     protected final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
 
     private StatusInfo health = StatusInfo.unknown();

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/CompositeCachingHealthCheckingActor.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/CompositeCachingHealthCheckingActor.java
@@ -76,7 +76,7 @@ public final class CompositeCachingHealthCheckingActor extends AbstractHealthChe
             private static final long serialVersionUID = 1L;
 
             @Override
-            public CompositeCachingHealthCheckingActor create() throws Exception {
+            public CompositeCachingHealthCheckingActor create() {
                 return new CompositeCachingHealthCheckingActor(childActorProps, updateInterval, enabled);
             }
         });

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/DefaultHealthCheckingActorFactory.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/DefaultHealthCheckingActorFactory.java
@@ -26,9 +26,9 @@ public final class DefaultHealthCheckingActorFactory {
     }
 
     /**
-     * The (suggested) name of the Actor to be created in the ActorSystem.
+     * The actor name of the Actor to be created in the ActorSystem.
      */
-    public static final String ACTOR_NAME = "healthCheckingActor";
+    public static final String ACTOR_NAME = AbstractHealthCheckingActor.ACTOR_NAME;
 
     private static final String PERSISTENCE_LABEL = "persistence";
 

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/PersistenceHealthCheckingActor.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/PersistenceHealthCheckingActor.java
@@ -44,7 +44,7 @@ public final class PersistenceHealthCheckingActor extends AbstractHealthChecking
             private static final long serialVersionUID = 1L;
 
             @Override
-            public PersistenceHealthCheckingActor create() throws Exception {
+            public PersistenceHealthCheckingActor create() {
                 return new PersistenceHealthCheckingActor(mongoClientActor);
             }
         });

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/status/StatusSupplierActor.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/status/StatusSupplierActor.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.akka.SimpleCommand;
 import org.eclipse.ditto.services.utils.akka.SimpleCommandResponse;
-import org.eclipse.ditto.services.utils.health.DefaultHealthCheckingActorFactory;
+import org.eclipse.ditto.services.utils.health.AbstractHealthCheckingActor;
 import org.eclipse.ditto.services.utils.health.RetrieveHealth;
 import org.eclipse.ditto.services.utils.health.StatusInfo;
 
@@ -62,7 +62,7 @@ public final class StatusSupplierActor extends AbstractActor {
      * Creates Akka configuration object Props for this StatusSupplierActor.
      *
      * @param rootActorName sets the name of the root actor (e.g. "thingsRoot") which is used as the parent of
-     * {@link DefaultHealthCheckingActorFactory#ACTOR_NAME}.
+     * {@link org.eclipse.ditto.services.utils.health.AbstractHealthCheckingActor#ACTOR_NAME}.
      * @return the Akka configuration Props object
      */
     public static Props props(final String rootActorName) {
@@ -91,7 +91,7 @@ public final class StatusSupplierActor extends AbstractActor {
                             final ActorRef sender = getSender();
                             final ActorRef self = getSelf();
                             PatternsCS.ask(getContext().system().actorSelection("/user/" + rootActorName + "/" +
-                                            DefaultHealthCheckingActorFactory.ACTOR_NAME),
+                                            AbstractHealthCheckingActor.ACTOR_NAME),
                                     RetrieveHealth.newInstance(), Timeout.apply(2, TimeUnit.SECONDS))
                                     .thenAccept(health -> {
                                         log.info("Sending the health of this system as requested: {}", health);

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoSearchSyncPersistenceIT.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoSearchSyncPersistenceIT.java
@@ -95,14 +95,13 @@ public final class MongoSearchSyncPersistenceIT {
     }
 
     /**
-     * Checks that the fallback is returned when the timestamp has not yet been persisted.
+     * Checks that an empty {@link Optional} is returned when the timestamp has not yet been persisted.
      */
     @Test
     public void retrieveFallbackForLastSuccessfulSyncTimestamp() {
-        final Instant fallbackTs = Instant.now();
+        final Optional<Instant> actualTs = syncPersistence.retrieveLastSuccessfulStreamEnd();
 
-        final Instant actualTs = syncPersistence.retrieveLastSuccessfulStreamEnd(fallbackTs);
-        assertThat(actualTs).isEqualTo(fallbackTs);
+        assertThat(actualTs).isEmpty();
     }
 
     /**
@@ -112,12 +111,10 @@ public final class MongoSearchSyncPersistenceIT {
     public void updateAndRetrieveLastSuccessfulSyncTimestamp() {
         final Instant ts = Instant.now();
 
-
         runBlocking(syncPersistence.updateLastSuccessfulStreamEnd(ts));
 
-        final Instant fallbackTs = ts.minusSeconds(1000);
-        final Instant persistedTs = syncPersistence.retrieveLastSuccessfulStreamEnd(fallbackTs);
-        assertThat(persistedTs).isEqualTo(ts);
+        final Optional<Instant> persistedTs = syncPersistence.retrieveLastSuccessfulStreamEnd();
+        assertThat(persistedTs).hasValue(ts);
     }
 
     private void runBlocking(final Source<?, ?>... publishers) {


### PR DESCRIPTION
monitor last successful search-sync end-timestamp in /status/health endpoint

- refactoring: create SearchUpdaterRootActor as child actor of
SearchRootActor -> no more need to overwrite method DittoService#getAdditionalRootActorsInformation in SearchService
- add configuration option "outdated-error-offset" for both things and
policies sync, configure "outdated-warning-offset" smaller than
"outdated-error-offset"
- add LastSuccessfulStreamCheckingActor which monitors an arbitrary
StreamMetadataPersistence using "outdated-error-offset" and
"outdated-warning-offset"
- add SearchHealthCheckingActorFactory as a composite of
LastSuccessfulStreamCheckingActors for things and policies sync and
PersistenceHealthCheckingActor
- provide the actor created by SearchHealthCheckingActorFactory as
"healthCheckingActor"

Co-authored by @Yannic92.

Signed-off-by: Daniel Fesenmeyer <daniel.fesenmeyer@bosch-si.com>