### PR TITLE
Upgrade to Akka 2.5.12

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -34,7 +34,7 @@
         <!-- ### Compile dependencies versions -->
         <minimal-json.version>0.9.5</minimal-json.version>
         <typesafe-config.version>1.3.1</typesafe-config.version>
-        <akka.version>2.5.8</akka.version>
+        <akka.version>2.5.12</akka.version>
         <akka-http.version>10.0.11</akka-http.version>
         <akka-sse.version>3.0.0</akka-sse.version>
         <akka-persistence-mongo.version>2.0.4</akka-persistence-mongo.version>

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/testhelper/PoliciesSnapshotTestHelper.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/testhelper/PoliciesSnapshotTestHelper.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.mongodb.DBObject;
+import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -66,7 +67,7 @@ public final class PoliciesSnapshotTestHelper<S> {
         this.domainIdToPersistenceId = requireNonNull(domainIdToPersistenceId);
 
         snapshotPlugin =
-                Persistence.get(actorSystem).snapshotStoreFor(SNAPSHOT_PLUGIN_ID);
+                Persistence.get(actorSystem).snapshotStoreFor(SNAPSHOT_PLUGIN_ID, ConfigFactory.empty());
     }
 
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/snapshotting/ThingSnapshotter.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/snapshotting/ThingSnapshotter.java
@@ -40,6 +40,7 @@ import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import org.eclipse.ditto.signals.commands.things.exceptions.ThingUnavailableException;
 
 import com.mongodb.annotations.NotThreadSafe;
+import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
@@ -176,7 +177,7 @@ public abstract class ThingSnapshotter<T extends Command<?>, R extends CommandRe
                 Duration.create(3000, TimeUnit.MILLISECONDS),
 
                 Persistence.get(persistenceActor.getContext().system())
-                        .snapshotStoreFor(persistenceActor.snapshotPluginId()));
+                        .snapshotStoreFor(persistenceActor.snapshotPluginId(), ConfigFactory.empty()));
     }
 
     /**

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/testhelper/ThingsSnapshotTestHelper.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/testhelper/ThingsSnapshotTestHelper.java
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import com.mongodb.DBObject;
+import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
@@ -66,7 +67,7 @@ public final class ThingsSnapshotTestHelper<S> {
         this.domainIdToPersistenceId = requireNonNull(domainIdToPersistenceId);
 
         snapshotPlugin =
-                Persistence.get(actorSystem).snapshotStoreFor(SNAPSHOT_PLUGIN_ID);
+                Persistence.get(actorSystem).snapshotStoreFor(SNAPSHOT_PLUGIN_ID, ConfigFactory.empty());
     }
 
 

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/PoliciesStreamSupervisorCreator.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/PoliciesStreamSupervisorCreator.java
@@ -19,6 +19,7 @@ import org.eclipse.ditto.services.utils.akka.streaming.DefaultStreamSupervisor;
 import org.eclipse.ditto.services.utils.akka.streaming.StreamConsumerSettings;
 import org.eclipse.ditto.services.utils.akka.streaming.StreamMetadataPersistence;
 
+import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.cluster.pubsub.DistributedPubSubMediator;
@@ -72,7 +73,7 @@ public final class PoliciesStreamSupervisorCreator {
                 true);
     }
 
-    private static Source<PolicyReferenceTag, ?> toPolicyReferenceTags(final PolicyTag policyTag,
+    private static Source<Object, NotUsed> toPolicyReferenceTags(final PolicyTag policyTag,
             final ThingsSearchUpdaterPersistence searchUpdaterPersistence) {
 
         return searchUpdaterPersistence.getOutdatedThingIds(policyTag)

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/AbstractStreamForwarder.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/AbstractStreamForwarder.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.eclipse.ditto.services.models.streaming.BatchedEntityIdWithRevisions;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 
+import akka.NotUsed;
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
@@ -125,7 +126,7 @@ public abstract class AbstractStreamForwarder<E> extends AbstractActor {
      * @param element The stream element.
      * @return A source of messages.
      */
-    protected abstract Source<?, ?> mapEntity(final E element);
+    protected abstract Source<Object, NotUsed> mapEntity(final E element);
 
     private Receive initialBehavior() {
         return ReceiveBuilder.create()

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamForwarder.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamForwarder.java
@@ -16,6 +16,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.Duration;
 import java.util.function.Function;
 
+import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.stream.javadsl.Source;
@@ -32,11 +33,11 @@ public final class DefaultStreamForwarder<E> extends AbstractStreamForwarder<E> 
     private final ActorRef completionRecipient;
     private final Duration maxIdleTime;
     private final Class<E> elementClass;
-    private final Function<E, Source<?, ?>> mapEntityFunction;
+    private final Function<E, Source<Object, NotUsed>> mapEntityFunction;
 
     private DefaultStreamForwarder(final ActorRef recipient, final ActorRef completionRecipient,
             final Duration maxIdleTime, final Class<E> elementClass,
-            final Function<E, Source<?, ?>> mapEntityFunction) {
+            final Function<E, Source<Object, NotUsed>> mapEntityFunction) {
         this.recipient = requireNonNull(recipient);
         this.completionRecipient = requireNonNull(completionRecipient);
         this.maxIdleTime = requireNonNull(maxIdleTime);
@@ -57,7 +58,7 @@ public final class DefaultStreamForwarder<E> extends AbstractStreamForwarder<E> 
      */
     public static <E> Props props(final ActorRef recipient, final ActorRef completionRecipient,
             final Duration maxIdleTime, final Class<E> elementClass,
-            final Function<E, Source<?, ?>> mapEntity) {
+            final Function<E, Source<Object, NotUsed>> mapEntity) {
         return Props.create(DefaultStreamForwarder.class, () ->
                 new DefaultStreamForwarder<>(recipient, completionRecipient, maxIdleTime, elementClass, mapEntity));
     }
@@ -83,7 +84,7 @@ public final class DefaultStreamForwarder<E> extends AbstractStreamForwarder<E> 
     }
 
     @Override
-    protected Source<?, ?> mapEntity(final E element) {
+    protected Source<Object, NotUsed> mapEntity(final E element) {
         return mapEntityFunction.apply(element);
     }
 

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/streaming/DefaultStreamSupervisor.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.services.models.streaming.SudoStreamModifiedEntities;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 
+import akka.NotUsed;
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Cancellable;
@@ -135,7 +136,7 @@ public final class DefaultStreamSupervisor<E> extends AbstractActor {
     private final ActorRef forwardTo;
     private final ActorRef provider;
     private final Class<E> elementClass;
-    private final Function<E, Source<?, ?>> mapEntityFunction;
+    private final Function<E, Source<Object, NotUsed>> mapEntityFunction;
     private final Function<SudoStreamModifiedEntities, ?> streamTriggerMessageMapper;
     private final StreamMetadataPersistence streamMetadataPersistence;
     private final Materializer materializer;
@@ -147,7 +148,7 @@ public final class DefaultStreamSupervisor<E> extends AbstractActor {
 
     private DefaultStreamSupervisor(final ActorRef forwardTo, final ActorRef provider,
             final Class<E> elementClass,
-            final Function<E, Source<?, ?>> mapEntityFunction,
+            final Function<E, Source<Object, NotUsed>> mapEntityFunction,
             final Function<SudoStreamModifiedEntities, ?> streamTriggerMessageMapper,
             final StreamMetadataPersistence streamMetadataPersistence,
             final Materializer materializer,
@@ -180,7 +181,7 @@ public final class DefaultStreamSupervisor<E> extends AbstractActor {
      */
     public static <E> Props props(final ActorRef forwardTo, final ActorRef provider,
             final Class<E> elementClass,
-            final Function<E, Source<?, ?>> mapEntityFunction,
+            final Function<E, Source<Object, NotUsed>> mapEntityFunction,
             final Function<SudoStreamModifiedEntities, ?> streamTriggerMessageMapper,
             final StreamMetadataPersistence streamMetadataPersistence,
             final Materializer materializer,


### PR DESCRIPTION
Changes due to Akka issue 24368 made it necessary to spell out
element types in AbstractStreamForwarder.mapEntity.

https://github.com/akka/akka/issues/24368

All uses of the (Akka-internal) method `Persistence.snapshotStoreFor`
needs an additional argument `ConfigFactory.empty()` because
Akka added a default parameter to it.