### PR TITLE
Extend monitoring of MongoDB client

### DIFF
--- a/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
+++ b/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
@@ -55,6 +55,16 @@ public final class ConfigKeys {
     public static final String MONGO_CIRCUIT_BREAKER_TIMEOUT_RESET =
             MONGO_CIRCUIT_BREAKER_CONFIG_PREFIX + "timeout.reset";
 
+    private static final String MONITORING_PREFIX = MONGO_CONFIG_PREFIX + "monitoring.";
+    /**
+     * Whether all commands should be monitored and reported with Kamon.
+     */
+    public static final String MONITORING_COMMANDS_ENABLED = MONITORING_PREFIX + "commands";
+    /**
+     * Whether connection pool statistics should be reported with Kamon.
+     */
+    public static final String MONITORING_CONNECTION_POOL_ENABLED = MONITORING_PREFIX + "connection-pool";
+
     private static final String ENABLED_SUFFIX = "enabled";
 
     /**

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -19,6 +19,8 @@ ditto {
       maxWaitTime = ${?MONGO_DB_CONNECTION_POOL_WAIT_TIME}
       maxWaitQueueSize = 1000
       maxWaitQueueSize = ${?MONGO_DB_CONNECTION_POOL_QUEUE_SIZE}
+      jmxListenerEnabled = false
+      jmxListenerEnabled = ${?MONGO_DB_CONNECTION_POOL_JMX_LISTENER_ENABLED}
     }
   }
 
@@ -58,6 +60,12 @@ ditto {
           reset = 10s # after this time in "Open" state, the cicuitBreaker is "Half-opened" again
           reset = ${?BREAKER_RESET}
         }
+      }
+      monitoring {
+        commands = true
+        commands = ${?MONGODB_MONITORING_COMMANDS_ENABLED}
+        connection-pool = true
+        commands = ${?MONGODB_MONITORING_CONNECTION_POOL_ENABLED}
       }
     }
 

--- a/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/MongoConfig.java
+++ b/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/MongoConfig.java
@@ -64,6 +64,11 @@ public final class MongoConfig {
     public static final String POOL_MAX_WAIT_TIME = POOL_PREFIX + ".maxWaitTimeSecs";
 
     /**
+     * Whether a jmx connection pool listener should be added.
+     */
+    public static final String POOL_JMX_LISTENER_ENABLED = POOL_PREFIX + ".jmxListenerEnabled";
+
+    /**
      * Fallback client configuration.
      */
     private static final Config fallbackMongoConfig;
@@ -74,6 +79,7 @@ public final class MongoConfig {
         fallbackMap.put(POOL_MAX_SIZE, 100);
         fallbackMap.put(POOL_MAX_WAIT_QUEUE_SIZE, 100);
         fallbackMap.put(POOL_MAX_WAIT_TIME, Duration.ofSeconds(30));
+        fallbackMap.put(POOL_JMX_LISTENER_ENABLED, false);
         fallbackMap.put(MAX_QUERY_TIME, Duration.ofSeconds(60));
         fallbackMongoConfig = ConfigFactory.parseMap(fallbackMap);
     }
@@ -118,6 +124,16 @@ public final class MongoConfig {
      */
     public static Duration getPoolMaxWaitTime(final Config config) {
         return config.withFallback(fallbackMongoConfig).getDuration(POOL_MAX_WAIT_TIME);
+    }
+
+    /**
+     * Whether a JMX {@code ConnectionPoolListener} should be added.
+     *
+     * @param config The configuration.
+     * @return whether the JMXConnectionPoolListener should be added.
+     */
+    public static boolean getJmxListenerEnabled(final Config config) {
+        return config.withFallback(fallbackMongoConfig).getBoolean(POOL_JMX_LISTENER_ENABLED);
     }
 
     /**

--- a/services/utils/persistence/pom.xml
+++ b/services/utils/persistence/pom.xml
@@ -69,6 +69,11 @@
             <groupId>com.github.scullxbones</groupId>
             <artifactId>akka-persistence-mongo-common_${scala.version}</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>io.kamon</groupId>
+            <artifactId>kamon-core_${scala.version}</artifactId>
+        </dependency>
         
         <!-- test dependencies -->
         <dependency>

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/monitoring/KamonCommandListener.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/monitoring/KamonCommandListener.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ *
+ */
+package org.eclipse.ditto.services.utils.persistence.mongo.monitoring;
+
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.ditto.model.base.common.ConditionChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandStartedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+
+import kamon.Kamon;
+import kamon.metric.instrument.Time;
+
+/**
+ * Reports elapsed time for every MongoDB command to Kamon.
+ */
+public class KamonCommandListener implements CommandListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KamonCommandListener.class);
+    private final String histogramPrefix;
+
+    public KamonCommandListener(final String metricName) {
+        this.histogramPrefix = ConditionChecker.argumentNotEmpty(metricName, "metricName") + ".mongodb.";
+    }
+
+    @Override
+    public void commandStarted(final CommandStartedEvent event) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Sent command '{}:{}' with id {} to database '{}' "
+                            + "on connection '{}' to server '{}'",
+                    event.getCommandName(),
+                    event.getCommand().get(event.getCommandName()),
+                    event.getRequestId(),
+                    event.getDatabaseName(),
+                    event.getConnectionDescription().getConnectionId(),
+                    event.getConnectionDescription().getServerAddress());
+        }
+    }
+
+    @Override
+    public void commandSucceeded(final CommandSucceededEvent event) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Successfully executed command '{}' with id {} "
+                            + "on connection '{}' to server '{}' after {}ms",
+                    event.getCommandName(),
+                    event.getRequestId(),
+                    event.getConnectionDescription().getConnectionId(),
+                    event.getConnectionDescription().getServerAddress(),
+                    event.getElapsedTime(TimeUnit.MILLISECONDS));
+        }
+
+        final long elapsedTime = event.getElapsedTime(TimeUnit.NANOSECONDS);
+        final String commandName = event.getCommandName();
+        Kamon.metrics().histogram(histogramPrefix + commandName, Time.Nanoseconds()).record(elapsedTime);
+    }
+
+    @Override
+    public void commandFailed(final CommandFailedEvent event) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Failed execution of command '{}' with id {} "
+                            + "on connection '{}' to server '{}'  after {}ms with exception '{}'",
+                    event.getCommandName(),
+                    event.getRequestId(),
+                    event.getConnectionDescription().getConnectionId(),
+                    event.getConnectionDescription().getServerAddress(),
+                    event.getElapsedTime(TimeUnit.MILLISECONDS),
+                    event.getThrowable());
+        }
+
+        final long elapsedTime = event.getElapsedTime(TimeUnit.NANOSECONDS);
+        final String commandName = event.getCommandName();
+        Kamon.metrics().histogram(histogramPrefix + commandName, Time.Nanoseconds()).record(elapsedTime);
+    }
+}

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/monitoring/KamonConnectionPoolListener.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/monitoring/KamonConnectionPoolListener.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ *
+ */
+package org.eclipse.ditto.services.utils.persistence.mongo.monitoring;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.mongodb.connection.ServerId;
+import com.mongodb.event.ConnectionAddedEvent;
+import com.mongodb.event.ConnectionCheckedInEvent;
+import com.mongodb.event.ConnectionCheckedOutEvent;
+import com.mongodb.event.ConnectionPoolClosedEvent;
+import com.mongodb.event.ConnectionPoolListener;
+import com.mongodb.event.ConnectionPoolOpenedEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueEnteredEvent;
+import com.mongodb.event.ConnectionPoolWaitQueueExitedEvent;
+import com.mongodb.event.ConnectionRemovedEvent;
+
+import kamon.Kamon;
+import kamon.metric.instrument.Gauge;
+
+/**
+ * Reports MongoDB connection pool statistics to Kamon.
+ */
+public class KamonConnectionPoolListener implements ConnectionPoolListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KamonCommandListener.class);
+    private final ConcurrentMap<ServerId, PoolMetric> metrics = new ConcurrentHashMap<>();
+    private final String metricName;
+
+    public KamonConnectionPoolListener(final String metricName) {
+        this.metricName = metricName;
+    }
+
+    @Override
+    public void connectionPoolOpened(final ConnectionPoolOpenedEvent event) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Connection pool opened: {}", event);
+        }
+        final PoolMetric metric = new PoolMetric(event.getServerId());
+        metrics.put(event.getServerId(), metric);
+    }
+
+    @Override
+    public void connectionPoolClosed(final ConnectionPoolClosedEvent event) {
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Connection pool closed: {}", event);
+        }
+        final PoolMetric metric = metrics.remove(event.getServerId());
+        if (metric != null) {
+            metric.remove();
+        }
+    }
+
+    @Override
+    public void connectionCheckedOut(final ConnectionCheckedOutEvent event) {
+        metrics.compute(event.getConnectionId().getServerId(), (serverId, metric) -> metric.incCheckedOutCount());
+    }
+
+    @Override
+    public void connectionCheckedIn(final ConnectionCheckedInEvent event) {
+        metrics.compute(event.getConnectionId().getServerId(), (serverId, metric) -> metric.decCheckedOutCount());
+
+    }
+
+    @Override
+    public void waitQueueEntered(final ConnectionPoolWaitQueueEnteredEvent event) {
+        metrics.compute(event.getServerId(), (serverId, metric) -> metric.incWaitQueueSize());
+    }
+
+    @Override
+    public void waitQueueExited(final ConnectionPoolWaitQueueExitedEvent event) {
+        metrics.compute(event.getServerId(), (serverId, metric) -> metric.decWaitQueueSize());
+    }
+
+    @Override
+    public void connectionAdded(final ConnectionAddedEvent event) {
+        metrics.compute(event.getConnectionId().getServerId(), (serverId, metric) -> metric.incPoolSize());
+    }
+
+    @Override
+    public void connectionRemoved(final ConnectionRemovedEvent event) {
+        metrics.compute(event.getConnectionId().getServerId(), (serverId, metric) -> metric.decPoolSize());
+
+    }
+
+    private class PoolMetric {
+
+        private static final String POOL_PREFIX = ".pool.";
+        private static final String CHECKED_OUT_COUNT = ".checkedOutCount";
+        private static final String POOL_SIZE = ".poolSize";
+        private static final String WAIT_QUEUE_SIZE = ".waitQueueSize";
+
+        private final AtomicLong poolSize = new AtomicLong();
+        private final AtomicLong checkedOutCount = new AtomicLong();
+        private final AtomicLong waitQueueSize = new AtomicLong();
+        private final String name;
+        private final Gauge poolSizeGauge;
+        private final Gauge checkOutCountGauge;
+        private final Gauge waitQueueGauge;
+
+        private PoolMetric(final ServerId serverId) {
+            this.name = serverId.getClusterId().getValue();
+            poolSizeGauge = Kamon.metrics().gauge(metricName + POOL_PREFIX + name + POOL_SIZE, poolSize::get);
+            checkOutCountGauge =
+                    Kamon.metrics().gauge(metricName + POOL_PREFIX + name + CHECKED_OUT_COUNT, checkedOutCount::get);
+            waitQueueGauge =
+                    Kamon.metrics().gauge(metricName + POOL_PREFIX + name + WAIT_QUEUE_SIZE, waitQueueSize::get);
+        }
+
+        private PoolMetric incPoolSize() {
+            poolSizeGauge.record(poolSize.incrementAndGet());
+            return this;
+        }
+
+        private PoolMetric decPoolSize() {
+            poolSizeGauge.record(poolSize.decrementAndGet());
+            return this;
+        }
+
+        private PoolMetric incCheckedOutCount() {
+            checkOutCountGauge.record(checkedOutCount.incrementAndGet());
+            return this;
+        }
+
+        private PoolMetric decCheckedOutCount() {
+            checkOutCountGauge.record(checkedOutCount.decrementAndGet());
+            return this;
+        }
+
+        private PoolMetric incWaitQueueSize() {
+            waitQueueGauge.record(waitQueueSize.incrementAndGet());
+            return this;
+        }
+
+        private PoolMetric decWaitQueueSize() {
+            waitQueueGauge.record(waitQueueSize.decrementAndGet());
+            return this;
+        }
+
+        private void remove() {
+            Kamon.metrics().removeGauge(metricName + POOL_PREFIX + name + POOL_SIZE);
+            Kamon.metrics().removeGauge(metricName + POOL_PREFIX + name + CHECKED_OUT_COUNT);
+            Kamon.metrics().removeGauge(metricName + POOL_PREFIX + name + WAIT_QUEUE_SIZE);
+        }
+    }
+}


### PR DESCRIPTION
Add the possibility to enable a CommandListener and a ConnectionPoolListener which report statistics via Kamon.