### PR TITLE
Improve performance of like predicate

### DIFF
--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/query/model/criteria/LikePredicateImplTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/query/model/criteria/LikePredicateImplTest.java
@@ -25,26 +25,71 @@ import com.mongodb.client.model.Filters;
 public final class LikePredicateImplTest {
 
     private static final String KNOWN_FIELD_NAME = "knownFieldName";
-    private static final String KNOWN_VALUE = "knownValue*";
-    private static final String ESCAPED_KNOWN_VALUE = "^\\QknownValue\\E.*\\Q\\E$";
+
+    private static final String KNOWN_VALUE_STARTS_WITH = "knownValue*";
+    private static final String ESCAPED_KNOWN_VALUE_STARTS_WITH = "^\\QknownValue\\E";
+
+    private static final String KNOWN_VALUE_ENDS_WITH = "*knownValue";
+    private static final String ESCAPED_KNOWN_VALUE_ENDS_WITH = "\\QknownValue\\E$";
+
+    private static final String KNOWN_VALUE_CONTAINS = "known*Value";
+    private static final String ESCAPED_KNOWN_VALUE_CONTAINS = "^\\Qknown\\E.*\\QValue\\E$";
+
+    private static final String KNOWN_VALUE_REPEATING = "**known***Value****";
+    private static final String ESCAPED_KNOWN_VALUE_REPEATING = "\\Qknown\\E.*\\QValue\\E";
+
+    private static final String KNOWN_VALUE_ONLY_WILDCARDS = "***";
+    private static final String ESCAPED_KNOWN_VALUE_ONLY_WILDCARDS = ".*";
+
+    private static final String KNOWN_VALUE_MINIMAL_PRE_AND_POSTFIX = "*a*";
+    private static final String ESCAPED_KNOWN_VALUE_MINIMAL_PRE_AND_POSTFIX = "\\Qa\\E";
 
     /** */
     @Test(expected = NullPointerException.class)
     public void withNullValue() {
-        valueCheck(null);
+        valueCheck(null, ESCAPED_KNOWN_VALUE_STARTS_WITH);
     }
 
     /** */
     @Test
     public void startsWith() {
-        valueCheck(KNOWN_VALUE);
+        valueCheck(KNOWN_VALUE_STARTS_WITH, ESCAPED_KNOWN_VALUE_STARTS_WITH);
     }
 
-    private static void valueCheck(final String value) {
-        final Bson expectedBson = Filters.regex(KNOWN_FIELD_NAME, ESCAPED_KNOWN_VALUE, "");
+    /** */
+    @Test
+    public void contains() {
+        valueCheck(KNOWN_VALUE_CONTAINS, ESCAPED_KNOWN_VALUE_CONTAINS);
+    }
+
+    /** */
+    @Test
+    public void endsWith() {
+        valueCheck(KNOWN_VALUE_ENDS_WITH, ESCAPED_KNOWN_VALUE_ENDS_WITH);
+    }
+
+    /** */
+    @Test
+    public void repeatingWildcard() {
+        valueCheck(KNOWN_VALUE_REPEATING, ESCAPED_KNOWN_VALUE_REPEATING);
+    }
+
+    /** */
+    @Test
+    public void onlyWildcards() {
+        valueCheck(KNOWN_VALUE_ONLY_WILDCARDS, ESCAPED_KNOWN_VALUE_ONLY_WILDCARDS);
+    }
+
+    /** */
+    @Test
+    public void preAndPostfix() {
+        valueCheck(KNOWN_VALUE_MINIMAL_PRE_AND_POSTFIX, ESCAPED_KNOWN_VALUE_MINIMAL_PRE_AND_POSTFIX);
+    }
+
+    private static void valueCheck(final String value, final String expected) {
+        final Bson expectedBson = Filters.regex(KNOWN_FIELD_NAME, expected, "");
         final Bson actualBson = CreateBsonPredicateVisitor.apply(new LikePredicateImpl(value), KNOWN_FIELD_NAME);
 
         BsonAssertions.assertThat(actualBson).isEqualTo(expectedBson);
     }
-
 }


### PR DESCRIPTION
The performance of the like predicate can be improved by translating prefix/postfix matches like `like(prefix*)` or `like(*postfix)` to a regex `/^prefix/` and `/postfix$/`  (instead of `/^prefix.*$/` and `/^.*postfix$/`). This is also described in the [MongoDB documentation](https://docs.mongodb.com/manual/reference/operator/query/regex/#index-use).