### PR TITLE
NullPointerException trying to retrieve things without ids-parameter

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
@@ -90,9 +91,9 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.Directives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.PathMatchers;
+import akka.http.javadsl.server.RejectionHandler;
 import akka.http.javadsl.server.RequestContext;
 import akka.http.javadsl.server.Route;
-import akka.japi.function.Function;
 import akka.util.ByteString;
 
 /**
@@ -134,6 +135,7 @@ public final class RootRoute {
     private final StatsRoute statsRoute;
     private final ExceptionHandler exceptionHandler;
     private final List<Integer> supportedSchemaVersions;
+    private final RejectionHandler rejectionHandler = DittoRejectionHandlerFactory.createInstance();
 
     /**
      * Constructs the {@code /} route builder.
@@ -249,53 +251,52 @@ public final class RootRoute {
         );
     }
 
-    private Route wrapWithRootDirectives(final java.util.function.Function<String, Route> rootRoute) {
-        /* the outer handleExceptions is for handling exceptions in the directives wrapping the rootRoute (which
-           normally should not occur */
-        return handleExceptions(exceptionHandler, () ->
-                ensureCorrelationId(correlationId ->
-                        rewriteResponse(correlationId, () ->
-                                RequestTimeoutHandlingDirective.handleRequestTimeout(correlationId, () ->
-                                        logRequestResult(correlationId, () ->
-                                                EncodingEnsuringDirective.ensureEncoding(correlationId, () ->
-                                                        HttpsEnsuringDirective.ensureHttps(correlationId, () ->
-                                                                CorsEnablingDirective.enableCors(() ->
-                                                                                SecurityResponseHeadersDirective.addSecurityResponseHeaders(
-                                                                                        () ->
-                                                            /* handling the rejections is done by akka automatically, but if we
-                                                               do it here explicitly, we are able to log the status code for the
-                                                               rejection (e.g. 404 or 405) in a wrapping directive. */
-                                                                                                handleRejections(
-                                                                                                        DittoRejectionHandlerFactory.createInstance(),
-                                                                                                        () ->
-                                                                    /* the inner handleExceptions is for handling exceptions
-                                                                       occurring in the route route. It makes sure that the
-                                                                       wrapping directives such as addSecurityResponseHeaders are
-                                                                       even called in an error case in the route route. */
-                                                                                                                handleExceptions(
-                                                                                                                        exceptionHandler,
-                                                                                                                        () -> rootRoute
-                                                                                                                                .apply(
-                                                                                                                                        correlationId))
-                                                                                                )
-                                                                                )
-                                                                )
+    private Route wrapWithRootDirectives(final Function<String, Route> rootRoute) {
+        final Function<Function<String, Route>, Route> outerRouteProvider = innerRouteProvider ->
+                /* the outer handleExceptions is for handling exceptions in the directives wrapping the rootRoute
+                   (which normally should not occur */
+                handleExceptions(exceptionHandler, () ->
+                        ensureCorrelationId(correlationId ->
+                                rewriteResponse(correlationId, () ->
+                                        RequestTimeoutHandlingDirective.handleRequestTimeout(correlationId, () ->
+                                                logRequestResult(correlationId, () ->
+                                                        innerRouteProvider.apply(correlationId)
+                                                )
+                                        )
+                                )
+                        )
+                );
+
+        final Function<String, Route> innerRouteProvider = correlationId ->
+                EncodingEnsuringDirective.ensureEncoding(correlationId, () ->
+                        HttpsEnsuringDirective.ensureHttps(correlationId, () ->
+                                CorsEnablingDirective.enableCors(() ->
+                                        SecurityResponseHeadersDirective.addSecurityResponseHeaders(() ->
+                                                /* handling the rejections is done by akka automatically, but if we
+                                                   do it here explicitly, we are able to log the status code for the
+                                                   rejection (e.g. 404 or 405) in a wrapping directive. */
+                                                handleRejections(rejectionHandler, () ->
+                                                        /* the inner handleExceptions is for handling exceptions
+                                                           occurring in the route route. It makes sure that the
+                                                           wrapping directives such as addSecurityResponseHeaders are
+                                                           even called in an error case in the route route. */
+                                                        handleExceptions(exceptionHandler, () ->
+                                                                rootRoute.apply(correlationId)
                                                         )
                                                 )
                                         )
                                 )
                         )
-                )
-        );
+                );
+
+        return outerRouteProvider.apply(innerRouteProvider);
     }
 
-    private Route apiAuthentication(final String correlationId,
-            final java.util.function.Function<AuthorizationContext, Route> inner) {
+    private Route apiAuthentication(final String correlationId, final Function<AuthorizationContext, Route> inner) {
         return apiAuthenticationDirective.authenticate(correlationId, inner);
     }
 
-    private Route wsAuthentication(final String correlationId,
-            final java.util.function.Function<AuthorizationContext, Route> inner) {
+    private Route wsAuthentication(final String correlationId, final Function<AuthorizationContext, Route> inner) {
         return wsAuthenticationDirective.authenticate(correlationId, inner);
     }
 
@@ -384,7 +385,8 @@ public final class RootRoute {
 
     private static Route extractDittoHeaders(final AuthorizationContext authorizationContext,
             final Integer version, final String correlationId,
-            final java.util.function.Function<DittoHeaders, Route> inner) {
+            final Function<DittoHeaders, Route> inner) {
+
         final DittoHeaders dittoHeaders = buildDittoHeaders(authorizationContext, version, correlationId);
         return inner.apply(dittoHeaders);
     }

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
@@ -69,6 +69,7 @@ import org.eclipse.ditto.services.gateway.endpoints.routes.status.OverallStatusR
 import org.eclipse.ditto.services.gateway.endpoints.routes.things.ThingsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.thingsearch.ThingSearchRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.websocket.WebsocketRoute;
+import org.eclipse.ditto.services.gateway.endpoints.utils.DittoRejectionHandlerFactory;
 import org.eclipse.ditto.services.gateway.health.DittoStatusAndHealthProviderFactory;
 import org.eclipse.ditto.services.gateway.health.StatusAndHealthProvider;
 import org.eclipse.ditto.services.gateway.starter.service.util.ConfigKeys;
@@ -89,7 +90,6 @@ import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.Directives;
 import akka.http.javadsl.server.ExceptionHandler;
 import akka.http.javadsl.server.PathMatchers;
-import akka.http.javadsl.server.RejectionHandler;
 import akka.http.javadsl.server.RequestContext;
 import akka.http.javadsl.server.Route;
 import akka.japi.function.Function;
@@ -266,7 +266,7 @@ public final class RootRoute {
                                                                do it here explicitly, we are able to log the status code for the
                                                                rejection (e.g. 404 or 405) in a wrapping directive. */
                                                                                                 handleRejections(
-                                                                                                        RejectionHandler.defaultHandler(),
+                                                                                                        DittoRejectionHandlerFactory.createInstance(),
                                                                                                         () ->
                                                                     /* the inner handleExceptions is for handling exceptions
                                                                        occurring in the route route. It makes sure that the

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
@@ -11,12 +11,10 @@
  */
 package org.eclipse.ditto.services.gateway.endpoints.routes.things;
 
-import static akka.http.javadsl.server.Directives.complete;
 import static akka.http.javadsl.server.Directives.delete;
 import static akka.http.javadsl.server.Directives.extractDataBytes;
 import static akka.http.javadsl.server.Directives.extractUnmatchedPath;
 import static akka.http.javadsl.server.Directives.get;
-import static akka.http.javadsl.server.Directives.handleRejections;
 import static akka.http.javadsl.server.Directives.parameter;
 import static akka.http.javadsl.server.Directives.parameterOptional;
 import static akka.http.javadsl.server.Directives.path;
@@ -43,7 +41,6 @@ import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingBuilder;
 import org.eclipse.ditto.model.things.ThingsModelFactory;
-import org.eclipse.ditto.services.gateway.endpoints.utils.DittoRejectionHandlerFactory;
 import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.services.gateway.endpoints.utils.UriEncoding;
 import org.eclipse.ditto.signals.commands.things.exceptions.ThingIdNotExplicitlySettableException;
@@ -163,15 +160,14 @@ public final class ThingsRoute extends AbstractRoute {
 
 
     private Route buildRetrieveThingsRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
-        return handleRejections(DittoRejectionHandlerFactory.createInstance(),
-                () -> parameter(ThingsParameter.IDS.toString(), idsString ->
-                        parameterOptional(ThingsParameter.FIELDS.toString(), fieldsString ->
-                                handlePerRequest(ctx, dittoHeaders, Source.empty(), emptyRequestBody -> RetrieveThings
-                                        .getBuilder((idsString).isEmpty() ? new String[0] : idsString.split(","))
-                                        .selectedFields(calculateSelectedFields(fieldsString))
-                                        .dittoHeaders(dittoHeaders).build())
-                        )
+        return parameter(ThingsParameter.IDS.toString(), idsString ->
+                parameterOptional(ThingsParameter.FIELDS.toString(), fieldsString ->
+                        handlePerRequest(ctx, dittoHeaders, Source.empty(), emptyRequestBody -> RetrieveThings
+                                .getBuilder((idsString).isEmpty() ? new String[0] : idsString.split(","))
+                                .selectedFields(calculateSelectedFields(fieldsString))
+                                .dittoHeaders(dittoHeaders).build())
                 )
+
         );
     }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/utils/DittoRejectionHandlerFactory.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/utils/DittoRejectionHandlerFactory.java
@@ -13,24 +13,28 @@ package org.eclipse.ditto.services.gateway.endpoints.utils;
 
 import static akka.http.javadsl.server.Directives.complete;
 
+import java.text.MessageFormat;
+
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.server.MissingQueryParamRejection;
 import akka.http.javadsl.server.RejectionHandler;
 import akka.http.javadsl.server.Route;
 
 /**
- * Factory to create a custom {@link akka.http.javadsl.server.RejectionHandler}
+ * Factory to create a custom {@link akka.http.javadsl.server.RejectionHandler}.
  */
 public final class DittoRejectionHandlerFactory {
 
-    private static final String MISSING_QUERY_PARAM_TEMPLATE = "Request is missing parameter: '%s'";
+    private static final String MISSING_QUERY_PARAM_TEMPLATE = "Request is missing required query parameter '{0}'";
 
-    private DittoRejectionHandlerFactory() {}
+    private DittoRejectionHandlerFactory() {
+        throw new AssertionError();
+    }
 
     /**
-     * Creates a new instance of {@link akka.http.javadsl.server.RejectionHandler} with custom behaviour
+     * Creates a new instance of {@link akka.http.javadsl.server.RejectionHandler} with custom behaviour.
      *
-     * @return The new instance
+     * @return The new instance.
      */
     public static RejectionHandler createInstance() {
         return RejectionHandler.newBuilder()
@@ -40,7 +44,8 @@ public final class DittoRejectionHandlerFactory {
     }
 
     private static Route handleMissingQueryParam(MissingQueryParamRejection missingQueryParamRejection) {
+        // return status code 400 instead of the akka default 404
         return complete(StatusCodes.BAD_REQUEST,
-                String.format(MISSING_QUERY_PARAM_TEMPLATE, missingQueryParamRejection.parameterName()));
+                MessageFormat.format(MISSING_QUERY_PARAM_TEMPLATE, missingQueryParamRejection.parameterName()));
     }
 }

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/utils/DittoRejectionHandlerFactory.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/utils/DittoRejectionHandlerFactory.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.gateway.endpoints.utils;
+
+import static akka.http.javadsl.server.Directives.complete;
+
+import akka.http.javadsl.model.StatusCodes;
+import akka.http.javadsl.server.MissingQueryParamRejection;
+import akka.http.javadsl.server.RejectionHandler;
+import akka.http.javadsl.server.Route;
+
+/**
+ * Factory to create a custom {@link akka.http.javadsl.server.RejectionHandler}
+ */
+public final class DittoRejectionHandlerFactory {
+
+    private static final String MISSING_QUERY_PARAM_TEMPLATE = "Request is missing parameter: '%s'";
+
+    private DittoRejectionHandlerFactory() {}
+
+    /**
+     * Creates a new instance of {@link akka.http.javadsl.server.RejectionHandler} with custom behaviour
+     *
+     * @return The new instance
+     */
+    public static RejectionHandler createInstance() {
+        return RejectionHandler.newBuilder()
+                .handle(MissingQueryParamRejection.class, DittoRejectionHandlerFactory::handleMissingQueryParam)
+                .build()
+                .withFallback(RejectionHandler.defaultHandler());
+    }
+
+    private static Route handleMissingQueryParam(MissingQueryParamRejection missingQueryParamRejection) {
+        return complete(StatusCodes.BAD_REQUEST,
+                String.format(MISSING_QUERY_PARAM_TEMPLATE, missingQueryParamRejection.parameterName()));
+    }
+}

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -112,7 +112,7 @@ public final class RootRouteTest extends EndpointTestBase {
     public void getThingsUrlWithoutIds() {
         final TestRouteResult result =
                 rootTestRoute.run(withHttps(withDummyAuthentication(HttpRequest.GET(THINGS_1_PATH))));
-        result.assertStatusCode(StatusCodes.NOT_FOUND);
+        result.assertStatusCode(StatusCodes.BAD_REQUEST);
     }
 
     @Test

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
@@ -73,11 +73,4 @@ public class ThingsRouteTest extends EndpointTestBase {
                 "\"description\":\"Please provide at least one thing id and try again.\"" +
                 "}");
     }
-
-    @Test
-    public void getThingsWithoutIds() {
-        final TestRouteResult result = underTest.run(HttpRequest.GET("/things"));
-        result.assertStatusCode(StatusCodes.BAD_REQUEST);
-        result.assertEntity("Request is missing parameter: 'ids'");
-    }
 }

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestBase;
-import org.eclipse.ditto.services.gateway.endpoints.routes.RootRoute;
+import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,7 +41,7 @@ public class ThingsRouteTest extends EndpointTestBase {
                 Duration.ZERO, Duration.ZERO);
 
         final Route route =
-                extractRequestContext(ctx -> thingsRoute.buildThingsRoute(ctx, DittoHeaders.newBuilder().build()));
+                extractRequestContext(ctx -> thingsRoute.buildThingsRoute(ctx, DittoHeaders.empty()));
         underTest = testRoute(route);
     }
 
@@ -63,14 +63,12 @@ public class ThingsRouteTest extends EndpointTestBase {
     }
 
     @Test
-    public void getThingsWitEmptyIdsList() {
+    public void getThingsWithEmptyIdsList() {
         final TestRouteResult result = underTest.run(HttpRequest.GET("/things?ids="));
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
-        result.assertEntity("{" +
-                "\"status\":400," +
-                "\"error\":\"things:thing.ids.missing\"," +
-                "\"message\":\"The required list of thing ids was null or empty.\"," +
-                "\"description\":\"Please provide at least one thing id and try again.\"" +
-                "}");
+        final MissingThingIdsException expectedEx = MissingThingIdsException.newBuilder()
+                .dittoHeaders(DittoHeaders.empty())
+                .build();
+        result.assertEntity(expectedEx.toJsonString());
     }
 }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -24,7 +25,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.things.ThingException;
 
 /**
- * This exception indicates that the attribute thingIds must not be null or empty.
+ * This exception is thrown when multiple things are requested without specifying IDs.
  */
 @Immutable
 public class MissingThingIdsException extends DittoRuntimeException implements ThingException {
@@ -32,41 +33,54 @@ public class MissingThingIdsException extends DittoRuntimeException implements T
     /**
      * Error code of this exception.
      */
-    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "thing.ids.missing";
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "things.ids.missing";
 
-    private static final String DEFAULT_MESSAGE = "The required list of thing ids was null or empty.";
+    /**
+     * Status code of this exception.
+     */
+    public static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
+
+    private static final String DEFAULT_MESSAGE = "The required list of thing ids was missing.";
 
     private static final String DEFAULT_DESCRIPTION = "Please provide at least one thing id and try again.";
 
-    /**
-     * Constructs a new {@code DittoRuntimeException} object.
-     *
-     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
-     * @param message the detail message for later retrieval with {@link #getMessage()}.
-     * @param description a description with further information about the exception.
-     * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
-     * @param href a link to a resource which provides further information about the exception.
-     * @throws NullPointerException if {@code errorCode}, {@code statusCode} or {@code dittoHeaders} is {@code null}.
-     */
     private MissingThingIdsException(final DittoHeaders dittoHeaders, @Nullable final String message,
             @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
-        super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+        super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
+    }
+
+    @Override
+    protected Builder getEmptyBuilder() {
+        return new Builder();
     }
 
     /**
-     * Constructs new {@link MissingThingIdsException} object with the given {@link DittoHeaders}.
+     * A mutable builder for a {@link MissingThingIdsException}.
      *
-     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
-     * @return the new MissingThingsIdsException
+     * @return the builder.
      */
-    public static MissingThingIdsException fromDittoHeaders(DittoHeaders dittoHeaders) {
-        return new Builder()
+    public static MissingThingIdsException.Builder newBuilder() {
+        return new MissingThingIdsException.Builder();
+    }
+
+    /**
+     * Constructs a new {@link MissingThingIdsException} object with the exception message extracted from the
+     * given JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new {@link MissingThingIdsException}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static MissingThingIdsException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return new MissingThingIdsException.Builder()
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
                 .build();
     }
-
     /**
-     * A mutable builder with a fluent API for a {@link org.eclipse.ditto.model.things.PolicyIdMissingException}.
+     * A mutable builder with a fluent API for a {@link MissingThingIdsException}.
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<MissingThingIdsException> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.signals.commands.things.exceptions;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.things.ThingException;
+
+/**
+ * This exception indicates that the attribute thingIds must not be null or empty.
+ */
+@Immutable
+public class MissingThingIdsException extends DittoRuntimeException implements ThingException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "thing.ids.missing";
+
+    private static final String DEFAULT_MESSAGE = "The required list of thing ids was null or empty.";
+
+    private static final String DEFAULT_DESCRIPTION = "Please provide at least one thing id and try again.";
+
+    /**
+     * Constructs a new {@code DittoRuntimeException} object.
+     *
+     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+     * @param message the detail message for later retrieval with {@link #getMessage()}.
+     * @param description a description with further information about the exception.
+     * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+     * @param href a link to a resource which provides further information about the exception.
+     * @throws NullPointerException if {@code errorCode}, {@code statusCode} or {@code dittoHeaders} is {@code null}.
+     */
+    private MissingThingIdsException(final DittoHeaders dittoHeaders, @Nullable final String message,
+            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * Constructs new {@link MissingThingIdsException} object with the given {@link DittoHeaders}.
+     *
+     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+     * @return the new MissingThingsIdsException
+     */
+    public static MissingThingIdsException fromDittoHeaders(DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link org.eclipse.ditto.model.things.PolicyIdMissingException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<MissingThingIdsException> {
+
+        private Builder() {
+            message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        @Override
+        protected MissingThingIdsException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
+                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+            return new MissingThingIdsException(dittoHeaders, message, description, cause, href);
+        }
+    }
+}

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
@@ -111,6 +111,7 @@ public final class ThingErrorRegistry extends AbstractErrorRegistry<DittoRuntime
         parseStrategies.put(FeatureDefinitionEmptyException.ERROR_CODE, FeatureDefinitionEmptyException::fromJson);
         parseStrategies.put(FeatureDefinitionIdentifierInvalidException.ERROR_CODE,
                 FeatureDefinitionIdentifierInvalidException::fromJson);
+        parseStrategies.put(MissingThingIdsException.ERROR_CODE, MissingThingIdsException::fromJson);
 
         return new ThingErrorRegistry(parseStrategies);
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThings.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThings.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.ditto.signals.commands.things.query;
 
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -40,6 +42,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.WithNamespace;
+import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 
 /**
  * Command which retrieves several {@link org.eclipse.ditto.model.things.Thing}s based on the the passed in List of
@@ -79,12 +82,19 @@ public final class RetrieveThings extends AbstractCommand<RetrieveThings>
         this(builder.thingIds, builder.selectedFields, builder.namespace, builder.dittoHeaders);
     }
 
+    /**
+     * @throws MissingThingIdsException When {@code thingIds} is empty
+     */
     private RetrieveThings(final List<String> thingIds,
             @Nullable final JsonFieldSelector selectedFields,
             @Nullable final String namespace,
             final DittoHeaders dittoHeaders) {
 
         super(TYPE, dittoHeaders);
+
+        if (thingIds.isEmpty()) {
+            throw MissingThingIdsException.fromDittoHeaders(dittoHeaders);
+        }
 
         this.thingIds = Collections.unmodifiableList(new ArrayList<>(thingIds));
         this.selectedFields = selectedFields;
@@ -122,10 +132,10 @@ public final class RetrieveThings extends AbstractCommand<RetrieveThings>
      *
      * @param thingIds one or more Thing IDs to be retrieved.
      * @return a builder for a Thing retrieving command.
-     * @throws NullPointerException if {@code authorizationContext} is {@code null}.
+     * @throws NullPointerException if {@code thingIds} is {@code null}.
      */
     public static Builder getBuilder(final String... thingIds) {
-        return new Builder(Arrays.asList(thingIds));
+        return new Builder(Arrays.asList(checkNotNull(thingIds, "thing ids")));
     }
 
     /**
@@ -133,10 +143,10 @@ public final class RetrieveThings extends AbstractCommand<RetrieveThings>
      *
      * @param thingIds the Thing IDs to be retrieved.
      * @return a builder for a Thing retrieving command.
-     * @throws NullPointerException if {@code authorizationContext} is {@code null}.
+     * @throws NullPointerException if {@code thingIds} is {@code null}.
      */
     public static Builder getBuilder(final List<String> thingIds) {
-        return new Builder(thingIds);
+        return new Builder(checkNotNull(thingIds, "thing ids"));
     }
 
     /**
@@ -145,7 +155,6 @@ public final class RetrieveThings extends AbstractCommand<RetrieveThings>
      *
      * @param retrieveThings a {@code RetrieveThings} object which acts as template for the new builder.
      * @return a builder for a Thing retrieving command.
-     * @throws NullPointerException if {@code authorizationContext} is {@code null}.
      */
     public static Builder getBuilder(final RetrieveThings retrieveThings) {
         return new Builder(retrieveThings);

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThings.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThings.java
@@ -93,7 +93,9 @@ public final class RetrieveThings extends AbstractCommand<RetrieveThings>
         super(TYPE, dittoHeaders);
 
         if (thingIds.isEmpty()) {
-            throw MissingThingIdsException.fromDittoHeaders(dittoHeaders);
+            throw MissingThingIdsException.newBuilder()
+                    .dittoHeaders(dittoHeaders)
+                    .build();
         }
 
         this.thingIds = Collections.unmodifiableList(new ArrayList<>(thingIds));

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/TestConstants.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/TestConstants.java
@@ -49,6 +49,7 @@ import org.eclipse.ditto.signals.commands.things.exceptions.FeaturePropertyNotAc
 import org.eclipse.ditto.signals.commands.things.exceptions.FeaturePropertyNotModifiableException;
 import org.eclipse.ditto.signals.commands.things.exceptions.FeaturesNotAccessibleException;
 import org.eclipse.ditto.signals.commands.things.exceptions.FeaturesNotModifiableException;
+import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 import org.eclipse.ditto.signals.commands.things.exceptions.PolicyIdNotAllowedException;
 import org.eclipse.ditto.signals.commands.things.exceptions.PolicyIdNotModifiableException;
 import org.eclipse.ditto.signals.commands.things.exceptions.PolicyNotAllowedException;
@@ -309,6 +310,9 @@ public final class TestConstants {
         public static final ThingTooManyModifyingRequestsException THING_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION =
                 ThingTooManyModifyingRequestsException.newBuilder(THING_ID).build();
 
+        public static final MissingThingIdsException MISSING_THING_IDS_EXCEPTION =
+                MissingThingIdsException.newBuilder().build();
+
         private Thing() {
             throw new AssertionError();
         }
@@ -426,7 +430,6 @@ public final class TestConstants {
         public static final FeaturePropertyNotModifiableException FEATURE_PROPERTY_NOT_MODIFIABLE_EXCEPTION =
                 FeaturePropertyNotModifiableException
                         .newBuilder(Thing.THING_ID, FLUX_CAPACITOR_ID, FLUX_CAPACITOR_PROPERTY_POINTER).build();
-
 
         private Feature() {
             throw new AssertionError();

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsExceptionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.signals.commands.things.exceptions;
+
+import static org.eclipse.ditto.signals.commands.things.TestConstants.EMPTY_DITTO_HEADERS;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Thing.MISSING_THING_IDS_EXCEPTION;
+import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.net.URI;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link MissingThingIdsException}.
+ */
+public class MissingThingIdsExceptionTest {
+
+    private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
+            .set(DittoRuntimeException.JsonFields.STATUS, MissingThingIdsException.STATUS_CODE.toInt())
+            .set(DittoRuntimeException.JsonFields.ERROR_CODE, MissingThingIdsException.ERROR_CODE)
+            .set(DittoRuntimeException.JsonFields.MESSAGE, MISSING_THING_IDS_EXCEPTION.getMessage())
+            .set(DittoRuntimeException.JsonFields.DESCRIPTION,
+                    MISSING_THING_IDS_EXCEPTION.getDescription().orElse(null),
+                    JsonField.isValueNonNull())
+            .set(DittoRuntimeException.JsonFields.HREF,
+                    MISSING_THING_IDS_EXCEPTION.getHref()
+                            .map(URI::toString)
+                            .orElse(null),
+                    JsonField.isValueNonNull())
+            .build();
+
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(MissingThingIdsException.class, areImmutable());
+    }
+
+
+    @Test
+    public void toJsonReturnsExpected() {
+        final JsonObject jsonObject = MISSING_THING_IDS_EXCEPTION.toJson();
+
+        assertThat(jsonObject).isEqualTo(KNOWN_JSON);
+    }
+
+
+    @Test
+    public void createInstanceFromValidJson() {
+        final MissingThingIdsException underTest =
+                MissingThingIdsException.fromJson(KNOWN_JSON, EMPTY_DITTO_HEADERS);
+
+        assertThat(underTest).isEqualTo(MISSING_THING_IDS_EXCEPTION);
+    }
+
+
+    @Test
+    public void checkThingErrorCodeWorks() {
+        final DittoRuntimeException actual =
+                ThingErrorRegistry.newInstance().parse(KNOWN_JSON, EMPTY_DITTO_HEADERS);
+
+        assertThat(actual).isEqualTo(MISSING_THING_IDS_EXCEPTION);
+    }
+
+
+    @Test
+    public void copy() {
+        final DittoRuntimeException copy = DittoRuntimeException.newBuilder(MISSING_THING_IDS_EXCEPTION).build();
+
+        assertThat(copy).isEqualTo(MISSING_THING_IDS_EXCEPTION);
+    }
+
+}

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsTest.java
@@ -32,15 +32,12 @@ import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommand;
 import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Unit test for {@link RetrieveThings}.
  */
-@RunWith(MockitoJUnitRunner.class)
 public final class RetrieveThingsTest {
 
     private static final JsonArray THING_IDS = JsonFactory.newArrayBuilder()

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsTest.java
@@ -16,6 +16,7 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommand;
+import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -180,4 +182,25 @@ public final class RetrieveThingsTest {
         assertThat(retrieveThings).isEqualTo(retrieveThings2);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void initializationWithNullForThingIdsArrayThrowsNullPointerException(){
+        //This cast is used to resolve the ambiguous call
+        RetrieveThings.getBuilder( (String[]) null).build();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void initializationWithNullForThingIdsListThrowsNullPointerException(){
+        //This cast is used to resolve the ambiguous call
+        RetrieveThings.getBuilder( (List<String>) null).build();
+    }
+
+    @Test(expected = MissingThingIdsException.class)
+    public void initializationWithoutThingIdsThrowsMissingThingIdsException(){
+        RetrieveThings.getBuilder().build();
+    }
+
+    @Test(expected = MissingThingIdsException.class)
+    public void initializationWithEmptyThingIdsListThrowsMissingThingIdsException(){
+        RetrieveThings.getBuilder(new ArrayList<>()).build();
+    }
 }


### PR DESCRIPTION
A NullPointerException occured when a user tried to retrieve things with an empty ids-parameter, e.g. by running the following REST request:
`GET '/api/2/things?ids=`

The user got status code 503 as a consequence. This PR fixes this by returning status code 400 with an appropriate error message instead.

In this context, we also changed the way missing parameters are handled (for ditto in general). If the user did not specify the ids-parameter at all, she got a 404 status code (akka default for _MissingQueryParamRejection_). We changed this to a 400 response, because we consider such a request as bad input, so "Bad Request" is more helpful than "Not Found". 

