### PR TITLE
Optimize search indexes, take 2

### DIFF
--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/Indices.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/Indices.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.ditto.services.thingsearch.persistence;
 
+import static org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants.FIELD_DELETED;
 import static org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants.FIELD_FEATURE_PATH_KEY;
 import static org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants.FIELD_ID;
 import static org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants.FIELD_INTERNAL_ACL;
@@ -53,13 +54,16 @@ public final class Indices {
                 keys(FIELD_INTERNAL_GLOBAL_READS), false)
                 .withPartialFilterExpression(filterNotDeleted());
 
+        private static final Index DELETED = IndexFactory.newInstance("deleted",
+                keys(FIELD_DELETED), false);
+
         /**
          * Gets all defined indices.
          *
          * @return the indices
          */
         public static List<Index> all() {
-            return Collections.unmodifiableList(Arrays.asList(KEY_VALUE, ACL, GLOBAL_READS));
+            return Collections.unmodifiableList(Arrays.asList(KEY_VALUE, ACL, GLOBAL_READS, DELETED));
         }
 
         private static List<String> keys(final String... keyNames) {

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/Indices.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/Indices.java
@@ -45,12 +45,12 @@ public final class Indices {
                 keys(FIELD_NAMESPACE, FIELD_FEATURE_PATH_KEY, FIELD_PATH_KEY, FIELD_PATH_VALUE, FIELD_ID), false)
                 .withPartialFilterExpression(filterNotDeleted());
 
-        private static final Index GLOBAL_READS = IndexFactory.newInstance("ngr",
-                keys(FIELD_NAMESPACE, FIELD_INTERNAL_GLOBAL_READS, FIELD_ID), false)
+        private static final Index ACL = IndexFactory.newInstance("acl",
+                keys(FIELD_INTERNAL_ACL, FIELD_ID), false)
                 .withPartialFilterExpression(filterNotDeleted());
 
-        private static final Index ACL = IndexFactory.newInstance("na",
-                keys(FIELD_NAMESPACE, FIELD_INTERNAL_ACL, FIELD_ID), false)
+        private static final Index GLOBAL_READS = IndexFactory.newInstance("gr",
+                keys(FIELD_INTERNAL_GLOBAL_READS), false)
                 .withPartialFilterExpression(filterNotDeleted());
 
         /**


### PR DESCRIPTION
This follows up #159 
- Remove the dimension `namespace` from indices on `__internal.acl` and `__internal.gr`.
- Add an index on `__deleted`.

Reason:
Search queries without the namespace parameter cannot take full advantage of compound indices starting with `namespace`. Such queries are generated by `StatsRoute` for example.