### PR TITLE
Fix activity check in Policy- and ThingPersistenceActor

### DIFF
--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
@@ -894,6 +894,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
     public void checkForActivityOfNonexistentPolicy() {
         new TestKit(actorSystem) {
             {
+                watch(actorSystem.guardian());
+
                 // GIVEN: props increments counter whenever a PolicyPersistenceActor is created
                 final AtomicInteger restartCounter = new AtomicInteger(0);
                 final String policyId = "test.ns:nonexistent.policy";
@@ -909,9 +911,9 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                 underTest.tell(checkForActivity, ActorRef.noSender());
                 underTest.tell(checkForActivity, ActorRef.noSender());
                 underTest.tell(checkForActivity, ActorRef.noSender());
-                // ensure processing of check-for-activity messages by waiting for 1 cycle
-                underTest.tell(RetrievePolicy.of(policyId, DittoHeaders.empty()), getRef());
-                expectMsgClass(PolicyNotAccessibleException.class);
+
+                // THEN: persistence actor shuts down parent (user guardian)
+                expectTerminated(actorSystem.guardian());
 
                 // THEN: actor should not restart itself.
                 assertThat(restartCounter.get()).isEqualTo(1);

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActorTest.java
@@ -1515,6 +1515,8 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
     public void checkForActivityOfNonexistentThing() {
         new TestKit(actorSystem) {
             {
+                watch(actorSystem.guardian());
+
                 // GIVEN: props increments counter whenever a ThingPersistenceActor is created
                 final AtomicInteger restartCounter = new AtomicInteger(0);
                 final String thingId = "test.ns:nonexistent.thing";
@@ -1530,9 +1532,9 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                 underTest.tell(checkForActivity, ActorRef.noSender());
                 underTest.tell(checkForActivity, ActorRef.noSender());
                 underTest.tell(checkForActivity, ActorRef.noSender());
-                // ensure processing of check-for-activity messages by waiting for 1 message roundtrip
-                underTest.tell(RetrieveThing.of(thingId, DittoHeaders.empty()), getRef());
-                expectMsgClass(ThingNotAccessibleException.class);
+
+                // THEN: persistence actor shuts down parent (user guardian)
+                expectTerminated(actorSystem.guardian());
 
                 // THEN: actor should not restart itself.
                 assertThat(restartCounter.get()).isEqualTo(1);


### PR DESCRIPTION
- Activity check should not be ignored by nonexistent things;
  it could lead to memory leak.

- Fixed concurrency issue in unit tests: Activity checks cause
  persistence actors to terminate parents, after which they
  cannot process any message. Tests now wait for actor
  termination instead of any reply from persistence actors.