### PR TITLE
hide details about the "namespace hotness" behind secured HTTP resource

### DIFF
--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutablePayload.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutablePayload.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -37,18 +38,21 @@ final class ImmutablePayload implements Payload {
     @Nullable private final JsonValue value;
     @Nullable private final HttpStatusCode status;
     @Nullable private final Long revision;
+    @Nullable private final Instant timestamp;
     @Nullable private final JsonFieldSelector fields;
 
     private ImmutablePayload(final MessagePath path,
             @Nullable final JsonValue value,
             @Nullable final HttpStatusCode status,
             @Nullable final Long revision,
+            @Nullable final Instant timestamp,
             @Nullable final JsonFieldSelector fields) {
 
         this.path = checkNotNull(path, "path");
         this.value = value;
         this.status = status;
         this.revision = revision;
+        this.timestamp = timestamp;
         this.fields = fields;
     }
 
@@ -69,7 +73,29 @@ final class ImmutablePayload implements Payload {
             @Nullable final HttpStatusCode status,
             @Nullable final Long revision,
             @Nullable final JsonFieldSelector fields) {
-        return new ImmutablePayload(ImmutableMessagePath.of(path), value, status, revision, fields);
+        return of(ImmutableMessagePath.of(path), value, status, revision, null, fields);
+    }
+
+    /**
+     * Returns a new ImmutablePayload for the specified {@code path}, {@code value}, {@code status}, {@code revision},
+     * {@code timestamp} and {@code fields}.
+     *
+     * @param path the path.
+     * @param value the optional value.
+     * @param status the optional status.
+     * @param revision the optional revision.
+     * @param timestamp the optional timestamp.
+     * @param fields the optional fields.
+     * @return the payload.
+     * @throws NullPointerException if {@code path} is {@code null}.
+     */
+    public static ImmutablePayload of(final JsonPointer path,
+            @Nullable final JsonValue value,
+            @Nullable final HttpStatusCode status,
+            @Nullable final Long revision,
+            @Nullable final Instant timestamp,
+            @Nullable final JsonFieldSelector fields) {
+        return new ImmutablePayload(ImmutableMessagePath.of(path), value, status, revision, timestamp, fields);
     }
 
     /**
@@ -90,12 +116,13 @@ final class ImmutablePayload implements Payload {
                 .orElse(null);
 
         final Long revision = jsonObject.getValue(JsonFields.REVISION).orElse(null);
+        final Instant timestamp = jsonObject.getValue(JsonFields.TIMESTAMP).map(Instant::parse).orElse(null);
 
         final JsonFieldSelector fields = jsonObject.getValue(JsonFields.FIELDS)
                 .map(JsonFieldSelector::newInstance)
                 .orElse(null);
 
-        return of(path, value, status, revision, fields);
+        return of(path, value, status, revision, timestamp, fields);
     }
 
     @Override
@@ -116,6 +143,11 @@ final class ImmutablePayload implements Payload {
     @Override
     public Optional<Long> getRevision() {
         return Optional.ofNullable(revision);
+    }
+
+    @Override
+    public Optional<Instant> getTimestamp() {
+        return Optional.ofNullable(timestamp);
     }
 
     @Override
@@ -140,6 +172,10 @@ final class ImmutablePayload implements Payload {
             jsonObjectBuilder.set(JsonFields.REVISION, revision);
         }
 
+        if (null != timestamp) {
+            jsonObjectBuilder.set(JsonFields.TIMESTAMP, timestamp.toString());
+        }
+
         if (null != fields) {
             jsonObjectBuilder.set(JsonFields.FIELDS, fields.toString());
         }
@@ -158,18 +194,19 @@ final class ImmutablePayload implements Payload {
         }
         final ImmutablePayload that = (ImmutablePayload) o;
         return Objects.equals(path, that.path) && Objects.equals(value, that.value) && status == that.status
-                && Objects.equals(revision, that.revision) && Objects.equals(fields, that.fields);
+                && Objects.equals(revision, that.revision) && Objects.equals(timestamp, that.timestamp)
+                && Objects.equals(fields, that.fields);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(path, value, status, revision, fields);
+        return Objects.hash(path, value, status, revision, timestamp, fields);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" + "path=" + path + ", value=" + value + ", status=" + status
-                + ", revision=" + revision + ", fields=" + fields + ']';
+                + ", revision=" + revision + ", timestamp=" + timestamp + ", fields=" + fields + ']';
     }
 
 }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutablePayloadBuilder.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutablePayloadBuilder.java
@@ -11,6 +11,8 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
+import java.time.Instant;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -30,6 +32,7 @@ final class ImmutablePayloadBuilder implements PayloadBuilder {
     private JsonValue value;
     private HttpStatusCode status;
     private Long revision;
+    @Nullable private Instant timestamp;
     private JsonFieldSelector fields;
 
     private ImmutablePayloadBuilder(@Nullable final JsonPointer path) {
@@ -72,6 +75,12 @@ final class ImmutablePayloadBuilder implements PayloadBuilder {
     }
 
     @Override
+    public PayloadBuilder withTimestamp(@Nullable final Instant timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    @Override
     public PayloadBuilder withFields(final JsonFieldSelector fields) {
         this.fields = fields;
         return this;
@@ -85,7 +94,7 @@ final class ImmutablePayloadBuilder implements PayloadBuilder {
 
     @Override
     public Payload build() {
-        return ImmutablePayload.of(path, value, status, revision, fields);
+        return ImmutablePayload.of(path, value, status, revision, timestamp, fields);
     }
 
 }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Payload.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Payload.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
+import java.time.Instant;
 import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
@@ -79,6 +80,13 @@ public interface Payload extends Jsonifiable<JsonObject> {
     Optional<Long> getRevision();
 
     /**
+     * Returns the {@code timestamp} of this {@code Payload} if present.
+     *
+     * @return the optional timestamp.
+     */
+    Optional<Instant> getTimestamp();
+
+    /**
      * Returns the {@code fields} of this {@code Payload} if present.
      *
      * @return the optional fields.
@@ -110,6 +118,11 @@ public interface Payload extends Jsonifiable<JsonObject> {
          * JSON field containing the revision.
          */
         static final JsonFieldDefinition<Long> REVISION = JsonFactory.newLongFieldDefinition("revision");
+
+        /**
+         * JSON field containing the revision.
+         */
+        static final JsonFieldDefinition<String> TIMESTAMP = JsonFactory.newStringFieldDefinition("timestamp");
 
         /**
          * JSON field containing the fields.

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/PayloadBuilder.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/PayloadBuilder.java
@@ -11,6 +11,10 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
+import java.time.Instant;
+
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -51,6 +55,14 @@ public interface PayloadBuilder {
      * @return this builder to allow method chaining.
      */
     PayloadBuilder withRevision(long revision);
+
+    /**
+     * Sets the given {@code timestamp} to this builder. A previously set timestamp is replaced.
+     *
+     * @param timestamp the timestamp to set.
+     * @return this builder to allow method chaining.
+     */
+    PayloadBuilder withTimestamp(@Nullable Instant timestamp);
 
     /**
      * Sets the given {@code fields} to this builder. Previously set fields are replaced.

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ThingEventAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ThingEventAdapter.java
@@ -11,9 +11,12 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+
+import javax.annotation.Nullable;
 
 import org.eclipse.ditto.json.JsonMissingFieldException;
 import org.eclipse.ditto.json.JsonPointer;
@@ -53,9 +56,9 @@ import org.eclipse.ditto.signals.events.things.ThingModified;
 /**
  * Adapter for mapping a {@link ThingEvent} to and from an {@link Adaptable}.
  */
-final class ThingEventAdapter extends AbstractAdapter<ThingEvent> {
+final class ThingEventAdapter extends AbstractAdapter<ThingEvent<?>> {
 
-    private ThingEventAdapter(final Map<String, JsonifiableMapper<ThingEvent>> mappingStrategies) {
+    private ThingEventAdapter(final Map<String, JsonifiableMapper<ThingEvent<?>>> mappingStrategies) {
         super(mappingStrategies);
     }
 
@@ -68,106 +71,113 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent> {
         return new ThingEventAdapter(mappingStrategies());
     }
 
-    private static Map<String, JsonifiableMapper<ThingEvent>> mappingStrategies() {
-        final Map<String, JsonifiableMapper<ThingEvent>> mappingStrategies = new HashMap<>();
+    private static Map<String, JsonifiableMapper<ThingEvent<?>>> mappingStrategies() {
+        final Map<String, JsonifiableMapper<ThingEvent<?>>> mappingStrategies = new HashMap<>();
 
         mappingStrategies.put(ThingCreated.TYPE,
-                adaptable -> ThingCreated.of(thingFrom(adaptable), revisionFrom(adaptable),
+                adaptable -> ThingCreated.of(thingFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(ThingModified.TYPE,
-                adaptable -> ThingModified.of(thingFrom(adaptable), revisionFrom(adaptable),
+                adaptable -> ThingModified.of(thingFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(ThingDeleted.TYPE,
-                adaptable -> ThingDeleted.of(thingIdFrom(adaptable), revisionFrom(adaptable),
+                adaptable -> ThingDeleted.of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(AclModified.TYPE, adaptable -> AclModified
-                .of(thingIdFrom(adaptable), aclFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), aclFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(AclEntryCreated.TYPE, adaptable -> AclEntryCreated
-                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AclEntryModified.TYPE, adaptable -> AclEntryModified
-                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AclEntryDeleted.TYPE, adaptable -> AclEntryDeleted
                 .of(thingIdFrom(adaptable), authorizationSubjectFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(AttributesCreated.TYPE, adaptable -> AttributesCreated
                 .of(thingIdFrom(adaptable), attributesFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AttributesModified.TYPE, adaptable -> AttributesModified
                 .of(thingIdFrom(adaptable), attributesFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AttributesDeleted.TYPE, adaptable -> AttributesDeleted
-                .of(thingIdFrom(adaptable), revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                .of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(AttributeCreated.TYPE, adaptable -> AttributeCreated
                 .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), attributeValueFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AttributeModified.TYPE, adaptable -> AttributeModified
                 .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), attributeValueFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(AttributeDeleted.TYPE, adaptable -> AttributeDeleted
                 .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), revisionFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(FeaturesCreated.TYPE, adaptable -> FeaturesCreated
-                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturesModified.TYPE, adaptable -> FeaturesModified
-                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturesDeleted.TYPE, adaptable -> FeaturesDeleted
-                .of(thingIdFrom(adaptable), revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                .of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(FeatureCreated.TYPE, adaptable -> FeatureCreated
-                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeatureModified.TYPE, adaptable -> FeatureModified
-                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeatureDeleted.TYPE, adaptable -> FeatureDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(FeatureDefinitionCreated.TYPE, adaptable -> FeatureDefinitionCreated
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featureDefinitionFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeatureDefinitionModified.TYPE, adaptable -> FeatureDefinitionModified
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featureDefinitionFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeatureDefinitionDeleted.TYPE, adaptable -> FeatureDefinitionDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(FeaturePropertiesCreated.TYPE, adaptable -> FeaturePropertiesCreated
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertiesFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturePropertiesModified.TYPE, adaptable -> FeaturePropertiesModified
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertiesFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturePropertiesDeleted.TYPE, adaptable -> FeaturePropertiesDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(FeaturePropertyCreated.TYPE, adaptable -> FeaturePropertyCreated
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
-                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturePropertyModified.TYPE, adaptable -> FeaturePropertyModified
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
-                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
         mappingStrategies.put(FeaturePropertyDeleted.TYPE, adaptable -> FeaturePropertyDeleted
                 .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
-                        revisionFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
 
         mappingStrategies.put(PolicyIdCreated.TYPE, adaptable -> PolicyIdCreated
-                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
         mappingStrategies.put(PolicyIdModified.TYPE, adaptable -> PolicyIdModified
-                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable),
+                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
         return mappingStrategies;
@@ -176,6 +186,11 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent> {
     private static long revisionFrom(final Adaptable adaptable) {
         return adaptable.getPayload().getRevision().orElseThrow(() -> JsonMissingFieldException.newBuilder()
                 .fieldName(Payload.JsonFields.REVISION.getPointer().toString()).build());
+    }
+
+    @Nullable
+    private static Instant timestampFrom(final Adaptable adaptable) {
+        return adaptable.getPayload().getTimestamp().orElse(null);
     }
 
     @Override
@@ -194,7 +209,7 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent> {
     }
 
     @Override
-    public Adaptable toAdaptable(final ThingEvent event, final TopicPath.Channel channel) {
+    public Adaptable toAdaptable(final ThingEvent<?> event, final TopicPath.Channel channel) {
         final TopicPathBuilder topicPathBuilder = ProtocolFactory.newTopicPathBuilder(event.getThingId());
 
         final EventsTopicPathBuilder eventsTopicPathBuilder;
@@ -217,16 +232,17 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent> {
             throw UnknownEventException.newBuilder(eventName).build();
         }
 
-        final PayloadBuilder payloadBuilder = Payload.newBuilder(event.getResourcePath()) //
+        final PayloadBuilder payloadBuilder = Payload.newBuilder(event.getResourcePath())
                 .withRevision(event.getRevision());
+        event.getTimestamp().ifPresent(payloadBuilder::withTimestamp);
 
         final Optional<JsonValue> value =
                 event.getEntity(event.getDittoHeaders().getSchemaVersion().orElse(event.getLatestSchemaVersion()));
         value.ifPresent(payloadBuilder::withValue);
 
-        return Adaptable.newBuilder(eventsTopicPathBuilder.build()) //
-                .withPayload(payloadBuilder.build()) //
-                .withHeaders(ProtocolFactory.newHeadersWithDittoContentType(event.getDittoHeaders())) //
+        return Adaptable.newBuilder(eventsTopicPathBuilder.build())
+                .withPayload(payloadBuilder.build())
+                .withHeaders(ProtocolFactory.newHeadersWithDittoContentType(event.getDittoHeaders()))
                 .build();
     }
 

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ThingEventAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ThingEventAdapter.java
@@ -84,101 +84,105 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent<?>> {
                 adaptable -> ThingDeleted.of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
 
-        mappingStrategies.put(AclModified.TYPE, adaptable -> AclModified
-                .of(thingIdFrom(adaptable), aclFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(AclModified.TYPE,
+                adaptable -> AclModified.of(thingIdFrom(adaptable), aclFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
 
-        mappingStrategies.put(AclEntryCreated.TYPE, adaptable -> AclEntryCreated
-                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AclEntryModified.TYPE, adaptable -> AclEntryModified
-                .of(thingIdFrom(adaptable), aclEntryFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AclEntryDeleted.TYPE, adaptable -> AclEntryDeleted
-                .of(thingIdFrom(adaptable), authorizationSubjectFrom(adaptable), revisionFrom(adaptable),
-                        timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(AttributesCreated.TYPE, adaptable -> AttributesCreated
-                .of(thingIdFrom(adaptable), attributesFrom(adaptable), revisionFrom(adaptable),
-                        timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AttributesModified.TYPE, adaptable -> AttributesModified
-                .of(thingIdFrom(adaptable), attributesFrom(adaptable), revisionFrom(adaptable),
-                        timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AttributesDeleted.TYPE, adaptable -> AttributesDeleted
-                .of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(AttributeCreated.TYPE, adaptable -> AttributeCreated
-                .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), attributeValueFrom(adaptable),
+        mappingStrategies.put(AclEntryCreated.TYPE,
+                adaptable -> AclEntryCreated.of(thingIdFrom(adaptable), aclEntryFrom(adaptable),
                         revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AttributeModified.TYPE, adaptable -> AttributeModified
-                .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), attributeValueFrom(adaptable),
+        mappingStrategies.put(AclEntryModified.TYPE,
+                adaptable -> AclEntryModified.of(thingIdFrom(adaptable), aclEntryFrom(adaptable),
                         revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(AttributeDeleted.TYPE, adaptable -> AttributeDeleted
-                .of(thingIdFrom(adaptable), attributePointerFrom(adaptable), revisionFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(FeaturesCreated.TYPE, adaptable -> FeaturesCreated
-                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturesModified.TYPE, adaptable -> FeaturesModified
-                .of(thingIdFrom(adaptable), featuresFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturesDeleted.TYPE, adaptable -> FeaturesDeleted
-                .of(thingIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(FeatureCreated.TYPE, adaptable -> FeatureCreated
-                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeatureModified.TYPE, adaptable -> FeatureModified
-                .of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeatureDeleted.TYPE, adaptable -> FeatureDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(FeatureDefinitionCreated.TYPE, adaptable -> FeatureDefinitionCreated
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featureDefinitionFrom(adaptable),
-                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeatureDefinitionModified.TYPE, adaptable -> FeatureDefinitionModified
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featureDefinitionFrom(adaptable),
-                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeatureDefinitionDeleted.TYPE, adaptable -> FeatureDefinitionDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(FeaturePropertiesCreated.TYPE, adaptable -> FeaturePropertiesCreated
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertiesFrom(adaptable),
-                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturePropertiesModified.TYPE, adaptable -> FeaturePropertiesModified
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertiesFrom(adaptable),
-                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturePropertiesDeleted.TYPE, adaptable -> FeaturePropertiesDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-
-        mappingStrategies.put(FeaturePropertyCreated.TYPE, adaptable -> FeaturePropertyCreated
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
-                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturePropertyModified.TYPE, adaptable -> FeaturePropertyModified
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
-                        featurePropertyValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
-                        dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(FeaturePropertyDeleted.TYPE, adaptable -> FeaturePropertyDeleted
-                .of(thingIdFrom(adaptable), featureIdFrom(adaptable), featurePropertyPointerFrom(adaptable),
+        mappingStrategies.put(AclEntryDeleted.TYPE,
+                adaptable -> AclEntryDeleted.of(thingIdFrom(adaptable), authorizationSubjectFrom(adaptable),
                         revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
 
-        mappingStrategies.put(PolicyIdCreated.TYPE, adaptable -> PolicyIdCreated
-                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+        mappingStrategies.put(AttributesCreated.TYPE,
+                adaptable -> AttributesCreated.of(thingIdFrom(adaptable), attributesFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(AttributesModified.TYPE,
+                adaptable -> AttributesModified.of(thingIdFrom(adaptable), attributesFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(AttributesDeleted.TYPE,
+                adaptable -> AttributesDeleted.of(thingIdFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(AttributeCreated.TYPE,
+                adaptable -> AttributeCreated.of(thingIdFrom(adaptable), attributePointerFrom(adaptable),
+                        attributeValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
-        mappingStrategies.put(PolicyIdModified.TYPE, adaptable -> PolicyIdModified
-                .of(thingIdFrom(adaptable), policyIdFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+        mappingStrategies.put(AttributeModified.TYPE,
+                adaptable -> AttributeModified.of(thingIdFrom(adaptable), attributePointerFrom(adaptable),
+                        attributeValueFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
                         dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(AttributeDeleted.TYPE,
+                adaptable -> AttributeDeleted.of(thingIdFrom(adaptable), attributePointerFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(FeaturesCreated.TYPE,
+                adaptable -> FeaturesCreated.of(thingIdFrom(adaptable), featuresFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturesModified.TYPE,
+                adaptable -> FeaturesModified.of(thingIdFrom(adaptable), featuresFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturesDeleted.TYPE,
+                adaptable -> FeaturesDeleted.of(thingIdFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(FeatureCreated.TYPE,
+                adaptable -> FeatureCreated.of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeatureModified.TYPE,
+                adaptable -> FeatureModified.of(thingIdFrom(adaptable), featureFrom(adaptable), revisionFrom(adaptable),
+                        timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeatureDeleted.TYPE,
+                adaptable -> FeatureDeleted.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(FeatureDefinitionCreated.TYPE,
+                adaptable -> FeatureDefinitionCreated.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featureDefinitionFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeatureDefinitionModified.TYPE,
+                adaptable -> FeatureDefinitionModified.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featureDefinitionFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeatureDefinitionDeleted.TYPE,
+                adaptable -> FeatureDefinitionDeleted.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(FeaturePropertiesCreated.TYPE,
+                adaptable -> FeaturePropertiesCreated.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featurePropertiesFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturePropertiesModified.TYPE,
+                adaptable -> FeaturePropertiesModified.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featurePropertiesFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturePropertiesDeleted.TYPE,
+                adaptable -> FeaturePropertiesDeleted.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(FeaturePropertyCreated.TYPE,
+                adaptable -> FeaturePropertyCreated.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featurePropertyPointerFrom(adaptable), featurePropertyValueFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturePropertyModified.TYPE,
+                adaptable -> FeaturePropertyModified.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featurePropertyPointerFrom(adaptable), featurePropertyValueFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(FeaturePropertyDeleted.TYPE,
+                adaptable -> FeaturePropertyDeleted.of(thingIdFrom(adaptable), featureIdFrom(adaptable),
+                        featurePropertyPointerFrom(adaptable), revisionFrom(adaptable), timestampFrom(adaptable),
+                        dittoHeadersFrom(adaptable)));
+
+        mappingStrategies.put(PolicyIdCreated.TYPE,
+                adaptable -> PolicyIdCreated.of(thingIdFrom(adaptable), policyIdFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
+        mappingStrategies.put(PolicyIdModified.TYPE,
+                adaptable -> PolicyIdModified.of(thingIdFrom(adaptable), policyIdFrom(adaptable),
+                        revisionFrom(adaptable), timestampFrom(adaptable), dittoHeadersFrom(adaptable)));
 
         return mappingStrategies;
     }
@@ -193,19 +197,19 @@ final class ThingEventAdapter extends AbstractAdapter<ThingEvent<?>> {
         return adaptable.getPayload().getTimestamp().orElse(null);
     }
 
+    private static String getActionNameWithFirstLetterUpperCase(final TopicPath topicPath) {
+        return topicPath.getAction()
+                .map(TopicPath.Action::toString)
+                .map(AbstractAdapter::upperCaseFirst)
+                .orElseThrow(() -> new NullPointerException("TopicPath did not contain an Action!"));
+    }
+
     @Override
     protected String getType(final Adaptable adaptable) {
         final TopicPath topicPath = adaptable.getTopicPath();
         final JsonPointer path = adaptable.getPayload().getPath();
         final String eventName = PathMatcher.match(path) + getActionNameWithFirstLetterUpperCase(topicPath);
         return topicPath.getGroup() + "." + topicPath.getCriterion() + ":" + eventName;
-    }
-
-    private static String getActionNameWithFirstLetterUpperCase(final TopicPath topicPath) {
-        return topicPath.getAction()
-                .map(TopicPath.Action::toString)
-                .map(AbstractAdapter::upperCaseFirst)
-                .orElseThrow(() -> new NullPointerException("TopicPath did not contain an Action!"));
     }
 
     @Override

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptableTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptableTest.java
@@ -16,6 +16,8 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.time.Instant;
+
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -41,6 +43,7 @@ public final class ImmutableJsonifiableAdaptableTest {
     private static final JsonValue KNOWN_VALUE = JsonValue.of("foo");
     private static final HttpStatusCode KNOWN_STATUS = HttpStatusCode.OK;
     private static final long KNOWN_REVISION = 1337;
+    private static final Instant KNOWN_TIMESTAMP = Instant.now();
     private static final JsonFieldSelector KNOWN_FIELDS = JsonFieldSelector.newInstance("/foo");
 
     @Test
@@ -70,11 +73,13 @@ public final class ImmutableJsonifiableAdaptableTest {
                 .set(Payload.JsonFields.VALUE, KNOWN_VALUE)
                 .set(Payload.JsonFields.STATUS, KNOWN_STATUS.toInt())
                 .set(Payload.JsonFields.REVISION, KNOWN_REVISION)
+                .set(Payload.JsonFields.TIMESTAMP, KNOWN_TIMESTAMP.toString())
                 .set(Payload.JsonFields.FIELDS, KNOWN_FIELDS.toString())
                 .build();
 
         final ImmutablePayload payload =
-                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_FIELDS);
+                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_TIMESTAMP,
+                        KNOWN_FIELDS);
 
         final Adaptable adaptable = ImmutableAdaptable.of(ProtocolFactory.newTopicPath(KNOWN_TOPIC), payload,
                 DittoHeaders.newBuilder(KNOWN_HEADERS).build());
@@ -88,7 +93,8 @@ public final class ImmutableJsonifiableAdaptableTest {
     @Test
     public void jsonDeserializationWorksAsExpected() {
         final ImmutablePayload payload =
-                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_FIELDS);
+                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_TIMESTAMP,
+                        KNOWN_FIELDS);
 
         final Adaptable adaptable = ImmutableAdaptable.of(ProtocolFactory.newTopicPath(KNOWN_TOPIC), payload,
                 DittoHeaders.newBuilder(KNOWN_HEADERS).build());
@@ -101,6 +107,7 @@ public final class ImmutableJsonifiableAdaptableTest {
                 .set(Payload.JsonFields.VALUE, KNOWN_VALUE)
                 .set(Payload.JsonFields.STATUS, KNOWN_STATUS.toInt())
                 .set(Payload.JsonFields.REVISION, KNOWN_REVISION)
+                .set(Payload.JsonFields.TIMESTAMP, KNOWN_TIMESTAMP.toString())
                 .set(Payload.JsonFields.FIELDS, KNOWN_FIELDS.toString())
                 .build();
 

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ImmutablePayloadTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ImmutablePayloadTest.java
@@ -16,12 +16,16 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.time.Instant;
+
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.junit.Test;
+
+import com.sun.corba.se.impl.protocol.INSServerRequestDispatcher;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -34,6 +38,7 @@ public final class ImmutablePayloadTest {
     private static final JsonValue KNOWN_VALUE = JsonValue.of("foo");
     private static final HttpStatusCode KNOWN_STATUS = HttpStatusCode.OK;
     private static final long KNOWN_REVISION = 1337;
+    private static final Instant KNOWN_TIMESTAMP = Instant.now();
     private static final JsonFieldSelector KNOWN_FIELDS = JsonFieldSelector.newInstance("/foo");
 
     @Test
@@ -57,11 +62,13 @@ public final class ImmutablePayloadTest {
                 .set(Payload.JsonFields.VALUE, KNOWN_VALUE)
                 .set(Payload.JsonFields.STATUS, KNOWN_STATUS.toInt())
                 .set(Payload.JsonFields.REVISION, KNOWN_REVISION)
+                .set(Payload.JsonFields.TIMESTAMP, KNOWN_TIMESTAMP.toString())
                 .set(Payload.JsonFields.FIELDS, KNOWN_FIELDS.toString())
                 .build();
 
         final ImmutablePayload payload =
-                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_FIELDS);
+                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_TIMESTAMP,
+                        KNOWN_FIELDS);
 
         final JsonObject actual = payload.toJson();
 
@@ -71,13 +78,15 @@ public final class ImmutablePayloadTest {
     @Test
     public void jsonDeserializationWorksAsExpected() {
         final ImmutablePayload expected =
-                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_FIELDS);
+                ImmutablePayload.of(KNOWN_PATH, KNOWN_VALUE, KNOWN_STATUS, KNOWN_REVISION, KNOWN_TIMESTAMP,
+                        KNOWN_FIELDS);
 
         final JsonObject payloadJsonObject = JsonObject.newBuilder()
                 .set(Payload.JsonFields.PATH, KNOWN_PATH.toString())
                 .set(Payload.JsonFields.VALUE, KNOWN_VALUE)
                 .set(Payload.JsonFields.STATUS, KNOWN_STATUS.toInt())
                 .set(Payload.JsonFields.REVISION, KNOWN_REVISION)
+                .set(Payload.JsonFields.TIMESTAMP, KNOWN_TIMESTAMP.toString())
                 .set(Payload.JsonFields.FIELDS, KNOWN_FIELDS.toString())
                 .build();
 

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingEventAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingEventAdapterTest.java
@@ -108,8 +108,9 @@ public final class ThingEventAdapterTest {
 
     @Test
     public void thingCreatedFromAdaptable() {
+        final Instant now = Instant.now();
         final ThingCreated expected =
-                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, TestConstants.DITTO_HEADERS_V_2);
+                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, now, TestConstants.DITTO_HEADERS_V_2);
 
         final JsonPointer path = JsonPointer.empty();
 
@@ -117,6 +118,7 @@ public final class ThingEventAdapterTest {
                 .withPayload(Payload.newBuilder(path)
                         .withValue(TestConstants.THING.toJson(FieldType.notHidden()))
                         .withRevision(TestConstants.REVISION)
+                        .withTimestamp(now)
                         .build())
                 .withHeaders(TestConstants.HEADERS_V_2)
                 .build();
@@ -129,16 +131,18 @@ public final class ThingEventAdapterTest {
     public void thingCreatedToAdaptable() {
         final JsonPointer path = JsonPointer.empty();
 
+        final Instant now = Instant.now();
         final Adaptable expected = Adaptable.newBuilder(topicPathCreated)
                 .withPayload(Payload.newBuilder(path)
                         .withValue(TestConstants.THING.toJson(FieldType.notHidden()))
                         .withRevision(TestConstants.REVISION)
+                        .withTimestamp(now)
                         .build())
                 .withHeaders(TestConstants.HEADERS_V_2)
                 .build();
 
         final ThingCreated thingCreated =
-                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
+                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, now, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(thingCreated);
 
         assertThat(actual).isEqualTo(expected);

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/HttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/HttpRequestActor.java
@@ -35,7 +35,6 @@ import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import org.eclipse.ditto.signals.commands.base.ErrorResponse;
 import org.eclipse.ditto.signals.commands.base.WithEntity;
-import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsResponse;
 import org.eclipse.ditto.signals.commands.messages.MessageCommand;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandResponse;
 import org.eclipse.ditto.signals.commands.messages.SendMessageAcceptedResponse;
@@ -151,15 +150,6 @@ public final class HttpRequestActor extends AbstractActor {
                     logger.warning("Got 'CommandResponse' message which did not implement the required interfaces "
                             + "'WithEntity' / 'WithOptionalEntity': {}", commandResponse);
                     completeWithResult(HttpResponse.create().withStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.toInt())
-                    );
-                })
-                .match(RetrieveStatisticsResponse.class, statisticsResponse -> {
-                    logger.debug("Got 'RetrieveStatisticsResponse' message");
-                    final JsonObject statisticsJson = statisticsResponse.getStatistics();
-                    completeWithResult(
-                            HttpResponse.create()
-                                    .withEntity(CONTENT_TYPE_JSON, ByteString.fromString(statisticsJson.toString()))
-                                    .withStatus(HttpStatusCode.OK.toInt())
                     );
                 })
                 .match(Status.Failure.class, f -> f.cause() instanceof AskTimeoutException, failure -> {

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractProxyActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/AbstractProxyActor.java
@@ -18,6 +18,7 @@ import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatistics;
+import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetails;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorKilledException;
@@ -84,6 +85,10 @@ public abstract class AbstractProxyActor extends AbstractActor {
                 .match(RetrieveStatistics.class, retrieveStatistics -> {
                     log.debug("Got 'RetrieveStatistics' message");
                     statisticsActor.forward(retrieveStatistics, getContext());
+                })
+                .match(RetrieveStatisticsDetails.class, retrieveStatisticsDetails -> {
+                    log.debug("Got 'RetrieveStatisticsDetails' message");
+                    statisticsActor.forward(retrieveStatisticsDetails, getContext());
                 });
 
         // specific commands

--- a/services/gateway/util/src/test/java/org/eclipse/ditto/services/gateway/starter/service/util/GatewayMappingStrategyTest.java
+++ b/services/gateway/util/src/test/java/org/eclipse/ditto/services/gateway/starter/service/util/GatewayMappingStrategyTest.java
@@ -34,6 +34,7 @@ import org.eclipse.ditto.signals.commands.devops.ChangeLogLevelResponse;
 import org.eclipse.ditto.signals.commands.devops.RetrieveLoggerConfig;
 import org.eclipse.ditto.signals.commands.devops.RetrieveLoggerConfigResponse;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatistics;
+import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetails;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsResponse;
 import org.eclipse.ditto.signals.commands.messages.SendClaimMessage;
 import org.eclipse.ditto.signals.commands.messages.SendClaimMessageResponse;
@@ -97,6 +98,7 @@ public final class GatewayMappingStrategyTest {
                 .knows(ChangeLogLevel.TYPE)
                 .knows(RetrieveLoggerConfig.TYPE)
                 .knows(RetrieveStatistics.TYPE)
+                .knows(RetrieveStatisticsDetails.TYPE)
                 .knows(ChangeLogLevelResponse.TYPE)
                 .knows(RetrieveLoggerConfigResponse.TYPE)
                 .knows(RetrieveStatisticsResponse.TYPE);

--- a/services/utils/devops/src/main/java/org/eclipse/ditto/services/utils/devops/DevOpsCommandsActor.java
+++ b/services/utils/devops/src/main/java/org/eclipse/ditto/services/utils/devops/DevOpsCommandsActor.java
@@ -114,8 +114,11 @@ public final class DevOpsCommandsActor extends AbstractActor {
 
     /**
      * DevOps commands issued via the HTTP DevopsRoute are handled here on the (gateway) cluster node which got the HTTP
-     * request. The job now is to: <ul> <li>publish the command in the cluster (so that all services which should react
-     * on that command get it)</li> <li>start aggregation of responses</li> </ul>
+     * request. The job now is to:
+     * <ul>
+     *  <li>publish the command in the cluster (so that all services which should react on that command get it)</li>
+     *  <li>start aggregation of responses</li>
+     * </ul>
      *
      * @param command the initial DevOpsCommand to handle
      */

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandRegistry.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandRegistry.java
@@ -43,6 +43,7 @@ public final class DevOpsCommandRegistry extends AbstractJsonParsableRegistry<De
         parseStrategies.put(ChangeLogLevel.TYPE, ChangeLogLevel::fromJson);
         parseStrategies.put(RetrieveLoggerConfig.TYPE, RetrieveLoggerConfig::fromJson);
         parseStrategies.put(RetrieveStatistics.TYPE, RetrieveStatistics::fromJson);
+        parseStrategies.put(RetrieveStatisticsDetails.TYPE, RetrieveStatistics::fromJson);
         parseStrategies.put(ExecutePiggybackCommand.TYPE, ExecutePiggybackCommand::fromJson);
 
         return new DevOpsCommandRegistry(parseStrategies);

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandResponseRegistry.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandResponseRegistry.java
@@ -43,6 +43,7 @@ public final class DevOpsCommandResponseRegistry extends AbstractJsonParsableReg
         parseStrategies.put(ChangeLogLevelResponse.TYPE, ChangeLogLevelResponse::fromJson);
         parseStrategies.put(RetrieveLoggerConfigResponse.TYPE, RetrieveLoggerConfigResponse::fromJson);
         parseStrategies.put(RetrieveStatisticsResponse.TYPE, RetrieveStatisticsResponse::fromJson);
+        parseStrategies.put(RetrieveStatisticsDetailsResponse.TYPE, RetrieveStatisticsResponse::fromJson);
         parseStrategies.put(AggregatedDevOpsCommandResponse.TYPE,
                 (jsonObject, dittoHeaders) -> AggregatedDevOpsCommandResponse.fromJson(jsonObject, dittoHeaders, parseStrategies));
 

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
@@ -27,19 +27,19 @@ import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
  * Command which retrieves publicly available statistics about the stored Things currently present.
  */
 @Immutable
-public final class RetrieveStatistics extends AbstractDevOpsCommand<RetrieveStatistics> {
+public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<RetrieveStatisticsDetails> {
 
     /**
      * Name of the command.
      */
-    public static final String NAME = "retrieveStatistics";
+    public static final String NAME = "retrieveStatisticsDetails";
 
     /**
      * Type of this command.
      */
     public static final String TYPE = TYPE_PREFIX + NAME;
 
-    private RetrieveStatistics(final DittoHeaders dittoHeaders) {
+    private RetrieveStatisticsDetails(final DittoHeaders dittoHeaders) {
         super(TYPE, null, null, dittoHeaders);
     }
 
@@ -49,26 +49,26 @@ public final class RetrieveStatistics extends AbstractDevOpsCommand<RetrieveStat
      * @param dittoHeaders the optional command headers of the request.
      * @return a Command for retrieving statistics.
      */
-    public static RetrieveStatistics of(final DittoHeaders dittoHeaders) {
-        return new RetrieveStatistics(dittoHeaders);
+    public static RetrieveStatisticsDetails of(final DittoHeaders dittoHeaders) {
+        return new RetrieveStatisticsDetails(dittoHeaders);
     }
 
     /**
-     * Creates a new {@code RetrieveStatistics} from a JSON string.
+     * Creates a new {@code RetrieveStatisticsDetails} from a JSON string.
      *
-     * @param jsonString contains the data of the RetrieveStatistics command.
+     * @param jsonString contains the data of the RetrieveStatisticsDetails command.
      * @param dittoHeaders the headers of the request.
-     * @return the RetrieveStatistics command which is based on the data of {@code jsonString}.
+     * @return the RetrieveStatisticsDetails command which is based on the data of {@code jsonString}.
      * @throws NullPointerException if {@code jsonString} is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
      */
-    public static RetrieveStatistics fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
+    public static RetrieveStatisticsDetails fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
     }
 
     /**
-     * Creates a new {@code RetrieveStatistics} from a JSON object.
+     * Creates a new {@code RetrieveStatisticsDetails} from a JSON object.
      *
      * @param jsonObject the JSON object of which the command is to be created.
      * @param dittoHeaders the headers of the command.
@@ -77,9 +77,9 @@ public final class RetrieveStatistics extends AbstractDevOpsCommand<RetrieveStat
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
      */
-    public static RetrieveStatistics fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return new CommandJsonDeserializer<RetrieveStatistics>(TYPE, jsonObject)
-                .deserialize(() -> RetrieveStatistics.of(dittoHeaders));
+    public static RetrieveStatisticsDetails fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return new CommandJsonDeserializer<RetrieveStatisticsDetails>(TYPE, jsonObject)
+                .deserialize(() -> RetrieveStatisticsDetails.of(dittoHeaders));
     }
 
     @Override
@@ -97,7 +97,7 @@ public final class RetrieveStatistics extends AbstractDevOpsCommand<RetrieveStat
     }
 
     @Override
-    public RetrieveStatistics setDittoHeaders(final DittoHeaders dittoHeaders) {
+    public RetrieveStatisticsDetails setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(dittoHeaders);
     }
 

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetailsResponse.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetailsResponse.java
@@ -31,57 +31,60 @@ import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
 import org.eclipse.ditto.signals.commands.base.WithEntity;
 
 /**
- * Response to a {@link RetrieveStatistics} command containing a {@link JsonObject} of the retrieved Statistics.
+ * Response to a {@link RetrieveStatisticsDetails} command containing a {@link JsonObject} of the retrieved
+ * StatisticsDetails.
  */
 @Immutable
-public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandResponse<RetrieveStatisticsResponse>
-        implements WithEntity<RetrieveStatisticsResponse> {
+public final class RetrieveStatisticsDetailsResponse
+        extends AbstractDevOpsCommandResponse<RetrieveStatisticsDetailsResponse>
+        implements WithEntity<RetrieveStatisticsDetailsResponse> {
 
     /**
      * Type of this response.
      */
-    public static final String TYPE = TYPE_PREFIX + RetrieveStatistics.NAME;
+    public static final String TYPE = TYPE_PREFIX + RetrieveStatisticsDetails.NAME;
 
-    private static final JsonFieldDefinition<JsonObject> JSON_STATISTICS =
-            JsonFactory.newJsonObjectFieldDefinition("statistics", FieldType.REGULAR, JsonSchemaVersion.V_1,
+    private static final JsonFieldDefinition<JsonObject> JSON_STATISTICS_DETAILS =
+            JsonFactory.newJsonObjectFieldDefinition("statisticsDetails", FieldType.REGULAR, JsonSchemaVersion.V_1,
                     JsonSchemaVersion.V_2);
 
-    private final JsonObject statistics;
+    private final JsonObject statisticsDetails;
 
-    private RetrieveStatisticsResponse(final JsonObject statistics, final DittoHeaders dittoHeaders) {
+    private RetrieveStatisticsDetailsResponse(final JsonObject statisticsDetails, final DittoHeaders dittoHeaders) {
         super(TYPE, null, null, HttpStatusCode.OK, dittoHeaders);
-        this.statistics = Objects.requireNonNull(statistics, "The statistics JSON must not be null!");
+        this.statisticsDetails =
+                Objects.requireNonNull(statisticsDetails, "The statisticsDetails JSON must not be null!");
     }
 
     /**
-     * Returns a new instance of {@code RetrieveStatisticsResponse}.
+     * Returns a new instance of {@code RetrieveStatisticsDetailsResponse}.
      *
      * @param statistics the JSON representation of the retrieved Thing.
      * @param dittoHeaders the headers of the ThingCommand which caused this ThingCommandResponse.
      * @return a new statistics command response object.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static RetrieveStatisticsResponse of(final JsonObject statistics, final DittoHeaders dittoHeaders) {
-        return new RetrieveStatisticsResponse(statistics, dittoHeaders);
+    public static RetrieveStatisticsDetailsResponse of(final JsonObject statistics, final DittoHeaders dittoHeaders) {
+        return new RetrieveStatisticsDetailsResponse(statistics, dittoHeaders);
     }
 
     /**
-     * Creates a response to a {@code RetrieveStatisticsResponse} command from a JSON string.
+     * Creates a response to a {@code RetrieveStatisticsDetailsResponse} command from a JSON string.
      *
-     * @param jsonString contains the data of the RetrieveStatisticsResponse command.
+     * @param jsonString contains the data of the RetrieveStatisticsDetailsResponse command.
      * @param dittoHeaders the headers of the request.
-     * @return the RetrieveStatisticsResponse command which is based on the dta of {@code jsonString}.
+     * @return the RetrieveStatisticsDetailsResponse command which is based on the dta of {@code jsonString}.
      * @throws NullPointerException if {@code jsonString} is {@code null}.
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
      */
-    public static RetrieveStatisticsResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
+    public static RetrieveStatisticsDetailsResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
     }
 
     /**
-     * Creates a response to a {@code RetrieveStatisticsResponse} command from a JSON object.
+     * Creates a response to a {@code RetrieveStatisticsDetailsResponse} command from a JSON object.
      *
      * @param jsonObject the JSON object of which the response is to be created.
      * @param dittoHeaders the headers of the preceding command.
@@ -90,11 +93,12 @@ public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandRespo
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
      */
-    public static RetrieveStatisticsResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return new CommandResponseJsonDeserializer<RetrieveStatisticsResponse>(TYPE, jsonObject)
+    public static RetrieveStatisticsDetailsResponse fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new CommandResponseJsonDeserializer<RetrieveStatisticsDetailsResponse>(TYPE, jsonObject)
                 .deserialize(statusCode -> {
-                    final JsonObject statistics = jsonObject.getValueOrThrow(JSON_STATISTICS);
-                    return RetrieveStatisticsResponse.of(statistics, dittoHeaders);
+                    final JsonObject statistics = jsonObject.getValueOrThrow(JSON_STATISTICS_DETAILS);
+                    return RetrieveStatisticsDetailsResponse.of(statistics, dittoHeaders);
                 });
     }
 
@@ -103,18 +107,18 @@ public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandRespo
      *
      * @return the JSON representation of the statistics.
      */
-    public JsonObject getStatistics() {
-        return statistics;
+    public JsonObject getStatisticsDetails() {
+        return statisticsDetails;
     }
 
     @Override
-    public RetrieveStatisticsResponse setEntity(final JsonValue entity) {
+    public RetrieveStatisticsDetailsResponse setEntity(final JsonValue entity) {
         return of(entity.asObject(), getDittoHeaders());
     }
 
     @Override
     public JsonValue getEntity(final JsonSchemaVersion schemaVersion) {
-        return statistics;
+        return statisticsDetails;
     }
 
     @Override
@@ -124,12 +128,12 @@ public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandRespo
         super.appendPayload(jsonObjectBuilder, schemaVersion, thePredicate);
 
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
-        jsonObjectBuilder.set(JSON_STATISTICS, statistics, predicate);
+        jsonObjectBuilder.set(JSON_STATISTICS_DETAILS, statisticsDetails, predicate);
     }
 
     @Override
-    public RetrieveStatisticsResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return of(statistics, dittoHeaders);
+    public RetrieveStatisticsDetailsResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(statisticsDetails, dittoHeaders);
     }
 
     @SuppressWarnings("squid:S109")
@@ -137,7 +141,7 @@ public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandRespo
     public int hashCode() {
         final int prime = 31;
         int result = super.hashCode();
-        result = prime * result + Objects.hashCode(statistics);
+        result = prime * result + Objects.hashCode(statisticsDetails);
         return result;
     }
 
@@ -150,18 +154,18 @@ public final class RetrieveStatisticsResponse extends AbstractDevOpsCommandRespo
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        final RetrieveStatisticsResponse that = (RetrieveStatisticsResponse) o;
-        return that.canEqual(this) && Objects.equals(statistics, that.statistics) && super.equals(that);
+        final RetrieveStatisticsDetailsResponse that = (RetrieveStatisticsDetailsResponse) o;
+        return that.canEqual(this) && Objects.equals(statisticsDetails, that.statisticsDetails) && super.equals(that);
     }
 
     @Override
     protected boolean canEqual(@Nullable final Object other) {
-        return other instanceof RetrieveStatisticsResponse;
+        return other instanceof RetrieveStatisticsDetailsResponse;
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + super.toString() + ", statistics=" + statistics + "]";
+        return getClass().getSimpleName() + " [" + super.toString() + ", statisticsDetails=" + statisticsDetails + "]";
     }
 
 }

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/FeatureDeleted.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/FeatureDeleted.java
@@ -50,7 +50,7 @@ public final class FeatureDeleted extends AbstractThingEvent<FeatureDeleted> imp
     private final String featureId;
 
     private FeatureDeleted(final String thingId, final String featureId, final long revision,
-            final Instant timestamp, final DittoHeaders dittoHeaders) {
+            @Nullable final Instant timestamp, final DittoHeaders dittoHeaders) {
         super(TYPE, thingId, revision, timestamp, dittoHeaders);
         this.featureId = requireNonNull(featureId, "The Feature ID must not be null!");
     }
@@ -82,7 +82,7 @@ public final class FeatureDeleted extends AbstractThingEvent<FeatureDeleted> imp
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static FeatureDeleted of(final String thingId, final String featureId, final long revision,
-            final Instant timestamp, final DittoHeaders dittoHeaders) {
+            @Nullable final Instant timestamp, final DittoHeaders dittoHeaders) {
         return new FeatureDeleted(thingId, featureId, revision, timestamp, dittoHeaders);
     }
 


### PR DESCRIPTION
* added new resource /stats/things/details secured with devops auth
* split up statistics into publicly available ones (a.k.a hotness)
  and secured ones (hotness per namespace)