### PR TITLE
Fix handling of RetrieveConnectionMetrics command

### DIFF
--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MockClientActor.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MockClientActor.java
@@ -49,6 +49,11 @@ public class MockClientActor extends AbstractActor {
     }
 
     @Override
+    public void preStart() {
+        log.info("Mock client actor started.");
+    }
+
+    @Override
     public void postStop() {
         log.info("Mock client actor was stopped.");
     }


### PR DESCRIPTION
- RetrieveConnectionMetrics command should not start client actor but respond with status CLOSED
- simplified handling of DeleteConnection