### PR TITLE
Fixes related to connectivity

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -396,8 +396,10 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
      * @param actor the ActorRef
      */
     protected final void stopChildActor(final ActorRef actor) {
-        log.debug("Stopping child actor <{}>.", actor.path());
-        getContext().stop(actor);
+        if (actor != null) {
+            log.debug("Stopping child actor <{}>.", actor.path());
+            getContext().stop(actor);
+        }
     }
 
     /**

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
@@ -265,11 +265,11 @@ public final class ConnectionActor extends AbstractPersistentActor {
                         if (ConnectionStatus.OPEN.equals(connection.getConnectionStatus())) {
                             log.debug("Opening connection <{}> after recovery.", connectionId);
 
-                            final CreateConnection connect = CreateConnection.of(connection, DittoHeaders.empty());
+                            final OpenConnection connect = OpenConnection.of(connectionId, DittoHeaders.empty());
 
                             final ActorRef origin = getSender();
                             askClientActor(connect,
-                                    response -> log.info("CreateConnection result: {}", response),
+                                    response -> log.info("OpenConnection result: {}", response),
                                     error -> handleException("recovery-connect", origin, error)
                             );
                             subscribeForEvents();

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActor.java
@@ -274,7 +274,9 @@ public final class RabbitMQClientActor extends BaseClientActor {
                     if (throwable != null) {
                         future.complete(new Status.Failure(throwable));
                     } else {
-                        rmqPublisherActor.tell(reply, rmqConnectionActor);
+                        if (rmqPublisherActor != null) {
+                            rmqPublisherActor.tell(reply, rmqConnectionActor);
+                        }
                         future.complete(new Status.Success("channel created"));
                     }
                     return null;

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.model.connectivity.ConnectionConfigurationInvalidExcept
 import org.eclipse.ditto.model.connectivity.ConnectionStatus;
 import org.eclipse.ditto.model.connectivity.ConnectionType;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
+import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.model.connectivity.Topic;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientState;
 import org.eclipse.ditto.services.connectivity.messaging.TestConstants;
@@ -142,6 +143,25 @@ public class RabbitMQClientActorTest {
             expectMsg(CONNECTED_SUCCESS);
 
             rabbitClientActor.tell(CloseConnection.of(connectionId, DittoHeaders.empty()), getRef());
+            expectMsg(DISCONNECTED_SUCCESS);
+        }};
+    }
+
+    @Test
+    public void testConnectionWithoutPublisherHandling() {
+        new TestKit(actorSystem) {{
+            final String randomConnectionId = TestConstants.createRandomConnectionId();
+            final Connection connectionWithoutTargets =
+                    TestConstants.createConnection(randomConnectionId, actorSystem, new Target[0]);
+            final Props props = RabbitMQClientActor.propsForTests(connectionWithoutTargets, connectionStatus, getRef(),
+                    (con, exHandler) -> mockConnectionFactory).withDispatcher(CallingThreadDispatcher.Id());
+            final ActorRef rabbitClientActor = actorSystem.actorOf(props);
+            watch(rabbitClientActor);
+
+            rabbitClientActor.tell(OpenConnection.of(randomConnectionId, DittoHeaders.empty()), getRef());
+            expectMsg(CONNECTED_SUCCESS);
+
+            rabbitClientActor.tell(CloseConnection.of(randomConnectionId, DittoHeaders.empty()), getRef());
             expectMsg(DISCONNECTED_SUCCESS);
         }};
     }

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
@@ -20,17 +20,13 @@ import java.util.concurrent.TimeUnit;
 
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
-import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.gateway.streaming.StartStreaming;
 import org.eclipse.ditto.services.gateway.streaming.StopStreaming;
 import org.eclipse.ditto.services.gateway.streaming.StreamingAck;
 import org.eclipse.ditto.services.models.concierge.streaming.StreamingType;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.signals.base.Signal;
-import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.commands.base.CommandResponse;
-import org.eclipse.ditto.signals.commands.messages.MessageCommand;
-import org.eclipse.ditto.signals.events.base.Event;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -206,7 +202,6 @@ final class StreamingSessionActor extends AbstractActor {
 
     private void handleSignal(final Signal<?> signal) {
         LogUtil.enhanceLogWithCorrelationId(logger, signal);
-        acknowledgeSubscriptionForSignal(signal);
 
         final DittoHeaders dittoHeaders = signal.getDittoHeaders();
         if (connectionCorrelationId.equals(dittoHeaders.getOrigin().orElse(null))) {
@@ -224,28 +219,6 @@ final class StreamingSessionActor extends AbstractActor {
                 eventAndResponsePublisher.tell(signal, getSelf());
             }
         }
-    }
-
-    private void acknowledgeSubscriptionForSignal(final Signal signal) {
-        if (isLiveSignal(signal)) {
-            if (signal instanceof MessageCommand &&
-                    outstandingSubscriptionAcks.contains(StreamingType.MESSAGES)) {
-                acknowledgeSubscription(StreamingType.MESSAGES, getSelf());
-            } else if (signal instanceof Command && outstandingSubscriptionAcks.contains(StreamingType.LIVE_COMMANDS)) {
-                acknowledgeSubscription(StreamingType.LIVE_COMMANDS, getSelf());
-            } else if (signal instanceof Event && outstandingSubscriptionAcks.contains(StreamingType.LIVE_EVENTS)) {
-                acknowledgeSubscription(StreamingType.LIVE_EVENTS, getSelf());
-            }
-        } else if (signal instanceof Event && outstandingSubscriptionAcks.contains(StreamingType.EVENTS)) {
-            acknowledgeSubscription(StreamingType.EVENTS, getSelf());
-        }
-    }
-
-    private static boolean isLiveSignal(final Signal signal) {
-        return signal.getDittoHeaders().getChannel()
-                .flatMap(TopicPath.Channel::forName)
-                .filter(TopicPath.Channel.LIVE::equals)
-                .isPresent();
     }
 
     private void acknowledgeSubscription(final StreamingType streamingType, final ActorRef self) {


### PR DESCRIPTION
 - recovery of connection actors (send open instead of create)
 - opening amqp 0.9.1 connections without a publisher (NPE)

Signed-off-by: Dominik Guggemos <dominik.guggemos@bosch-si.com>