### PR TITLE
Remove 'source' from reserved header list

### DIFF
--- a/documentation/src/main/resources/pages/ditto/protocol-specification.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification.md
@@ -81,7 +81,6 @@ HTTP protocol, for example the prefix `ditto-*`.
   channel
   raw-request-url
   read-subjects
-  source
   subject
   timeout-access
   ```


### PR DESCRIPTION
`DittoHeaderDefinition.SOURCE` is readable and writable, hence not reserved.