### PR TITLE
ConnectionActor: don't flush pending ACK messages on signal arrival

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
@@ -345,9 +345,7 @@ public final class ConnectionActor extends AbstractPersistentActor {
     }
 
     private void handleSignal(final Signal<?> signal) {
-        // since a signal arrives, event subscription works in the absence of outdated events.
-        // flush pending responses regardless whether the signal is forwarded or not.
-        flushPendingResponses();
+        // Do not flush pending responses - pub/sub may not be ready on all nodes
 
         enhanceLogUtil(signal);
         if (clientActorRouter == null) {


### PR DESCRIPTION
Pub/sub may not be set up on all nodes when the first signal arrives.

This extends [43fa33d2930c88d344d540d7bb51a9812c71eac3](https://github.com/eclipse/ditto/pull/210/commits/43fa33d2930c88d344d540d7bb51a9812c71eac3).