### PR TITLE
physically delete Things from search index after configurable age

### DIFF
--- a/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
+++ b/services/thingsearch/common/src/main/java/org/eclipse/ditto/services/thingsearch/common/util/ConfigKeys.java
@@ -70,6 +70,30 @@ public final class ConfigKeys {
      */
     public static final String INDEX_INITIALIZATION_ENABLED = SEARCH_PREFIX + "index-initialization." + ENABLED_SUFFIX;
 
+    private static final String DELETION_PREFIX = SEARCH_PREFIX + "deletion.";
+
+    /**
+     * Key configuring the age (as Duration) after which marked as deleted Things are physically deleted from search
+     * index.
+     */
+    public static final String DELETION_AGE = DELETION_PREFIX + "deletion-age";
+
+    /**
+     * Whether or not the deletion of marked as deleted Things from the search index is enabled.
+     */
+    public static final String DELETION_ENABLED = DELETION_PREFIX + "enabled";
+
+    /**
+     * Key configuring the interval (as Duration) when marked as deleted Things should be deleted (e.g. once a day).
+     */
+    public static final String DELETION_RUN_INTERVAL = DELETION_PREFIX + "run-interval";
+
+    /**
+     * Key configuring the hour (as int) of the first time the deletion should be triggered. After that the deletion is
+     * done each {@link #DELETION_RUN_INTERVAL}.
+     */
+    public static final String DELETION_FIRST_INTERVAL_HOUR = DELETION_PREFIX + "first-interval-hour";
+
     /**
      * Controls whether thing and policy event processing should be active or not.
      */

--- a/services/thingsearch/starter/src/main/resources/things-search-dev.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search-dev.conf
@@ -13,6 +13,13 @@ ditto {
       #authentication = "user:password@"
     }
 
+    deletion {
+      enabled = true
+      deletion-age = 1h
+      run-interval = 15m
+      first-interval-hour = 10
+    }
+
     metrics.prometheus.port = 9013
   }
 

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -91,6 +91,18 @@ ditto {
       }
     }
 
+    # configuration regarding physical deletion of "__deleted" Things from "thingEntities" collection
+    deletion {
+      enabled = true
+
+      # delete "__deleted" Things older than:
+      deletion-age = 3d
+      # run each:
+      run-interval = 24h
+      # the first run should be at (UTC time):
+      first-interval-hour = 21 # 21:00 UTC
+    }
+
     updater {
 
       max-bulk-size = ${?MAX_BULK_SIZE}

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/SearchUpdaterRootActor.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/SearchUpdaterRootActor.java
@@ -136,6 +136,14 @@ public final class SearchUpdaterRootActor extends AbstractActor {
         } else {
             log.warning("Policies synchronization is not active");
         }
+
+        final boolean deletionEnabled = config.getBoolean(ConfigKeys.DELETION_ENABLED);
+        if (deletionEnabled) {
+            startClusterSingletonActor(ThingsSearchIndexDeletionActor.ACTOR_NAME,
+                    ThingsSearchIndexDeletionActor.props(mongoClientWrapper));
+        } else {
+            log.warning("Deletion of marked as deleted Things from search index is not enabled");
+        }
     }
 
     private static StreamConsumerSettings createThingsStreamConsumerSettings(final Config config) {

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsSearchIndexDeletionActor.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsSearchIndexDeletionActor.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.updater.actors;
+
+import static org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants.THINGS_COLLECTION_NAME;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import javax.annotation.Nullable;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.eclipse.ditto.services.thingsearch.common.util.ConfigKeys;
+import org.eclipse.ditto.services.thingsearch.persistence.PersistenceConstants;
+import org.eclipse.ditto.services.utils.persistence.mongo.MongoClientWrapper;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.typesafe.config.Config;
+
+import akka.ConfigurationException;
+import akka.actor.AbstractActor;
+import akka.actor.Cancellable;
+import akka.actor.Props;
+import akka.event.DiagnosticLoggingAdapter;
+import akka.event.Logging;
+import akka.stream.ActorMaterializer;
+import akka.stream.Materializer;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+
+/**
+ * Cluster singleton actor taking care of deleting marked as deleted Things (containing a "__deleted" field in the
+ * "thingEntities" collection) from the search index after a configurable {@code age}.
+ */
+public final class ThingsSearchIndexDeletionActor extends AbstractActor {
+
+    /**
+     * The name of this Actor.
+     */
+    static final String ACTOR_NAME = "thingsSearchIndexDeletionActor";
+
+    private static final Object PERFORM_DELETION_MESSAGE = new Object();
+
+    private final DiagnosticLoggingAdapter log = Logging.apply(this);
+
+    private final Duration age;
+    private final Duration runInterval;
+    private final int firstIntervalHour;
+    private final MongoCollection<Document> collection;
+    private final Materializer actorMaterializer;
+
+    @Nullable private Cancellable scheduler = null;
+
+    private ThingsSearchIndexDeletionActor(final MongoClientWrapper mongoClientWrapper) {
+        final Config config = getContext().getSystem().settings().config();
+        age = config.getDuration(ConfigKeys.DELETION_AGE);
+        runInterval = config.getDuration(ConfigKeys.DELETION_RUN_INTERVAL);
+        firstIntervalHour = config.getInt(ConfigKeys.DELETION_FIRST_INTERVAL_HOUR);
+        if (firstIntervalHour < 0 || firstIntervalHour > 23) {
+            throw new ConfigurationException(
+                    "The configured <" + ConfigKeys.DELETION_FIRST_INTERVAL_HOUR + "> must be" +
+                            "between 0 and 23");
+        }
+
+        actorMaterializer = ActorMaterializer.create(getContext());
+        collection = mongoClientWrapper.getDatabase().getCollection(THINGS_COLLECTION_NAME);
+    }
+
+    /**
+     * Creates Akka configuration object Props for this Actor.
+     *
+     * @param mongoClientWrapper the MongoDB client wrapper to use for deletion.
+     * @return the Akka configuration Props object.
+     */
+    public static Props props(final MongoClientWrapper mongoClientWrapper) {
+        return Props.create(ThingsSearchIndexDeletionActor.class, mongoClientWrapper);
+    }
+
+    @Override
+    public void preStart() {
+
+        final Instant now = Instant.now();
+        final Duration initialDelay = calculateInitialDelay(now, firstIntervalHour);
+        log.info("Initial deletion is scheduled at <{}>", now.plus(initialDelay));
+
+        scheduler = getContext().getSystem().scheduler()
+                .schedule(initialDelay, runInterval, getSelf(), PERFORM_DELETION_MESSAGE, getContext().dispatcher(),
+                        getSelf());
+    }
+
+    @Override
+    public void postStop() {
+        if (scheduler != null && !scheduler.isCancelled()) {
+            scheduler.cancel();
+            scheduler = null;
+        }
+    }
+
+    @Override
+    public Receive createReceive() {
+        return receiveBuilder()
+                .matchEquals(PERFORM_DELETION_MESSAGE, obj -> performDeletion())
+                .matchAny(a -> log.warning("Got unknown message: <{}>", a))
+                .build();
+    }
+
+    private void performDeletion() {
+
+        final Date deletionDate = Date.from(Instant.now().minus(age).truncatedTo(ChronoUnit.SECONDS));
+        final Bson deleteFilter = Filters.lte(PersistenceConstants.FIELD_DELETED, deletionDate);
+        log.info("About to delete marked as deleted fields in collection <{}> matching the filter: <{}>",
+                THINGS_COLLECTION_NAME, deleteFilter);
+
+        Source.fromPublisher(collection.deleteMany(deleteFilter))
+                .runWith(Sink.head(), actorMaterializer)
+                .whenComplete((deleteResult, throwable) -> {
+                    if (throwable != null) {
+                        log.error(throwable, "Deletion of marked as deleted Things failed due to: {}: <{}>",
+                                throwable.getClass().getSimpleName(), throwable.getMessage());
+                    } else {
+                        log.info("Deletion of marked as deleted Things was successful, response: {}",
+                                deleteResult);
+                    }
+                });
+    }
+
+    /**
+     * Calculates on the passed {@code now} Instant and the passed {@code firstIntervalHourUtc} the initial Duration.
+     * The Duration will be a max. of 23 hours and 59 minutes and a min. of 0 hours, 0 minutes if {@code now} matches
+     * exactly the current hour of the day.
+     *
+     * @param now the "now" Instant, passed in in order to test this method.
+     * @param firstIntervalHourUtc the first hour to schedule at in UTC time.
+     * @return the Duration of how long to wait until the first hour arrices
+     */
+    static Duration calculateInitialDelay(final Instant now, final int firstIntervalHourUtc) {
+        final LocalDateTime localDateTime = LocalDateTime.ofInstant(now, ZoneOffset.UTC);
+
+        final int currentHour = localDateTime.getHour();
+        final int currentMinute = localDateTime.getMinute();
+
+        final Duration durationSinceMidnight = Duration.ofHours(currentHour).plusMinutes(currentMinute);
+        final Duration delay = Duration.ofHours(firstIntervalHourUtc)
+                .minus(durationSinceMidnight);
+        if (delay.isNegative()) {
+            return Duration.ofHours(24).plus(delay);
+        } else {
+            return delay;
+        }
+    }
+
+}

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsSearchIndexDeletionActorTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsSearchIndexDeletionActorTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2017 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * Contributors:
+ *    Bosch Software Innovations GmbH - initial contribution
+ */
+package org.eclipse.ditto.services.thingsearch.updater.actors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+import org.junit.Test;
+
+/**
+ * Unit Tests for {@link ThingsSearchIndexDeletionActor}.
+ */
+public class ThingsSearchIndexDeletionActorTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    @Test
+    public void testInitialDelayCalculationInTheFuture1() {
+        final Instant now = getInstantAtHourAndMinute(9, 42);
+        final int firstIntervalHour = 10;
+
+        final Duration expectedDuration = Duration.ofMinutes(18);
+
+        assertThat(ThingsSearchIndexDeletionActor.calculateInitialDelay(now, firstIntervalHour))
+                .isEqualByComparingTo(expectedDuration);
+    }
+
+    @Test
+    public void testInitialDelayCalculationInTheFuture2() {
+        final Instant now = getInstantAtHourAndMinute(10, 1);
+        final int firstIntervalHour = 11;
+
+        final Duration expectedDuration = Duration.ofMinutes(59);
+
+        assertThat(ThingsSearchIndexDeletionActor.calculateInitialDelay(now, firstIntervalHour))
+                .isEqualByComparingTo(expectedDuration);
+    }
+
+    @Test
+    public void testInitialDelayCalculationInTheFutureNextDay1() {
+        final Instant now = getInstantAtHourAndMinute(20, 1);
+        final int firstIntervalHour = 2;
+
+        final Duration expectedDuration = Duration.ofHours(5).plusMinutes(59);
+
+        assertThat(ThingsSearchIndexDeletionActor.calculateInitialDelay(now, firstIntervalHour))
+                .isEqualByComparingTo(expectedDuration);
+    }
+
+    @Test
+    public void testInitialDelayCalculationCornerCase1() {
+        final Instant now = getInstantAtHourAndMinute(0, 0);
+        final int firstIntervalHour = 0;
+
+        final Duration expectedDuration = Duration.ofMillis(0);
+
+        assertThat(ThingsSearchIndexDeletionActor.calculateInitialDelay(now, firstIntervalHour))
+                .isEqualByComparingTo(expectedDuration);
+    }
+
+    @Test
+    public void testInitialDelayCalculationCornerCase2() {
+        final Instant now = getInstantAtHourAndMinute(23, 1);
+        final int firstIntervalHour = 23;
+
+        final Duration expectedDuration = Duration.ofHours(24).minusMinutes(1);
+
+        assertThat(ThingsSearchIndexDeletionActor.calculateInitialDelay(now, firstIntervalHour))
+                .isEqualByComparingTo(expectedDuration);
+    }
+
+    private static Instant getInstantAtHourAndMinute(final int hour, final int minute) {
+        final LocalDateTime dateTime = LocalDateTime.ofInstant(Instant.now(), UTC)
+                .withHour(hour)
+                .withMinute(minute);
+        return dateTime.atZone(UTC).toInstant();
+    }
+}


### PR DESCRIPTION
* up to now, orphaned search index entries in collection 'thingEntities' were never deleted
* this can now be enabled (and is by default) via search configuration