### PR TITLE
exclude target folder and flattened-pom from ditto-legal build

### DIFF
--- a/legal/pom.xml
+++ b/legal/pom.xml
@@ -33,6 +33,8 @@
                     <exclude>DOCUMENTATION-3RD-PARTY-NOTICES</exclude>
                     <exclude>templates/**</exclude>
                     <exclude>3rd-party-dependencies/*.sh</exclude>
+                    <exclude>target/**</exclude>
+                    <exclude>.flattened-pom.xml</exclude>
                 </excludes>
             </resource>
         </resources>


### PR DESCRIPTION
When building the ditto-legal artifact multiple times, it would include its own `target `directory in the `META-INF` folder of the artifact. I excluded the `target ` folder (and additionally `.flattened-pom.xml`) from being added to the `META-INF` folder.