### PR TITLE
Fix things search streaming memory bug

### DIFF
--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/ImmutablePolicyBuilder.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/ImmutablePolicyBuilder.java
@@ -93,11 +93,11 @@ final class ImmutablePolicyBuilder implements PolicyBuilder {
 
         @SuppressWarnings("ConstantConditions")
         final ImmutablePolicyBuilder result = new ImmutablePolicyBuilder()
-                .setId(existingPolicy.getId().orElse(null))
                 .setLifecycle(existingPolicy.getLifecycle().orElse(null))
                 .setRevision(existingPolicy.getRevision().orElse(null))
                 .setModified(existingPolicy.getModified().orElse(null));
 
+        existingPolicy.getId().ifPresent(result::setId);
         existingPolicy.forEach(result::set);
 
         return result;

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapter.java
@@ -78,7 +78,7 @@ public class DittoProtocolAdapter implements ProtocolAdapter {
         this.thingQueryCommandResponseAdapter = ThingQueryCommandResponseAdapter.of(headerTranslator);
         this.thingEventAdapter = ThingEventAdapter.of(headerTranslator);
         this.headerTranslator = headerTranslator;
-        logger.info("Created ProtocolAdapter with headerTranslator <{}>.", headerTranslator);
+        logger.debug("Created ProtocolAdapter with headerTranslator <{}>.", headerTranslator);
     }
 
     /**

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -70,7 +70,7 @@ ditto {
     things-aggregator {
       single-retrieve-thing-timeout = 30s
       single-retrieve-thing-timeout = ${?THINGS_AGGREGATOR_SINGLE_RETRIEVE_THING_TIMEOUT}
-      max-parallelism = 10
+      max-parallelism = 20
       max-parallelism = ${?THINGS_AGGREGATOR_MAX_PARALLELISM}
     }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
@@ -93,7 +93,7 @@ public abstract class AbstractRoute {
                 protocolConfig.loadProtocolAdapterProvider(actorSystem);
 
         headerTranslator = protocolAdapterProvider.getHttpHeaderTranslator();
-        LOGGER.info("Using headerTranslator <{}>.", headerTranslator);
+        LOGGER.debug("Using headerTranslator <{}>.", headerTranslator);
 
         materializer = ActorMaterializer.create(ActorMaterializerSettings.create(actorSystem)
                 .withSupervisionStrategy((Function<Throwable, Supervision.Directive>) exc ->

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
@@ -217,7 +217,7 @@ public final class RootRoute {
         protocolAdapterProvider = protocolConfig.loadProtocolAdapterProvider(actorSystem);
 
         headerTranslator = protocolAdapterProvider.getHttpHeaderTranslator();
-        LOGGER.info("Using headerTranslator <{}>.", headerTranslator);
+        LOGGER.debug("Using headerTranslator <{}>.", headerTranslator);
 
         this.customApiRoutesProvider = customApiRoutesProvider;
         this.customHeadersHandler = customHeadersHandler;

--- a/services/models/things/src/test/java/org/eclipse/ditto/services/models/things/commands/sudo/SudoRetrieveThingsResponseTest.java
+++ b/services/models/things/src/test/java/org/eclipse/ditto/services/models/things/commands/sudo/SudoRetrieveThingsResponseTest.java
@@ -18,6 +18,7 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -44,10 +45,10 @@ public final class SudoRetrieveThingsResponseTest {
             .set(SudoCommandResponse.JsonFields.TYPE, SudoRetrieveThingsResponse.TYPE)
             .set(SudoCommandResponse.JsonFields.STATUS, HttpStatusCode.OK.toInt())
 
-            .set(SudoRetrieveThingsResponse.JSON_THINGS,
+            .set(SudoRetrieveThingsResponse.JSON_THINGS_PLAIN_JSON,
                     KNOWN_THINGS.stream()
                             .map(thing -> thing.toJson(FieldType.notHidden()))
-                            .collect(JsonCollectors.valuesToArray()))
+                            .collect(JsonCollectors.valuesToArray()).toString())
             .build();
 
     private static final DittoHeaders EMPTY_DITTO_HEADERS = DittoHeaders.empty();
@@ -58,7 +59,8 @@ public final class SudoRetrieveThingsResponseTest {
         assertInstancesOf(SudoRetrieveThingsResponse.class,
                 areImmutable(),
                 provided(Thing.class).isAlsoImmutable(),
-                assumingFields("things").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements());
+                assumingFields("things").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements(),
+                assumingFields("things").areModifiedAsPartOfAnUnobservableCachingStrategy());
     }
 
     /** */
@@ -97,8 +99,10 @@ public final class SudoRetrieveThingsResponseTest {
     /** */
     @Test
     public void createInstanceFromJson() {
-        final SudoRetrieveThingsResponse response = SudoRetrieveThingsResponse.of(KNOWN_THINGS, FieldType.notHidden(),
-                EMPTY_DITTO_HEADERS);
+        final SudoRetrieveThingsResponse response =
+                SudoRetrieveThingsResponse.of(KNOWN_THINGS.stream().map(Thing::toJsonString).collect(
+                        Collectors.joining(",", "[", "]")),
+                        EMPTY_DITTO_HEADERS);
 
         final SudoRetrieveThingsResponse responseFromJson =
                 SudoRetrieveThingsResponse.fromJson(response.toJson(), EMPTY_DITTO_HEADERS);

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ETagTestUtils.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ETagTestUtils.java
@@ -59,13 +59,15 @@ public abstract class ETagTestUtils {
     public static RetrieveThingResponse retrieveThingResponse(final Thing expectedThing,
             final JsonObject expectedJsonRepresentation, final DittoHeaders dittoHeaders) {
         final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
-        return RetrieveThingResponse.of(expectedThing.getId().get(), expectedJsonRepresentation, dittoHeadersWithETag);
+        return RetrieveThingResponse.of(expectedThing.getId().get(), expectedJsonRepresentation.toString(),
+                dittoHeadersWithETag);
     }
 
     public static RetrieveThingResponse retrieveThingResponse(final Thing expectedThing,
             final DittoHeaders dittoHeaders) {
         final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
-        return RetrieveThingResponse.of(expectedThing.getId().get(), expectedThing, dittoHeadersWithETag);
+        return RetrieveThingResponse.of(expectedThing.getId().get(),
+                expectedThing.toJsonString(dittoHeaders.getSchemaVersion().get()), dittoHeadersWithETag);
     }
 
     public static ModifyThingResponse modifyThingResponse(final Thing currentThing, final Thing modifiedThing,

--- a/services/utils/aggregator/src/main/java/org/eclipse/ditto/services/utils/aggregator/ThingsAggregatorProxyActor.java
+++ b/services/utils/aggregator/src/main/java/org/eclipse/ditto/services/utils/aggregator/ThingsAggregatorProxyActor.java
@@ -22,6 +22,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
 import org.eclipse.ditto.model.things.Thing;
@@ -178,6 +179,7 @@ public final class ThingsAggregatorProxyActor extends AbstractActor {
         final CompletionStage<List<Pair<String, String>>> o =
                 (CompletionStage<List<Pair<String, String>>>) sourceRef.getSource()
                         .orElse(Source.single(ThingNotAccessibleException.newBuilder("").build()))
+                        .filterNot(el -> el instanceof DittoRuntimeException)
                         .map(param -> thingPairSupplier.apply((Jsonifiable<?>) param))
                         .log("retrieve-thing-response", log)
                         .recover(new PFBuilder()

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/WithEntity.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/WithEntity.java
@@ -10,6 +10,8 @@
  */
 package org.eclipse.ditto.signals.commands.base;
 
+import java.util.Optional;
+
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 
@@ -19,6 +21,20 @@ import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
  * @param <T> the type of the implementing class.
  */
 public interface WithEntity<T extends WithEntity> {
+
+    /**
+     * Returns the plain JSON string representation of the entity which is an
+     * optimization: WithEntity implementations may work on a plain representation, e.g. responses contain directly a
+     * plain JSON string which should be returned at API level.
+     * <p>
+     * By default, returns empty, so that not all implementing classes must be migrated at once.
+     * </p>
+     *
+     * @return the plain JSON string representation of the entity.
+     */
+    default Optional<String> getEntityPlainString() {
+        return Optional.empty();
+    }
 
     /**
      * Returns the entity as JSON.

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingResponseTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.ditto.signals.commands.things.query;
 
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
+import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
@@ -35,13 +36,14 @@ public class RetrieveThingResponseTest {
             .set(ThingCommandResponse.JsonFields.TYPE, RetrieveThingResponse.TYPE)
             .set(ThingCommandResponse.JsonFields.STATUS, HttpStatusCode.OK.toInt())
             .set(ThingCommandResponse.JsonFields.JSON_THING_ID, TestConstants.Thing.THING_ID)
-            .set(RetrieveThingResponse.JSON_THING, TestConstants.Thing.THING.toJson())
+            .set(RetrieveThingResponse.JSON_THING_PLAIN_JSON, TestConstants.Thing.THING.toJsonString())
             .build();
 
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(RetrieveThingResponse.class, areImmutable(), provided(JsonObject.class).isAlsoImmutable());
+        assertInstancesOf(RetrieveThingResponse.class, areImmutable(), provided(JsonObject.class).isAlsoImmutable(),
+                assumingFields("thing").areModifiedAsPartOfAnUnobservableCachingStrategy());
     }
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveThingsResponseTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.ditto.signals.commands.things.query;
 
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
+import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
@@ -38,13 +39,14 @@ public class RetrieveThingsResponseTest {
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommandResponse.JsonFields.TYPE, RetrieveThingsResponse.TYPE)
             .set(ThingCommandResponse.JsonFields.STATUS, HttpStatusCode.OK.toInt())
-            .set(RetrieveThingsResponse.JSON_THINGS, JsonFactory.newArray().add(TestConstants.Thing.THING.toJson()))
+            .set(RetrieveThingsResponse.JSON_THINGS_PLAIN_JSON, "[" + TestConstants.Thing.THING.toJsonString() + "]")
             .set(RetrieveThingsResponse.JSON_NAMESPACE, "example.com")
             .build();
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(RetrieveThingsResponse.class, areImmutable(), provided(JsonArray.class).isAlsoImmutable());
+        assertInstancesOf(RetrieveThingsResponse.class, areImmutable(), provided(JsonArray.class).isAlsoImmutable(),
+                assumingFields("things").areModifiedAsPartOfAnUnobservableCachingStrategy());
     }
 
     @Test
@@ -82,12 +84,6 @@ public class RetrieveThingsResponseTest {
                         null, TestConstants.EMPTY_DITTO_HEADERS);
 
         assertThat(retrieveThingsResponse.getNamespace()).isEmpty();
-    }
-
-    @Test(expected = IllegalArgumentException.class)
-    public void createInstanceWithInvalidNamespacesThrowsException() {
-        RetrieveThingsResponse.of(Collections.singletonList(TestConstants.Thing.THING), FieldType.notHidden(),
-                "namespace.that.does.not.match.the.result", TestConstants.EMPTY_DITTO_HEADERS);
     }
 
     @Test


### PR DESCRIPTION
Currently the ThingsAggregatorProxyActor allocates a lot of copies of ArrayLists (I build in that bug recently).
The bugfix uses the Akka streams `Sink.seq()` in order to prevent that.
It also optimizes the comparator-usage for sorting: sorting is now done only once.

Additionally I enhanced the `RetrieveThingResponse` and `RetrieveThingsResponse` to lazily load the JSON string which is send over the wire to a JsonValue (Object or Array).
For the search use-case the gatway does not need to render the JSON string into an object but instead it only needs to respond with the result string.