### PR TITLE
Reslove duplicate ERROR_CODE in common error registry

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/JsonParseException.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonParseException.java
@@ -23,7 +23,7 @@ public final class JsonParseException extends JsonRuntimeException {
     /**
      * Error code of this exception.
      */
-    public static final String ERROR_CODE = "json.format.invalid";
+    public static final String ERROR_CODE = "json.invalid";
 
     private static final String DEFAULT_DESCRIPTION =
             "Check if the JSON was valid (e.g. on https://jsonlint.com) and if it was in required format.";

--- a/json/src/main/java/org/eclipse/ditto/json/JsonParseException.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonParseException.java
@@ -23,10 +23,10 @@ public final class JsonParseException extends JsonRuntimeException {
     /**
      * Error code of this exception.
      */
-    public static final String ERROR_CODE = "json.invalid";
+    public static final String ERROR_CODE = "json.format.invalid";
 
     private static final String DEFAULT_DESCRIPTION =
-            "Check if the JSON was valid (e.g. on http://jsonlint.com) and if it was in required format.";
+            "Check if the JSON was valid (e.g. on https://jsonlint.com) and if it was in required format.";
 
     private static final long serialVersionUID = -7585793723086474449L;
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoHeaderInvalidException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoHeaderInvalidException.java
@@ -97,15 +97,14 @@ public final class DittoHeaderInvalidException extends DittoRuntimeException {
      * JsonFields#MESSAGE} field.
      */
     public static DittoHeaderInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
-    }
-
-    private static DittoHeaderInvalidException fromMessage(final String message, final DittoHeaders dittoHeaders) {
         return new Builder()
                 .dittoHeaders(dittoHeaders)
-                .message(message)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
+
     /**
      * A mutable builder with a fluent API for a {@link DittoHeaderInvalidException}.
      */

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoJsonException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoJsonException.java
@@ -29,7 +29,7 @@ public final class DittoJsonException extends DittoRuntimeException {
     /**
      * Fallback Error code of this exception.
      */
-    public static final String FALLBACK_ERROR_CODE = "json.invalid";
+    public static final String FALLBACK_ERROR_CODE = "json.format.invalid";
 
     private static final long serialVersionUID = -6003501868758251973L;
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoJsonException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoJsonException.java
@@ -74,7 +74,7 @@ public final class DittoJsonException extends DittoRuntimeException {
     }
 
     /**
-     * Executes the given Function. Executes the given Supplier. An occurring {@link JsonRuntimeException},
+     * Executes the given Function. An occurring {@link JsonRuntimeException},
      * {@code IllegalArgumentException} or {@code NullPointerException} is caught, wrapped and re-thrown as
      * {@code DittoJsonException}.
      *

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoRuntimeException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/DittoRuntimeException.java
@@ -140,12 +140,18 @@ public class DittoRuntimeException extends RuntimeException implements
                 .href(dittoRuntimeException.href);
     }
 
+    protected static Optional<URI> readHRef(final JsonObject jsonObject) {
+        checkNotNull(jsonObject, "JSON object");
+        return jsonObject.getValue(JsonFields.HREF).map(URI::create);
+    }
+
     protected static String readMessage(final JsonObject jsonObject) {
         checkNotNull(jsonObject, "JSON object");
         return jsonObject.getValueOrThrow(JsonFields.MESSAGE);
     }
 
     protected static Optional<String> readDescription(final JsonObject jsonObject) {
+        checkNotNull(jsonObject, "JSON object");
         return jsonObject.getValue(JsonFields.DESCRIPTION);
     }
 
@@ -196,9 +202,7 @@ public class DittoRuntimeException extends RuntimeException implements
      *
      * @return a link to provide the user with further information about this exception.
      */
-    public Optional<URI> getHref() {
-        return Optional.ofNullable(href);
-    }
+    public Optional<URI> getHref() { return Optional.ofNullable(href); }
 
     @Override
     public String getManifest() {

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/InvalidRqlExpressionException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/InvalidRqlExpressionException.java
@@ -78,7 +78,12 @@ public class InvalidRqlExpressionException extends DittoRuntimeException {
      * JsonFields#MESSAGE} field.
      */
     public static InvalidRqlExpressionException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionConfigurationInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionConfigurationInvalidException.java
@@ -44,7 +44,6 @@ public final class ConnectionConfigurationInvalidException extends DittoRuntimeE
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,7 +114,6 @@ public final class ConnectionConfigurationInvalidException extends DittoRuntimeE
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ConnectionConfigurationInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionConfigurationInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionConfigurationInvalidException.java
@@ -67,7 +67,6 @@ public final class ConnectionConfigurationInvalidException extends DittoRuntimeE
      */
     public static ConnectionConfigurationInvalidException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -87,11 +86,11 @@ public final class ConnectionConfigurationInvalidException extends DittoRuntimeE
      */
     public static ConnectionConfigurationInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionSignalIdEnforcementFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionSignalIdEnforcementFailedException.java
@@ -48,7 +48,6 @@ public final class ConnectionSignalIdEnforcementFailedException extends DittoRun
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -118,7 +117,6 @@ public final class ConnectionSignalIdEnforcementFailedException extends DittoRun
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ConnectionSignalIdEnforcementFailedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionSignalIdEnforcementFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionSignalIdEnforcementFailedException.java
@@ -71,7 +71,6 @@ public final class ConnectionSignalIdEnforcementFailedException extends DittoRun
      */
     public static ConnectionSignalIdEnforcementFailedException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -90,11 +89,11 @@ public final class ConnectionSignalIdEnforcementFailedException extends DittoRun
      */
     public static ConnectionSignalIdEnforcementFailedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
-                .description(readDescription(jsonObject).orElse(null))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionUriInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionUriInvalidException.java
@@ -86,6 +86,7 @@ public final class ConnectionUriInvalidException extends DittoRuntimeException i
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionUriInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionUriInvalidException.java
@@ -41,9 +41,11 @@ public final class ConnectionUriInvalidException extends DittoRuntimeException i
 
     private static final long serialVersionUID = -3899791430534146626L;
 
-    private ConnectionUriInvalidException(final DittoHeaders dittoHeaders, @Nullable final String message,
+    private ConnectionUriInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
             @Nullable final String description,
-            @Nullable final Throwable cause, @Nullable final URI href) {
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,8 +108,11 @@ public final class ConnectionUriInvalidException extends DittoRuntimeException i
         }
 
         @Override
-        protected ConnectionUriInvalidException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected ConnectionUriInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionUriInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationFailedException.java
@@ -41,9 +41,11 @@ public final class MessageMapperConfigurationFailedException extends DittoRuntim
 
     private static final long serialVersionUID = 3108439347153942427L;
 
-    private MessageMapperConfigurationFailedException(final DittoHeaders dittoHeaders, @Nullable final String message,
+    private MessageMapperConfigurationFailedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
             @Nullable final String description,
-            @Nullable final Throwable cause, @Nullable final URI href) {
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,8 +108,11 @@ public final class MessageMapperConfigurationFailedException extends DittoRuntim
         }
 
         @Override
-        protected MessageMapperConfigurationFailedException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected MessageMapperConfigurationFailedException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new MessageMapperConfigurationFailedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationFailedException.java
@@ -82,7 +82,12 @@ public final class MessageMapperConfigurationFailedException extends DittoRuntim
      * JsonFields#MESSAGE} field.
      */
     public static MessageMapperConfigurationFailedException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationInvalidException.java
@@ -43,9 +43,11 @@ public final class MessageMapperConfigurationInvalidException extends DittoRunti
 
     private static final long serialVersionUID = -2538489434734124572L;
 
-    private MessageMapperConfigurationInvalidException(final DittoHeaders dittoHeaders, @Nullable final String message,
+    private MessageMapperConfigurationInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
             @Nullable final String description,
-            @Nullable final Throwable cause, @Nullable final URI href) {
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -108,8 +110,11 @@ public final class MessageMapperConfigurationInvalidException extends DittoRunti
         }
 
         @Override
-        protected MessageMapperConfigurationInvalidException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected MessageMapperConfigurationInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new MessageMapperConfigurationInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationInvalidException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMapperConfigurationInvalidException.java
@@ -35,9 +35,11 @@ public final class MessageMapperConfigurationInvalidException extends DittoRunti
      */
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "message.mapper.config.invalid";
 
-    private static final String MESSAGE_TEMPLATE = "The message mapper was not configured correctly as property ''{0}'' was missing from the mapper's configuration.";
+    private static final String MESSAGE_TEMPLATE =
+            "The message mapper was not configured correctly as property ''{0}'' was missing from the mapper's configuration.";
 
-    private static final String DEFAULT_DESCRIPTION = "Make sure to add the missing property to the mapper's configuration.";
+    private static final String DEFAULT_DESCRIPTION =
+            "Make sure to add the missing property to the mapper's configuration.";
 
     private static final long serialVersionUID = -2538489434734124572L;
 
@@ -82,7 +84,12 @@ public final class MessageMapperConfigurationInvalidException extends DittoRunti
      * JsonFields#MESSAGE} field.
      */
     public static MessageMapperConfigurationInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMappingFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMappingFailedException.java
@@ -91,6 +91,7 @@ public final class MessageMappingFailedException extends DittoRuntimeException i
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMappingFailedException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/MessageMappingFailedException.java
@@ -45,9 +45,11 @@ public final class MessageMappingFailedException extends DittoRuntimeException i
 
     private static final long serialVersionUID = -6312489434534126579L;
 
-    private MessageMappingFailedException(final DittoHeaders dittoHeaders, @Nullable final String message,
+    private MessageMappingFailedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
             @Nullable final String description,
-            @Nullable final Throwable cause, @Nullable final URI href) {
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,8 +117,11 @@ public final class MessageMappingFailedException extends DittoRuntimeException i
         }
 
         @Override
-        protected MessageMappingFailedException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected MessageMappingFailedException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new MessageMappingFailedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/TopicParseException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/TopicParseException.java
@@ -80,7 +80,6 @@ public final class TopicParseException extends DittoRuntimeException implements 
      */
     public static TopicParseException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -99,8 +98,12 @@ public final class TopicParseException extends DittoRuntimeException implements 
      */
     public static TopicParseException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/TopicParseException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/TopicParseException.java
@@ -46,7 +46,6 @@ public final class TopicParseException extends DittoRuntimeException implements 
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -130,7 +129,6 @@ public final class TopicParseException extends DittoRuntimeException implements 
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new TopicParseException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/UnresolvedPlaceholderException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/UnresolvedPlaceholderException.java
@@ -79,7 +79,6 @@ public final class UnresolvedPlaceholderException extends DittoRuntimeException
      */
     public static UnresolvedPlaceholderException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -99,8 +98,12 @@ public final class UnresolvedPlaceholderException extends DittoRuntimeException
      */
     public static UnresolvedPlaceholderException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/UnresolvedPlaceholderException.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/UnresolvedPlaceholderException.java
@@ -47,7 +47,6 @@ public final class UnresolvedPlaceholderException extends DittoRuntimeException
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -127,7 +126,6 @@ public final class UnresolvedPlaceholderException extends DittoRuntimeException
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new UnresolvedPlaceholderException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
@@ -66,7 +66,6 @@ public final class MessageFormatInvalidException extends DittoRuntimeException i
             @Nullable final Throwable cause,
             @Nullable final URI href,
             @Nullable final JsonArray validationErrors) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
         this.validationErrors = validationErrors;
     }
@@ -164,7 +163,6 @@ public final class MessageFormatInvalidException extends DittoRuntimeException i
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new MessageFormatInvalidException(dittoHeaders, message, description, cause, href,
                     validationErrors);
         }

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
@@ -120,6 +120,9 @@ public final class MessageFormatInvalidException extends DittoRuntimeException i
         return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageFormatInvalidException.java
@@ -81,7 +81,6 @@ public final class MessageFormatInvalidException extends DittoRuntimeException i
         return new MessageFormatInvalidException.Builder(validationErrors);
     }
 
-
     @Override
     protected void appendToJson(final JsonObjectBuilder jsonObjectBuilder, final Predicate<JsonField> predicate) {
         jsonObjectBuilder.set(VALIDATION_ERRORS, null != validationErrors ? validationErrors : JsonFactory.nullArray(),

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
@@ -41,8 +41,11 @@ public final class MessagePayloadSizeTooLargeException extends DittoRuntimeExcep
 
     private static final long serialVersionUID = -2530157640888612975L;
 
-    private MessagePayloadSizeTooLargeException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private MessagePayloadSizeTooLargeException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.REQUEST_ENTITY_TOO_LARGE, dittoHeaders, message, description, cause, href);
     }
 
@@ -94,7 +97,9 @@ public final class MessagePayloadSizeTooLargeException extends DittoRuntimeExcep
         @Override
         protected MessagePayloadSizeTooLargeException doBuild(final DittoHeaders dittoHeaders,
                 @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new MessagePayloadSizeTooLargeException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
@@ -66,9 +66,12 @@ public final class MessagePayloadSizeTooLargeException extends DittoRuntimeExcep
      */
     public static MessagePayloadSizeTooLargeException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return new MessagePayloadSizeTooLargeException.Builder()
+        return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessagePayloadSizeTooLargeException.java
@@ -36,6 +36,7 @@ public final class MessagePayloadSizeTooLargeException extends DittoRuntimeExcep
 
     private static final String MESSAGE_TEMPLATE =
             "The message payload size of ''{0}'' kB exceeds the maximal allowed size of ''{1}'' kB.";
+
     private static final String DEFAULT_DESCRIPTION = "Reduce the message payload in the bounds of the specified limit";
 
     private static final long serialVersionUID = -2530157640888612975L;

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
@@ -92,10 +92,12 @@ public final class MessageSendNotAllowedException extends DittoRuntimeException 
      */
     public static MessageSendNotAllowedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
@@ -56,7 +56,6 @@ public final class MessageSendNotAllowedException extends DittoRuntimeException 
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -123,7 +122,6 @@ public final class MessageSendNotAllowedException extends DittoRuntimeException 
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new MessageSendNotAllowedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageTimeoutException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageTimeoutException.java
@@ -55,7 +55,6 @@ public final class MessageTimeoutException extends DittoRuntimeException impleme
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.REQUEST_TIMEOUT, dittoHeaders, message, description, cause, href);
     }
 
@@ -121,7 +120,6 @@ public final class MessageTimeoutException extends DittoRuntimeException impleme
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new MessageTimeoutException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageTimeoutException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageTimeoutException.java
@@ -93,6 +93,9 @@ public final class MessageTimeoutException extends DittoRuntimeException impleme
         return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/SubjectInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/SubjectInvalidException.java
@@ -91,10 +91,13 @@ public final class SubjectInvalidException extends DittoRuntimeException impleme
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static SubjectInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        final Builder builder = new Builder();
-        builder.loadJson(jsonObject);
-        builder.dittoHeaders(dittoHeaders);
-        return builder.build();
+        return new Builder()
+                .loadJson(jsonObject)
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/SubjectInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/SubjectInvalidException.java
@@ -56,7 +56,6 @@ public final class SubjectInvalidException extends DittoRuntimeException impleme
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -122,7 +121,6 @@ public final class SubjectInvalidException extends DittoRuntimeException impleme
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new SubjectInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
@@ -56,7 +56,6 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -125,7 +124,6 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ThingIdInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
@@ -96,7 +96,12 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
      * JsonFields#MESSAGE} field.
      */
     public static ThingIdInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(DittoRuntimeException.readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
@@ -57,7 +57,6 @@ public final class TimeoutInvalidException extends DittoRuntimeException impleme
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -124,7 +123,6 @@ public final class TimeoutInvalidException extends DittoRuntimeException impleme
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new TimeoutInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
@@ -93,10 +93,13 @@ public final class TimeoutInvalidException extends DittoRuntimeException impleme
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static TimeoutInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        final Builder builder = new Builder();
-        builder.loadJson(jsonObject);
-        builder.dittoHeaders(dittoHeaders);
-        return builder.build();
+        return new Builder()
+                .loadJson(jsonObject)
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
@@ -46,7 +46,6 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,7 +115,6 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new PolicyEntryInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
@@ -37,6 +37,8 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
 
     private static final String DEFAULT_MESSAGE = "The Policy Entry is invalid.";
 
+    private static final String DEFAULT_DESCRIPTION = "Policy entry does not contain any known permission like 'READ' or 'WRITE'";
+
     private static final long serialVersionUID = 7032353950909423082L;
 
     private PolicyEntryInvalidException(final DittoHeaders dittoHeaders,
@@ -67,7 +69,6 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
      */
     public static PolicyEntryInvalidException fromMessage(@Nullable final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .message(message)
                 .dittoHeaders(dittoHeaders)
@@ -86,7 +87,12 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
      * JsonFields#MESSAGE} field.
      */
     public static PolicyEntryInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyEntryInvalidException.java
@@ -107,6 +107,7 @@ public final class PolicyEntryInvalidException extends DittoRuntimeException imp
 
         private Builder() {
             message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
         }
 
         @Override

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
@@ -57,7 +57,6 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -133,7 +132,6 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new PolicyIdInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
@@ -81,7 +81,6 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
      */
     public static PolicyIdInvalidException fromMessage(@Nullable final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .message(message)
                 .dittoHeaders(dittoHeaders)
@@ -99,7 +98,12 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static PolicyIdInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyTooLargeException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyTooLargeException.java
@@ -66,9 +66,12 @@ public final class PolicyTooLargeException extends DittoRuntimeException impleme
      */
     public static PolicyTooLargeException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return new PolicyTooLargeException.Builder()
+        return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyTooLargeException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyTooLargeException.java
@@ -40,8 +40,11 @@ public final class PolicyTooLargeException extends DittoRuntimeException impleme
 
     private static final long serialVersionUID = 2434234324327234489L;
 
-    private PolicyTooLargeException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private PolicyTooLargeException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.REQUEST_ENTITY_TOO_LARGE, dittoHeaders, message, description, cause, href);
     }
 
@@ -91,8 +94,11 @@ public final class PolicyTooLargeException extends DittoRuntimeException impleme
         }
 
         @Override
-        protected PolicyTooLargeException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected PolicyTooLargeException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyTooLargeException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/SubjectIdInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/SubjectIdInvalidException.java
@@ -57,7 +57,6 @@ public final class SubjectIdInvalidException extends DittoRuntimeException imple
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -133,7 +132,6 @@ public final class SubjectIdInvalidException extends DittoRuntimeException imple
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new SubjectIdInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/SubjectIdInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/SubjectIdInvalidException.java
@@ -81,7 +81,6 @@ public final class SubjectIdInvalidException extends DittoRuntimeException imple
      */
     public static SubjectIdInvalidException fromMessage(@Nullable final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .message(message)
                 .dittoHeaders(dittoHeaders)
@@ -100,7 +99,12 @@ public final class SubjectIdInvalidException extends DittoRuntimeException imple
      * JsonFields#MESSAGE} field.
      */
     public static SubjectIdInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
@@ -105,6 +105,7 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
 
         private Builder() {
             message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
         }
 
         @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
@@ -36,6 +36,9 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
 
     private static final String DEFAULT_MESSAGE = "The Access Control List Entry is invalid.";
 
+    private static final String DEFAULT_DESCRIPTION = "Valid Access Control List Entries are 'READ', 'WRITE' or " +
+            "'ADMINISTRATE'.";
+
     private static final long serialVersionUID = 4590455181499641439L;
 
     private AclEntryInvalidException(final DittoHeaders dittoHeaders, final String message,
@@ -61,9 +64,9 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
      * @return the new AclEntryInvalidException.
      */
     public static AclEntryInvalidException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return newBuilder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return newBuilder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -77,7 +80,12 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static AclEntryInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return newBuilder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclEntryInvalidException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.model.things;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -41,9 +42,11 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
 
     private static final long serialVersionUID = 4590455181499641439L;
 
-    private AclEntryInvalidException(final DittoHeaders dittoHeaders, final String message,
-            final String description,
-            final Throwable cause, final URI href) {
+    private AclEntryInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -105,8 +108,11 @@ public final class AclEntryInvalidException extends DittoRuntimeException implem
         }
 
         @Override
-        protected AclEntryInvalidException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AclEntryInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AclEntryInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclInvalidException.java
@@ -71,9 +71,9 @@ public final class AclInvalidException extends DittoRuntimeException implements 
      * @return the new AclInvalidException.
      */
     public static AclInvalidException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -87,7 +87,12 @@ public final class AclInvalidException extends DittoRuntimeException implements 
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static AclInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclNotAllowedException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclNotAllowedException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.model.things;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class AclNotAllowedException extends DittoRuntimeException implemen
 
     private static final long serialVersionUID = -2640894758584381867L;
 
-    private AclNotAllowedException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private AclNotAllowedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,8 +115,11 @@ public final class AclNotAllowedException extends DittoRuntimeException implemen
         }
 
         @Override
-        protected AclNotAllowedException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AclNotAllowedException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AclNotAllowedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AclNotAllowedException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AclNotAllowedException.java
@@ -65,9 +65,9 @@ public final class AclNotAllowedException extends DittoRuntimeException implemen
      * @return the new AclNotAllowedException.
      */
     public static AclNotAllowedException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -81,7 +81,12 @@ public final class AclNotAllowedException extends DittoRuntimeException implemen
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static AclNotAllowedException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionEmptyException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionEmptyException.java
@@ -50,7 +50,6 @@ public final class FeatureDefinitionEmptyException extends DittoRuntimeException
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,7 +115,6 @@ public final class FeatureDefinitionEmptyException extends DittoRuntimeException
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new FeatureDefinitionEmptyException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionEmptyException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionEmptyException.java
@@ -72,7 +72,6 @@ public final class FeatureDefinitionEmptyException extends DittoRuntimeException
      */
     public static FeatureDefinitionEmptyException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -91,8 +90,12 @@ public final class FeatureDefinitionEmptyException extends DittoRuntimeException
      */
     public static FeatureDefinitionEmptyException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(DittoRuntimeException.readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionIdentifierInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionIdentifierInvalidException.java
@@ -77,7 +77,6 @@ public final class FeatureDefinitionIdentifierInvalidException extends DittoRunt
      */
     public static FeatureDefinitionIdentifierInvalidException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -96,8 +95,12 @@ public final class FeatureDefinitionIdentifierInvalidException extends DittoRunt
      */
     public static FeatureDefinitionIdentifierInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(DittoRuntimeException.readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionIdentifierInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/FeatureDefinitionIdentifierInvalidException.java
@@ -54,7 +54,6 @@ public final class FeatureDefinitionIdentifierInvalidException extends DittoRunt
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -125,7 +124,6 @@ public final class FeatureDefinitionIdentifierInvalidException extends DittoRunt
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new FeatureDefinitionIdentifierInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
@@ -60,8 +60,11 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
 
     private static final long serialVersionUID = -2640894758584381867L;
 
-    private PolicyIdMissingException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private PolicyIdMissingException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -135,8 +138,11 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
         }
 
         @Override
-        protected PolicyIdMissingException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected PolicyIdMissingException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyIdMissingException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
@@ -36,7 +36,6 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
      */
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "policy.id.missing";
 
-
     private static final String MESSAGE_TEMPLATE_UPDATE =
             "The schema version of the Thing with ID ''{0}'' does not allow an update on schema version ''{1}'' " +
                     "without providing a policy id";
@@ -53,23 +52,17 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
     private static final String DEFAULT_DESCRIPTION_CREATE =
             "You need to specify a policy id.";
 
+    private static final String DEFAULT_DESCRIPTION_GENERIC =
+            "Either you need to specific a PolicyId or when updating " +
+                    "a schema version 1 Thing using a higher schema version API, you need to add a policyId. " +
+                    "Be aware that this will convert the Thing to the higher schema version, thus removing all ACL " +
+                    "information from it.";
+
     private static final long serialVersionUID = -2640894758584381867L;
 
     private PolicyIdMissingException(final DittoHeaders dittoHeaders, @Nullable final String message,
             @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
-    }
-
-    private static PolicyIdMissingException fromMessage(final String message, @Nullable final String description,
-            final DittoHeaders dittoHeaders) {
-        final DittoRuntimeExceptionBuilder<PolicyIdMissingException> exceptionBuilder = new Builder()
-                .dittoHeaders(dittoHeaders)
-                .message(message);
-        if (description != null) {
-            return exceptionBuilder.description(description).build();
-        } else {
-            return exceptionBuilder.build();
-        }
     }
 
     /**
@@ -100,7 +93,6 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
                 .build();
     }
 
-
     /**
      * Constructs a new {@code PolicyIdMissingException} object with the exception message and description extracted
      * from the given JSON object.
@@ -113,7 +105,12 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
      * {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static PolicyIdMissingException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_CREATE), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_GENERIC))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/PolicyIdMissingException.java
@@ -127,7 +127,9 @@ public final class PolicyIdMissingException extends DittoRuntimeException implem
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyIdMissingException> {
 
-        private Builder() {}
+        private Builder() {
+            description(DEFAULT_DESCRIPTION_GENERIC);
+        }
 
         private Builder(final String thingId, final JsonSchemaVersion version, final String messageTemplate,
                 final String description) {

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.model.things;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -51,11 +52,10 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
     }
 
     private ThingIdInvalidException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -118,8 +118,11 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
         }
 
         @Override
-        protected ThingIdInvalidException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingIdInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingIdInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
@@ -77,9 +77,9 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
      * @return the new ThingIdInvalidException.
      */
     public static ThingIdInvalidException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -93,7 +93,12 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static ThingIdInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(DittoRuntimeException.readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingTooLargeException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingTooLargeException.java
@@ -69,6 +69,9 @@ public final class ThingTooLargeException extends DittoRuntimeException implemen
         return new ThingTooLargeException.Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingTooLargeException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingTooLargeException.java
@@ -36,12 +36,16 @@ public final class ThingTooLargeException extends DittoRuntimeException implemen
 
     private static final String MESSAGE_TEMPLATE =
             "The size of ''{0}'' kB exceeds the maximal allowed Thing size of ''{1}'' kB.";
+
     private static final String DEFAULT_DESCRIPTION = "Reduce the Thing size in the bounds of the specified limit";
 
     private static final long serialVersionUID = 6239157630841614456L;
 
-    private ThingTooLargeException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ThingTooLargeException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.REQUEST_ENTITY_TOO_LARGE, dittoHeaders, message, description, cause, href);
     }
 
@@ -91,8 +95,11 @@ public final class ThingTooLargeException extends DittoRuntimeException implemen
         }
 
         @Override
-        protected ThingTooLargeException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected ThingTooLargeException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingTooLargeException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapter.java
@@ -423,12 +423,18 @@ public class DittoProtocolAdapter implements ProtocolAdapter {
                     .forEach(type -> parseStrategies.put(type, messageErrorRegistry));
 
             // Protocol Adapter exceptions:
-            parseStrategies.put(UnknownSignalException.ERROR_CODE, UnknownSignalException::fromJson);
-            parseStrategies.put(UnknownCommandException.ERROR_CODE, UnknownCommandException::fromJson);
-            parseStrategies.put(UnknownCommandResponseException.ERROR_CODE, UnknownCommandResponseException::fromJson);
-            parseStrategies.put(UnknownEventException.ERROR_CODE, UnknownEventException::fromJson);
-            parseStrategies.put(UnknownPathException.ERROR_CODE, UnknownPathException::fromJson);
-            parseStrategies.put(UnknownTopicPathException.ERROR_CODE, UnknownTopicPathException::fromJson);
+            parseStrategies.put(UnknownCommandException.ERROR_CODE,
+                    UnknownCommandException::fromJson);
+            parseStrategies.put(UnknownCommandResponseException.ERROR_CODE,
+                    UnknownCommandResponseException::fromJson);
+            parseStrategies.put(UnknownEventException.ERROR_CODE,
+                    UnknownEventException::fromJson);
+            parseStrategies.put(UnknownPathException.ERROR_CODE,
+                    UnknownPathException::fromJson);
+            parseStrategies.put(UnknownSignalException.ERROR_CODE,
+                    UnknownSignalException::fromJson);
+            parseStrategies.put(UnknownTopicPathException.ERROR_CODE,
+                    UnknownTopicPathException::fromJson);
 
             return new ProtocolAdapterErrorRegistry(parseStrategies);
         }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public final class UnknownCommandException extends DittoRuntimeException {
 
     private static final long serialVersionUID = 1359090043587487779L;
 
-    private UnknownCommandException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private UnknownCommandException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -101,8 +105,11 @@ public final class UnknownCommandException extends DittoRuntimeException {
         }
 
         @Override
-        protected UnknownCommandException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownCommandException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownCommandException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandException.java
@@ -60,9 +60,9 @@ public final class UnknownCommandException extends DittoRuntimeException {
      * @return the new UnknownCommandException.
      */
     public static UnknownCommandException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -77,12 +77,16 @@ public final class UnknownCommandException extends DittoRuntimeException {
      * DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static UnknownCommandException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link UnknownCommandException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<UnknownCommandException> {

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandResponseException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandResponseException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public final class UnknownCommandResponseException extends DittoRuntimeException
 
     private static final long serialVersionUID = 3886410099324151406L;
 
-    private UnknownCommandResponseException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private UnknownCommandResponseException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -104,8 +108,11 @@ public final class UnknownCommandResponseException extends DittoRuntimeException
         }
 
         @Override
-        protected UnknownCommandResponseException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownCommandResponseException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownCommandResponseException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandResponseException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownCommandResponseException.java
@@ -61,9 +61,9 @@ public final class UnknownCommandResponseException extends DittoRuntimeException
      */
     public static UnknownCommandResponseException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -79,7 +79,12 @@ public final class UnknownCommandResponseException extends DittoRuntimeException
      */
     public static UnknownCommandResponseException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownEventException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownEventException.java
@@ -60,9 +60,9 @@ public final class UnknownEventException extends DittoRuntimeException {
      * @return the new UnknownEventException.
      */
     public static UnknownEventException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -77,12 +77,16 @@ public final class UnknownEventException extends DittoRuntimeException {
      * DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static UnknownEventException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link UnknownEventException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<UnknownEventException> {

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownEventException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownEventException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public final class UnknownEventException extends DittoRuntimeException {
 
     private static final long serialVersionUID = 1359090043587487779L;
 
-    private UnknownEventException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private UnknownEventException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -101,8 +105,11 @@ public final class UnknownEventException extends DittoRuntimeException {
         }
 
         @Override
-        protected UnknownEventException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownEventException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownEventException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownPathException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownPathException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -39,8 +40,11 @@ public final class UnknownPathException extends DittoRuntimeException {
 
     private static final long serialVersionUID = 3180803226245564305L;
 
-    private UnknownPathException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private UnknownPathException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -103,8 +107,11 @@ public final class UnknownPathException extends DittoRuntimeException {
         }
 
         @Override
-        protected UnknownPathException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownPathException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownPathException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownPathException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownPathException.java
@@ -62,9 +62,9 @@ public final class UnknownPathException extends DittoRuntimeException {
      * @return the new UnknownPathException.
      */
     public static UnknownPathException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -79,12 +79,16 @@ public final class UnknownPathException extends DittoRuntimeException {
      * DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static UnknownPathException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link UnknownPathException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<UnknownPathException> {

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownSignalException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownSignalException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public final class UnknownSignalException extends DittoRuntimeException {
 
     private static final long serialVersionUID = -4379093157473087421L;
 
-    private UnknownSignalException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private UnknownSignalException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -101,8 +105,11 @@ public final class UnknownSignalException extends DittoRuntimeException {
         }
 
         @Override
-        protected UnknownSignalException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownSignalException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownSignalException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownSignalException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownSignalException.java
@@ -5,7 +5,7 @@
  * are made available under the terms of the Eclipse Public License v2.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/org/documents/epl-2.0/index.php
- *  
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.eclipse.ditto.protocoladapter;
@@ -60,9 +60,9 @@ public final class UnknownSignalException extends DittoRuntimeException {
      * @return the new UnknownSignalException.
      */
     public static UnknownSignalException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -77,12 +77,16 @@ public final class UnknownSignalException extends DittoRuntimeException {
      * JsonFields#MESSAGE} field.
      */
     public static UnknownSignalException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link UnknownSignalException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<UnknownSignalException> {

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
 
     private static final long serialVersionUID = 5748920703966374167L;
 
-    private UnknownTopicPathException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private UnknownTopicPathException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,8 +115,11 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
         }
 
         @Override
-        protected UnknownTopicPathException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected UnknownTopicPathException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new UnknownTopicPathException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
@@ -70,9 +70,9 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
      * @return the new UnknownTopicPathException.
      */
     public static UnknownTopicPathException fromMessage(final String message, final DittoHeaders dittoHeaders) {
-        return new Builder() //
-                .dittoHeaders(dittoHeaders) //
-                .message(message) //
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 
@@ -87,12 +87,16 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
      * JsonFields#MESSAGE} field.
      */
     public static UnknownTopicPathException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link UnknownTopicPathException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<UnknownTopicPathException> {

--- a/signals/base/src/main/java/org/eclipse/ditto/signals/base/JsonTypeNotParsableException.java
+++ b/signals/base/src/main/java/org/eclipse/ditto/signals/base/JsonTypeNotParsableException.java
@@ -81,7 +81,12 @@ public final class JsonTypeNotParsableException extends DittoRuntimeException {
      */
     public static JsonTypeNotParsableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommandNotSupportedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommandNotSupportedException.java
@@ -69,7 +69,6 @@ public final class CommandNotSupportedException extends DittoRuntimeException {
      */
     public static CommandNotSupportedException fromMessage(@Nullable final String message,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -88,7 +87,12 @@ public final class CommandNotSupportedException extends DittoRuntimeException {
      * JsonFields#MESSAGE} field.
      */
     public static CommandNotSupportedException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return  new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommandNotSupportedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommandNotSupportedException.java
@@ -45,7 +45,6 @@ public final class CommandNotSupportedException extends DittoRuntimeException {
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -117,7 +116,6 @@ public final class CommandNotSupportedException extends DittoRuntimeException {
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new CommandNotSupportedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommonErrorRegistry.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommonErrorRegistry.java
@@ -58,6 +58,7 @@ public final class CommonErrorRegistry extends AbstractErrorRegistry<DittoRuntim
     public static CommonErrorRegistry newInstance() {
         final Map<String, JsonParsable<DittoRuntimeException>> parseStrategies = new HashMap<>();
 
+        // exceptions in package
         parseStrategies.put(JsonParseException.ERROR_CODE, (jsonObject, dittoHeaders) -> new DittoJsonException(
                 JsonParseException.newBuilder().message(getMessage(jsonObject)).build(), dittoHeaders));
 
@@ -74,13 +75,22 @@ public final class CommonErrorRegistry extends AbstractErrorRegistry<DittoRuntim
                         JsonPointerInvalidException.newBuilder().message(getMessage(jsonObject)).build(),
                         dittoHeaders));
 
-        // other common exceptions
-        parseStrategies.put(DittoHeaderInvalidException.ERROR_CODE, DittoHeaderInvalidException::fromJson);
-        parseStrategies.put(CommandNotSupportedException.ERROR_CODE, CommandNotSupportedException::fromJson);
-        parseStrategies.put(JsonTypeNotParsableException.ERROR_CODE, JsonTypeNotParsableException::fromJson);
-        parseStrategies.put(InvalidRqlExpressionException.ERROR_CODE, InvalidRqlExpressionException::fromJson);
+        // exceptions in package org.eclipse.ditto.model.base.exceptions
+        parseStrategies.put(DittoHeaderInvalidException.ERROR_CODE,
+                DittoHeaderInvalidException::fromJson);
 
-        // Gateway exceptions
+        parseStrategies.put(InvalidRqlExpressionException.ERROR_CODE,
+                InvalidRqlExpressionException::fromJson);
+
+        // exception in package org.eclipse.ditto.signals.commands.base
+        parseStrategies.put(CommandNotSupportedException.
+                ERROR_CODE, CommandNotSupportedException::fromJson);
+
+        // exception in package org.eclipse.ditto.signals.base
+        parseStrategies.put(JsonTypeNotParsableException.ERROR_CODE,
+                JsonTypeNotParsableException::fromJson);
+
+        // exceptions in package org.eclipse.ditto.signals.commands.base.exceptions
         parseStrategies.put(GatewayAuthenticationFailedException.ERROR_CODE,
                 GatewayAuthenticationFailedException::fromJson);
 
@@ -99,20 +109,20 @@ public final class CommonErrorRegistry extends AbstractErrorRegistry<DittoRuntim
         parseStrategies.put(GatewayMethodNotAllowedException.ERROR_CODE,
                 GatewayMethodNotAllowedException::fromJson);
 
+        parseStrategies.put(GatewayPlaceholderNotResolvableException.ERROR_CODE,
+                GatewayPlaceholderNotResolvableException::fromJson);
+
         parseStrategies.put(GatewayQueryTimeExceededException.ERROR_CODE,
                 GatewayQueryTimeExceededException::fromJson);
 
         parseStrategies.put(GatewayServiceTimeoutException.ERROR_CODE,
                 GatewayServiceTimeoutException::fromJson);
 
-        parseStrategies.put(GatewayServiceUnavailableException.ERROR_CODE,
-                GatewayServiceUnavailableException::fromJson);
-
         parseStrategies.put(GatewayServiceTooManyRequestsException.ERROR_CODE,
                 GatewayServiceTooManyRequestsException::fromJson);
 
-        parseStrategies.put(GatewayPlaceholderNotResolvableException.ERROR_CODE,
-                GatewayPlaceholderNotResolvableException::fromJson);
+        parseStrategies.put(GatewayServiceUnavailableException.ERROR_CODE,
+                GatewayServiceUnavailableException::fromJson);
 
         return new CommonErrorRegistry(parseStrategies);
     }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommonErrorRegistry.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/CommonErrorRegistry.java
@@ -31,6 +31,8 @@ import org.eclipse.ditto.signals.base.JsonTypeNotParsableException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationProviderUnavailableException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayInternalErrorException;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayJwtInvalidException;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayJwtIssuerNotSupportedException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayMethodNotAllowedException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayPlaceholderNotResolvableException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayQueryTimeExceededException;
@@ -73,7 +75,6 @@ public final class CommonErrorRegistry extends AbstractErrorRegistry<DittoRuntim
                         dittoHeaders));
 
         // other common exceptions
-
         parseStrategies.put(DittoHeaderInvalidException.ERROR_CODE, DittoHeaderInvalidException::fromJson);
         parseStrategies.put(CommandNotSupportedException.ERROR_CODE, CommandNotSupportedException::fromJson);
         parseStrategies.put(JsonTypeNotParsableException.ERROR_CODE, JsonTypeNotParsableException::fromJson);
@@ -84,32 +85,31 @@ public final class CommonErrorRegistry extends AbstractErrorRegistry<DittoRuntim
                 GatewayAuthenticationFailedException::fromJson);
 
         parseStrategies.put(GatewayAuthenticationProviderUnavailableException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayAuthenticationProviderUnavailableException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayAuthenticationProviderUnavailableException::fromJson);
 
         parseStrategies.put(GatewayInternalErrorException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayInternalErrorException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayInternalErrorException::fromJson);
+
+        parseStrategies.put(GatewayJwtInvalidException.ERROR_CODE,
+                GatewayJwtInvalidException::fromJson);
+
+        parseStrategies.put(GatewayJwtIssuerNotSupportedException.ERROR_CODE,
+                GatewayJwtIssuerNotSupportedException::fromJson);
 
         parseStrategies.put(GatewayMethodNotAllowedException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayMethodNotAllowedException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayMethodNotAllowedException::fromJson);
 
         parseStrategies.put(GatewayQueryTimeExceededException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayQueryTimeExceededException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayQueryTimeExceededException::fromJson);
 
         parseStrategies.put(GatewayServiceTimeoutException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayServiceTimeoutException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayServiceTimeoutException::fromJson);
 
         parseStrategies.put(GatewayServiceUnavailableException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayServiceUnavailableException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayServiceUnavailableException::fromJson);
 
         parseStrategies.put(GatewayServiceTooManyRequestsException.ERROR_CODE,
-                (jsonObject, dittoHeaders) -> GatewayServiceTooManyRequestsException
-                        .fromMessage(getMessage(jsonObject), dittoHeaders));
+                GatewayServiceTooManyRequestsException::fromJson);
 
         parseStrategies.put(GatewayPlaceholderNotResolvableException.ERROR_CODE,
                 GatewayPlaceholderNotResolvableException::fromJson);

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationFailedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationFailedException.java
@@ -37,8 +37,11 @@ public final class GatewayAuthenticationFailedException extends DittoRuntimeExce
 
     private static final long serialVersionUID = 2120928636274583181L;
 
-    private GatewayAuthenticationFailedException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayAuthenticationFailedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.UNAUTHORIZED, dittoHeaders, message, description, cause, href);
     }
 
@@ -103,7 +106,9 @@ public final class GatewayAuthenticationFailedException extends DittoRuntimeExce
 
         @Override
         protected GatewayAuthenticationFailedException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayAuthenticationFailedException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationFailedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationFailedException.java
@@ -82,6 +82,7 @@ public final class GatewayAuthenticationFailedException extends DittoRuntimeExce
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationProviderUnavailableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationProviderUnavailableException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -68,6 +69,26 @@ public final class GatewayAuthenticationProviderUnavailableException extends Dit
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayAuthenticationProviderUnavailableException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayAuthenticationProviderUnavailableException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayAuthenticationProviderUnavailableException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationProviderUnavailableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayAuthenticationProviderUnavailableException.java
@@ -36,6 +36,7 @@ public final class GatewayAuthenticationProviderUnavailableException extends Dit
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "authentication.provider.unavailable";
 
     private static final String DEFAULT_MESSAGE = "The authentication provider is not available.";
+
     private static final String DEFAULT_DESCRIPTION =
             "If after retry it is still unavailable, please contact the service team.";
 
@@ -44,7 +45,9 @@ public final class GatewayAuthenticationProviderUnavailableException extends Dit
 
     private GatewayAuthenticationProviderUnavailableException(final DittoHeaders dittoHeaders,
             @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,7 +109,9 @@ public final class GatewayAuthenticationProviderUnavailableException extends Dit
 
         @Override
         protected GatewayAuthenticationProviderUnavailableException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayAuthenticationProviderUnavailableException(dittoHeaders, message, description, cause,
                     href);

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayInternalErrorException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayInternalErrorException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -62,6 +63,26 @@ public final class GatewayInternalErrorException extends DittoRuntimeException i
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayInternalErrorException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayInternalErrorException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayInternalErrorException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayInternalErrorException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayInternalErrorException.java
@@ -38,8 +38,11 @@ public final class GatewayInternalErrorException extends DittoRuntimeException i
 
     private static final long serialVersionUID = -3752250243417604562L;
 
-    private GatewayInternalErrorException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayInternalErrorException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.INTERNAL_SERVER_ERROR, dittoHeaders, message, description, cause, href);
     }
 
@@ -99,7 +102,9 @@ public final class GatewayInternalErrorException extends DittoRuntimeException i
 
         @Override
         protected GatewayInternalErrorException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayInternalErrorException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtInvalidException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtInvalidException.java
@@ -34,12 +34,16 @@ public final class GatewayJwtInvalidException extends DittoRuntimeException impl
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "jwt.invalid";
 
     private static final String DEFAULT_MESSAGE = "The JWT could not be verified.";
+
     private static final String DEFAULT_DESCRIPTION = "Check if your JWT is correct.";
 
     private static final long serialVersionUID = -1840453579113250977L;
 
-    private GatewayJwtInvalidException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayJwtInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -100,7 +104,9 @@ public final class GatewayJwtInvalidException extends DittoRuntimeException impl
 
         @Override
         protected GatewayJwtInvalidException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayJwtInvalidException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtInvalidException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtInvalidException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -62,6 +63,26 @@ public final class GatewayJwtInvalidException extends DittoRuntimeException impl
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayJwtInvalidException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayJwtInvalidException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayJwtInvalidException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtIssuerNotSupportedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtIssuerNotSupportedException.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -66,6 +67,26 @@ public final class GatewayJwtIssuerNotSupportedException extends DittoRuntimeExc
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayJwtIssuerNotSupportedException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayJwtIssuerNotSupportedException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayJwtIssuerNotSupportedException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtIssuerNotSupportedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayJwtIssuerNotSupportedException.java
@@ -41,8 +41,11 @@ public final class GatewayJwtIssuerNotSupportedException extends DittoRuntimeExc
 
     private static final long serialVersionUID = -4550508438934221451L;
 
-    private GatewayJwtIssuerNotSupportedException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayJwtIssuerNotSupportedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -108,7 +111,9 @@ public final class GatewayJwtIssuerNotSupportedException extends DittoRuntimeExc
 
         @Override
         protected GatewayJwtIssuerNotSupportedException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayJwtIssuerNotSupportedException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayMethodNotAllowedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayMethodNotAllowedException.java
@@ -17,6 +17,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -65,6 +66,26 @@ public final class GatewayMethodNotAllowedException extends DittoRuntimeExceptio
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayMethodNotAllowedException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayMethodNotAllowedException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayMethodNotAllowedException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayMethodNotAllowedException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayMethodNotAllowedException.java
@@ -35,12 +35,16 @@ public final class GatewayMethodNotAllowedException extends DittoRuntimeExceptio
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "method.notallowed";
 
     private static final String MESSAGE_TEMPLATE = "The provided HTTP method ''{0}'' is not allowed on this resource.";
+
     private static final String DEFAULT_DESCRIPTION = "Check if you used the correct resource and method combination.";
 
     private static final long serialVersionUID = -4940757644888672775L;
 
-    private GatewayMethodNotAllowedException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayMethodNotAllowedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.METHOD_NOT_ALLOWED, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,7 +110,9 @@ public final class GatewayMethodNotAllowedException extends DittoRuntimeExceptio
 
         @Override
         protected GatewayMethodNotAllowedException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayMethodNotAllowedException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
@@ -51,8 +51,11 @@ public final class GatewayPlaceholderNotResolvableException extends DittoRuntime
 
     private static final long serialVersionUID = -8724890154457417912L;
 
-    private GatewayPlaceholderNotResolvableException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayPlaceholderNotResolvableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -131,7 +134,9 @@ public final class GatewayPlaceholderNotResolvableException extends DittoRuntime
 
         @Override
         protected GatewayPlaceholderNotResolvableException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayPlaceholderNotResolvableException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
@@ -124,7 +124,9 @@ public final class GatewayPlaceholderNotResolvableException extends DittoRuntime
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<GatewayPlaceholderNotResolvableException> {
 
-        private Builder() {}
+        private Builder() {
+            description(UNKNOWN_DESCRIPTION_TEMPLATE);
+        }
 
         private Builder(final String message, final String description) {
             this();

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayPlaceholderNotResolvableException.java
@@ -110,6 +110,7 @@ public final class GatewayPlaceholderNotResolvableException extends DittoRuntime
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(UNKNOWN_DESCRIPTION_TEMPLATE))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayQueryTimeExceededException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayQueryTimeExceededException.java
@@ -39,8 +39,11 @@ public final class GatewayQueryTimeExceededException extends DittoRuntimeExcepti
 
     private static final String DEFAULT_DESCRIPTION = "Optimize the request and try again later.";
 
-    private GatewayQueryTimeExceededException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayQueryTimeExceededException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
     }
 
@@ -101,7 +104,9 @@ public final class GatewayQueryTimeExceededException extends DittoRuntimeExcepti
 
         @Override
         protected GatewayQueryTimeExceededException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayQueryTimeExceededException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayQueryTimeExceededException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayQueryTimeExceededException.java
@@ -62,22 +62,30 @@ public final class GatewayQueryTimeExceededException extends DittoRuntimeExcepti
      */
     public static GatewayQueryTimeExceededException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new GatewayQueryTimeExceededException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
     }
 
     /**
-     * Deserialize a new {@code GatewayQueryTimeExceededException} object.
+     * Constructs a new {@code GatewayQueryTimeExceededException} object with the exception message extracted from the given
+     * JSON object.
      *
-     * @param json the json object. It is ignored because this object has no state.
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
      * @param dittoHeaders the headers of the command which resulted in this exception.
      * @return the new GatewayQueryTimeExceededException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
      */
-    public static GatewayQueryTimeExceededException fromJson(final JsonObject json,
+    public static GatewayQueryTimeExceededException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return new Builder().dittoHeaders(dittoHeaders).build();
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTimeoutException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTimeoutException.java
@@ -38,8 +38,11 @@ public final class GatewayServiceTimeoutException extends DittoRuntimeException 
 
     private static final long serialVersionUID = -858422215851104480L;
 
-    private GatewayServiceTimeoutException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayServiceTimeoutException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.GATEWAY_TIMEOUT, dittoHeaders, message, description, cause, href);
     }
 
@@ -100,7 +103,9 @@ public final class GatewayServiceTimeoutException extends DittoRuntimeException 
 
         @Override
         protected GatewayServiceTimeoutException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayServiceTimeoutException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTimeoutException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTimeoutException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -63,6 +64,26 @@ public final class GatewayServiceTimeoutException extends DittoRuntimeException 
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayServiceTimeoutException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayServiceTimeoutException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayServiceTimeoutException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTooManyRequestsException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTooManyRequestsException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -46,13 +47,6 @@ public class GatewayServiceTooManyRequestsException extends DittoRuntimeExceptio
     }
 
     /**
-     * A mutable builder for a {@code GatewayServiceTooManyRequestsException}.
-     *
-     * @return the builder.
-     */
-    public static Builder newBuilder() { return new Builder(); }
-
-    /**
      * Constructs a new {@code GatewayServiceTooManyRequestsException} object with given message.
      *
      * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
@@ -64,6 +58,33 @@ public class GatewayServiceTooManyRequestsException extends DittoRuntimeExceptio
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * A mutable builder for a {@code GatewayServiceTooManyRequestsException}.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() { return new Builder(); }
+
+    /**
+     * Constructs a new {@code GatewayServiceTooManyRequestsException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayServiceTooManyRequestsException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayServiceTooManyRequestsException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTooManyRequestsException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceTooManyRequestsException.java
@@ -41,8 +41,11 @@ public class GatewayServiceTooManyRequestsException extends DittoRuntimeExceptio
 
     private static final long serialVersionUID = 1164235483383640723L;
 
-    private GatewayServiceTooManyRequestsException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayServiceTooManyRequestsException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.TOO_MANY_REQUESTS, dittoHeaders, message, description, cause, href);
     }
 
@@ -100,7 +103,9 @@ public class GatewayServiceTooManyRequestsException extends DittoRuntimeExceptio
         }
 
         protected GatewayServiceTooManyRequestsException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayServiceTooManyRequestsException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceUnavailableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceUnavailableException.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
@@ -63,6 +64,26 @@ public final class GatewayServiceUnavailableException extends DittoRuntimeExcept
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayServiceUnavailableException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayServiceUnavailableException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static GatewayServiceUnavailableException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceUnavailableException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayServiceUnavailableException.java
@@ -38,8 +38,11 @@ public final class GatewayServiceUnavailableException extends DittoRuntimeExcept
 
     private static final long serialVersionUID = 1164234483383740723L;
 
-    private GatewayServiceUnavailableException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private GatewayServiceUnavailableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
     }
 
@@ -100,7 +103,9 @@ public final class GatewayServiceUnavailableException extends DittoRuntimeExcept
 
         @Override
         protected GatewayServiceUnavailableException doBuild(final DittoHeaders dittoHeaders,
-                @Nullable final String message, @Nullable final String description, @Nullable final Throwable cause,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
                 @Nullable final URI href) {
             return new GatewayServiceUnavailableException(dittoHeaders, message, description, cause, href);
         }

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchAlreadyExecutingException.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchAlreadyExecutingException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.batch.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class BatchAlreadyExecutingException extends DittoRuntimeException 
 
     private static final long serialVersionUID = 7202828974424543635L;
 
-    private BatchAlreadyExecutingException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private BatchAlreadyExecutingException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -113,8 +117,11 @@ public final class BatchAlreadyExecutingException extends DittoRuntimeException 
         }
 
         @Override
-        protected BatchAlreadyExecutingException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected BatchAlreadyExecutingException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new BatchAlreadyExecutingException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchAlreadyExecutingException.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchAlreadyExecutingException.java
@@ -88,7 +88,12 @@ public final class BatchAlreadyExecutingException extends DittoRuntimeException 
      */
     public static BatchAlreadyExecutingException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return  new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchErrorRegistry.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchErrorRegistry.java
@@ -58,9 +58,12 @@ public final class BatchErrorRegistry extends AbstractErrorRegistry<DittoRuntime
         final CommonErrorRegistry commonErrorRegistry = CommonErrorRegistry.newInstance();
         commonErrorRegistry.getTypes().forEach(type -> parseStrategies.put(type, commonErrorRegistry));
 
-        parseStrategies.put(BatchNotExecutableException.ERROR_CODE, BatchNotExecutableException::fromJson);
-        parseStrategies.put(BatchAlreadyExecutingException.ERROR_CODE, BatchAlreadyExecutingException::fromJson);
+        // exceptions in package org.eclipse.ditto.signals.commands.batch.exceptions
+        parseStrategies.put(BatchAlreadyExecutingException.ERROR_CODE,
+                BatchAlreadyExecutingException::fromJson);
 
+        parseStrategies.put(BatchNotExecutableException.ERROR_CODE,
+                BatchNotExecutableException::fromJson);
 
         return new BatchErrorRegistry(parseStrategies);
     }

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
@@ -203,11 +203,13 @@ public final class BatchNotExecutableException extends DittoRuntimeException imp
         @Nullable private String batchId;
         @Nullable private String commandCorrelationId;
 
-        private Builder() {}
+        private Builder() {
+            description(DEFAULT_DESCRIPTION_TEMPLATE);
+        }
 
         private Builder(final String batchId, final String commandCorrelationId,
                 final DittoRuntimeException dittoRuntimeException) {
-
+            this();
             this.batchId = batchId;
             this.commandCorrelationId = commandCorrelationId;
 

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
@@ -62,7 +62,6 @@ public final class BatchNotExecutableException extends DittoRuntimeException imp
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
         this.batchId = batchId;
         this.commandCorrelationId = commandCorrelationId;
@@ -236,7 +235,6 @@ public final class BatchNotExecutableException extends DittoRuntimeException imp
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new BatchNotExecutableException(batchId, commandCorrelationId, dittoHeaders, message,
                     description, cause, href);
         }

--- a/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
+++ b/signals/commands/batch/src/main/java/org/eclipse/ditto/signals/commands/batch/exceptions/BatchNotExecutableException.java
@@ -116,6 +116,8 @@ public final class BatchNotExecutableException extends DittoRuntimeException imp
                 .commandCorrelationId(commandCorrelationId)
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_TEMPLATE))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/ConnectivityErrorRegistry.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/ConnectivityErrorRegistry.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.signals.base.JsonParsable;
 import org.eclipse.ditto.signals.commands.base.CommonErrorRegistry;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionConflictException;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionFailedException;
+import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionIdNotExplicitlySettableException;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionNotAccessibleException;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionSignalIllegalException;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionUnavailableException;
@@ -71,23 +72,49 @@ public final class ConnectivityErrorRegistry extends AbstractErrorRegistry<Ditto
         final CommonErrorRegistry commonErrorRegistry = CommonErrorRegistry.newInstance();
         commonErrorRegistry.getTypes().forEach(type -> parseStrategies.put(type, commonErrorRegistry));
 
+        // exceptions in package org.eclipse.ditto.signals.commands.connectivity.exceptions
+        parseStrategies.put(ConnectionConflictException.ERROR_CODE,
+                ConnectionConflictException::fromJson);
+
+        parseStrategies.put(ConnectionFailedException.ERROR_CODE,
+                ConnectionFailedException::fromJson);
+
+        parseStrategies.put(ConnectionIdNotExplicitlySettableException.ERROR_CODE,
+                ConnectionIdNotExplicitlySettableException::fromJson);
+
+        parseStrategies.put(ConnectionNotAccessibleException.ERROR_CODE,
+                ConnectionNotAccessibleException::fromJson);
+
+        parseStrategies.put(ConnectionSignalIllegalException.ERROR_CODE,
+                ConnectionSignalIllegalException::fromJson);
+
+        parseStrategies.put(ConnectionUnavailableException.ERROR_CODE,
+                ConnectionUnavailableException::fromJson);
+
+        // exceptions in package org.eclipse.ditto.model.connectivity
         parseStrategies.put(ConnectionConfigurationInvalidException.ERROR_CODE,
                 ConnectionConfigurationInvalidException::fromJson);
-        parseStrategies.put(ConnectionUriInvalidException.ERROR_CODE, ConnectionUriInvalidException::fromJson);
-        parseStrategies.put(MessageMappingFailedException.ERROR_CODE, MessageMappingFailedException::fromJson);
-        parseStrategies.put(MessageMapperConfigurationInvalidException.ERROR_CODE,
-                MessageMapperConfigurationInvalidException::fromJson);
-        parseStrategies.put(MessageMapperConfigurationFailedException.ERROR_CODE,
-                MessageMapperConfigurationFailedException::fromJson);
-        parseStrategies.put(UnresolvedPlaceholderException.ERROR_CODE, UnresolvedPlaceholderException::fromJson);
-        parseStrategies.put(TopicParseException.ERROR_CODE, TopicParseException::fromJson);
-        parseStrategies.put(ConnectionNotAccessibleException.ERROR_CODE, ConnectionNotAccessibleException::fromJson);
-        parseStrategies.put(ConnectionUnavailableException.ERROR_CODE, ConnectionUnavailableException::fromJson);
-        parseStrategies.put(ConnectionFailedException.ERROR_CODE, ConnectionFailedException::fromJson);
-        parseStrategies.put(ConnectionConflictException.ERROR_CODE, ConnectionConflictException::fromJson);
-        parseStrategies.put(ConnectionSignalIllegalException.ERROR_CODE, ConnectionSignalIllegalException::fromJson);
+
         parseStrategies.put(ConnectionSignalIdEnforcementFailedException.ERROR_CODE,
                 ConnectionSignalIdEnforcementFailedException::fromJson);
+
+        parseStrategies.put(ConnectionUriInvalidException.ERROR_CODE,
+                ConnectionUriInvalidException::fromJson);
+
+        parseStrategies.put(MessageMapperConfigurationFailedException.ERROR_CODE,
+                MessageMapperConfigurationFailedException::fromJson);
+
+        parseStrategies.put(MessageMapperConfigurationInvalidException.ERROR_CODE,
+                MessageMapperConfigurationInvalidException::fromJson);
+
+        parseStrategies.put(MessageMappingFailedException.ERROR_CODE,
+                MessageMappingFailedException::fromJson);
+
+        parseStrategies.put(TopicParseException.ERROR_CODE,
+                TopicParseException::fromJson);
+
+        parseStrategies.put(UnresolvedPlaceholderException.ERROR_CODE,
+                UnresolvedPlaceholderException::fromJson);
 
         return new ConnectivityErrorRegistry(parseStrategies);
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionConflictException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionConflictException.java
@@ -85,7 +85,12 @@ public final class ConnectionConflictException extends DittoRuntimeException imp
      */
     public static ConnectionConflictException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionConflictException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionConflictException.java
@@ -44,8 +44,11 @@ public final class ConnectionConflictException extends DittoRuntimeException imp
     private static final long serialVersionUID = -4525302146860945435L;
 
 
-    private ConnectionConflictException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ConnectionConflictException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.CONFLICT, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +112,11 @@ public final class ConnectionConflictException extends DittoRuntimeException imp
         }
 
         @Override
-        protected ConnectionConflictException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected ConnectionConflictException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionConflictException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionFailedException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionFailedException.java
@@ -73,7 +73,6 @@ public final class ConnectionFailedException extends DittoRuntimeException imple
      */
     public static ConnectionFailedException from(final String message, @Nullable final String description,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
@@ -93,7 +92,12 @@ public final class ConnectionFailedException extends DittoRuntimeException imple
      * org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
      */
     public static ConnectionFailedException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return from(readMessage(jsonObject), readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionFailedException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionFailedException.java
@@ -43,13 +43,11 @@ public final class ConnectionFailedException extends DittoRuntimeException imple
 
     private static final long serialVersionUID = 897914540900650802L;
 
-
     private ConnectionFailedException(final DittoHeaders dittoHeaders,
             @Nullable final String message,
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.GATEWAY_TIMEOUT, dittoHeaders, message, description, cause, href);
     }
 
@@ -121,7 +119,6 @@ public final class ConnectionFailedException extends DittoRuntimeException imple
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ConnectionFailedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionIdNotExplicitlySettableException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionIdNotExplicitlySettableException.java
@@ -41,8 +41,11 @@ public final class ConnectionIdNotExplicitlySettableException extends DittoRunti
 
     private static final long serialVersionUID = -5528368754415335490L;
 
-    private ConnectionIdNotExplicitlySettableException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ConnectionIdNotExplicitlySettableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -105,7 +108,9 @@ public final class ConnectionIdNotExplicitlySettableException extends DittoRunti
         @Override
         protected ConnectionIdNotExplicitlySettableException doBuild(final DittoHeaders dittoHeaders,
                 @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionIdNotExplicitlySettableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionIdNotExplicitlySettableException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionIdNotExplicitlySettableException.java
@@ -83,7 +83,12 @@ public final class ConnectionIdNotExplicitlySettableException extends DittoRunti
      */
     public static ConnectionIdNotExplicitlySettableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionNotAccessibleException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionNotAccessibleException.java
@@ -84,7 +84,12 @@ public final class ConnectionNotAccessibleException extends DittoRuntimeExceptio
      */
     public static ConnectionNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionNotAccessibleException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionNotAccessibleException.java
@@ -42,8 +42,11 @@ public final class ConnectionNotAccessibleException extends DittoRuntimeExceptio
 
     private static final long serialVersionUID = -3207647419678933094L;
 
-    private ConnectionNotAccessibleException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ConnectionNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -110,7 +113,9 @@ public final class ConnectionNotAccessibleException extends DittoRuntimeExceptio
         @Override
         protected ConnectionNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
                 @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
@@ -39,6 +39,8 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
 
     private static final String OPERATING_DESCRIPTION_TEMPLATE = "Please retry in {0} {1}.";
 
+    private static final String DEFAULT_DESCRIPTION ="Please retry later.";
+
     private static final String STAYING_MESSAGE_TEMPLATE = "The message ''{2}'' is illegal for the {1} Connection " +
             "with ID ''{0}''";
 
@@ -78,7 +80,7 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
-                .description(readDescription(jsonObject).orElse(null))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
                 .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
@@ -91,7 +93,9 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
 
         private String connectionId = "UNKNOWN";
 
-        private Builder() {}
+        private Builder() {
+            this.description(DEFAULT_DESCRIPTION);
+        }
 
         /**
          * Set the connection ID.

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
@@ -71,11 +71,12 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
      */
     public static ConnectionSignalIllegalException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        final Builder builder = new Builder();
-        builder.message(readMessage(jsonObject));
-        readDescription(jsonObject).ifPresent(builder::description);
-        builder.dittoHeaders(dittoHeaders);
-        return builder.build();
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(null))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionSignalIllegalException.java
@@ -36,6 +36,7 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "signal.illegal";
 
     private static final String OPERATING_MESSAGE_TEMPLATE = "The Connection with ID ''{0}'' is {1}.";
+
     private static final String OPERATING_DESCRIPTION_TEMPLATE = "Please retry in {0} {1}.";
 
     private static final String STAYING_MESSAGE_TEMPLATE = "The message ''{2}'' is illegal for the {1} Connection " +
@@ -44,8 +45,11 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
     private static final long serialVersionUID = 2648721759252899991L;
 
 
-    private ConnectionSignalIllegalException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ConnectionSignalIllegalException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.CONFLICT, dittoHeaders, message, description, cause, href);
     }
 
@@ -139,7 +143,9 @@ public final class ConnectionSignalIllegalException extends DittoRuntimeExceptio
         @Override
         protected ConnectionSignalIllegalException doBuild(final DittoHeaders dittoHeaders,
                 @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionSignalIllegalException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionUnavailableException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionUnavailableException.java
@@ -44,8 +44,11 @@ public final class ConnectionUnavailableException extends DittoRuntimeException 
     private static final long serialVersionUID = 9075301177869840493L;
 
 
-    private ConnectionUnavailableException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private ConnectionUnavailableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,7 +114,9 @@ public final class ConnectionUnavailableException extends DittoRuntimeException 
         @Override
         protected ConnectionUnavailableException doBuild(final DittoHeaders dittoHeaders,
                 @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ConnectionUnavailableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionUnavailableException.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/exceptions/ConnectionUnavailableException.java
@@ -89,6 +89,7 @@ public final class ConnectionUnavailableException extends DittoRuntimeException 
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 
 import java.net.URI;
 import java.text.MessageFormat;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -80,7 +81,13 @@ public final class PolicyConflictException extends DittoRuntimeException impleme
      * JsonFields#MESSAGE} field.
      */
     public static PolicyConflictException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        final Optional<URI> uri = readHRef(jsonObject);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(uri.orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
@@ -12,7 +12,6 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 
 import java.net.URI;
 import java.text.MessageFormat;
-import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -81,18 +80,16 @@ public final class PolicyConflictException extends DittoRuntimeException impleme
      * JsonFields#MESSAGE} field.
      */
     public static PolicyConflictException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        final Optional<URI> uri = readHRef(jsonObject);
         return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
-                .href(uri.orElse(null))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 
     /**
      * A mutable builder with a fluent API for a {@link PolicyConflictException}.
-     *
      */
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyConflictException> {

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -40,8 +41,11 @@ public final class PolicyConflictException extends DittoRuntimeException impleme
 
     private static final long serialVersionUID = 4742964538205322837L;
 
-    private PolicyConflictException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private PolicyConflictException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.CONFLICT, dittoHeaders, message, description, cause, href);
     }
 
@@ -104,8 +108,11 @@ public final class PolicyConflictException extends DittoRuntimeException impleme
         }
 
         @Override
-        protected PolicyConflictException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyConflictException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyConflictException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidException.java
@@ -72,7 +72,6 @@ public final class PolicyEntryModificationInvalidException extends DittoRuntimeE
      */
     public static PolicyEntryModificationInvalidException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-
         return fromMessage(message, null, dittoHeaders);
     }
 
@@ -86,7 +85,6 @@ public final class PolicyEntryModificationInvalidException extends DittoRuntimeE
      */
     public static PolicyEntryModificationInvalidException fromMessage(final String message, final String description,
             final DittoHeaders dittoHeaders) {
-
         final DittoRuntimeExceptionBuilder<PolicyEntryModificationInvalidException> builder =
                 new PolicyEntryModificationInvalidException.Builder()
                         .dittoHeaders(dittoHeaders)
@@ -109,8 +107,12 @@ public final class PolicyEntryModificationInvalidException extends DittoRuntimeE
      */
     public static PolicyEntryModificationInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class PolicyEntryModificationInvalidException extends DittoRuntimeE
     private static final long serialVersionUID = -3234448123780175035L;
 
     private PolicyEntryModificationInvalidException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -133,11 +133,10 @@ public final class PolicyEntryModificationInvalidException extends DittoRuntimeE
 
         @Override
         protected PolicyEntryModificationInvalidException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyEntryModificationInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
@@ -109,7 +109,7 @@ public final class PolicyEntryNotAccessibleException extends DittoRuntimeExcepti
         }
 
         private Builder(final CharSequence label, final String policyId) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
@@ -89,8 +89,12 @@ public final class PolicyEntryNotAccessibleException extends DittoRuntimeExcepti
      */
     public static PolicyEntryNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class PolicyEntryNotAccessibleException extends DittoRuntimeExcepti
     private static final long serialVersionUID = 3798954052492368034L;
 
     private PolicyEntryNotAccessibleException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public final class PolicyEntryNotAccessibleException extends DittoRuntimeExcepti
 
         @Override
         protected PolicyEntryNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyEntryNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
@@ -109,7 +109,7 @@ public final class PolicyEntryNotModifiableException extends DittoRuntimeExcepti
         }
 
         private Builder(final String policyId, final CharSequence label) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class PolicyEntryNotModifiableException extends DittoRuntimeExcepti
     private static final long serialVersionUID = -1730675737558918923L;
 
     private PolicyEntryNotModifiableException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public final class PolicyEntryNotModifiableException extends DittoRuntimeExcepti
 
         @Override
         protected PolicyEntryNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyEntryNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableException.java
@@ -89,8 +89,12 @@ public final class PolicyEntryNotModifiableException extends DittoRuntimeExcepti
      */
     public static PolicyEntryNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyErrorRegistry.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyErrorRegistry.java
@@ -42,34 +42,79 @@ public final class PolicyErrorRegistry extends AbstractErrorRegistry<DittoRuntim
     public static PolicyErrorRegistry newInstance() {
         final Map<String, JsonParsable<DittoRuntimeException>> parseStrategies = new HashMap<>();
 
-        parseStrategies.put(PolicyConflictException.ERROR_CODE, PolicyConflictException::fromJson);
-        parseStrategies.put(PolicyIdInvalidException.ERROR_CODE, PolicyIdInvalidException::fromJson);
-        parseStrategies.put(PolicyTooLargeException.ERROR_CODE, PolicyTooLargeException::fromJson);
-        parseStrategies.put(PolicyEntryInvalidException.ERROR_CODE, PolicyEntryInvalidException::fromJson);
-        parseStrategies.put(SubjectIdInvalidException.ERROR_CODE, SubjectIdInvalidException::fromJson);
-        parseStrategies.put(PolicyNotAccessibleException.ERROR_CODE, PolicyNotAccessibleException::fromJson);
-        parseStrategies.put(PolicyNotModifiableException.ERROR_CODE, PolicyNotModifiableException::fromJson);
-        parseStrategies.put(PolicyIdNotExplicitlySettableException.ERROR_CODE,
-                PolicyIdNotExplicitlySettableException::fromJson);
-        parseStrategies.put(PolicyUnavailableException.ERROR_CODE, PolicyUnavailableException::fromJson);
-        parseStrategies.put(PolicyTooManyModifyingRequestsException.ERROR_CODE,
-                PolicyTooManyModifyingRequestsException::fromJson);
-        parseStrategies.put(PolicyEntryNotAccessibleException.ERROR_CODE, PolicyEntryNotAccessibleException::fromJson);
-        parseStrategies.put(PolicyPreconditionFailedException.ERROR_CODE, PolicyPreconditionFailedException::fromJson);
-        parseStrategies.put(PolicyPreconditionNotModifiedException.ERROR_CODE,
-                PolicyPreconditionNotModifiedException::fromJson);
-        parseStrategies.put(PolicyEntryNotModifiableException.ERROR_CODE, PolicyEntryNotModifiableException::fromJson);
+        // exceptions in package org.eclipse.ditto.signals.commands.policies.exceptions
+        parseStrategies.put(PolicyConflictException.ERROR_CODE,
+                PolicyConflictException::fromJson);
+
         parseStrategies.put(PolicyEntryModificationInvalidException.ERROR_CODE,
                 PolicyEntryModificationInvalidException::fromJson);
+
+        parseStrategies.put(PolicyEntryNotAccessibleException.ERROR_CODE,
+                PolicyEntryNotAccessibleException::fromJson);
+
+        parseStrategies.put(PolicyEntryNotModifiableException.ERROR_CODE,
+                PolicyEntryNotModifiableException::fromJson);
+
+        parseStrategies.put(PolicyIdNotExplicitlySettableException.ERROR_CODE,
+                PolicyIdNotExplicitlySettableException::fromJson);
+
         parseStrategies.put(PolicyModificationInvalidException.ERROR_CODE,
                 PolicyModificationInvalidException::fromJson);
-        parseStrategies.put(ResourcesNotModifiableException.ERROR_CODE, ResourcesNotModifiableException::fromJson);
-        parseStrategies.put(ResourceNotAccessibleException.ERROR_CODE, ResourceNotAccessibleException::fromJson);
-        parseStrategies.put(ResourcesNotAccessibleException.ERROR_CODE, ResourcesNotAccessibleException::fromJson);
-        parseStrategies.put(ResourceNotModifiableException.ERROR_CODE, ResourceNotModifiableException::fromJson);
-        parseStrategies.put(SubjectsNotModifiableException.ERROR_CODE, SubjectsNotModifiableException::fromJson);
-        parseStrategies.put(SubjectNotAccessibleException.ERROR_CODE, SubjectNotAccessibleException::fromJson);
-        parseStrategies.put(SubjectNotModifiableException.ERROR_CODE, SubjectNotModifiableException::fromJson);
+
+        parseStrategies.put(PolicyNotAccessibleException.ERROR_CODE,
+                PolicyNotAccessibleException::fromJson);
+
+        parseStrategies.put(PolicyNotModifiableException.ERROR_CODE,
+                PolicyNotModifiableException::fromJson);
+
+        parseStrategies.put(PolicyPreconditionFailedException.ERROR_CODE,
+                PolicyPreconditionFailedException::fromJson);
+
+        parseStrategies.put(PolicyPreconditionNotModifiedException.ERROR_CODE,
+                PolicyPreconditionNotModifiedException::fromJson);
+
+        parseStrategies.put(PolicyTooManyModifyingRequestsException.ERROR_CODE,
+                PolicyTooManyModifyingRequestsException::fromJson);
+
+        parseStrategies.put(PolicyUnavailableException.ERROR_CODE,
+                PolicyUnavailableException::fromJson);
+
+        parseStrategies.put(ResourceNotAccessibleException.ERROR_CODE,
+                ResourceNotAccessibleException::fromJson);
+
+        parseStrategies.put(ResourceNotModifiableException.ERROR_CODE,
+                ResourceNotModifiableException::fromJson);
+
+        parseStrategies.put(ResourcesNotAccessibleException.ERROR_CODE,
+                ResourcesNotAccessibleException::fromJson);
+
+        parseStrategies.put(ResourcesNotModifiableException.ERROR_CODE,
+                ResourcesNotModifiableException::fromJson);
+
+        parseStrategies.put(SubjectNotAccessibleException.ERROR_CODE,
+                SubjectNotAccessibleException::fromJson);
+
+        parseStrategies.put(SubjectNotModifiableException.ERROR_CODE,
+                SubjectNotModifiableException::fromJson);
+
+        parseStrategies.put(SubjectsNotAccessibleException.ERROR_CODE,
+                SubjectsNotAccessibleException::fromJson);
+
+        parseStrategies.put(SubjectsNotModifiableException.ERROR_CODE,
+                SubjectsNotModifiableException::fromJson);
+
+        // exceptions in package org.eclipse.ditto.model.policies
+        parseStrategies.put(PolicyEntryInvalidException.ERROR_CODE,
+                PolicyEntryInvalidException::fromJson);
+
+        parseStrategies.put(PolicyIdInvalidException.ERROR_CODE,
+                PolicyIdInvalidException::fromJson);
+
+        parseStrategies.put(PolicyTooLargeException.ERROR_CODE,
+                PolicyTooLargeException::fromJson);
+
+        parseStrategies.put(SubjectIdInvalidException.ERROR_CODE,
+                SubjectIdInvalidException::fromJson);
 
         return new PolicyErrorRegistry(parseStrategies);
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableException.java
@@ -34,10 +34,10 @@ public final class PolicyIdNotExplicitlySettableException extends DittoRuntimeEx
      */
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "id.notsettable";
 
-    private static final String MESSAGE_TEMPLATE_PUT =
+    private static final String MESSAGE_TEMPLATE =
             "The Policy ID in the request body is not equal to the Policy ID in the request URL.";
 
-    private static final String DEFAULT_DESCRIPTION_PUT =
+    private static final String DEFAULT_DESCRIPTION =
             "Either delete the Policy ID from the request body or use the same Policy ID as in the request URL.";
 
 
@@ -84,7 +84,12 @@ public final class PolicyIdNotExplicitlySettableException extends DittoRuntimeEx
      */
     public static PolicyIdNotExplicitlySettableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
@@ -95,8 +100,8 @@ public final class PolicyIdNotExplicitlySettableException extends DittoRuntimeEx
     public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyIdNotExplicitlySettableException> {
 
         private Builder() {
-            message(MESSAGE_TEMPLATE_PUT);
-            description(DEFAULT_DESCRIPTION_PUT);
+            message(MESSAGE_TEMPLATE);
+            description(DEFAULT_DESCRIPTION);
         }
 
         @Override

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -41,8 +42,11 @@ public final class PolicyIdNotExplicitlySettableException extends DittoRuntimeEx
             "Either delete the Policy ID from the request body or use the same Policy ID as in the request URL.";
 
 
-    private PolicyIdNotExplicitlySettableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyIdNotExplicitlySettableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,8 +110,10 @@ public final class PolicyIdNotExplicitlySettableException extends DittoRuntimeEx
 
         @Override
         protected PolicyIdNotExplicitlySettableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyIdNotExplicitlySettableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidException.java
@@ -44,8 +44,11 @@ public final class PolicyModificationInvalidException extends DittoRuntimeExcept
 
     private static final long serialVersionUID = -3418662685041958745L;
 
-    private PolicyModificationInvalidException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyModificationInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -130,8 +133,11 @@ public final class PolicyModificationInvalidException extends DittoRuntimeExcept
         }
 
         @Override
-        protected PolicyModificationInvalidException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyModificationInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyModificationInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidException.java
@@ -105,7 +105,12 @@ public final class PolicyModificationInvalidException extends DittoRuntimeExcept
      */
     public static PolicyModificationInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,8 +45,11 @@ public final class PolicyNotAccessibleException extends DittoRuntimeException im
 
     private static final long serialVersionUID = 5223919721644302865L;
 
-    private PolicyNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -110,8 +114,11 @@ public final class PolicyNotAccessibleException extends DittoRuntimeException im
         }
 
         @Override
-        protected PolicyNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleException.java
@@ -85,7 +85,12 @@ public final class PolicyNotAccessibleException extends DittoRuntimeException im
      */
     public static PolicyNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,8 +44,11 @@ public final class PolicyNotModifiableException extends DittoRuntimeException im
 
     private static final long serialVersionUID = 6405617723219643100L;
 
-    private PolicyNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public final class PolicyNotModifiableException extends DittoRuntimeException im
         }
 
         @Override
-        protected PolicyNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableException.java
@@ -84,7 +84,12 @@ public final class PolicyNotModifiableException extends DittoRuntimeException im
      */
     public static PolicyNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedException.java
@@ -48,7 +48,6 @@ public final class PolicyPreconditionFailedException extends DittoRuntimeExcepti
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.PRECONDITION_FAILED, dittoHeaders, message, description, cause, href);
     }
 
@@ -121,7 +120,6 @@ public final class PolicyPreconditionFailedException extends DittoRuntimeExcepti
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new PolicyPreconditionFailedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedException.java
@@ -65,6 +65,21 @@ public final class PolicyPreconditionFailedException extends DittoRuntimeExcepti
     }
 
     /**
+     * Constructs a new {@code PolicyPreconditionFailedException} object with given message.
+     *
+     * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyPreconditionFailedException.
+     */
+    public static PolicyPreconditionFailedException fromMessage(final String message,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
+                .build();
+    }
+
+    /**
      * Constructs a new {@link PolicyPreconditionFailedException} object with the exception message extracted from
      * the given JSON object.
      *
@@ -76,16 +91,11 @@ public final class PolicyPreconditionFailedException extends DittoRuntimeExcepti
      */
     public static PolicyPreconditionFailedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
-    }
-
-    private static PolicyPreconditionFailedException fromMessage(final String message,
-            final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
-                .message(message)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedException.java
@@ -66,6 +66,21 @@ public final class PolicyPreconditionNotModifiedException extends DittoRuntimeEx
     }
 
     /**
+     * Constructs a new {@code PolicyPreconditionNotModifiedException} object with given message.
+     *
+     * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PolicyPreconditionNotModifiedException.
+     */
+    public static PolicyPreconditionNotModifiedException fromMessage(final String message,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
+                .build();
+    }
+
+    /**
      * Constructs a new {@link PolicyPreconditionNotModifiedException} object with the exception message extracted from
      * the given JSON object.
      *
@@ -78,16 +93,11 @@ public final class PolicyPreconditionNotModifiedException extends DittoRuntimeEx
      */
     public static PolicyPreconditionNotModifiedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
-    }
-
-    private static PolicyPreconditionNotModifiedException fromMessage(final String message,
-            final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
-                .message(message)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedException.java
@@ -50,7 +50,6 @@ public final class PolicyPreconditionNotModifiedException extends DittoRuntimeEx
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.NOT_MODIFIED, dittoHeaders, message, description, cause, href);
     }
 
@@ -122,7 +121,6 @@ public final class PolicyPreconditionNotModifiedException extends DittoRuntimeEx
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new PolicyPreconditionNotModifiedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsException.java
@@ -85,7 +85,12 @@ public final class PolicyTooManyModifyingRequestsException extends DittoRuntimeE
      */
     public static PolicyTooManyModifyingRequestsException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,8 +44,11 @@ public final class PolicyTooManyModifyingRequestsException extends DittoRuntimeE
 
     private static final long serialVersionUID = -3295800477795006307L;
 
-    private PolicyTooManyModifyingRequestsException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyTooManyModifyingRequestsException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.TOO_MANY_REQUESTS, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,7 +115,10 @@ public final class PolicyTooManyModifyingRequestsException extends DittoRuntimeE
 
         @Override
         protected PolicyTooManyModifyingRequestsException doBuild(final DittoHeaders dittoHeaders,
-                final String message, final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyTooManyModifyingRequestsException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableException.java
@@ -83,7 +83,12 @@ public final class PolicyUnavailableException extends DittoRuntimeException impl
      */
     public static PolicyUnavailableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class PolicyUnavailableException extends DittoRuntimeException impl
     private static final long serialVersionUID = 1987286804137290070L;
 
 
-    private PolicyUnavailableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyUnavailableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
     }
 
@@ -108,8 +112,11 @@ public final class PolicyUnavailableException extends DittoRuntimeException impl
         }
 
         @Override
-        protected PolicyUnavailableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyUnavailableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyUnavailableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class ResourceNotAccessibleException extends DittoRuntimeException 
     private static final long serialVersionUID = 2620243998960976955L;
 
     private ResourceNotAccessibleException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -117,11 +117,10 @@ public final class ResourceNotAccessibleException extends DittoRuntimeException 
 
         @Override
         protected ResourceNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ResourceNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
@@ -91,8 +91,12 @@ public final class ResourceNotAccessibleException extends DittoRuntimeException 
      */
     public static ResourceNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleException.java
@@ -111,7 +111,7 @@ public final class ResourceNotAccessibleException extends DittoRuntimeException 
         }
 
         private Builder(final String policyId, final CharSequence label, final String path) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, path, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
@@ -91,8 +91,12 @@ public final class ResourceNotModifiableException extends DittoRuntimeException 
      */
     public static ResourceNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
@@ -111,7 +111,7 @@ public final class ResourceNotModifiableException extends DittoRuntimeException 
         }
 
         private Builder(final String policyId, final CharSequence label, final CharSequence path) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, path, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class ResourceNotModifiableException extends DittoRuntimeException 
     private static final long serialVersionUID = -3333742392554340824L;
 
     private ResourceNotModifiableException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -117,11 +117,10 @@ public final class ResourceNotModifiableException extends DittoRuntimeException 
 
         @Override
         protected ResourceNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ResourceNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
@@ -89,8 +89,12 @@ public class ResourcesNotAccessibleException extends DittoRuntimeException imple
      */
     public static ResourcesNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
@@ -109,7 +109,7 @@ public class ResourcesNotAccessibleException extends DittoRuntimeException imple
         }
 
         private Builder(final String policyId, final CharSequence label) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,11 +44,10 @@ public class ResourcesNotAccessibleException extends DittoRuntimeException imple
     private static final long serialVersionUID = -4536941108007531198L;
 
     private ResourcesNotAccessibleException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public class ResourcesNotAccessibleException extends DittoRuntimeException imple
 
         @Override
         protected ResourcesNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ResourcesNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
@@ -109,7 +109,7 @@ public final class ResourcesNotModifiableException extends DittoRuntimeException
         }
 
         private Builder(final String policyId, final CharSequence label) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class ResourcesNotModifiableException extends DittoRuntimeException
     private static final long serialVersionUID = 798042490341996073L;
 
     private ResourcesNotModifiableException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public final class ResourcesNotModifiableException extends DittoRuntimeException
 
         @Override
         protected ResourcesNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ResourcesNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableException.java
@@ -89,8 +89,12 @@ public final class ResourcesNotModifiableException extends DittoRuntimeException
      */
     public static ResourcesNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
@@ -109,7 +109,7 @@ public final class SubjectNotAccessibleException extends DittoRuntimeException i
         }
 
         private Builder(final String policyId, final CharSequence label, final CharSequence subjectId) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, subjectId, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class SubjectNotAccessibleException extends DittoRuntimeException i
     private static final long serialVersionUID = -316536964837269703L;
 
     private SubjectNotAccessibleException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public final class SubjectNotAccessibleException extends DittoRuntimeException i
 
         @Override
         protected SubjectNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new SubjectNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleException.java
@@ -89,8 +89,12 @@ public final class SubjectNotAccessibleException extends DittoRuntimeException i
      */
     public static SubjectNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class SubjectNotModifiableException extends DittoRuntimeException i
     private static final long serialVersionUID = -2998602993431173066L;
 
     private SubjectNotModifiableException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public final class SubjectNotModifiableException extends DittoRuntimeException i
 
         @Override
         protected SubjectNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new SubjectNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
@@ -89,8 +89,12 @@ public final class SubjectNotModifiableException extends DittoRuntimeException i
      */
     public static SubjectNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableException.java
@@ -109,7 +109,7 @@ public final class SubjectNotModifiableException extends DittoRuntimeException i
         }
 
         private Builder(final String policyId, final CharSequence label, final CharSequence path) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, path, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
@@ -71,7 +71,7 @@ public class SubjectsNotAccessibleException extends DittoRuntimeException implem
      */
     public static SubjectsNotAccessibleException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new SubjectsNotAccessibleException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
@@ -89,8 +89,12 @@ public class SubjectsNotAccessibleException extends DittoRuntimeException implem
      */
     public static SubjectsNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
@@ -109,7 +109,7 @@ public class SubjectsNotAccessibleException extends DittoRuntimeException implem
         }
 
         private Builder(final String policyId, final CharSequence label) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,11 +44,10 @@ public class SubjectsNotAccessibleException extends DittoRuntimeException implem
     private static final long serialVersionUID = 7355557968103689705L;
 
     private SubjectsNotAccessibleException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,11 +115,10 @@ public class SubjectsNotAccessibleException extends DittoRuntimeException implem
 
         @Override
         protected SubjectsNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new SubjectsNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
@@ -110,7 +110,7 @@ public final class SubjectsNotModifiableException extends DittoRuntimeException 
         }
 
         private Builder(final String policyId, final CharSequence label) {
-            description(DEFAULT_DESCRIPTION);
+            this();
             message(MessageFormat.format(MESSAGE_TEMPLATE, label, policyId));
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,11 +45,10 @@ public final class SubjectsNotModifiableException extends DittoRuntimeException 
     private static final long serialVersionUID = -5186610086408398973L;
 
     private SubjectsNotModifiableException(final DittoHeaders dittoHeaders,
-            final String message,
-            final String description,
-            final Throwable cause,
-            final URI href) {
-
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,11 +116,10 @@ public final class SubjectsNotModifiableException extends DittoRuntimeException 
 
         @Override
         protected SubjectsNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description,
-                final Throwable cause,
-                final URI href) {
-
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new SubjectsNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
+++ b/signals/commands/policies/src/main/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableException.java
@@ -90,8 +90,12 @@ public final class SubjectsNotModifiableException extends DittoRuntimeException 
      */
     public static SubjectsNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyConflictExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -33,7 +35,8 @@ public class PolicyConflictExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_CONFLICT_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_CONFLICT_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_CONFLICT_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 
@@ -45,6 +48,7 @@ public class PolicyConflictExceptionTest {
 
     @Test
     public void checkPolicyErrorCodeWorks() {
+
         final DittoRuntimeException actual =
                 PolicyErrorRegistry.newInstance().parse(KNOWN_JSON, TestConstants.EMPTY_DITTO_HEADERS);
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryModificationInvalidExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,9 @@ public class PolicyEntryModificationInvalidExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_ENTRY_MODIFICATION_INVALID_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_ENTRY_MODIFICATION_INVALID_EXCEPTION.getHref().toString())
+
+                    TestConstants.Policy.POLICY_ENTRY_MODIFICATION_INVALID_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public final class PolicyEntryNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_ENTRY_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_ENTRY_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_ENTRY_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyEntryNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public final class PolicyEntryNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_ENTRY_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_ENTRY_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_ENTRY_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyIdNotExplicitlySettableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyIdNotExplicitlySettableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyModificationInvalidExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyModificationInvalidExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_MODIFICATION_INVALID_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_MODIFICATION_INVALID_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_MODIFICATION_INVALID_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionFailedExceptionTest.java
@@ -13,6 +13,8 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.assertions.DittoBaseAssertions;
@@ -34,7 +36,8 @@ public class PolicyPreconditionFailedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_PRECONDITION_FAILED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_PRECONDITION_FAILED_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_PRECONDITION_FAILED_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyPreconditionNotModifiedExceptionTest.java
@@ -13,6 +13,8 @@ package org.eclipse.ditto.signals.commands.policies.exceptions;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.assertions.DittoBaseAssertions;
@@ -34,7 +36,8 @@ public class PolicyPreconditionNotModifiedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_PRECONDITION_NOT_MODIFIED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_PRECONDITION_NOT_MODIFIED_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_PRECONDITION_NOT_MODIFIED_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyTooManyModifyingRequestsExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyTooManyModifyingRequestsExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/PolicyUnavailableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyUnavailableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.POLICY_UNAVAILABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.POLICY_UNAVAILABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.POLICY_UNAVAILABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ResourceNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.RESOURCE_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.RESOURCE_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.RESOURCE_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourceNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ResourceNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.RESOURCE_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.RESOURCE_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.RESOURCE_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/ResourcesNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ResourcesNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.RESOURCES_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.RESOURCES_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.RESOURCES_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class SubjectNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.SUBJECT_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.SUBJECT_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.SUBJECT_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class SubjectNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.SUBJECT_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.SUBJECT_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.SUBJECT_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableExceptionTest.java
+++ b/signals/commands/policies/src/test/java/org/eclipse/ditto/signals/commands/policies/exceptions/SubjectsNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.util.Objects;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class SubjectsNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Policy.SUBJECTS_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Policy.SUBJECTS_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Policy.SUBJECTS_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(Objects::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclModificationInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclModificationInvalidException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,8 +45,11 @@ public final class AclModificationInvalidException extends DittoRuntimeException
 
     private static final long serialVersionUID = -7682501681225514808L;
 
-    private AclModificationInvalidException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AclModificationInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,8 +115,11 @@ public final class AclModificationInvalidException extends DittoRuntimeException
         }
 
         @Override
-        protected AclModificationInvalidException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AclModificationInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AclModificationInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclModificationInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclModificationInvalidException.java
@@ -86,7 +86,12 @@ public final class AclModificationInvalidException extends DittoRuntimeException
      */
     public static AclModificationInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -45,8 +46,11 @@ public final class AclNotAccessibleException extends DittoRuntimeException imple
 
     private static final long serialVersionUID = 6811033520675841466L;
 
-    private AclNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AclNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -112,8 +116,11 @@ public final class AclNotAccessibleException extends DittoRuntimeException imple
         }
 
         @Override
-        protected AclNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AclNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AclNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotAccessibleException.java
@@ -87,7 +87,12 @@ public final class AclNotAccessibleException extends DittoRuntimeException imple
      * JsonFields#MESSAGE} field.
      */
     public static AclNotAccessibleException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -45,8 +46,11 @@ public final class AclNotModifiableException extends DittoRuntimeException imple
 
     private static final long serialVersionUID = -2579965621491355738L;
 
-    private AclNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AclNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -110,8 +114,11 @@ public final class AclNotModifiableException extends DittoRuntimeException imple
         }
 
         @Override
-        protected AclNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AclNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AclNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AclNotModifiableException.java
@@ -85,7 +85,12 @@ public final class AclNotModifiableException extends DittoRuntimeException imple
      * JsonFields#MESSAGE} field.
      */
     public static AclNotModifiableException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleException.java
@@ -85,7 +85,12 @@ public final class AttributeNotAccessibleException extends DittoRuntimeException
      */
     public static AttributeNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class AttributeNotAccessibleException extends DittoRuntimeException
 
     private static final long serialVersionUID = 2326664361301515934L;
 
-    private AttributeNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AttributeNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -110,8 +114,11 @@ public final class AttributeNotAccessibleException extends DittoRuntimeException
         }
 
         @Override
-        protected AttributeNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AttributeNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AttributeNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -42,8 +43,11 @@ public final class AttributeNotModifiableException extends DittoRuntimeException
     
     private static final long serialVersionUID = 2892397125359904460L;
 
-    private AttributeNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AttributeNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,8 +115,11 @@ public final class AttributeNotModifiableException extends DittoRuntimeException
         }
 
         @Override
-        protected AttributeNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AttributeNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AttributeNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableException.java
@@ -68,7 +68,7 @@ public final class AttributeNotModifiableException extends DittoRuntimeException
      */
     public static AttributeNotModifiableException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new AttributeNotModifiableException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
@@ -86,7 +86,12 @@ public final class AttributeNotModifiableException extends DittoRuntimeException
      */
     public static AttributeNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidException.java
@@ -47,7 +47,6 @@ public final class AttributePointerInvalidException extends DittoRuntimeExceptio
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,7 +115,6 @@ public final class AttributePointerInvalidException extends DittoRuntimeExceptio
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new AttributePointerInvalidException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidException.java
@@ -87,8 +87,12 @@ public final class AttributePointerInvalidException extends DittoRuntimeExceptio
      */
     public static AttributePointerInvalidException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -40,8 +41,11 @@ public final class AttributesNotAccessibleException extends DittoRuntimeExceptio
 
     private static final long serialVersionUID = 4127445496936034126L;
 
-    private AttributesNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AttributesNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable  final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -107,8 +111,11 @@ public final class AttributesNotAccessibleException extends DittoRuntimeExceptio
         }
 
         @Override
-        protected AttributesNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AttributesNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AttributesNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleException.java
@@ -82,7 +82,12 @@ public final class AttributesNotAccessibleException extends DittoRuntimeExceptio
      */
     public static AttributesNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -41,8 +42,11 @@ public final class AttributesNotModifiableException extends DittoRuntimeExceptio
     private static final String DEFAULT_DESCRIPTION =
             "Check if the ID of your requested Thing was correct and you have sufficient permissions.";
 
-    private AttributesNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private AttributesNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -108,8 +112,11 @@ public final class AttributesNotModifiableException extends DittoRuntimeExceptio
         }
 
         @Override
-        protected AttributesNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected AttributesNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new AttributesNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableException.java
@@ -83,7 +83,12 @@ public final class AttributesNotModifiableException extends DittoRuntimeExceptio
      */
     public static AttributesNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
@@ -57,7 +57,6 @@ public final class EventSendNotAllowedException extends DittoRuntimeException im
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -123,7 +122,6 @@ public final class EventSendNotAllowedException extends DittoRuntimeException im
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new EventSendNotAllowedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
@@ -93,10 +93,12 @@ public final class EventSendNotAllowedException extends DittoRuntimeException im
      */
     public static EventSendNotAllowedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .loadJson(jsonObject)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleException.java
@@ -91,8 +91,12 @@ public final class FeatureDefinitionNotAccessibleException extends DittoRuntimeE
      */
     public static FeatureDefinitionNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleException.java
@@ -48,7 +48,6 @@ public final class FeatureDefinitionNotAccessibleException extends DittoRuntimeE
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -120,7 +119,6 @@ public final class FeatureDefinitionNotAccessibleException extends DittoRuntimeE
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new FeatureDefinitionNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableException.java
@@ -49,7 +49,6 @@ public final class FeatureDefinitionNotModifiableException extends DittoRuntimeE
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -123,7 +122,6 @@ public final class FeatureDefinitionNotModifiableException extends DittoRuntimeE
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new FeatureDefinitionNotModifiableException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableException.java
@@ -94,8 +94,12 @@ public final class FeatureDefinitionNotModifiableException extends DittoRuntimeE
      */
     public static FeatureDefinitionNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -42,8 +43,11 @@ public final class FeatureNotAccessibleException extends DittoRuntimeException i
 
     private static final long serialVersionUID = 7276337778530053496L;
 
-    private FeatureNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeatureNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public final class FeatureNotAccessibleException extends DittoRuntimeException i
         }
 
         @Override
-        protected FeatureNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected FeatureNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeatureNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleException.java
@@ -85,7 +85,12 @@ public final class FeatureNotAccessibleException extends DittoRuntimeException i
      */
     public static FeatureNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableException.java
@@ -85,7 +85,12 @@ public class FeatureNotModifiableException extends DittoRuntimeException impleme
      */
     public static FeatureNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -42,8 +43,11 @@ public class FeatureNotModifiableException extends DittoRuntimeException impleme
 
     private static final long serialVersionUID = 7276337778530053496L;
 
-    private FeatureNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeatureNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public class FeatureNotModifiableException extends DittoRuntimeException impleme
         }
 
         @Override
-        protected FeatureNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected FeatureNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeatureNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class FeaturePropertiesNotAccessibleException extends DittoRuntimeE
 
     private static final long serialVersionUID = 3148170836485607502L;
 
-    private FeaturePropertiesNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturePropertiesNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,7 +115,10 @@ public final class FeaturePropertiesNotAccessibleException extends DittoRuntimeE
 
         @Override
         protected FeaturePropertiesNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message, final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturePropertiesNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleException.java
@@ -85,7 +85,12 @@ public final class FeaturePropertiesNotAccessibleException extends DittoRuntimeE
      */
     public static FeaturePropertiesNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -41,8 +42,11 @@ public class FeaturePropertiesNotModifiableException extends DittoRuntimeExcepti
 
     private static final long serialVersionUID = 3148170836485607502L;
 
-    private FeaturePropertiesNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturePropertiesNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -111,7 +115,10 @@ public class FeaturePropertiesNotModifiableException extends DittoRuntimeExcepti
 
         @Override
         protected FeaturePropertiesNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message, final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturePropertiesNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableException.java
@@ -67,7 +67,7 @@ public class FeaturePropertiesNotModifiableException extends DittoRuntimeExcepti
      */
     public static FeaturePropertiesNotModifiableException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new FeaturePropertiesNotModifiableException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
@@ -85,7 +85,12 @@ public class FeaturePropertiesNotModifiableException extends DittoRuntimeExcepti
      */
     public static FeaturePropertiesNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -46,8 +47,11 @@ public final class FeaturePropertyNotAccessibleException extends DittoRuntimeExc
 
     private static final long serialVersionUID = -1793783227991859251L;
 
-    private FeaturePropertyNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturePropertyNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,8 +120,10 @@ public final class FeaturePropertyNotAccessibleException extends DittoRuntimeExc
 
         @Override
         protected FeaturePropertyNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturePropertyNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleException.java
@@ -90,7 +90,12 @@ public final class FeaturePropertyNotAccessibleException extends DittoRuntimeExc
      */
     public static FeaturePropertyNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -44,8 +45,11 @@ public class FeaturePropertyNotModifiableException extends DittoRuntimeException
 
     private static final long serialVersionUID = -1793783227991859251L;
 
-    private FeaturePropertyNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturePropertyNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -115,8 +119,10 @@ public class FeaturePropertyNotModifiableException extends DittoRuntimeException
 
         @Override
         protected FeaturePropertyNotModifiableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturePropertyNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableException.java
@@ -89,7 +89,12 @@ public class FeaturePropertyNotModifiableException extends DittoRuntimeException
      */
     public static FeaturePropertyNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleException.java
@@ -84,7 +84,12 @@ public final class FeaturesNotAccessibleException extends DittoRuntimeException 
      */
     public static FeaturesNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class FeaturesNotAccessibleException extends DittoRuntimeException 
 
     private static final long serialVersionUID = -707524055354192288L;
 
-    private FeaturesNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturesNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public final class FeaturesNotAccessibleException extends DittoRuntimeException 
         }
 
         @Override
-        protected FeaturesNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected FeaturesNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturesNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -40,8 +41,11 @@ public final class FeaturesNotModifiableException extends DittoRuntimeException 
 
     private static final long serialVersionUID = -707524055354192288L;
 
-    private FeaturesNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private FeaturesNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -107,8 +111,11 @@ public final class FeaturesNotModifiableException extends DittoRuntimeException 
         }
 
         @Override
-        protected FeaturesNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected FeaturesNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new FeaturesNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableException.java
@@ -64,7 +64,7 @@ public final class FeaturesNotModifiableException extends DittoRuntimeException 
      */
     public static FeaturesNotModifiableException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new FeaturesNotModifiableException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
@@ -82,7 +82,12 @@ public final class FeaturesNotModifiableException extends DittoRuntimeException 
      */
     public static FeaturesNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
@@ -60,8 +60,8 @@ public class MissingThingIdsException extends DittoRuntimeException implements T
      *
      * @return the builder.
      */
-    public static MissingThingIdsException.Builder newBuilder() {
-        return new MissingThingIdsException.Builder();
+    public static Builder newBuilder() {
+        return new Builder();
     }
 
     /**
@@ -75,9 +75,11 @@ public class MissingThingIdsException extends DittoRuntimeException implements T
      * JsonFields#MESSAGE} field.
      */
     public static MissingThingIdsException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return new MissingThingIdsException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsException.java
@@ -45,8 +45,11 @@ public class MissingThingIdsException extends DittoRuntimeException implements T
     
     private static final long serialVersionUID = -5672699009682971258L;
 
-    private MissingThingIdsException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private MissingThingIdsException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
     }
 
@@ -94,8 +97,11 @@ public class MissingThingIdsException extends DittoRuntimeException implements T
         }
 
         @Override
-        protected MissingThingIdsException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected MissingThingIdsException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new MissingThingIdsException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAccessibleException.java
@@ -67,7 +67,7 @@ public final class PolicyIdNotAccessibleException extends DittoRuntimeException 
      */
     public static PolicyIdNotAccessibleException fromMessage(final String message,
             final DittoHeaders dittoHeaders) {
-        return new PolicyIdNotAccessibleException.Builder()
+        return new Builder()
                 .dittoHeaders(dittoHeaders)
                 .message(message)
                 .build();
@@ -85,7 +85,12 @@ public final class PolicyIdNotAccessibleException extends DittoRuntimeException 
      */
     public static PolicyIdNotAccessibleException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAccessibleException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,8 +44,11 @@ public final class PolicyIdNotAccessibleException extends DittoRuntimeException 
 
     private static final long serialVersionUID = -623037881914361095L;
 
-    private PolicyIdNotAccessibleException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyIdNotAccessibleException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -110,8 +114,11 @@ public final class PolicyIdNotAccessibleException extends DittoRuntimeException 
         }
 
         @Override
-        protected PolicyIdNotAccessibleException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyIdNotAccessibleException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyIdNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
@@ -43,8 +43,11 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
 
     private static final long serialVersionUID = 4511420390758955872L;
 
-    private PolicyIdNotAllowedException(final DittoHeaders dittoHeaders, @Nullable final String message,
-            @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+    private PolicyIdNotAllowedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -108,8 +111,11 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
         }
 
         @Override
-        protected PolicyIdNotAllowedException doBuild(final DittoHeaders dittoHeaders, @Nullable final String message,
-                @Nullable final String description, @Nullable final Throwable cause, @Nullable final URI href) {
+        protected PolicyIdNotAllowedException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyIdNotAllowedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedException.java
@@ -84,7 +84,12 @@ public final class PolicyIdNotAllowedException extends DittoRuntimeException imp
      */
     public static PolicyIdNotAllowedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableException.java
@@ -84,7 +84,12 @@ public final class PolicyIdNotModifiableException extends DittoRuntimeException 
      */
     public static PolicyIdNotModifiableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,8 +44,11 @@ public final class PolicyIdNotModifiableException extends DittoRuntimeException 
 
     private static final long serialVersionUID = 4150912739739802552L;
 
-    private PolicyIdNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyIdNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public final class PolicyIdNotModifiableException extends DittoRuntimeException 
         }
 
         @Override
-        protected PolicyIdNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyIdNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyIdNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collection;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -49,8 +50,11 @@ public final class PolicyInvalidException extends DittoRuntimeException implemen
 
     private static final long serialVersionUID = -4503670096839743360L;
 
-    private PolicyInvalidException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private PolicyInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
     }
 
@@ -128,8 +132,11 @@ public final class PolicyInvalidException extends DittoRuntimeException implemen
         }
 
         @Override
-        protected PolicyInvalidException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyInvalidException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
@@ -118,7 +118,9 @@ public final class PolicyInvalidException extends DittoRuntimeException implemen
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<PolicyInvalidException> {
 
-        private Builder() {}
+        private Builder() {
+            description(DESCRIPTION_TEMPLATE);
+        }
 
         private Builder(final Collection<String> permissions, final String thingId) {
             message(MessageFormat.format(MESSAGE_TEMPLATE, thingId));

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidException.java
@@ -90,13 +90,11 @@ public final class PolicyInvalidException extends DittoRuntimeException implemen
      * JsonFields#MESSAGE} field.
      */
     public static PolicyInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        final String message = readMessage(jsonObject);
-        final String description = readDescription(jsonObject).orElse(DESCRIPTION_TEMPLATE);
-
         return new Builder()
-                .message(message)
-                .description(description)
                 .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DESCRIPTION_TEMPLATE))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -41,8 +42,11 @@ public class PolicyNotAllowedException extends DittoRuntimeException implements 
 
     private static final long serialVersionUID = -8456383404788481857L;
 
-    private PolicyNotAllowedException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private PolicyNotAllowedException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,8 +110,11 @@ public class PolicyNotAllowedException extends DittoRuntimeException implements 
         }
 
         @Override
-        protected PolicyNotAllowedException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected PolicyNotAllowedException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new PolicyNotAllowedException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedException.java
@@ -82,7 +82,12 @@ public class PolicyNotAllowedException extends DittoRuntimeException implements 
      */
     public static PolicyNotAllowedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictException.java
@@ -80,7 +80,12 @@ public final class ThingConflictException extends DittoRuntimeException implemen
      * JsonFields#MESSAGE} field.
      */
     public static ThingConflictException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -40,8 +41,11 @@ public final class ThingConflictException extends DittoRuntimeException implemen
 
     private static final long serialVersionUID = -5987230030980819468L;
 
-    private ThingConflictException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private ThingConflictException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.CONFLICT, dittoHeaders, message, description, cause, href);
     }
 
@@ -105,8 +109,11 @@ public final class ThingConflictException extends DittoRuntimeException implemen
         }
 
         @Override
-        protected ThingConflictException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingConflictException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingConflictException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingErrorRegistry.java
@@ -66,43 +66,33 @@ public final class ThingErrorRegistry extends AbstractErrorRegistry<DittoRuntime
         final Map<String, JsonParsable<DittoRuntimeException>> parseStrategies =
                 new HashMap<>(additionalParseStrategies);
 
-        parseStrategies.put(AclInvalidException.ERROR_CODE, AclInvalidException::fromJson);
-        parseStrategies.put(AclEntryInvalidException.ERROR_CODE, AclEntryInvalidException::fromJson);
-        parseStrategies.put(AclNotAllowedException.ERROR_CODE, AclNotAllowedException::fromJson);
-        parseStrategies.put(AclModificationInvalidException.ERROR_CODE, AclModificationInvalidException::fromJson);
-        parseStrategies.put(AclNotAccessibleException.ERROR_CODE, AclNotAccessibleException::fromJson);
-        parseStrategies.put(AclNotModifiableException.ERROR_CODE, AclNotModifiableException::fromJson);
-        parseStrategies.put(ThingConflictException.ERROR_CODE, ThingConflictException::fromJson);
-        parseStrategies.put(ThingIdInvalidException.ERROR_CODE, ThingIdInvalidException::fromJson);
-        parseStrategies.put(ThingTooLargeException.ERROR_CODE, ThingTooLargeException::fromJson);
-        parseStrategies.put(ThingIdNotExplicitlySettableException.ERROR_CODE,
-                ThingIdNotExplicitlySettableException::fromJson);
-        parseStrategies.put(ThingNotAccessibleException.ERROR_CODE, ThingNotAccessibleException::fromJson);
-        parseStrategies.put(ThingNotDeletableException.ERROR_CODE, ThingNotDeletableException::fromJson);
-        parseStrategies.put(ThingNotCreatableException.ERROR_CODE, ThingNotCreatableException::fromJson);
-        parseStrategies.put(ThingNotModifiableException.ERROR_CODE, ThingNotModifiableException::fromJson);
-        parseStrategies.put(PolicyIdNotAccessibleException.ERROR_CODE, PolicyIdNotAccessibleException::fromJson);
-        parseStrategies.put(PolicyIdNotModifiableException.ERROR_CODE, PolicyIdNotModifiableException::fromJson);
-        parseStrategies.put(PolicyIdNotAllowedException.ERROR_CODE, PolicyIdNotAllowedException::fromJson);
-        parseStrategies.put(PolicyNotAllowedException.ERROR_CODE, PolicyNotAllowedException::fromJson);
-        parseStrategies.put(PolicyInvalidException.ERROR_CODE, PolicyInvalidException::fromJson);
-        parseStrategies.put(PolicyIdMissingException.ERROR_CODE, PolicyIdMissingException::fromJson);
-        parseStrategies.put(ThingUnavailableException.ERROR_CODE, ThingUnavailableException::fromJson);
-        parseStrategies.put(ThingTooManyModifyingRequestsException.ERROR_CODE,
-                ThingTooManyModifyingRequestsException::fromJson);
-        parseStrategies.put(AttributesNotAccessibleException.ERROR_CODE, AttributesNotAccessibleException::fromJson);
-        parseStrategies.put(AttributeNotAccessibleException.ERROR_CODE, AttributeNotAccessibleException::fromJson);
-        parseStrategies.put(AttributesNotModifiableException.ERROR_CODE, AttributesNotModifiableException::fromJson);
-        parseStrategies.put(AttributeNotModifiableException.ERROR_CODE, AttributeNotModifiableException::fromJson);
-        parseStrategies.put(AttributePointerInvalidException.ERROR_CODE, AttributePointerInvalidException::fromJson);
-        parseStrategies.put(FeaturesNotAccessibleException.ERROR_CODE, FeaturesNotAccessibleException::fromJson);
-        parseStrategies.put(FeaturesNotModifiableException.ERROR_CODE, FeaturesNotModifiableException::fromJson);
-        parseStrategies.put(FeatureNotAccessibleException.ERROR_CODE, FeatureNotAccessibleException::fromJson);
-        parseStrategies.put(FeatureNotModifiableException.ERROR_CODE, FeatureNotModifiableException::fromJson);
+        // org.eclipse.ditto.signals.commands.things.exceptions
+        parseStrategies.put(AclModificationInvalidException.ERROR_CODE,
+                AclModificationInvalidException::fromJson);
+        parseStrategies.put(AclNotAccessibleException.ERROR_CODE,
+                AclNotAccessibleException::fromJson);
+        parseStrategies.put(AclNotModifiableException.ERROR_CODE,
+                AclNotModifiableException::fromJson);
+        parseStrategies.put(AttributeNotAccessibleException.ERROR_CODE,
+                AttributeNotAccessibleException::fromJson);
+        parseStrategies.put(AttributeNotModifiableException.ERROR_CODE,
+                AttributeNotModifiableException::fromJson);
+        parseStrategies.put(AttributePointerInvalidException.ERROR_CODE,
+                AttributePointerInvalidException::fromJson);
+        parseStrategies.put(AttributesNotAccessibleException.ERROR_CODE,
+                AttributesNotAccessibleException::fromJson);
+        parseStrategies.put(AttributesNotModifiableException.ERROR_CODE,
+                AttributesNotModifiableException::fromJson);
+        parseStrategies.put(EventSendNotAllowedException.ERROR_CODE,
+                EventSendNotAllowedException::fromJson);
         parseStrategies.put(FeatureDefinitionNotAccessibleException.ERROR_CODE,
                 FeatureDefinitionNotAccessibleException::fromJson);
         parseStrategies.put(FeatureDefinitionNotModifiableException.ERROR_CODE,
                 FeatureDefinitionNotModifiableException::fromJson);
+        parseStrategies.put(FeatureNotAccessibleException.ERROR_CODE,
+                FeatureNotAccessibleException::fromJson);
+        parseStrategies.put(FeatureNotModifiableException.ERROR_CODE,
+                FeatureNotModifiableException::fromJson);
         parseStrategies.put(FeaturePropertiesNotAccessibleException.ERROR_CODE,
                 FeaturePropertiesNotAccessibleException::fromJson);
         parseStrategies.put(FeaturePropertiesNotModifiableException.ERROR_CODE,
@@ -111,12 +101,59 @@ public final class ThingErrorRegistry extends AbstractErrorRegistry<DittoRuntime
                 FeaturePropertyNotAccessibleException::fromJson);
         parseStrategies.put(FeaturePropertyNotModifiableException.ERROR_CODE,
                 FeaturePropertyNotModifiableException::fromJson);
-        parseStrategies.put(FeatureDefinitionEmptyException.ERROR_CODE, FeatureDefinitionEmptyException::fromJson);
+        parseStrategies.put(FeaturesNotAccessibleException.ERROR_CODE,
+                FeaturesNotAccessibleException::fromJson);
+        parseStrategies.put(FeaturesNotModifiableException.ERROR_CODE,
+                FeaturesNotModifiableException::fromJson);
+        parseStrategies.put(MissingThingIdsException.ERROR_CODE, MissingThingIdsException::fromJson);
+        parseStrategies.put(PolicyIdNotAccessibleException.ERROR_CODE,
+                PolicyIdNotAccessibleException::fromJson);
+        parseStrategies.put(PolicyIdNotAllowedException.ERROR_CODE,
+                PolicyIdNotAllowedException::fromJson);
+        parseStrategies.put(PolicyIdNotModifiableException.ERROR_CODE,
+                PolicyIdNotModifiableException::fromJson);
+        parseStrategies.put(PolicyInvalidException.ERROR_CODE,
+                PolicyInvalidException::fromJson);
+        parseStrategies.put(PolicyNotAllowedException.ERROR_CODE,
+                PolicyNotAllowedException::fromJson);
+        parseStrategies.put(ThingConflictException.ERROR_CODE,
+                ThingConflictException::fromJson);
+        parseStrategies.put(ThingIdNotExplicitlySettableException.ERROR_CODE,
+                ThingIdNotExplicitlySettableException::fromJson);
+        parseStrategies.put(ThingNotAccessibleException.ERROR_CODE,
+                ThingNotAccessibleException::fromJson);
+        parseStrategies.put(ThingNotCreatableException.ERROR_CODE,
+                ThingNotCreatableException::fromJson);
+        parseStrategies.put(ThingNotDeletableException.ERROR_CODE,
+                ThingNotDeletableException::fromJson);
+        parseStrategies.put(ThingNotModifiableException.ERROR_CODE,
+                ThingNotModifiableException::fromJson);
+        parseStrategies.put(ThingPreconditionFailedException.ERROR_CODE,
+                ThingPreconditionFailedException::fromJson);
+        parseStrategies.put(ThingPreconditionNotModifiedException.ERROR_CODE,
+                ThingPreconditionNotModifiedException::fromJson);
+        parseStrategies.put(ThingTooManyModifyingRequestsException.ERROR_CODE,
+                ThingTooManyModifyingRequestsException::fromJson);
+        parseStrategies.put(ThingUnavailableException.ERROR_CODE,
+                ThingUnavailableException::fromJson);
+
+        // org.eclipse.ditto.model.things
+        parseStrategies.put(AclEntryInvalidException.ERROR_CODE,
+                AclEntryInvalidException::fromJson);
+        parseStrategies.put(AclInvalidException.ERROR_CODE,
+                AclInvalidException::fromJson);
+        parseStrategies.put(AclNotAllowedException.ERROR_CODE,
+                AclNotAllowedException::fromJson);
+        parseStrategies.put(FeatureDefinitionEmptyException.ERROR_CODE,
+                FeatureDefinitionEmptyException::fromJson);
         parseStrategies.put(FeatureDefinitionIdentifierInvalidException.ERROR_CODE,
                 FeatureDefinitionIdentifierInvalidException::fromJson);
-        parseStrategies.put(MissingThingIdsException.ERROR_CODE, MissingThingIdsException::fromJson);
-        parseStrategies.put(ThingPreconditionNotModifiedException.ERROR_CODE, ThingPreconditionNotModifiedException::fromJson);
-        parseStrategies.put(ThingPreconditionFailedException.ERROR_CODE, ThingPreconditionFailedException::fromJson);
+        parseStrategies.put(PolicyIdMissingException.ERROR_CODE,
+                PolicyIdMissingException::fromJson);
+        parseStrategies.put(ThingIdInvalidException.ERROR_CODE,
+                ThingIdInvalidException::fromJson);
+        parseStrategies.put(ThingTooLargeException.ERROR_CODE,
+                ThingTooLargeException::fromJson);
 
         return new ThingErrorRegistry(parseStrategies);
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableException.java
@@ -38,13 +38,14 @@ public final class ThingIdNotExplicitlySettableException extends DittoRuntimeExc
             "It is not allowed to provide a Thing ID in the request body for "
                     + "method POST. The method POST will generate the Thing ID by itself.";
 
-    private static final String DEFAULT_DESCRIPTION_POST = "To provide your own Thing ID use a PUT request instead.";
+    private static final String DEFAULT_DESCRIPTION_POST =
+            "To provide your own Thing ID use a PUT request instead.";
 
     private static final String MESSAGE_TEMPLATE_PUT =
-            "The Thing ID in the request body is not equal to the Thing ID in " + "the request URL.";
+            "The Thing ID in the request body is not equal to the Thing ID in the request URL.";
 
     private static final String DEFAULT_DESCRIPTION_PUT =
-            "Either delete the Thing ID from the request body or use the " + "same Thing ID as in the request URL.";
+            "Either delete the Thing ID from the request body or use the same Thing ID as in the request URL.";
 
     private static final long serialVersionUID = 5477658033219182854L;
 
@@ -91,7 +92,23 @@ public final class ThingIdNotExplicitlySettableException extends DittoRuntimeExc
      */
     public static ThingIdNotExplicitlySettableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        final String message = readMessage(jsonObject);
+        if (MESSAGE_TEMPLATE_POST.equalsIgnoreCase(message)) {
+            return new Builder(true)
+                    .dittoHeaders(dittoHeaders)
+                    .message(message)
+                    .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_POST))
+                    .href(readHRef(jsonObject).orElse(null))
+                    .build();
+        }
+        else {
+            return new Builder(false)
+                    .dittoHeaders(dittoHeaders)
+                    .message(message)
+                    .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_PUT))
+                    .href(readHRef(jsonObject).orElse(null))
+                    .build();
+        }
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -49,8 +50,11 @@ public final class ThingIdNotExplicitlySettableException extends DittoRuntimeExc
 
     private static final long serialVersionUID = 5477658033219182854L;
 
-    private ThingIdNotExplicitlySettableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingIdNotExplicitlySettableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -125,8 +129,10 @@ public final class ThingIdNotExplicitlySettableException extends DittoRuntimeExc
 
         @Override
         protected ThingIdNotExplicitlySettableException doBuild(final DittoHeaders dittoHeaders,
-                final String message,
-                final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingIdNotExplicitlySettableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleException.java
@@ -51,7 +51,6 @@ public final class ThingNotAccessibleException extends DittoRuntimeException imp
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.NOT_FOUND, dittoHeaders, message, description, cause, href);
     }
 
@@ -136,7 +135,6 @@ public final class ThingNotAccessibleException extends DittoRuntimeException imp
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ThingNotAccessibleException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleException.java
@@ -111,6 +111,7 @@ public final class ThingNotAccessibleException extends DittoRuntimeException imp
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableException.java
@@ -42,11 +42,16 @@ public final class ThingNotCreatableException extends DittoRuntimeException impl
             "The Thing with ID ''{0}'' could not be created with " +
                     "implicit Policy as the Policy with ID ''{1}'' is already existing.";
 
-    private static final String DEFAULT_DESCRIPTION =
+    private static final String DEFAULT_DESCRIPTION_NOT_EXISTING =
             "Check if the ID of the Policy you created the Thing with is correct and that the Policy is existing.";
 
     private static final String DEFAULT_DESCRIPTION_POLICY_EXISTING =
             "If you want to use the existing Policy, specify it as 'policyId' in the Thing JSON you create.";
+
+    private static final String DEFAULT_DESCRIPTION_GENERIC =
+            "Either check if the ID of the Policy you created the Thing with is correct and that the " +
+                    "Policy is existing or If you want to use the existing Policy, specify it as 'policyId' " +
+                    "in the Thing JSON you create.";
 
     private static final long serialVersionUID = 2153912949789822362L;
 
@@ -113,7 +118,12 @@ public final class ThingNotCreatableException extends DittoRuntimeException impl
      */
     public static ThingNotCreatableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION_GENERIC))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**
@@ -123,9 +133,13 @@ public final class ThingNotCreatableException extends DittoRuntimeException impl
     @NotThreadSafe
     public static final class Builder extends DittoRuntimeExceptionBuilder<ThingNotCreatableException> {
 
+        private Builder() {
+            description(DEFAULT_DESCRIPTION_GENERIC);
+        }
+
         private Builder(final boolean policyMissing) {
             if (policyMissing) {
-                description(DEFAULT_DESCRIPTION);
+                description(DEFAULT_DESCRIPTION_NOT_EXISTING);
             } else {
                 description(DEFAULT_DESCRIPTION_POLICY_EXISTING);
             }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableException.java
@@ -55,8 +55,11 @@ public final class ThingNotCreatableException extends DittoRuntimeException impl
 
     private static final long serialVersionUID = 2153912949789822362L;
 
-    private ThingNotCreatableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingNotCreatableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
     }
 
@@ -155,8 +158,11 @@ public final class ThingNotCreatableException extends DittoRuntimeException impl
         }
 
         @Override
-        protected ThingNotCreatableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingNotCreatableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingNotCreatableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableException.java
@@ -89,7 +89,12 @@ public final class ThingNotDeletableException extends DittoRuntimeException impl
      */
     public static ThingNotDeletableException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableException.java
@@ -15,6 +15,7 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -48,8 +49,11 @@ public final class ThingNotDeletableException extends DittoRuntimeException impl
 
     private static final long serialVersionUID = -8123337828934144618L;
 
-    private ThingNotDeletableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingNotDeletableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -116,8 +120,11 @@ public final class ThingNotDeletableException extends DittoRuntimeException impl
         }
 
         @Override
-        protected ThingNotDeletableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingNotDeletableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             final JsonSchemaVersion schemaVersion =
                     checkNotNull(dittoHeaders, "command headers").getSchemaVersion().orElse(JsonSchemaVersion.LATEST);
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -43,8 +44,11 @@ public final class ThingNotModifiableException extends DittoRuntimeException imp
 
     private static final long serialVersionUID = 7150912939789802382L;
 
-    private ThingNotModifiableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingNotModifiableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.FORBIDDEN, dittoHeaders, message, description, cause, href);
     }
 
@@ -109,8 +113,11 @@ public final class ThingNotModifiableException extends DittoRuntimeException imp
         }
 
         @Override
-        protected ThingNotModifiableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingNotModifiableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingNotModifiableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableException.java
@@ -88,6 +88,7 @@ public final class ThingNotModifiableException extends DittoRuntimeException imp
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedException.java
@@ -48,7 +48,6 @@ public final class ThingPreconditionFailedException extends DittoRuntimeExceptio
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.PRECONDITION_FAILED, dittoHeaders, message, description, cause, href);
     }
 
@@ -106,7 +105,6 @@ public final class ThingPreconditionFailedException extends DittoRuntimeExceptio
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ThingPreconditionFailedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedException.java
@@ -76,16 +76,11 @@ public final class ThingPreconditionFailedException extends DittoRuntimeExceptio
      */
     public static ThingPreconditionFailedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
-    }
-
-    private static ThingPreconditionFailedException fromMessage(final String message,
-            final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
-                .message(message)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedException.java
@@ -78,16 +78,11 @@ public final class ThingPreconditionNotModifiedException extends DittoRuntimeExc
      */
     public static ThingPreconditionNotModifiedException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
-    }
-
-    private static ThingPreconditionNotModifiedException fromMessage(final String message,
-            final DittoHeaders dittoHeaders) {
-
         return new Builder()
                 .dittoHeaders(dittoHeaders)
-                .message(message)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
                 .build();
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedException.java
@@ -50,7 +50,6 @@ public final class ThingPreconditionNotModifiedException extends DittoRuntimeExc
             @Nullable final String description,
             @Nullable final Throwable cause,
             @Nullable final URI href) {
-
         super(ERROR_CODE, HttpStatusCode.NOT_MODIFIED, dittoHeaders, message, description, cause, href);
     }
 
@@ -107,7 +106,6 @@ public final class ThingPreconditionNotModifiedException extends DittoRuntimeExc
                 @Nullable final String description,
                 @Nullable final Throwable cause,
                 @Nullable final URI href) {
-
             return new ThingPreconditionNotModifiedException(dittoHeaders, message, description, cause, href);
         }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -44,8 +45,11 @@ public final class ThingTooManyModifyingRequestsException extends DittoRuntimeEx
     private static final long serialVersionUID = 5780041246404245765L;
 
 
-    private ThingTooManyModifyingRequestsException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingTooManyModifyingRequestsException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.TOO_MANY_REQUESTS, dittoHeaders, message, description, cause, href);
     }
 
@@ -112,7 +116,10 @@ public final class ThingTooManyModifyingRequestsException extends DittoRuntimeEx
 
         @Override
         protected ThingTooManyModifyingRequestsException doBuild(final DittoHeaders dittoHeaders,
-                final String message, final String description, final Throwable cause, final URI href) {
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingTooManyModifyingRequestsException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsException.java
@@ -86,7 +86,12 @@ public final class ThingTooManyModifyingRequestsException extends DittoRuntimeEx
      */
     public static ThingTooManyModifyingRequestsException fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableException.java
@@ -82,7 +82,12 @@ public final class ThingUnavailableException extends DittoRuntimeException imple
      * JsonFields#MESSAGE} field.
      */
     public static ThingUnavailableException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableException.java
@@ -13,6 +13,7 @@ package org.eclipse.ditto.signals.commands.things.exceptions;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -42,8 +43,11 @@ public final class ThingUnavailableException extends DittoRuntimeException imple
     private static final long serialVersionUID = 1987286804137290070L;
 
 
-    private ThingUnavailableException(final DittoHeaders dittoHeaders, final String message,
-            final String description, final Throwable cause, final URI href) {
+    private ThingUnavailableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
     }
 
@@ -107,8 +111,11 @@ public final class ThingUnavailableException extends DittoRuntimeException imple
         }
 
         @Override
-        protected ThingUnavailableException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected ThingUnavailableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new ThingUnavailableException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class AttributeNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.ATTRIBUTE_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.ATTRIBUTE_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.ATTRIBUTE_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributeNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class AttributeNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.ATTRIBUTE_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.ATTRIBUTE_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.ATTRIBUTE_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributePointerInvalidExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.model.base.assertions.DittoBaseAssertions.assert
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public final class AttributePointerInvalidExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.ATTRIBUTE_POINTER_INVALID_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.ATTRIBUTE_POINTER_INVALID_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.ATTRIBUTE_POINTER_INVALID_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
     @Test

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class AttributesNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.ATTRIBUTES_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.ATTRIBUTES_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.ATTRIBUTES_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/AttributesNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class AttributesNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.ATTRIBUTES_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.ATTRIBUTES_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.ATTRIBUTES_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public final class FeatureDefinitionNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
     @Test

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureDefinitionNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public final class FeatureDefinitionNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
     @Test

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeatureNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeatureNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeatureNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -35,7 +37,8 @@ public class FeaturePropertiesNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertiesNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeaturePropertiesNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTIES_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeaturePropertyNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTY_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTY_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTY_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturePropertyNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeaturePropertyNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURE_PROPERTY_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURE_PROPERTY_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURE_PROPERTY_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeaturesNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURES_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURES_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURES_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/FeaturesNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class FeaturesNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Feature.FEATURES_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Feature.FEATURES_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Feature.FEATURES_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/MissingThingIdsExceptionTest.java
@@ -37,9 +37,7 @@ public class MissingThingIdsExceptionTest {
                     MISSING_THING_IDS_EXCEPTION.getDescription().orElse(null),
                     JsonField.isValueNonNull())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    MISSING_THING_IDS_EXCEPTION.getHref()
-                            .map(URI::toString)
-                            .orElse(null),
+                    MISSING_THING_IDS_EXCEPTION.getHref().map(URI::toString).orElse(null),
                     JsonField.isValueNonNull())
             .build();
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotAllowedExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyIdNotAllowedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.POLICY_ID_NOT_ALLOWED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.POLICY_ID_NOT_ALLOWED_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.POLICY_ID_NOT_ALLOWED_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyIdNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyIdNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.POLICY_ID_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.POLICY_ID_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.POLICY_ID_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyInvalidExceptionTest.java
@@ -40,8 +40,7 @@ public class PolicyInvalidExceptionTest {
                     JsonField.isValueNonNull())
             .set(DittoRuntimeException.JsonFields.HREF,
                     TestConstants.Thing.POLICY_INVALID_EXCEPTION.getHref()
-                            .map(URI::toString)
-                            .orElse(null),
+                            .map(URI::toString).orElse(null),
                     JsonField.isValueNonNull())
             .build();
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/PolicyNotAllowedExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class PolicyNotAllowedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.POLICY_NOT_ALLOWED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.POLICY_NOT_ALLOWED_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.POLICY_NOT_ALLOWED_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingConflictExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -33,7 +35,8 @@ public class ThingConflictExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_CONFLICT_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_CONFLICT_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_CONFLICT_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingIdNotExplicitlySettableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ThingIdNotExplicitlySettableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_ID_NOT_EXPLICITLY_SETTABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotAccessibleExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -35,7 +37,8 @@ public class ThingNotAccessibleExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_NOT_ACCESSIBLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_NOT_ACCESSIBLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_NOT_ACCESSIBLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotCreatableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -35,7 +37,8 @@ public class ThingNotCreatableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_NOT_CREATABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_NOT_CREATABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_NOT_CREATABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotDeletableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -37,7 +39,8 @@ public final class ThingNotDeletableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_NOT_DELETABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_NOT_DELETABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_NOT_DELETABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingNotModifiableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ThingNotModifiableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_NOT_MODIFIABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_NOT_MODIFIABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_NOT_MODIFIABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionFailedExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ThingPreconditionFailedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_PRECONDITION_FAILED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_PRECONDITION_FAILED_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_PRECONDITION_FAILED_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingPreconditionNotModifiedExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ThingPreconditionNotModifiedExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_PRECONDITION_NOT_MODIFIED_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_PRECONDITION_NOT_MODIFIED_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_PRECONDITION_NOT_MODIFIED_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingTooManyModifyingRequestsExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -34,7 +36,8 @@ public class ThingTooManyModifyingRequestsExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_TOO_MANY_MODIFYING_REQUESTS_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableExceptionTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/exceptions/ThingUnavailableExceptionTest.java
@@ -14,6 +14,8 @@ import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandA
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.URI;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -33,7 +35,8 @@ public class ThingUnavailableExceptionTest {
             .set(DittoRuntimeException.JsonFields.DESCRIPTION,
                     TestConstants.Thing.THING_UNAVAILABLE_EXCEPTION.getDescription().get())
             .set(DittoRuntimeException.JsonFields.HREF,
-                    TestConstants.Thing.THING_UNAVAILABLE_EXCEPTION.getHref().toString())
+                    TestConstants.Thing.THING_UNAVAILABLE_EXCEPTION.getHref()
+                            .map(URI::toString).orElse(null))
             .build();
 
 

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidNamespacesException.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidNamespacesException.java
@@ -32,6 +32,7 @@ public class InvalidNamespacesException extends DittoRuntimeException implements
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "search.namespaces.invalid";
 
     static final String DEFAULT_DESCRIPTION = "The list of provided namespaces is too long.";
+
     static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
 
     private static final long serialVersionUID = 8900314242209005665L;
@@ -80,7 +81,12 @@ public class InvalidNamespacesException extends DittoRuntimeException implements
      * JsonFields#MESSAGE} field.
      */
     public static InvalidNamespacesException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidNamespacesException.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidNamespacesException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.signals.commands.thingsearch.exceptions;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -37,8 +38,11 @@ public class InvalidNamespacesException extends DittoRuntimeException implements
 
     private static final long serialVersionUID = 8900314242209005665L;
 
-    private InvalidNamespacesException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private InvalidNamespacesException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
     }
 
@@ -101,8 +105,11 @@ public class InvalidNamespacesException extends DittoRuntimeException implements
         }
 
         @Override
-        protected InvalidNamespacesException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected InvalidNamespacesException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new InvalidNamespacesException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidOptionException.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidOptionException.java
@@ -79,7 +79,12 @@ public class InvalidOptionException extends DittoRuntimeException implements Thi
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link JsonFields#MESSAGE} field.
      */
     public static InvalidOptionException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return fromMessage(readMessage(jsonObject), dittoHeaders);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
     }
 
     /**

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidOptionException.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/InvalidOptionException.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.signals.commands.thingsearch.exceptions;
 
 import java.net.URI;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -32,12 +33,16 @@ public class InvalidOptionException extends DittoRuntimeException implements Thi
     public static final String ERROR_CODE = ERROR_CODE_PREFIX + "search.option.invalid";
 
     static final String DEFAULT_DESCRIPTION = "At least one provided option is invalid.";
+
     static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
 
     private static final long serialVersionUID = -2341639110057194874L;
 
-    private InvalidOptionException(final DittoHeaders dittoHeaders, final String message, final String description,
-            final Throwable cause, final URI href) {
+    private InvalidOptionException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
     }
 
@@ -99,8 +104,11 @@ public class InvalidOptionException extends DittoRuntimeException implements Thi
         }
 
         @Override
-        protected InvalidOptionException doBuild(final DittoHeaders dittoHeaders, final String message,
-                final String description, final Throwable cause, final URI href) {
+        protected InvalidOptionException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
             return new InvalidOptionException(dittoHeaders, message, description, cause, href);
         }
     }

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/ThingSearchErrorRegistry.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/exceptions/ThingSearchErrorRegistry.java
@@ -59,8 +59,12 @@ public final class ThingSearchErrorRegistry extends AbstractErrorRegistry<DittoR
         commonErrorRegistry.getTypes()
                 .forEach(type -> parseStrategies.put(type, commonErrorRegistry::parse));
 
-        parseStrategies.put(InvalidOptionException.ERROR_CODE, InvalidOptionException::fromJson);
-        parseStrategies.put(InvalidNamespacesException.ERROR_CODE, InvalidNamespacesException::fromJson);
+
+        parseStrategies.put(InvalidOptionException.ERROR_CODE,
+                InvalidOptionException::fromJson);
+
+        parseStrategies.put(InvalidNamespacesException.ERROR_CODE,
+                InvalidNamespacesException::fromJson);
 
         return new ThingSearchErrorRegistry(parseStrategies);
     }


### PR DESCRIPTION
Extend de-serialization of all DittoRuntimeExceptions by de-serializing all properties of a Exception.
Now the message, description and hRef are de-serialized correctly.