### PR TITLE
Fix empty JavaScript payload mapping bug

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -561,7 +560,6 @@ final class ImmutableConnection implements Connection {
         @Override
         public ConnectionBuilder mappingContext(@Nullable final MappingContext mappingContext) {
             this.mappingContext = mappingContext;
-            checkMappingIsValid();
             return this;
         }
 
@@ -581,7 +579,6 @@ final class ImmutableConnection implements Connection {
         public Connection build() {
             checkSourceAndTargetAreValid();
             checkAuthorizationContextsAreValid();
-            //checkMappingIsValid();
             return new ImmutableConnection(this);
         }
 
@@ -589,20 +586,6 @@ final class ImmutableConnection implements Connection {
             if (sources.isEmpty() && targets.isEmpty()) {
                 throw ConnectionConfigurationInvalidException.newBuilder("Either a source or a target must be " +
                         "specified in the configuration of a connection!").build();
-            }
-        }
-
-        /**
-         * Both the incoming and the outgoing payload mapping script is not allowed to be empty.
-         */
-        private void checkMappingIsValid() {
-            if (mappingContext != null) {
-                mappingContext.getOptions().values().forEach(entry -> {
-                    if (entry.trim().length() == 0) {
-                        throw ConnectionConfigurationInvalidException.newBuilder("Empty Javascript could not be " +
-                                "applied for payload mapping!").build();
-                    }
-                });
             }
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -560,6 +561,7 @@ final class ImmutableConnection implements Connection {
         @Override
         public ConnectionBuilder mappingContext(@Nullable final MappingContext mappingContext) {
             this.mappingContext = mappingContext;
+            checkMappingIsValid();
             return this;
         }
 
@@ -579,6 +581,7 @@ final class ImmutableConnection implements Connection {
         public Connection build() {
             checkSourceAndTargetAreValid();
             checkAuthorizationContextsAreValid();
+            //checkMappingIsValid();
             return new ImmutableConnection(this);
         }
 
@@ -586,6 +589,20 @@ final class ImmutableConnection implements Connection {
             if (sources.isEmpty() && targets.isEmpty()) {
                 throw ConnectionConfigurationInvalidException.newBuilder("Either a source or a target must be " +
                         "specified in the configuration of a connection!").build();
+            }
+        }
+
+        /**
+         * Both the incoming and the outgoing payload mapping script is not allowed to be empty.
+         */
+        private void checkMappingIsValid() {
+            if (mappingContext != null) {
+                mappingContext.getOptions().values().forEach(entry -> {
+                    if (entry.trim().length() == 0) {
+                        throw ConnectionConfigurationInvalidException.newBuilder("Empty Javascript could not be " +
+                                "applied for payload mapping!").build();
+                    }
+                });
             }
         }
 

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
@@ -53,7 +53,7 @@ public interface MessageMapper {
     }
 
     /**
-     * Maps an {@link org.eclipse.ditto.services.models.connectivity.ExternalMessage} to an {@link org.eclipse.ditto.protocoladapter.Adaptable}
+     * Maps an {@link ExternalMessage} to an {@link Adaptable}
      *
      * @param message the ExternalMessage to map
      * @return the mapped Adaptable or an empty Optional if the ExternalMessage should not be mapped after all
@@ -64,13 +64,13 @@ public interface MessageMapper {
     Optional<Adaptable> map(ExternalMessage message);
 
     /**
-     * Maps an {@link org.eclipse.ditto.protocoladapter.Adaptable} to an {@link org.eclipse.ditto.services.models.connectivity.ExternalMessage}
+     * Maps an {@link Adaptable} to an {@link ExternalMessage}
      *
      * @param adaptable the Adaptable to map
      * @return the ExternalMessage or an empty Optional if the Adaptable should not be mapped after all
      * @throws org.eclipse.ditto.model.connectivity.MessageMappingFailedException if the given adaptable can not be mapped
      */
-    Optional<org.eclipse.ditto.services.models.connectivity.ExternalMessage> map(Adaptable adaptable);
+    Optional<ExternalMessage> map(Adaptable adaptable);
 
     /**
      * Finds the content-type header from the passed ExternalMessage.

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMapping.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.mapping.javascript;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
+import org.eclipse.ditto.protocoladapter.Adaptable;
+import org.eclipse.ditto.protocoladapter.ProtocolFactory;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+
+/**
+ * The default mapping for incoming messages that maps messages from Ditto protocol format.
+ */
+public class DefaultIncomingMapping implements MappingFunction<ExternalMessage, Optional<Adaptable>> {
+
+    private static DefaultIncomingMapping INSTANCE = new DefaultIncomingMapping();
+
+    private DefaultIncomingMapping() {
+    }
+
+    static DefaultIncomingMapping get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Optional<Adaptable> apply(final ExternalMessage message) {
+        return Optional.ofNullable(
+                message.getTextPayload()
+                        .orElseGet(() -> message.getBytePayload()
+                                .map(b -> StandardCharsets.UTF_8.decode(b).toString())
+                                .orElse(null))
+        ).map(plainString -> DittoJsonException.wrapJsonRuntimeException(() -> {
+            final JsonObject jsonObject = JsonFactory.readFrom(plainString).asObject();
+            return ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
+        }));
+    }
+}

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.mapping.javascript;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.eclipse.ditto.model.base.common.DittoConstants;
+import org.eclipse.ditto.protocoladapter.Adaptable;
+import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
+import org.eclipse.ditto.protocoladapter.ProtocolFactory;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageBuilder;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
+
+/**
+ * The default mapping for outgoing messages that maps to Ditto protocol format.
+ */
+public class DefaultOutgoingMapping implements MappingFunction<Adaptable, Optional<ExternalMessage>> {
+
+    private static DefaultOutgoingMapping INSTANCE = new DefaultOutgoingMapping();
+
+    private DefaultOutgoingMapping() {
+    }
+
+    static DefaultOutgoingMapping get() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Optional<ExternalMessage> apply(final Adaptable adaptable) {
+        final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable);
+        final ExternalMessageBuilder messageBuilder = ExternalMessageFactory.newExternalMessageBuilder(
+                adaptable.getHeaders().orElseGet(adaptable::getDittoHeaders));
+        messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
+                DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);
+        messageBuilder.withText(jsonifiableAdaptable.toJsonString());
+        return Optional.of(messageBuilder.build());
+    }
+
+}

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhino.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhino.java
@@ -79,7 +79,7 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
 
         try {
             // create scope once and load the required libraries in order to get best performance:
-            final Scriptable scope1 = (Scriptable) contextFactory.call(cx -> {
+            contextFactory.call(cx -> {
                 final Scriptable scope = cx.initSafeStandardObjects(); // that one disables "print, exit, quit", etc.
                 initLibraries(cx, scope);
                 return scope;

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhino.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhino.java
@@ -10,49 +10,22 @@
  */
 package org.eclipse.ditto.services.connectivity.mapping.javascript;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import javax.annotation.Nullable;
-import javax.script.Bindings;
 
-import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.model.base.common.DittoConstants;
-import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
-import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.MessageMapperConfigurationFailedException;
-import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
 import org.eclipse.ditto.protocoladapter.Adaptable;
-import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
-import org.eclipse.ditto.protocoladapter.ProtocolFactory;
 import org.eclipse.ditto.services.connectivity.mapping.MessageMapper;
 import org.eclipse.ditto.services.connectivity.mapping.MessageMapperConfiguration;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
-import org.eclipse.ditto.services.models.connectivity.ExternalMessageBuilder;
-import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
-import org.mozilla.javascript.Callable;
 import org.mozilla.javascript.Context;
 import org.mozilla.javascript.ContextFactory;
-import org.mozilla.javascript.Function;
-import org.mozilla.javascript.NativeJSON;
-import org.mozilla.javascript.NativeObject;
 import org.mozilla.javascript.RhinoException;
 import org.mozilla.javascript.Scriptable;
-import org.mozilla.javascript.Undefined;
-import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
 
 import com.typesafe.config.Config;
 
@@ -70,26 +43,15 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
     private static final String INCOMING_SCRIPT = "/javascript/incoming-mapping.js";
     private static final String OUTGOING_SCRIPT = "/javascript/outgoing-mapping.js";
 
-    private static final String EXTERNAL_MESSAGE_HEADERS = "headers";
-    private static final String EXTERNAL_MESSAGE_CONTENT_TYPE = "contentType";
-    private static final String EXTERNAL_MESSAGE_TEXT_PAYLOAD = "textPayload";
-    private static final String EXTERNAL_MESSAGE_BYTE_PAYLOAD = "bytePayload";
-
-    private static final String INCOMING_FUNCTION_NAME = "mapToDittoProtocolMsgWrapper";
-    private static final String OUTGOING_FUNCTION_NAME = "mapFromDittoProtocolMsgWrapper";
-
     private static final String CONFIG_JAVASCRIPT_MAX_SCRIPT_SIZE_BYTES = "javascript.maxScriptSizeBytes";
     private static final String CONFIG_JAVASCRIPT_MAX_SCRIPT_EXECUTION_TIME = "javascript.maxScriptExecutionTime";
     private static final String CONFIG_JAVASCRIPT_MAX_SCRIPT_STACK_DEPTH = "javascript.maxScriptStackDepth";
 
-    @Nullable
-    private ContextFactory contextFactory;
-    @Nullable
-    private Scriptable scope;
-
+    @Nullable private ContextFactory contextFactory;
     @Nullable private JavaScriptMessageMapperConfiguration configuration;
-    private boolean incomingScriptIsEmpty = false;
-    private boolean outgoingScriptIsEmpty = false;
+
+    private MappingFunction<ExternalMessage, Optional<Adaptable>> incomingMapping = DefaultIncomingMapping.get();
+    private MappingFunction<Adaptable, Optional<ExternalMessage>> outgoingMapping = DefaultOutgoingMapping.get();
 
     JavaScriptMessageMapperRhino() {
         // no-op
@@ -117,7 +79,7 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
 
         try {
             // create scope once and load the required libraries in order to get best performance:
-            scope = (Scriptable) contextFactory.call(cx -> {
+            final Scriptable scope1 = (Scriptable) contextFactory.call(cx -> {
                 final Scriptable scope = cx.initSafeStandardObjects(); // that one disables "print, exit, quit", etc.
                 initLibraries(cx, scope);
                 return scope;
@@ -136,165 +98,13 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
 
     @Override
     public Optional<Adaptable> map(final ExternalMessage message) {
-
-        if (incomingScriptIsEmpty) {
-            // shortcut: the user defined an empty incoming mapping script -> assume that the ExternalMessage is in DittoProtocol
-            return Optional.ofNullable(
-                    message.getTextPayload()
-                            .orElseGet(() -> message.getBytePayload()
-                                    .map(b -> StandardCharsets.UTF_8.decode(b).toString())
-                                    .orElse(null))
-            ).map(plainString -> DittoJsonException.wrapJsonRuntimeException(() -> {
-                final JsonObject jsonObject = JsonFactory.readFrom(plainString).asObject();
-                return ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
-            }));
-        } else {
-            try {
-                return Optional.ofNullable((Adaptable) contextFactory.call(cx -> {
-                    final NativeObject headersObj = new NativeObject();
-                    message.getHeaders().forEach((key, value) -> headersObj.put(key, headersObj, value));
-
-                    final NativeArrayBuffer bytePayload;
-                    if (message.getBytePayload().isPresent()) {
-                        final ByteBuffer byteBuffer = message.getBytePayload().get();
-                        final byte[] array = byteBuffer.array();
-                        bytePayload = new NativeArrayBuffer(array.length);
-                        for (int a = 0; a < array.length; a++) {
-                            bytePayload.getBuffer()[a] = array[a];
-                        }
-                    } else {
-                        bytePayload = null;
-                    }
-
-                    final String contentType = message.getHeaders().get(ExternalMessage.CONTENT_TYPE_HEADER);
-                    final String textPayload = message.getTextPayload().orElse(null);
-
-                    final NativeObject externalMessage = new NativeObject();
-                    externalMessage.put(EXTERNAL_MESSAGE_HEADERS, externalMessage, headersObj);
-                    externalMessage.put(EXTERNAL_MESSAGE_TEXT_PAYLOAD, externalMessage, textPayload);
-                    externalMessage.put(EXTERNAL_MESSAGE_BYTE_PAYLOAD, externalMessage, bytePayload);
-                    externalMessage.put(EXTERNAL_MESSAGE_CONTENT_TYPE, externalMessage, contentType);
-
-                    final Function mapToDittoProtocolMsgWrapper = (Function) scope.get(INCOMING_FUNCTION_NAME, scope);
-                    final Object result = mapToDittoProtocolMsgWrapper.call(cx, scope, scope, new Object[] {externalMessage});
-
-                    if (result == null) {
-                        // return null if result is null causing the wrapping Optional to be empty
-                        return null;
-                    }
-
-                    final String dittoProtocolJsonStr = (String) NativeJSON.stringify(cx, scope, result, null, null);
-
-                    return DittoJsonException.wrapJsonRuntimeException(() -> {
-                        final JsonObject jsonObject = JsonFactory.readFrom(dittoProtocolJsonStr).asObject();
-                        return ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
-                    });
-                }));
-            } catch (final RhinoException e) {
-                throw buildMessageMappingFailedException(e, message.findContentType().orElse(""),
-                        DittoHeaders.of(message.getHeaders()));
-            } catch (final Throwable e) {
-                throw MessageMappingFailedException.newBuilder(message.findContentType().orElse(null))
-                        .description(e.getMessage())
-                        .dittoHeaders(DittoHeaders.of(message.getHeaders()))
-                        .cause(e)
-                        .build();
-            }
-        }
-    }
-
-    private MessageMappingFailedException buildMessageMappingFailedException(final RhinoException e,
-            final String contentType, final DittoHeaders dittoHeaders) {
-        final boolean sourceExists = e.lineSource() != null && !e.lineSource().isEmpty();
-        final String lineSource = sourceExists ? (", source:\n" + e.lineSource()) : "";
-        final boolean stackExists = e.getScriptStackTrace() != null && !e.getScriptStackTrace().isEmpty();
-        final String scriptStackTrace = stackExists ? (", stack:\n" + e.getScriptStackTrace()) : "";
-        return MessageMappingFailedException.newBuilder(contentType)
-                .description(e.getMessage() + " - in line/column #" + e.lineNumber() + "/" + e.columnNumber() +
-                        lineSource + scriptStackTrace)
-                .dittoHeaders(dittoHeaders)
-                .cause(e)
-                .build();
+        return incomingMapping.apply(message);
     }
 
     @Override
     public Optional<ExternalMessage> map(final Adaptable adaptable) {
-        final JsonifiableAdaptable jsonifiableAdaptable =
-                ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable);
-
-        if (outgoingScriptIsEmpty) {
-            // shortcut: the user defined an empty outgoing mapping script -> send the Adaptable as DittoProtocol JSON
-            final ExternalMessageBuilder messageBuilder = ExternalMessageFactory.newExternalMessageBuilder(
-                    adaptable.getHeaders().orElseGet(adaptable::getDittoHeaders));
-            messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
-                    DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);
-            messageBuilder.withText(jsonifiableAdaptable.toJsonString());
-            return Optional.of(messageBuilder.build());
-        } else {
-            try {
-                return Optional.ofNullable((ExternalMessage) contextFactory.call(cx -> {
-                    final Object dittoProtocolMessage =
-                            NativeJSON.parse(cx, scope, jsonifiableAdaptable.toJsonString(), new NullCallable());
-
-                    final Function mapFromDittoProtocolMsgWrapper = (Function) scope.get(OUTGOING_FUNCTION_NAME, scope);
-                    final NativeObject result =
-                            (NativeObject) mapFromDittoProtocolMsgWrapper.call(cx, scope, scope,
-                                    new Object[]{dittoProtocolMessage});
-
-                    if (result == null) {
-                        // return null if result is null causing the wrapping Optional to be empty
-                        return null;
-                    }
-
-                    final Object contentType = result.get(EXTERNAL_MESSAGE_CONTENT_TYPE);
-                    final Object textPayload = result.get(EXTERNAL_MESSAGE_TEXT_PAYLOAD);
-                    final Object bytePayload = result.get(EXTERNAL_MESSAGE_BYTE_PAYLOAD);
-                    final Object mappingHeaders = result.get(EXTERNAL_MESSAGE_HEADERS);
-
-                    final Map<String, String> headers;
-                    if (mappingHeaders != null && !(mappingHeaders instanceof Undefined)) {
-                        headers = new HashMap<>();
-                        final Map jsHeaders = (Map) mappingHeaders;
-                        jsHeaders.forEach((key, value) -> headers.put((String) key, value.toString()));
-                    } else {
-                        headers = Collections.emptyMap();
-                    }
-
-                    final ExternalMessageBuilder messageBuilder =
-                            ExternalMessageFactory.newExternalMessageBuilder(headers);
-
-                    if (!(contentType instanceof Undefined)) {
-                        messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
-                                ((CharSequence) contentType).toString());
-                    }
-
-                    final Optional<ByteBuffer> byteBuffer = convertToByteBuffer(bytePayload);
-                    if (byteBuffer.isPresent()) {
-                        messageBuilder.withBytes(byteBuffer.get());
-                    } else if (!(textPayload instanceof Undefined)) {
-                        messageBuilder.withText(((CharSequence) textPayload).toString());
-                    } else {
-                        throw MessageMappingFailedException.newBuilder("")
-                                .description("Neither <bytePayload> nor <textPayload> were defined in the outgoing script")
-                                .dittoHeaders(adaptable.getHeaders().orElse(DittoHeaders.empty()))
-                                .build();
-                    }
-
-                    return messageBuilder.build();
-                }));
-            } catch (final RhinoException e) {
-                throw buildMessageMappingFailedException(e, MessageMapper.findContentType(adaptable).orElse(""),
-                        adaptable.getHeaders().orElseGet(DittoHeaders::empty));
-            } catch (final Throwable e) {
-                throw MessageMappingFailedException.newBuilder(MessageMapper.findContentType(adaptable).orElse(""))
-                        .description(e.getMessage())
-                        .dittoHeaders(adaptable.getHeaders().orElseGet(DittoHeaders::empty))
-                        .cause(e)
-                        .build();
-            }
-        }
+        return outgoingMapping.apply(adaptable);
     }
-
 
     private void initLibraries(final Context cx, final Scriptable scope) {
         if (getConfiguration().map(JavaScriptMessageMapperConfiguration::isLoadLongJS).orElse(false)) {
@@ -316,8 +126,11 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
         final String userIncomingScript = getConfiguration()
                 .flatMap(JavaScriptMessageMapperConfiguration::getIncomingScript)
                 .orElse("");
-        incomingScriptIsEmpty = userIncomingScript.isEmpty();
-        if (!incomingScriptIsEmpty) {
+        if (userIncomingScript.isEmpty()) {
+            // shortcut: the user defined an empty incoming mapping script -> assume that the ExternalMessage is in DittoProtocol
+            incomingMapping = DefaultIncomingMapping.get();
+        } else {
+            incomingMapping = new ScriptedIncomingMapping(contextFactory, scope);
             cx.evaluateString(scope, userIncomingScript,
                     JavaScriptMessageMapperConfigurationProperties.INCOMING_SCRIPT, 1, null);
         }
@@ -325,8 +138,11 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
         final String userOutgoingScript = getConfiguration()
                 .flatMap(JavaScriptMessageMapperConfiguration::getOutgoingScript)
                 .orElse("");
-        outgoingScriptIsEmpty = userOutgoingScript.isEmpty();
-        if (!outgoingScriptIsEmpty) {
+        if (userOutgoingScript.isEmpty()) {
+            // shortcut: the user defined an empty outgoing mapping script -> send the Adaptable as DittoProtocol JSON
+            outgoingMapping = DefaultOutgoingMapping.get();
+        } else {
+            outgoingMapping = new ScriptedOutgoingMapping(contextFactory, scope);
             cx.evaluateString(scope, userOutgoingScript,
                     JavaScriptMessageMapperConfigurationProperties.OUTGOING_SCRIPT, 1, null);
         }
@@ -343,48 +159,6 @@ final class JavaScriptMessageMapperRhino implements MessageMapper {
             cx.evaluateReader(scope, reader, libraryName, 1, null);
         } catch (final IOException e) {
             throw new IllegalStateException("Could not load script <" + libraryName + ">", e);
-        }
-    }
-
-    private static Optional<ByteBuffer> convertToByteBuffer(final Object obj) {
-        if (obj instanceof NativeArrayBuffer) {
-            return Optional.of(ByteBuffer.wrap(((NativeArrayBuffer) obj).getBuffer()));
-        } else if (obj instanceof Bindings) {
-            try {
-                final Class<?> cls = Class.forName("jdk.nashorn.api.scripting.ScriptObjectMirror");
-                if (cls.isAssignableFrom(obj.getClass())) {
-                    final Method isArray = cls.getMethod("isArray");
-                    final Object result = isArray.invoke(obj);
-                    if (result != null && result.equals(true)) {
-                        final Method values = cls.getMethod("values");
-                        final Object vals = values.invoke(obj);
-                        if (vals instanceof Collection) {
-                            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                            final Collection coll = (Collection) vals;
-                            coll.forEach(e -> baos.write(((Number) e).intValue()));
-                            return Optional.of(ByteBuffer.wrap(baos.toByteArray()));
-                        }
-                    }
-                }
-            } catch (final ClassNotFoundException | NoSuchMethodException | SecurityException
-                    | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
-                throw new IllegalStateException("Could not retrieve array values", e);
-            }
-        } else if (obj instanceof List<?>) {
-            final List<?> list = (List<?>) obj;
-            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            list.forEach(e -> baos.write(((Number) e).intValue()));
-            return Optional.of(ByteBuffer.wrap(baos.toByteArray()));
-        }
-        return Optional.empty();
-    }
-
-    private static class NullCallable implements Callable {
-
-        @Override
-        public Object call(final Context context, final Scriptable scope, final Scriptable holdable,
-                final Object[] objects) {
-            return objects[1];
         }
     }
 }

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/MappingFunction.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/MappingFunction.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.mapping.javascript;
+
+import java.util.function.Function;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
+import org.mozilla.javascript.RhinoException;
+
+/**
+ * Mapping interface that also provides common methods.
+ *
+ * @param <I> input data type
+ * @param <O> output data type
+ */
+public interface MappingFunction<I, O> extends Function<I, O> {
+
+    default MessageMappingFailedException buildMessageMappingFailedException(final RhinoException e,
+            final String contentType, final DittoHeaders dittoHeaders) {
+        final boolean sourceExists = e.lineSource() != null && !e.lineSource().isEmpty();
+        final String lineSource = sourceExists ? (", source:\n" + e.lineSource()) : "";
+        final boolean stackExists = e.getScriptStackTrace() != null && !e.getScriptStackTrace().isEmpty();
+        final String scriptStackTrace = stackExists ? (", stack:\n" + e.getScriptStackTrace()) : "";
+        return MessageMappingFailedException.newBuilder(contentType)
+                .description(e.getMessage() + " - in line/column #" + e.lineNumber() + "/" + e.columnNumber() +
+                        lineSource + scriptStackTrace)
+                .dittoHeaders(dittoHeaders)
+                .cause(e)
+                .build();
+    }
+}

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/MappingFunction.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/MappingFunction.java
@@ -24,6 +24,13 @@ import org.mozilla.javascript.RhinoException;
  */
 public interface MappingFunction<I, O> extends Function<I, O> {
 
+    /**
+     * Build {@link MessageMappingFailedException} from a {@link RhinoException}.
+     * @param e the original exception thrown by the rhino engine
+     * @param contentType the content type of the message which could not be mapped
+     * @param dittoHeaders the {@link DittoHeaders} of the original message
+     * @return a {@link MessageMappingFailedException} containing information about the javascript error that occurred
+     */
     default MessageMappingFailedException buildMessageMappingFailedException(final RhinoException e,
             final String contentType, final DittoHeaders dittoHeaders) {
         final boolean sourceExists = e.lineSource() != null && !e.lineSource().isEmpty();

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedIncomingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedIncomingMapping.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.mapping.javascript;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
+import org.eclipse.ditto.protocoladapter.Adaptable;
+import org.eclipse.ditto.protocoladapter.ProtocolFactory;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.NativeJSON;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
+
+/**
+ * Mapping function for incoming messages based on JavaScript.
+ */
+public class ScriptedIncomingMapping implements MappingFunction<ExternalMessage, Optional<Adaptable>> {
+
+    private static final String EXTERNAL_MESSAGE_HEADERS = "headers";
+    private static final String EXTERNAL_MESSAGE_CONTENT_TYPE = "contentType";
+    private static final String EXTERNAL_MESSAGE_TEXT_PAYLOAD = "textPayload";
+    private static final String EXTERNAL_MESSAGE_BYTE_PAYLOAD = "bytePayload";
+
+    private static final String INCOMING_FUNCTION_NAME = "mapToDittoProtocolMsgWrapper";
+
+    @Nullable
+    private ContextFactory contextFactory;
+    @Nullable
+    private Scriptable scope;
+
+    ScriptedIncomingMapping(@Nullable final ContextFactory contextFactory, @Nullable final Scriptable scope) {
+        this.contextFactory = contextFactory;
+        this.scope = scope;
+    }
+
+    @Override
+    public Optional<Adaptable> apply(final ExternalMessage message) {
+        try {
+            return Optional.ofNullable((Adaptable) contextFactory.call(cx -> {
+                final NativeObject headersObj = new NativeObject();
+                message.getHeaders().forEach((key, value) -> headersObj.put(key, headersObj, value));
+
+                final NativeArrayBuffer bytePayload;
+                if (message.getBytePayload().isPresent()) {
+                    final ByteBuffer byteBuffer = message.getBytePayload().get();
+                    final byte[] array = byteBuffer.array();
+                    bytePayload = new NativeArrayBuffer(array.length);
+                    for (int a = 0; a < array.length; a++) {
+                        bytePayload.getBuffer()[a] = array[a];
+                    }
+                } else {
+                    bytePayload = null;
+                }
+
+                final String contentType = message.getHeaders().get(ExternalMessage.CONTENT_TYPE_HEADER);
+                final String textPayload = message.getTextPayload().orElse(null);
+
+                final NativeObject externalMessage = new NativeObject();
+                externalMessage.put(EXTERNAL_MESSAGE_HEADERS, externalMessage, headersObj);
+                externalMessage.put(EXTERNAL_MESSAGE_TEXT_PAYLOAD, externalMessage, textPayload);
+                externalMessage.put(EXTERNAL_MESSAGE_BYTE_PAYLOAD, externalMessage, bytePayload);
+                externalMessage.put(EXTERNAL_MESSAGE_CONTENT_TYPE, externalMessage, contentType);
+
+                final org.mozilla.javascript.Function
+                        mapToDittoProtocolMsgWrapper = (org.mozilla.javascript.Function) scope.get(INCOMING_FUNCTION_NAME, scope);
+                final Object result = mapToDittoProtocolMsgWrapper.call(cx, scope, scope, new Object[] {externalMessage});
+
+                if (result == null) {
+                    // return null if result is null causing the wrapping Optional to be empty
+                    return null;
+                }
+
+                final String dittoProtocolJsonStr = (String) NativeJSON.stringify(cx, scope, result, null, null);
+
+                return DittoJsonException.wrapJsonRuntimeException(() -> {
+                    final JsonObject jsonObject = JsonFactory.readFrom(dittoProtocolJsonStr).asObject();
+                    return ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
+                });
+            }));
+        } catch (final RhinoException e) {
+            throw buildMessageMappingFailedException(e, message.findContentType().orElse(""),
+                    DittoHeaders.of(message.getHeaders()));
+        } catch (final Throwable e) {
+            throw MessageMappingFailedException.newBuilder(message.findContentType().orElse(null))
+                    .description(e.getMessage())
+                    .dittoHeaders(DittoHeaders.of(message.getHeaders()))
+                    .cause(e)
+                    .build();
+        }
+    }
+}

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedOutgoingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedOutgoingMapping.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.mapping.javascript;
+
+import java.io.ByteArrayOutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+import javax.script.Bindings;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
+import org.eclipse.ditto.protocoladapter.Adaptable;
+import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
+import org.eclipse.ditto.protocoladapter.ProtocolFactory;
+import org.eclipse.ditto.services.connectivity.mapping.MessageMapper;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageBuilder;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
+import org.mozilla.javascript.Callable;
+import org.mozilla.javascript.Context;
+import org.mozilla.javascript.ContextFactory;
+import org.mozilla.javascript.NativeJSON;
+import org.mozilla.javascript.NativeObject;
+import org.mozilla.javascript.RhinoException;
+import org.mozilla.javascript.Scriptable;
+import org.mozilla.javascript.Undefined;
+import org.mozilla.javascript.typedarrays.NativeArrayBuffer;
+
+/**
+ * Mapping function for outgoing messages based on JavaScript.
+ */
+public class ScriptedOutgoingMapping implements MappingFunction<Adaptable, Optional<ExternalMessage>> {
+
+    private static final String EXTERNAL_MESSAGE_HEADERS = "headers";
+    private static final String EXTERNAL_MESSAGE_CONTENT_TYPE = "contentType";
+    private static final String EXTERNAL_MESSAGE_TEXT_PAYLOAD = "textPayload";
+    private static final String EXTERNAL_MESSAGE_BYTE_PAYLOAD = "bytePayload";
+
+    private static final String OUTGOING_FUNCTION_NAME = "mapFromDittoProtocolMsgWrapper";
+
+    @Nullable
+    private ContextFactory contextFactory;
+    @Nullable
+    private Scriptable scope;
+
+    ScriptedOutgoingMapping(@Nullable final ContextFactory contextFactory, @Nullable final Scriptable scope) {
+        this.contextFactory = contextFactory;
+        this.scope = scope;
+    }
+
+    @Override
+    public Optional<ExternalMessage> apply(final Adaptable adaptable) {
+        try {
+            final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable);
+            return Optional.ofNullable((ExternalMessage) contextFactory.call(cx -> {
+                final Object dittoProtocolMessage =
+                        NativeJSON.parse(cx, scope, jsonifiableAdaptable.toJsonString(), new NullCallable());
+
+                final org.mozilla.javascript.Function
+                        mapFromDittoProtocolMsgWrapper = (org.mozilla.javascript.Function) scope.get(OUTGOING_FUNCTION_NAME, scope);
+                final NativeObject result =
+                        (NativeObject) mapFromDittoProtocolMsgWrapper.call(cx, scope, scope,
+                                new Object[]{dittoProtocolMessage});
+
+                if (result == null) {
+                    // return null if result is null causing the wrapping Optional to be empty
+                    return null;
+                }
+
+                final Object contentType = result.get(EXTERNAL_MESSAGE_CONTENT_TYPE);
+                final Object textPayload = result.get(EXTERNAL_MESSAGE_TEXT_PAYLOAD);
+                final Object bytePayload = result.get(EXTERNAL_MESSAGE_BYTE_PAYLOAD);
+                final Object mappingHeaders = result.get(EXTERNAL_MESSAGE_HEADERS);
+
+                final Map<String, String> headers;
+                if (mappingHeaders != null && !(mappingHeaders instanceof Undefined)) {
+                    headers = new HashMap<>();
+                    final Map jsHeaders = (Map) mappingHeaders;
+                    jsHeaders.forEach((key, value) -> headers.put((String) key, value.toString()));
+                } else {
+                    headers = Collections.emptyMap();
+                }
+
+                final ExternalMessageBuilder messageBuilder =
+                        ExternalMessageFactory.newExternalMessageBuilder(headers);
+
+                if (!(contentType instanceof Undefined)) {
+                    messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
+                            ((CharSequence) contentType).toString());
+                }
+
+                final Optional<ByteBuffer> byteBuffer = convertToByteBuffer(bytePayload);
+                if (byteBuffer.isPresent()) {
+                    messageBuilder.withBytes(byteBuffer.get());
+                } else if (!(textPayload instanceof Undefined)) {
+                    messageBuilder.withText(((CharSequence) textPayload).toString());
+                } else {
+                    throw MessageMappingFailedException.newBuilder("")
+                            .description("Neither <bytePayload> nor <textPayload> were defined in the outgoing script")
+                            .dittoHeaders(adaptable.getHeaders().orElse(DittoHeaders.empty()))
+                            .build();
+                }
+
+                return messageBuilder.build();
+            }));
+        } catch (final RhinoException e) {
+            throw buildMessageMappingFailedException(e, MessageMapper.findContentType(adaptable).orElse(""),
+                    adaptable.getHeaders().orElseGet(DittoHeaders::empty));
+        } catch (final Throwable e) {
+            throw MessageMappingFailedException.newBuilder(MessageMapper.findContentType(adaptable).orElse(""))
+                    .description(e.getMessage())
+                    .dittoHeaders(adaptable.getHeaders().orElseGet(DittoHeaders::empty))
+                    .cause(e)
+                    .build();
+        }
+    }
+
+    private static Optional<ByteBuffer> convertToByteBuffer(final Object obj) {
+        if (obj instanceof NativeArrayBuffer) {
+            return Optional.of(ByteBuffer.wrap(((NativeArrayBuffer) obj).getBuffer()));
+        } else if (obj instanceof Bindings) {
+            try {
+                final Class<?> cls = Class.forName("jdk.nashorn.api.scripting.ScriptObjectMirror");
+                if (cls.isAssignableFrom(obj.getClass())) {
+                    final Method isArray = cls.getMethod("isArray");
+                    final Object result = isArray.invoke(obj);
+                    if (result != null && result.equals(true)) {
+                        final Method values = cls.getMethod("values");
+                        final Object vals = values.invoke(obj);
+                        if (vals instanceof Collection) {
+                            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                            final Collection coll = (Collection) vals;
+                            coll.forEach(e -> baos.write(((Number) e).intValue()));
+                            return Optional.of(ByteBuffer.wrap(baos.toByteArray()));
+                        }
+                    }
+                }
+            } catch (final ClassNotFoundException | NoSuchMethodException | SecurityException
+                    | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+                throw new IllegalStateException("Could not retrieve array values", e);
+            }
+        } else if (obj instanceof List<?>) {
+            final List<?> list = (List<?>) obj;
+            final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            list.forEach(e -> baos.write(((Number) e).intValue()));
+            return Optional.of(ByteBuffer.wrap(baos.toByteArray()));
+        }
+        return Optional.empty();
+    }
+
+    private static class NullCallable implements Callable {
+
+        @Override
+        public Object call(final Context context, final Scriptable scope, final Scriptable holdable,
+                final Object[] objects) {
+            return objects[1];
+        }
+    }
+}

--- a/services/connectivity/mapping/src/main/resources/javascript/incoming-mapping.js
+++ b/services/connectivity/mapping/src/main/resources/javascript/incoming-mapping.js
@@ -15,10 +15,16 @@ function mapToDittoProtocolMsg(
 
     // ###
     // Insert your mapping logic here:
-    // ###
-    if (headers) {
-        return null;
+    if (contentType === 'application/vnd.eclipse.ditto+json') {
+        let dittoProtocolMsg = JSON.parse(textPayload);
+        Object.assign(dittoProtocolMsg.headers, headers);
+        return dittoProtocolMsg;
     }
+    if (headers) {
+        return null; // returning 'null' means that the message will be dropped
+        // TODO replace with something useful
+    }
+    // ###
 
     return Ditto.buildDittoProtocolMsg(
         namespace,

--- a/services/connectivity/mapping/src/main/resources/javascript/outgoing-mapping.js
+++ b/services/connectivity/mapping/src/main/resources/javascript/outgoing-mapping.js
@@ -27,6 +27,7 @@ function mapFromDittoProtocolMsg(
     // Insert your mapping logic here:
     let headers = dittoHeaders;
     let textPayload = JSON.stringify(Ditto.buildDittoProtocolMsg(namespace, id, group, channel, criterion, action, path, dittoHeaders, value));
+    // TODO replace with something useful, this will publish the message in Ditto Protocol JSON
     let bytePayload = null;
     let contentType = 'application/vnd.eclipse.ditto+json';
     // ###

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
@@ -38,6 +38,7 @@ import org.eclipse.ditto.model.connectivity.ConnectionMetrics;
 import org.eclipse.ditto.model.connectivity.ConnectionStatus;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.FilteredTopic;
+import org.eclipse.ditto.model.connectivity.MappingContext;
 import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.model.connectivity.Topic;
 import org.eclipse.ditto.services.connectivity.messaging.amqp.AmqpValidator;

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/modify/CreateConnection.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/modify/CreateConnection.java
@@ -101,7 +101,6 @@ public final class CreateConnection extends AbstractCommand<CreateConnection>
         return new CommandJsonDeserializer<CreateConnection>(TYPE, jsonObject).deserialize(() -> {
             final JsonObject jsonConnection = jsonObject.getValueOrThrow(JSON_CONNECTION);
             final Connection readConnection = ConnectivityModelFactory.connectionFromJson(jsonConnection);
-
             return of(readConnection, dittoHeaders);
         });
     }


### PR DESCRIPTION
When an empty JavaScript payload mapping was defined in a connection, the message was silently dropped.
Now, for empty payload mappings the message is assumed to be handled as "Ditto Protocol" JSON message which is a comprehensible fallback.