### PR TITLE
remove fallback queries on policiesBasedSearchIndex

### DIFF
--- a/documentation/src/main/resources/_includes/file.html
+++ b/documentation/src/main/resources/_includes/file.html
@@ -1,0 +1,1 @@
+<a class="no_icon" target="_blank" href="files/{{include.file}}">{{include.title}}</a>

--- a/documentation/src/main/resources/files/migration_mongodb_0.8.0-M2_0.8.0-M3.js
+++ b/documentation/src/main/resources/files/migration_mongodb_0.8.0-M2_0.8.0-M3.js
@@ -1,0 +1,16 @@
+const policiesBasedSearchIndex = db.getCollection('policiesBasedSearchIndex');
+policiesBasedSearchIndex.find().forEach(function (entry) {
+    const id = entry._id;
+    const splittedId = id.split(':');
+    if (splittedId.length === 3) {
+        const thingId = `${splittedId[0]}:${ splittedId[1]}`;
+
+        policiesBasedSearchIndex.updateOne(
+            {'_id': id},
+            {$set: {'_thingId': thingId}}
+        );
+    } else {
+        print(
+            `Cannot migrate entry with id ${id}, as it seems to contain extra colons in its thingId, features or attributes.`);
+    }
+});

--- a/documentation/src/main/resources/pages/ditto/release_notes_080M3.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_080M3.md
@@ -1,0 +1,23 @@
+---
+title: Release notes 0.8.0-M3
+tags: [release_notes]
+keywords: release notes, announcements, changelog
+summary: "Version 0.8.0-M3 of Eclipse Ditto, released on <>"
+permalink: release_notes_080-M3.html
+---
+
+## Changes
+
+### Speed up Search
+
+With more and more Things, the Search service was slowing down massively.
+
+Two Pull Requests ([#275](https://github.com/eclipse/ditto/pull/275), [#278](https://github.com/eclipse/ditto/pull/278)) 
+addressed this issue with the following changes:
+* add an index on `_policyId` and `__policyRev` for the `thingEntities` collection.
+* add the field `_thingId` to new documents in `policiesBasedSearchIndex`.
+* add an index on `_thingId` for the `policiesBasedSearchIndex` collection.
+* rewrite queries on `policiesBasedSearchIndex` to always look for the indexed `_thingId` first. 
+
+**Since the access to the Search database was changed, data in `policiesBasedSearchIndex` needs to be
+ migrated using the {% include file.html title="MongoDB migration script from 0.8.0-M2 to 0.8.0-M3" file="migration_mongodb_0.8.0-M2_0.8.0-M3.js" %}.**

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/PolicyUpdateFactory.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/PolicyUpdateFactory.java
@@ -322,16 +322,13 @@ final class PolicyUpdateFactory {
     }
 
     private static Bson createThingRemovalFilter(final CharSequence thingId) {
-        final Bson filter = createThingIdFilter(thingId);
-        final Bson fallback = featureRemovalFilter(thingId, "");
-        return createFallbackFilterForMissingThingId(filter, fallback);
+        return createThingIdFilter(thingId);
     }
 
     private static Bson createFeatureRemovalFilter(final CharSequence thingId, final String featureId) {
         final Bson featureRegex = featureRemovalFilter(thingId, featureId);
-        final Bson filter = and(createThingIdFilter(thingId), featureRegex);
 
-        return createFallbackFilterForMissingThingId(filter, featureRegex);
+        return and(createThingIdFilter(thingId), featureRegex);
     }
 
     private static Bson featureRemovalFilter(final CharSequence thingId, final String featureId) {
@@ -343,9 +340,8 @@ final class PolicyUpdateFactory {
         final Bson pointerRegex = Filters.regex(PersistenceConstants.FIELD_ID,
                 PersistenceConstants.REGEX_START_THING_ID + thingId + ":" + pointer +
                         PersistenceConstants.REGEX_FIELD_END);
-        final Bson filter = and(createThingIdFilter(thingId), pointerRegex);
 
-        return createFallbackFilterForMissingThingId(filter, pointerRegex);
+        return and(createThingIdFilter(thingId), pointerRegex);
     }
 
     private static Bson createFeaturesRemovalFilter(final CharSequence thingId) {
@@ -354,30 +350,7 @@ final class PolicyUpdateFactory {
         final Bson featuresRegex =
                 Filters.regex(PersistenceConstants.FIELD_RESOURCE, PersistenceConstants.REGEX_START_THING_ID +
                         Pattern.quote(PersistenceConstants.FIELD_FEATURES));
-        final Bson filter = and(createThingIdFilter(thingId), thingRegex, featuresRegex);
-        final Bson fallback = and(thingRegex, featuresRegex);
-
-        return createFallbackFilterForMissingThingId(filter, fallback);
-    }
-
-    /**
-     * Creates a fallback filter for missing _thingId.
-     *
-     * @param filter The filter to use if thing id exists (does not check if it exists explicitly but expects.
-     * @param fallback The fallback filter.
-     * @return a Bson like this: or {[filter], and{ "_thingId": {$exists:false}, [fallback]}}
-     */
-    private static Bson createFallbackFilterForMissingThingId(final Bson filter, final Bson fallback) {
-        return Filters.or(
-                filter,
-                Filters.and(
-                        filterThingIdNotExists(),
-                        fallback)
-        );
-    }
-
-    private static Bson filterThingIdNotExists() {
-        return Filters.exists(PersistenceConstants.FIELD_THING_ID, false);
+        return and(createThingIdFilter(thingId), thingRegex, featuresRegex);
     }
 
     private static Bson createThingIdFilter(final CharSequence thingId) {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/PolicyUpdateFactoryTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/PolicyUpdateFactoryTest.java
@@ -249,29 +249,12 @@ public final class PolicyUpdateFactoryTest {
 
         BsonAssertions.assertThat(policyUpdate.getPolicyIndexInsertEntries()).isEqualTo(expectedPolicyDocs);
 
-        final Bson startsWithThingIdRegex =
-                Filters.regex(FIELD_ID, REGEX_START_THING_ID + Pattern.quote(TestConstants.Thing.THING_ID + ":"));
-        final Bson expectedIndexRemoveFilter = filterWithFallback(TestConstants.Thing.THING_ID, startsWithThingIdRegex);
+        final Bson expectedIndexRemoveFilter = Filters.eq(FIELD_THING_ID, TestConstants.Thing.THING_ID);
         BsonAssertions.assertThat(policyUpdate.getPolicyIndexRemoveFilter()).isEqualTo(expectedIndexRemoveFilter);
         assertPushGlobalReads(expectedPushGlobalReads, policyUpdate.getPushGlobalReads());
         BsonAssertions.assertThat(policyUpdate.getPullGlobalReads()).isEqualTo(PolicyUpdateFactory.PULL_GLOBAL_READS);
         BsonAssertions.assertThat(policyUpdate.getPullAclEntries()).isEqualTo(PolicyUpdateFactory.PULL_ACL);
     }
-
-    private static Bson filterWithFallback(final CharSequence thingId, final Bson... additionalFilters) {
-        final Bson[] original = new Bson[]{Filters.eq(FIELD_THING_ID, thingId)};
-
-        final List<Bson> fallbackFilters = new ArrayList<>(Arrays.asList(additionalFilters));
-        fallbackFilters.add(0, Filters.exists(FIELD_THING_ID, false));
-        final Bson[] fallback = fallbackFilters.toArray(new Bson[fallbackFilters.size()]);
-
-        return Filters.or(
-                Filters.and(original),
-                Filters.and(fallback)
-        );
-
-    }
-
 
     private static void assertPushGlobalReads(final Bson expected, final Bson actual) {
         // order does not matter for the global-reads documents, so it is a bit complicated to test this


### PR DESCRIPTION
removed fallback queries that assumed that `_thingId` might be missing in `policiesBasedSearchIndex` collection.

Signed-off-by: Florian Fendt <Florian.Fendt@bosch-si.com>