### PR TITLE
Fixed concierge cache invalidation in clustered environment

### DIFF
--- a/services/base/src/main/java/org/eclipse/ditto/services/base/config/ClusterConfigReader.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/config/ClusterConfigReader.java
@@ -50,7 +50,8 @@ public final class ClusterConfigReader extends AbstractConfigReader {
      * @return instance index.
      */
     public int instanceIndex() {
-        return getIfPresent(PATH_INSTANCE_INDEX, config::getInt).orElse(-1);
+        return getIfPresent(PATH_INSTANCE_INDEX, config::getInt)
+                .orElseThrow(() -> new IllegalStateException("Could not determine the 'instance_index' of this cluster node"));
     }
 
     /**

--- a/services/base/src/main/resources/ditto-cluster.conf
+++ b/services/base/src/main/resources/ditto-cluster.conf
@@ -1,4 +1,0 @@
-ditto.cluster {
-  become-leader = false
-  instance-index = ${?INSTANCE_INDEX}
-}

--- a/services/base/src/main/resources/ditto-service-base.conf
+++ b/services/base/src/main/resources/ditto-service-base.conf
@@ -1,7 +1,6 @@
 // Common configurations of Ditto services
 
 include "ditto-akka-config"
-include "ditto-cluster"
 include "ditto-limits"
 include "ditto-protocol"
 include "ditto-services-utils-config"

--- a/services/concierge/cache/src/main/java/org/eclipse/ditto/services/concierge/cache/update/AbstractPubSubListenerActor.java
+++ b/services/concierge/cache/src/main/java/org/eclipse/ditto/services/concierge/cache/update/AbstractPubSubListenerActor.java
@@ -42,8 +42,10 @@ public abstract class AbstractPubSubListenerActor extends AbstractActor {
         requireNonNull(eventTopics);
 
         final String group = getSelf().path().name() + instanceIndex;
-        eventTopics.forEach(topic ->
-                pubSubMediator.tell(subscribe(topic, group), getSelf()));
+        eventTopics.forEach(topic -> {
+            log.info("Subscribing for pub/sub topic <{}> with group <{}>", topic, group);
+            pubSubMediator.tell(subscribe(topic, group), getSelf());
+        });
     }
 
     @Override

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -11,6 +11,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # as a rule of thumb: should be factor ten of the amount of cluster nodes available
       # be aware that it must be the same as for all other services (e.g. search-updater)
       number-of-shards = 30

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -24,6 +24,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # as a rule of thumb: should be factor ten of the amount of cluster nodes available
       # be aware that it must be the same as for all other services (e.g. search-updater)
       number-of-shards = 30

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -16,6 +16,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # as a rule of thumb: should be factor ten of the amount of cluster nodes available
       # be aware that it must be the same as for all other services (e.g. search-updater)
       number-of-shards = 30

--- a/services/policies/starter/src/main/resources/policies.conf
+++ b/services/policies/starter/src/main/resources/policies.conf
@@ -19,6 +19,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # as a rule of thumb: should be factor ten of the amount of cluster nodes available
       number-of-shards = 30
       number-of-shards = ${?CLUSTER_NUMBER_OF_SHARDS}

--- a/services/things/starter/src/main/resources/things.conf
+++ b/services/things/starter/src/main/resources/things.conf
@@ -22,6 +22,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # as a rule of thumb: should be factor ten of the amount of cluster nodes available
       # be aware that it must be the same as for all other services (e.g. search-updater)
       number-of-shards = 30

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -26,6 +26,8 @@ ditto {
     }
 
     cluster {
+      instance-index = ${?INSTANCE_INDEX}
+
       # enables the majority check that solves network partitions automatically
       majority-check.enabled = false
       majority-check.enabled = ${?CLUSTER_MAJORITY_CHECK_ENABLED}


### PR DESCRIPTION
fixed bug that "instance-index" was not read correctly read via ClusterConfigReader

* throw exception instead of returning "-1" if it cannot be determined