### PR TITLE
Extend AuthorizationContext interface to allow to preserve the original subtype

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/auth/AuthorizationContext.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/auth/AuthorizationContext.java
@@ -57,6 +57,22 @@ public interface AuthorizationContext
     List<AuthorizationSubject> getAuthorizationSubjects();
 
     /**
+     * Adds the given authorization subjects at the beginning of the list.
+     *
+     * @param authorizationSubjects the authorization subjects to be added
+     * @return a new authorization context with the given {@code authorizationSubjects} added at the beginning.
+     */
+    AuthorizationContext addHead(List<AuthorizationSubject> authorizationSubjects);
+
+    /**
+     * Adds the given authorization subjects at the end of the list.
+     *
+     * @param authorizationSubjects the authorization subjects to be added
+     * @return a new authorization context with the given {@code authorizationSubjects} added at the end.
+     */
+    AuthorizationContext addTail(List<AuthorizationSubject> authorizationSubjects);
+
+    /**
      * This convenience method returns a list containing the IDs of all AuthorizationSubjects of this context. Changes
      * on the returned list have no influence on this context object.
      *

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/auth/ImmutableAuthorizationContext.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/auth/ImmutableAuthorizationContext.java
@@ -118,6 +118,30 @@ final class ImmutableAuthorizationContext implements AuthorizationContext {
     }
 
     @Override
+    public AuthorizationContext addHead(final List<AuthorizationSubject> authorizationSubjects) {
+        checkNotNull(authorizationSubjects, "authorizationSubjects");
+
+        final List<AuthorizationSubject> newAuthorizationSubjects =
+                new ArrayList<>(this.authorizationSubjects.size() + authorizationSubjects.size());
+        newAuthorizationSubjects.addAll(authorizationSubjects);
+        newAuthorizationSubjects.addAll(this.authorizationSubjects);
+
+        return new ImmutableAuthorizationContext(newAuthorizationSubjects);
+    }
+
+    @Override
+    public AuthorizationContext addTail(final List<AuthorizationSubject> authorizationSubjects) {
+        checkNotNull(authorizationSubjects, "authorizationSubjects");
+
+        final List<AuthorizationSubject> newAuthorizationSubjects =
+                new ArrayList<>(this.authorizationSubjects.size() + authorizationSubjects.size());
+        newAuthorizationSubjects.addAll(this.authorizationSubjects);
+        newAuthorizationSubjects.addAll(authorizationSubjects);
+
+        return new ImmutableAuthorizationContext(newAuthorizationSubjects);
+    }
+
+    @Override
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         return JsonFactory.newObjectBuilder()

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/auth/ImmutableAuthorizationContextTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/auth/ImmutableAuthorizationContextTest.java
@@ -10,9 +10,14 @@
  */
 package org.eclipse.ditto.model.base.auth;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -23,6 +28,11 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class ImmutableAuthorizationContextTest {
 
+    private static final List<AuthorizationSubject> SUBJECTS_1 =
+            Arrays.asList(AuthorizationSubject.newInstance("sub_1_1"), AuthorizationSubject.newInstance("sub_1_2"));
+
+    private static final List<AuthorizationSubject> SUBJECTS_2 =
+            Arrays.asList(AuthorizationSubject.newInstance("sub_2_1"), AuthorizationSubject.newInstance("sub_2_2"));
 
     @Test
     public void assertImmutability() {
@@ -40,4 +50,31 @@ public final class ImmutableAuthorizationContextTest {
                 .verify();
     }
 
+    @Test
+    public void addHead() {
+        final AuthorizationContext initialContext = ImmutableAuthorizationContext.of(SUBJECTS_1);
+
+        final AuthorizationContext newContext = initialContext.addHead(SUBJECTS_2);
+
+        final List<AuthorizationSubject> expectedAuthSubjects = new ArrayList<>();
+        expectedAuthSubjects.addAll(SUBJECTS_2);
+        expectedAuthSubjects.addAll(SUBJECTS_1);
+        final AuthorizationContext expectedContext = ImmutableAuthorizationContext.of(expectedAuthSubjects);
+
+        assertThat(newContext).isEqualTo(expectedContext);
+    }
+
+    @Test
+    public void addTail() {
+        final AuthorizationContext initialContext = ImmutableAuthorizationContext.of(SUBJECTS_1);
+
+        final AuthorizationContext newContext = initialContext.addTail(SUBJECTS_2);
+
+        final List<AuthorizationSubject> expectedAuthSubjects = new ArrayList<>();
+        expectedAuthSubjects.addAll(SUBJECTS_1);
+        expectedAuthSubjects.addAll(SUBJECTS_2);
+        final AuthorizationContext expectedContext = ImmutableAuthorizationContext.of(expectedAuthSubjects);
+
+        assertThat(newContext).isEqualTo(expectedContext);
+    }
 }

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/directives/auth/AuthorizationContextVersioningDirective.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/directives/auth/AuthorizationContextVersioningDirective.java
@@ -10,7 +10,6 @@
  */
 package org.eclipse.ditto.services.gateway.endpoints.directives.auth;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -62,7 +61,6 @@ public final class AuthorizationContextVersioningDirective {
 
     private static AuthorizationContext mapAuthorizationContext(
             final AuthorizationContext authenticationContextWithPrefixedSubjects, final int version) {
-        final List<AuthorizationSubject> subjects = new ArrayList<>();
         final List<AuthorizationSubject> subjectsWithPrefix = authenticationContextWithPrefixedSubjects
                 .getAuthorizationSubjects();
         final List<AuthorizationSubject> subjectsWithoutPrefix =
@@ -78,19 +76,15 @@ public final class AuthorizationContextVersioningDirective {
                AuthorizationSubject is used to create a default ACL
             */
 
-            subjects.addAll(subjectsWithoutPrefix);
-            subjects.addAll(subjectsWithPrefix);
+            return authenticationContextWithPrefixedSubjects.addHead(subjectsWithoutPrefix);
         } else {
             /* for V2 and above, we must enhance the List of
                AuthorizationSubjects by APPENDING AuthorizationSubjects without prefix - because the first
                AuthorizationSubject is used to create a default ACL
             */
 
-            subjects.addAll(subjectsWithPrefix);
-            subjects.addAll(subjectsWithoutPrefix);
+            return authenticationContextWithPrefixedSubjects.addTail(subjectsWithoutPrefix);
         }
-
-        return AuthorizationModelFactory.newAuthContext(subjects);
     }
 
 }


### PR DESCRIPTION
When adding authorization subjects to the AuthorizationContext in AuthorizationContextVersioningDirective (which handles backwards-compatibility for api version 1), the original subtype of AuthorizationContext was lost (an instance of ImmutableAuthorizationContext was created in all cases). This worked fine for ditto, but caused an issue in the Bosch IoT Things Service.
This PR extends the AuthorizationContext class with method addHead() and addTail() which allows to add subjects to a context with preserving the original context subtype,