### PR TITLE
fixed retrieving shard region stats and aggregation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -300,7 +300,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.22.0</version>
+                    <version>3.0.0-M1</version>
                     <configuration>
                         <systemProperties>
                             <kamon.auto-start>true</kamon.auto-start>
@@ -315,7 +315,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>2.20.1</version>
+                    <version>3.0.0-M1</version>
                     <executions>
                         <execution>
                             <id>integration-test</id>

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
@@ -29,12 +29,14 @@ import org.eclipse.ditto.services.models.concierge.ConciergeMessagingConstants;
 import org.eclipse.ditto.services.models.concierge.actors.ConciergeForwarderActor;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.cluster.ClusterStatusSupplier;
+import org.eclipse.ditto.services.utils.cluster.RetrieveStatisticsDetailsResponseSupplier;
 import org.eclipse.ditto.services.utils.config.ConfigUtil;
 import org.eclipse.ditto.services.utils.config.MongoConfig;
 import org.eclipse.ditto.services.utils.health.DefaultHealthCheckingActorFactory;
 import org.eclipse.ditto.services.utils.health.HealthCheckingActorOptions;
 import org.eclipse.ditto.services.utils.health.routes.StatusRoute;
 import org.eclipse.ditto.services.utils.persistence.mongo.MongoClientActor;
+import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetails;
 
 import com.typesafe.config.Config;
 
@@ -53,7 +55,6 @@ import akka.actor.Status;
 import akka.actor.SupervisorStrategy;
 import akka.cluster.Cluster;
 import akka.cluster.pubsub.DistributedPubSubMediator;
-import akka.cluster.sharding.ShardRegion;
 import akka.cluster.singleton.ClusterSingletonManager;
 import akka.cluster.singleton.ClusterSingletonManagerSettings;
 import akka.event.DiagnosticLoggingAdapter;
@@ -64,6 +65,7 @@ import akka.http.javadsl.server.Route;
 import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
 import akka.pattern.AskTimeoutException;
+import akka.pattern.PatternsCS;
 import akka.stream.ActorMaterializer;
 
 /**
@@ -79,9 +81,6 @@ public final class ConciergeRootActor extends AbstractActor {
     private static final String RESTARTING_CHILD_MSG = "Restarting child...";
 
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
-
-    private final ActorRef conciergeShardRegion;
-
     private final SupervisorStrategy supervisorStrategy = new OneForOneStrategy(true, DeciderBuilder
             .match(NullPointerException.class, e -> {
                 log.error(e, "NullPointer in child actor: {}", e.getMessage());
@@ -129,6 +128,8 @@ public final class ConciergeRootActor extends AbstractActor {
                 return SupervisorStrategy.escalate();
             }).build());
 
+    private final RetrieveStatisticsDetailsResponseSupplier retrieveStatisticsDetailsResponseSupplier;
+
     private <C extends AbstractConciergeConfigReader> ConciergeRootActor(final C configReader,
             final ActorRef pubSubMediator,
             final AbstractEnforcerActorFactory<C> authorizationProxyPropsFactory,
@@ -141,7 +142,11 @@ public final class ConciergeRootActor extends AbstractActor {
 
         final ActorContext context = getContext();
 
-        conciergeShardRegion = authorizationProxyPropsFactory.startEnforcerActor(context, configReader, pubSubMediator);
+        final ActorRef conciergeShardRegion =
+                authorizationProxyPropsFactory.startEnforcerActor(context, configReader, pubSubMediator);
+
+        retrieveStatisticsDetailsResponseSupplier = RetrieveStatisticsDetailsResponseSupplier.of(conciergeShardRegion,
+                ConciergeMessagingConstants.SHARD_REGION, log);
 
         final ActorRef conciergeForwarder = startChildActor(context, ConciergeForwarderActor.ACTOR_NAME,
                 ConciergeForwarderActor.props(pubSubMediator, conciergeShardRegion));
@@ -233,13 +238,18 @@ public final class ConciergeRootActor extends AbstractActor {
     @Override
     public Receive createReceive() {
         return ReceiveBuilder.create()
-                .matchEquals(ShardRegion.getShardRegionStateInstance(), getShardRegionState ->
-                        conciergeShardRegion.forward(getShardRegionState, getContext()))
+                .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
                 .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure <{}>!", f))
                 .matchAny(m -> {
                     log.warning("Unknown message <{}>.", m);
                     unhandled(m);
                 }).build();
+    }
+
+    private void handleRetrieveStatisticsDetails(final RetrieveStatisticsDetails command) {
+        log.info("Sending the namespace stats of the concierge shard as requested..");
+        PatternsCS.pipe(retrieveStatisticsDetailsResponseSupplier
+                .apply(command.getDittoHeaders()), getContext().dispatcher()).to(getSender());
     }
 
     private void bindHttpStatusRoute(final ActorRef healthCheckingActor, final HttpConfigReader httpConfig,

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
@@ -282,15 +282,10 @@ public final class StatisticsActor extends AbstractActor {
                         retrieveStatisticsDetailsResponse.getStatisticsDetails().getValue(shardRegion)
                                 .map(JsonValue::asObject)
                                 .map(JsonObject::stream)
-                                .ifPresent(namespaceEntries -> namespaceEntries.forEach(field -> {
-                                    if (shardStatistics.hotnessMap.containsKey(field.getKeyName())) {
-                                        shardStatistics.hotnessMap.put(field.getKeyName(),
-                                                shardStatistics.hotnessMap.get(field.getKeyName()) +
-                                                        field.getValue().asLong());
-                                    } else {
-                                        shardStatistics.hotnessMap.put(field.getKeyName(), field.getValue().asLong());
-                                    }
-                                }));
+                                .ifPresent(namespaceEntries -> namespaceEntries.forEach(field ->
+                                        shardStatistics.hotnessMap
+                                                .merge(field.getKeyName(), field.getValue().asLong(), Long::sum)
+                                ));
                     }
                 })
                 .match(AskTimeoutException.class, askTimeout -> {

--- a/services/models/thingsearch/src/main/java/org/eclipse/ditto/services/models/thingsearch/ThingsSearchConstants.java
+++ b/services/models/thingsearch/src/main/java/org/eclipse/ditto/services/models/thingsearch/ThingsSearchConstants.java
@@ -39,7 +39,7 @@ public final class ThingsSearchConstants {
     /**
      * Path of the updater root actor.
      */
-    public static final String UPDATER_ROOT_ACTOR_PATH = USER_PATH + "/searchUpdaterRoot";
+    public static final String UPDATER_ROOT_ACTOR_PATH = ROOT_ACTOR_PATH + "/searchUpdaterRoot";
 
     /**
      * Path of the search actor.

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
@@ -47,7 +47,6 @@ import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.cluster.sharding.ShardRegion;
 import akka.pattern.CircuitBreaker;
 import akka.stream.javadsl.Source;
 import akka.testkit.TestProbe;
@@ -135,17 +134,6 @@ public class ThingsUpdaterTest {
             expectShardedMessage(shardMessageReceiver, message, message.getEntityId());
         }};
     }
-
-    @Test
-    public void shardRegionStateIsForwarded() {
-        final ShardRegion.GetShardRegionState$ shardRegionState = ShardRegion.getShardRegionStateInstance();
-        new TestKit(actorSystem) {{
-            final ActorRef underTest = createThingsUpdater();
-            underTest.tell(shardRegionState, getRef());
-            shardMessageReceiver.expectMsg(shardRegionState);
-        }};
-    }
-
 
     private void expectShardedMessage(final TestProbe probe, final Jsonifiable event, final String id) {
         final ShardedMessageEnvelope envelope = probe.expectMsgClass(ShardedMessageEnvelope.class);

--- a/services/utils/cluster/pom.xml
+++ b/services/utils/cluster/pom.xml
@@ -47,6 +47,10 @@
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-signals-commands-base</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-signals-commands-devops</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.typesafe.akka</groupId>

--- a/services/utils/cluster/src/main/java/org/eclipse/ditto/services/utils/cluster/RetrieveStatisticsDetailsResponseSupplier.java
+++ b/services/utils/cluster/src/main/java/org/eclipse/ditto/services/utils/cluster/RetrieveStatisticsDetailsResponseSupplier.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.cluster;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetailsResponse;
+
+import akka.actor.ActorRef;
+import akka.cluster.sharding.ShardRegion;
+import akka.event.DiagnosticLoggingAdapter;
+import akka.pattern.PatternsCS;
+
+/**
+ * Supplier of {@link RetrieveStatisticsDetailsResponse}s for a specific shard region - determines the "hot entities"
+ * per namespace and aggregates them into a single {@link RetrieveStatisticsDetailsResponse}.
+ */
+public final class RetrieveStatisticsDetailsResponseSupplier
+        implements Function<DittoHeaders, CompletionStage<RetrieveStatisticsDetailsResponse>> {
+
+    private static final String EMPTY_ID = "<empty>";
+
+    private final ActorRef shardRegion;
+    private final String shardRegionName;
+    private final DiagnosticLoggingAdapter log;
+
+    private RetrieveStatisticsDetailsResponseSupplier(final ActorRef shardRegion, final String shardRegionName,
+            final DiagnosticLoggingAdapter log) {
+        this.shardRegion = shardRegion;
+        this.shardRegionName = shardRegionName;
+        this.log = log;
+    }
+
+    /**
+     * Creates a new instance of a {@link RetrieveStatisticsDetailsResponse} supplier for the passed {@code shardRegion}
+     * and {@code shardRegionName}.
+     *
+     * @param shardRegion the shard region ActoRef to use for retrieving the shard region state.
+     * @param shardRegionName the shard region name.
+     * @param log the logger to use.
+     * @return the new RetrieveStatisticsDetailsResponse supplier
+     */
+    public static RetrieveStatisticsDetailsResponseSupplier of(final ActorRef shardRegion, final String shardRegionName,
+            final DiagnosticLoggingAdapter log) {
+        return new RetrieveStatisticsDetailsResponseSupplier(shardRegion, shardRegionName, log);
+    }
+
+    @Override
+    public CompletionStage<RetrieveStatisticsDetailsResponse> apply(final DittoHeaders dittoHeaders) {
+        return PatternsCS.ask(shardRegion, ShardRegion.getShardRegionStateInstance(),
+                Duration.ofSeconds(5))
+                .handle((result, throwable) -> {
+                    if (throwable != null) {
+                        log.error(throwable, "Could not determine 'ShardRegionState' for shard region <{}>",
+                                shardRegionName);
+                        return RetrieveStatisticsDetailsResponse.of(JsonObject.newBuilder()
+                                        .set(shardRegionName, JsonFactory.newObject())
+                                        .build(),
+                                dittoHeaders);
+                    } else if (result instanceof ShardRegion.CurrentShardRegionState) {
+                        final Map<String, Long> shardStats =
+                                ((ShardRegion.CurrentShardRegionState) result).getShards()
+                                        .stream()
+                                        .map(ShardRegion.ShardState::getEntityIds)
+                                        .flatMap(strSet -> strSet.stream()
+                                                .map(str -> {
+                                                    // groupKey may be either namespace or resource-type+namespace (in case of concierge)
+                                                    final String[] groupKeys = str.split(":", 3);
+                                                    // assume String.split(String, int) may not return an empty array
+                                                    switch (groupKeys.length) {
+                                                        case 0:
+                                                            // should not happen with Java 8 strings, but just in case
+                                                            return EMPTY_ID;
+                                                        case 1:
+                                                        case 2:
+                                                            // normal: namespace
+                                                            return ensureNonemptyString(
+                                                                    groupKeys[0]);
+                                                        default:
+                                                            // concierge: resource-type + namespace
+                                                            return groupKeys[0] + ":" +
+                                                                    groupKeys[1];
+                                                    }
+                                                })
+                                        )
+                                        .collect(Collectors.groupingBy(Function.identity(),
+                                                Collectors.mapping(Function.identity(),
+                                                        Collectors.counting())));
+
+                        final JsonObject namespaceStats = shardStats.entrySet().stream()
+                                .map(entry -> JsonField.newInstance(entry.getKey(),
+                                        JsonValue.of(entry.getValue())))
+                                .collect(JsonCollectors.fieldsToObject());
+
+                        final JsonObject thingNamespacesStats = JsonObject.newBuilder()
+                                .set(shardRegionName, namespaceStats)
+                                .build();
+
+                        return RetrieveStatisticsDetailsResponse.of(thingNamespacesStats,
+                                dittoHeaders);
+                    } else {
+                        log.warning("Unexpected answer to " +
+                                "'ShardRegion.getShardRegionStateInstance()': {}", result);
+                        return RetrieveStatisticsDetailsResponse.of(JsonObject.newBuilder()
+                                        .set(shardRegionName, JsonFactory.newObject())
+                                        .build(),
+                                dittoHeaders);
+                    }
+                });
+    }
+
+    private static String ensureNonemptyString(final String possiblyEmptyString) {
+        return possiblyEmptyString.isEmpty() ? EMPTY_ID : possiblyEmptyString;
+    }
+}

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandRegistry.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandRegistry.java
@@ -42,7 +42,7 @@ public final class DevOpsCommandRegistry extends AbstractJsonParsableRegistry<De
         parseStrategies.put(ChangeLogLevel.TYPE, ChangeLogLevel::fromJson);
         parseStrategies.put(RetrieveLoggerConfig.TYPE, RetrieveLoggerConfig::fromJson);
         parseStrategies.put(RetrieveStatistics.TYPE, RetrieveStatistics::fromJson);
-        parseStrategies.put(RetrieveStatisticsDetails.TYPE, RetrieveStatistics::fromJson);
+        parseStrategies.put(RetrieveStatisticsDetails.TYPE, RetrieveStatisticsDetails::fromJson);
         parseStrategies.put(ExecutePiggybackCommand.TYPE, ExecutePiggybackCommand::fromJson);
 
         return new DevOpsCommandRegistry(parseStrategies);

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandResponseRegistry.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/DevOpsCommandResponseRegistry.java
@@ -42,7 +42,7 @@ public final class DevOpsCommandResponseRegistry extends AbstractJsonParsableReg
         parseStrategies.put(ChangeLogLevelResponse.TYPE, ChangeLogLevelResponse::fromJson);
         parseStrategies.put(RetrieveLoggerConfigResponse.TYPE, RetrieveLoggerConfigResponse::fromJson);
         parseStrategies.put(RetrieveStatisticsResponse.TYPE, RetrieveStatisticsResponse::fromJson);
-        parseStrategies.put(RetrieveStatisticsDetailsResponse.TYPE, RetrieveStatisticsResponse::fromJson);
+        parseStrategies.put(RetrieveStatisticsDetailsResponse.TYPE, RetrieveStatisticsDetailsResponse::fromJson);
         parseStrategies.put(AggregatedDevOpsCommandResponse.TYPE,
                 (jsonObject, dittoHeaders) -> AggregatedDevOpsCommandResponse.fromJson(jsonObject, dittoHeaders, parseStrategies));
 


### PR DESCRIPTION
* on HTTP route /stats/things/details
* was affected by max cluster size limits and Java serialization of response messages
* added RetrieveStatisticsDetailsResponseSupplier which is used in the services in order to calculate the "hot entities" per namespace