### PR TITLE
Fix creation of new Thing by PUT without ID in body

### DIFF
--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -989,8 +989,10 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
             final ModifyThing modifyThing = (ModifyThing) receivedCommand;
             final JsonObject initialPolicy = modifyThing.getInitialPolicy().orElse(null);
             final String policyIdOrPlaceholder = modifyThing.getPolicyIdOrPlaceholder().orElse(null);
-            return CreateThing.of(modifyThing.getThing(), initialPolicy, policyIdOrPlaceholder,
-                    modifyThing.getDittoHeaders());
+            final Thing newThing = modifyThing.getThing().toBuilder()
+                    .setId(modifyThing.getThingId())
+                    .build();
+            return CreateThing.of(newThing, initialPolicy, policyIdOrPlaceholder, modifyThing.getDittoHeaders());
         } else {
             return receivedCommand;
         }


### PR DESCRIPTION
Fixed a bug where PUT requests to new Things are not answered if the body contains no Thing ID.