### PR TITLE
fixed that HTTP message requests with timeout 60s were aborted

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/HttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/HttpRequestActor.java
@@ -102,8 +102,7 @@ public final class HttpRequestActor extends AbstractActor {
         this.httpResponseFuture = httpResponseFuture;
 
         final Config config = getContext().system().settings().config();
-        serverRequestTimeout = config.getDuration(ConfigKeys.AKKA_HTTP_SERVER_REQUEST_TIMEOUT)
-                .minusSeconds(5);
+        serverRequestTimeout = config.getDuration(ConfigKeys.AKKA_HTTP_SERVER_REQUEST_TIMEOUT);
         getContext().setReceiveTimeout(serverRequestTimeout);
 
         // wrap JsonRuntimeExceptions
@@ -156,7 +155,7 @@ public final class HttpRequestActor extends AbstractActor {
                 })
                 .match(CommandResponse.class, commandResponse -> {
                     LogUtil.enhanceLogWithCorrelationId(logger, commandResponse);
-                    logger.warning("Got 'CommandResponse' message which did not implement the required interfaces "
+                    logger.error("Got 'CommandResponse' message which did not implement the required interfaces "
                             + "'WithEntity' / 'WithOptionalEntity': {}", commandResponse);
                     completeWithResult(HttpResponse.create().withStatus(HttpStatusCode.INTERNAL_SERVER_ERROR.toInt()));
                 })
@@ -292,7 +291,9 @@ public final class HttpRequestActor extends AbstractActor {
     }
 
     private void logDittoRuntimeException(final DittoRuntimeException dre) {
-        LogUtil.enhanceLogWithCorrelationId(logger, dre);
+        if (dre.getDittoHeaders().getCorrelationId().isPresent()) {
+            LogUtil.enhanceLogWithCorrelationId(logger, dre);
+        }
         logger.info("DittoRuntimeException '{}': {}", dre.getErrorCode(), dre.getMessage());
     }
 
@@ -446,16 +447,14 @@ public final class HttpRequestActor extends AbstractActor {
 
     private void handleReceiveTimeout(final ReceiveTimeout receiveTimeout) {
         if (messageTimeout != null && !isFireAndForgetMessage) {
-            logger.info("Got ReceiveTimeout when a message response was expected: {}", receiveTimeout);
-            final MessageTimeoutException mte = new MessageTimeoutException(messageTimeout.getSeconds());
-            completeWithResult(HttpResponse.create().withStatus(mte.getStatusCode().toInt())
-                    .withEntity(CONTENT_TYPE_JSON, ByteString.fromString(mte.toJsonString())));
+            logger.info("Got ReceiveTimeout when a message response was expected after timeout {}", messageTimeout);
+            handleDittoRuntimeException(new MessageTimeoutException(messageTimeout.getSeconds()));
         } else {
             logger.warning("No response within server request timeout ({}), shutting actor down.",
                     serverRequestTimeout);
             // note that we do not need to send a response here, this is handled by RequestTimeoutHandlingDirective
+            stop();
         }
-        stop();
     }
 
     private void handleDittoRuntimeException(final DittoRuntimeException dre) {
@@ -481,12 +480,12 @@ public final class HttpRequestActor extends AbstractActor {
     }
 
     private void completeWithResult(final HttpResponse response) {
-        httpResponseFuture.complete(response);
         final int statusCode = response.status().intValue();
-        logger.debug("Responding with HttpResponse code '{}'", statusCode);
         if (logger.isDebugEnabled()) {
+            logger.debug("Responding with HttpResponse code '{}'", statusCode);
             logger.debug("Responding with Entity: {}", response.entity());
         }
+        httpResponseFuture.complete(response);
         stop();
     }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
@@ -86,7 +86,6 @@ public abstract class AbstractRoute {
         this.proxyActor = proxyActor;
         this.actorSystem = actorSystem;
 
-
         final Config config = actorSystem.settings().config();
         final ProtocolConfigReader protocolConfig = ProtocolConfigReader.fromRawConfig(config);
         final ProtocolAdapterProvider protocolAdapterProvider =
@@ -96,8 +95,10 @@ public abstract class AbstractRoute {
         LOGGER.debug("Using headerTranslator <{}>.", headerTranslator);
 
         materializer = ActorMaterializer.create(ActorMaterializerSettings.create(actorSystem)
-                .withSupervisionStrategy((Function<Throwable, Supervision.Directive>) exc ->
-                        Supervision.stop() // in any case, stop!
+                .withSupervisionStrategy((Function<Throwable, Supervision.Directive>) exc -> {
+                            LOGGER.error("Exception during materialization of HTTP request: {}", exc.getMessage(), exc);
+                            return Supervision.stop(); // in any case, stop!
+                        }
                 ), actorSystem);
     }
 

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
@@ -59,7 +59,7 @@ final class QueryThingsPerRequestActor extends AbstractActor {
         queryThingsResponse = null;
 
         final Duration timeout = Duration.create(getContext().system().settings().config()
-                        .getDuration(ConfigKeys.AKKA_HTTP_SERVER_REQUEST_TIMEOUT).minusSeconds(5).getSeconds(),
+                        .getDuration(ConfigKeys.AKKA_HTTP_SERVER_REQUEST_TIMEOUT).getSeconds(),
                 TimeUnit.SECONDS);
         getContext().setReceiveTimeout(timeout);
     }

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -178,8 +178,10 @@ akka {
 
     server {
       server-header = "" # default: akka-http/${akka.http.version}
-      request-timeout = 65s # default: 20 s
+      request-timeout = 60s # default: 20 s
       request-timeout = ${?REQUEST_TIMEOUT}
+      idle-timeout = 610s # default: 60s
+      idle-timeout = ${?IDLE_TIMEOUT}
       max-connections = 4096 # default: 1024
       backlog = 100 # default: 100
       raw-request-uri-header = on # default: off
@@ -229,7 +231,6 @@ blocking-dispatcher {
   type = Dispatcher
   executor = "thread-pool-executor"
   thread-pool-executor {
-    // or in Akka 2.4.2+
     fixed-pool-size = 8
   }
   throughput = 100


### PR DESCRIPTION
cause: Akka HTTP had a default "idle-timeout" of 60s which aborted the
request when there was nothing happening on that connection