### PR TITLE
performance-fix: add missing dispatchers

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,6 +58,7 @@
         <metrics.version>3.1.2</metrics.version>
 
         <kamon-core.version>1.1.2</kamon-core.version>
+        <kamon-executors.version>1.0.2</kamon-executors.version>
         <kamon-system-metrics.version>1.0.0</kamon-system-metrics.version>
         <kamon-prometheus.version>1.1.1</kamon-prometheus.version>
         <prometheus.java-client.version>0.4.0</prometheus.java-client.version>
@@ -407,6 +408,11 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>io.kamon</groupId>
+                <artifactId>kamon-executors_${scala.version}</artifactId>
+                <version>${kamon-executors.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.kamon</groupId>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -58,7 +58,6 @@
         <metrics.version>3.1.2</metrics.version>
 
         <kamon-core.version>1.1.2</kamon-core.version>
-        <kamon-executors.version>1.0.2</kamon-executors.version>
         <kamon-system-metrics.version>1.0.0</kamon-system-metrics.version>
         <kamon-prometheus.version>1.1.1</kamon-prometheus.version>
         <prometheus.java-client.version>0.4.0</prometheus.java-client.version>
@@ -408,11 +407,6 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>io.kamon</groupId>
-                <artifactId>kamon-executors_${scala.version}</artifactId>
-                <version>${kamon-executors.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.kamon</groupId>

--- a/services/concierge/batch/src/test/resources/test.conf
+++ b/services/concierge/batch/src/test/resources/test.conf
@@ -97,4 +97,5 @@ batch-persistence-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
   }
+  throughput = 5
 }

--- a/services/concierge/batch/src/test/resources/test.conf
+++ b/services/concierge/batch/src/test/resources/test.conf
@@ -87,11 +87,8 @@ akka-contrib-mongodb-persistence-batch-supervisor-snapshots {
 }
 
 batch-persistence-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -100,8 +97,4 @@ batch-persistence-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -62,8 +62,7 @@ public abstract class AbstractEnforcement<T extends Signal> {
     }
 
     /**
-     * TODO TJ doc
-     * @return
+     * @return the Executor to use in order to perform asynchronous operations in enforcement.
      */
     protected Executor getEnforcementExecutor() {
         return context.enforcerExecutor;
@@ -335,7 +334,7 @@ public abstract class AbstractEnforcement<T extends Signal> {
          *
          * @param actorContext the actor context.
          * @param log the logger.
-         * @param enforcerExecutor TODO TJ log
+         * @param enforcerExecutor the Executor to use in order to perform asynchronous operations in enforcement.
          * @return the created instance.
          */
         public Context with(final AbstractActor.ActorContext actorContext, final DiagnosticLoggingAdapter log,

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
 
 import javax.annotation.Nullable;
@@ -58,6 +59,14 @@ public abstract class AbstractEnforcement<T extends Signal> {
 
     protected AbstractEnforcement(final Context context) {
         this.context = context;
+    }
+
+    /**
+     * TODO TJ doc
+     * @return
+     */
+    protected Executor getEnforcementExecutor() {
+        return context.enforcerExecutor;
     }
 
     /**
@@ -294,24 +303,28 @@ public abstract class AbstractEnforcement<T extends Signal> {
 
         private final ActorRef conciergeForwarder;
 
+        private final Executor enforcerExecutor;
+
         Context(
                 final ActorRef pubSubMediator,
                 final Duration askTimeout,
-                final ActorRef conciergeForwarder) {
+                final ActorRef conciergeForwarder, final Executor enforcerExecutor) {
 
-            this(pubSubMediator, askTimeout, conciergeForwarder, null, null, null);
+            this(pubSubMediator, askTimeout, conciergeForwarder, enforcerExecutor, null, null, null);
         }
 
         Context(
                 final ActorRef pubSubMediator,
                 final Duration askTimeout,
                 @Nullable final ActorRef conciergeForwarder,
+                final Executor enforcerExecutor,
                 @Nullable final EntityId entityId,
                 @Nullable final DiagnosticLoggingAdapter log,
                 @Nullable final ActorRef self) {
             this.pubSubMediator = pubSubMediator;
             this.askTimeout = askTimeout;
             this.conciergeForwarder = conciergeForwarder;
+            this.enforcerExecutor = enforcerExecutor;
             this.entityId = entityId;
             this.log = log;
             this.self = self;
@@ -322,12 +335,14 @@ public abstract class AbstractEnforcement<T extends Signal> {
          *
          * @param actorContext the actor context.
          * @param log the logger.
+         * @param enforcerExecutor TODO TJ log
          * @return the created instance.
          */
-        public Context with(final AbstractActor.ActorContext actorContext, final DiagnosticLoggingAdapter log) {
+        public Context with(final AbstractActor.ActorContext actorContext, final DiagnosticLoggingAdapter log,
+                final Executor enforcerExecutor) {
             final ActorRef contextSelf = actorContext.self();
-            return new Context(pubSubMediator, askTimeout, conciergeForwarder, decodeEntityId(contextSelf), log,
-                    contextSelf);
+            return new Context(pubSubMediator, askTimeout, conciergeForwarder, enforcerExecutor,
+                    decodeEntityId(contextSelf), log, contextSelf);
         }
 
         private static EntityId decodeEntityId(final ActorRef self) {

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
@@ -249,7 +249,7 @@ public final class PolicyCommandEnforcement extends AbstractEnforcement<PolicyCo
                                 commandWithReadSubjects.getDittoHeaders());
                     }
                     return null;
-                });
+                }, getEnforcementExecutor());
     }
 
     private void reportTimeoutForPolicyQuery(

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -102,6 +102,8 @@ import org.eclipse.ditto.signals.commands.things.query.RetrieveThing;
 import org.eclipse.ditto.signals.commands.things.query.RetrieveThingResponse;
 import org.eclipse.ditto.signals.commands.things.query.ThingQueryCommand;
 import org.eclipse.ditto.signals.commands.things.query.ThingQueryCommandResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import akka.actor.ActorRef;
 import akka.event.DiagnosticLoggingAdapter;
@@ -112,6 +114,8 @@ import akka.pattern.PatternsCS;
  * Authorize {@code ThingCommand}.
  */
 public final class ThingCommandEnforcement extends AbstractEnforcement<ThingCommand> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ThingCommandEnforcement.class);
 
     /**
      * Label of default policy entry in default policy.
@@ -348,7 +352,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                                 sender, response, error, retrieveThing.getDittoHeaders());
                     }
                     return null;
-                });
+                }, getEnforcementExecutor());
     }
 
     /**
@@ -431,7 +435,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                                 commandWithReadSubjects.getDittoHeaders());
                     }
                     return null;
-                });
+                }, getEnforcementExecutor());
         return true;
     }
 
@@ -505,7 +509,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                                 sender, response, error, retrieveThing.getDittoHeaders());
                     }
                     return Optional.empty();
-                });
+                }, getEnforcementExecutor());
     }
 
     private void reportThingUnavailable(final String thingId, final DittoHeaders dittoHeaders, final ActorRef sender) {
@@ -526,8 +530,9 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
             final RetrievePolicy retrievePolicy) {
 
         return blockCachedNamespaces.apply(retrievePolicy)
-                .thenCompose(msg -> PatternsCS.ask(policiesShardRegion, msg, getAskTimeout().toMillis()))
+                .thenCompose(msg -> PatternsCS.ask(policiesShardRegion, msg, getAskTimeout()))
                 .handleAsync((response, error) -> {
+                    LOGGER.debug("Response of policiesShardRegion: <{}>", response);
                     if (response instanceof RetrievePolicyResponse) {
                         return Optional.of((RetrievePolicyResponse) response);
                     } else if (error != null) {
@@ -538,7 +543,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                                 retrievePolicy.getId(), retrieveThing.getThingId(), response);
                     }
                     return Optional.empty();
-                });
+                }, getEnforcementExecutor());
     }
 
     /**
@@ -1269,7 +1274,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                     });
 
                     return null;
-                });
+                }, getEnforcementExecutor());
 
         return true;
     }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -877,7 +877,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
 
         final CompletionStage<Policy> policyCompletionStage =
                 PatternsCS.ask(conciergeForwarder(), RetrievePolicy.of(policyId, dittoHeaders), getAskTimeout())
-                        .thenApply(response -> {
+                        .thenApplyAsync(response -> {
                             if (response instanceof RetrievePolicyResponse) {
                                 return ((RetrievePolicyResponse) response).getPolicy();
                             } else if (response instanceof PolicyErrorResponse) {
@@ -890,7 +890,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                                                 " during Thing creation: {}", response);
                                 throw GatewayInternalErrorException.newBuilder().build();
                             }
-                        });
+                        }, getEnforcementExecutor());
 
         return awaitPolicyCompletionStage(policyCompletionStage, dittoHeaders);
 

--- a/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcementTest.java
+++ b/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcementTest.java
@@ -501,7 +501,7 @@ public class PolicyCommandEnforcementTest {
         enforcementProviders.add(enforcementProvider);
 
         return system.actorOf(EnforcerActorCreator.props(pubSubMediator, enforcementProviders, Duration.ofSeconds(10),
-                conciergeForwarder),
+                conciergeForwarder, system.dispatcher()),
                 ENTITY_ID.toString());
     }
 

--- a/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/TestSetup.java
+++ b/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/TestSetup.java
@@ -105,7 +105,7 @@ public class TestSetup {
                 new LiveSignalEnforcement.Provider(thingIdCache, policyEnforcerCache, aclEnforcerCache));
 
         final Props props = EnforcerActorCreator.props(testActorRef, enforcementProviders, Duration.ofSeconds(10),
-                conciergeForwarder, preEnforcer, null);
+                conciergeForwarder, system.dispatcher(), preEnforcer, null);
         return system.actorOf(props, THING + ":" + THING_ID);
     }
 

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/AbstractEnforcerActorFactory.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/AbstractEnforcerActorFactory.java
@@ -30,7 +30,7 @@ import akka.cluster.sharding.ClusterShardingSettings;
 public abstract class AbstractEnforcerActorFactory<C extends AbstractConciergeConfigReader> {
 
     /**
-     * TODO TJ doc
+     * The dispatcher name of the Executor to use in order to perform asynchronous operations in enforcement.
      */
     protected static final String ENFORCER_DISPATCHER = "enforcer-dispatcher";
 

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/AbstractEnforcerActorFactory.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/AbstractEnforcerActorFactory.java
@@ -30,6 +30,11 @@ import akka.cluster.sharding.ClusterShardingSettings;
 public abstract class AbstractEnforcerActorFactory<C extends AbstractConciergeConfigReader> {
 
     /**
+     * TODO TJ doc
+     */
+    protected static final String ENFORCER_DISPATCHER = "enforcer-dispatcher";
+
+    /**
      * Start a proxy to a shard region.
      *
      * @param actorSystem actor system to start the proxy in.

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/DefaultEnforcerActorFactory.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/DefaultEnforcerActorFactory.java
@@ -18,6 +18,7 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
 import java.util.function.Function;
 
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
@@ -119,9 +120,10 @@ public final class DefaultEnforcerActorFactory extends AbstractEnforcerActorFact
         // set activity check interval identical to cache retention
         final Duration activityCheckInterval = configReader.caches().id().expireAfterWrite();
         final ActorRef conciergeForwarder = getInternalConciergeForwarder(context, configReader, pubSubMediator);
+        final Executor enforcerExecutor = actorSystem.dispatchers().lookup(ENFORCER_DISPATCHER);
         final Props enforcerProps =
                 EnforcerActorCreator.props(pubSubMediator, enforcementProviders, enforcementAskTimeout,
-                        conciergeForwarder, preEnforcer, activityCheckInterval);
+                        conciergeForwarder, enforcerExecutor, preEnforcer, activityCheckInterval);
         final ActorRef enforcerShardRegion = startShardRegion(context.system(), configReader.cluster(), enforcerProps);
 
         // start cache updaters

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -148,11 +148,8 @@ aggregator-internal-dispatcher {
 }
 
 batch-persistence-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -162,10 +159,6 @@ batch-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 cached-namespace-invalidator-dispatcher {
@@ -175,11 +168,8 @@ cached-namespace-invalidator-dispatcher {
 }
 
 blocked-namespaces-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -189,18 +179,11 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 enforcer-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -210,10 +193,6 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 thing-id-cache-dispatcher {

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -174,6 +174,48 @@ cached-namespace-invalidator-dispatcher {
   executor = "thread-pool-executor"
 }
 
+blocked-namespaces-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}
+
+enforcer-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}
+
 thing-id-cache-dispatcher {
     type = "Dispatcher"
     executor = "thread-pool-executor"

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -159,6 +159,7 @@ batch-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 cached-namespace-invalidator-dispatcher {
@@ -179,6 +180,7 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 enforcer-dispatcher {
@@ -193,6 +195,7 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 thing-id-cache-dispatcher {

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -237,10 +237,6 @@ connection-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 reconnect-persistence-dispatcher {
@@ -252,18 +248,11 @@ reconnect-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 message-mapping-processor-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -272,10 +261,6 @@ message-mapping-processor-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 64
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 jms-connection-handling-dispatcher {

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -237,6 +237,7 @@ connection-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 reconnect-persistence-dispatcher {
@@ -248,6 +249,7 @@ reconnect-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 message-mapping-processor-dispatcher {
@@ -261,6 +263,7 @@ message-mapping-processor-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 64
   }
+  throughput = 5
 }
 
 jms-connection-handling-dispatcher {

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -203,11 +203,8 @@ rabbit-stats-bounded-mailbox {
 }
 
 message-mapping-processor-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -216,10 +213,7 @@ message-mapping-processor-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 64
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
+  throughput = 5
 }
 
 jms-connection-handling-dispatcher {

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -306,6 +306,7 @@ public final class WebsocketRoute {
         if (jsonifiable instanceof WithDittoHeaders) {
             ((WithDittoHeaders) jsonifiable).getDittoHeaders()
                     .getCorrelationId()
+                    .filter(c -> jsonifiable instanceof CommandResponse) // only create ResponsePublished for CommandResponses, not events with the same correlationId
                     .map(ResponsePublished::new)
                     .ifPresent(eventStream::publish);
         }

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -303,10 +303,10 @@ public final class WebsocketRoute {
 
     private Jsonifiable.WithPredicate<JsonObject, JsonField> publishResponsePublishedEvent(
             final Jsonifiable.WithPredicate<JsonObject, JsonField> jsonifiable) {
-        if (jsonifiable instanceof WithDittoHeaders) {
+        if (jsonifiable instanceof CommandResponse) {
+            // only create ResponsePublished for CommandResponses, not for Events with the same correlationId
             ((WithDittoHeaders) jsonifiable).getDittoHeaders()
                     .getCorrelationId()
-                    .filter(c -> jsonifiable instanceof CommandResponse) // only create ResponsePublished for CommandResponses, not events with the same correlationId
                     .map(ResponsePublished::new)
                     .ifPresent(eventStream::publish);
         }

--- a/services/gateway/endpoints/src/test/resources/test.conf
+++ b/services/gateway/endpoints/src/test/resources/test.conf
@@ -198,9 +198,6 @@ sharding-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
   throughput = 5 # default is 5
 }
 

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
@@ -12,7 +12,7 @@ package org.eclipse.ditto.services.gateway.streaming.actors;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,8 +86,8 @@ final class StreamingSessionActor extends AbstractActor {
         this.pubSubMediator = pubSubMediator;
         this.eventAndResponsePublisher = eventAndResponsePublisher;
         outstandingSubscriptionAcks = new HashSet<>();
-        namespacesForStreamingTypes = new HashMap<>();
-        eventFilterCriteriaForStreamingTypes = new HashMap<>();
+        namespacesForStreamingTypes = new EnumMap<>(StreamingType.class);
+        eventFilterCriteriaForStreamingTypes = new EnumMap<>(StreamingType.class);
 
         getContext().watch(eventAndResponsePublisher);
     }

--- a/services/policies/persistence/src/test/resources/test.conf
+++ b/services/policies/persistence/src/test/resources/test.conf
@@ -72,11 +72,8 @@ akka-contrib-mongodb-persistence-policies-snapshots {
 }
 
 policy-persistence-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -85,8 +82,5 @@ policy-persistence-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
+  throughput = 5
 }

--- a/services/policies/starter/src/main/resources/policies.conf
+++ b/services/policies/starter/src/main/resources/policies.conf
@@ -224,10 +224,7 @@ policy-journal-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 5 # default is 5
+  throughput = 5
 }
 
 policy-snaps-persistence-dispatcher {
@@ -242,10 +239,7 @@ policy-snaps-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 5 # default is 5
+  throughput = 5
 }
 
 akka.contrib.persistence.mongodb.mongo.suffix-builder {

--- a/services/things/persistence/src/test/resources/test.conf
+++ b/services/things/persistence/src/test/resources/test.conf
@@ -80,11 +80,8 @@ akka-contrib-mongodb-persistence-things-snapshots {
 }
 
 thing-persistence-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -93,8 +90,5 @@ thing-persistence-dispatcher {
     # Max number of threads to cap factor-based parallelism number to
     parallelism-max = 32
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
   throughput = 2
 }

--- a/services/things/starter/src/main/resources/things.conf
+++ b/services/things/starter/src/main/resources/things.conf
@@ -185,10 +185,7 @@ thing-journal-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 5 # default is 5
+  throughput = 5
 }
 
 thing-snaps-persistence-dispatcher {
@@ -203,10 +200,7 @@ thing-snaps-persistence-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 5 # default is 5
+  throughput = 5
 }
 
 akka.contrib.persistence.mongodb.mongo.suffix-builder {

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -201,3 +201,24 @@ search-dispatcher {
   # Set to 1 for as fair as possible.
   throughput = 5
 }
+
+blocked-namespaces-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -196,9 +196,6 @@ search-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
   throughput = 5
 }
 
@@ -214,4 +211,5 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -203,11 +203,8 @@ search-dispatcher {
 }
 
 blocked-namespaces-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -217,8 +214,4 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -204,10 +205,17 @@ public final class ThingsUpdaterTest {
 
     private static void expectShardedMessage(final TestProbe probe, final Jsonifiable event,
             final Collection<String> ids) {
-        final ShardedMessageEnvelope envelope = probe.expectMsgClass(ShardedMessageEnvelope.class);
+        final Collection<String> receivedIds = new ArrayList<>(ids.size());
 
-        assertThat(envelope.getMessage()).isEqualTo(event.toJson());
-        assertThat(envelope.getId()).isIn(ids);
+        for (int i = 0; i < ids.size(); ++i) {
+            final ShardedMessageEnvelope envelope = probe.expectMsgClass(ShardedMessageEnvelope.class);
+            assertThat(envelope.getMessage()).isEqualTo(event.toJson());
+            assertThat(envelope.getId()).isIn(ids);
+
+            receivedIds.add(envelope.getId());
+        }
+
+        assertThat(receivedIds).containsAll(ids);
     }
 
     private ActorRef createThingsUpdater() {

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingsUpdaterTest.java
@@ -18,6 +18,7 @@ import static org.mockito.Mockito.when;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -121,7 +122,7 @@ public final class ThingsUpdaterTest {
             underTest.tell(event, getRef());
 
             waitUntil().getThingIdsForPolicy(KNOWN_POLICY_ID);
-            thingIds.forEach(thingId -> expectShardedMessage(shardMessageReceiver, event, thingId));
+            expectShardedMessage(shardMessageReceiver, event, thingIds);
         }};
     }
 
@@ -199,6 +200,14 @@ public final class ThingsUpdaterTest {
 
         assertThat(envelope.getMessage()).isEqualTo(event.toJson());
         assertThat(envelope.getId()).isEqualTo(id);
+    }
+
+    private static void expectShardedMessage(final TestProbe probe, final Jsonifiable event,
+            final Collection<String> ids) {
+        final ShardedMessageEnvelope envelope = probe.expectMsgClass(ShardedMessageEnvelope.class);
+
+        assertThat(envelope.getMessage()).isEqualTo(event.toJson());
+        assertThat(envelope.getId()).isIn(ids);
     }
 
     private ActorRef createThingsUpdater() {

--- a/services/thingsearch/updater-actors/src/test/resources/test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/test.conf
@@ -129,9 +129,6 @@ sharding-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
   throughput = 5 # default is 5
 }
 
@@ -147,6 +144,7 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 enforcer-dispatcher {
@@ -161,4 +159,5 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }

--- a/services/thingsearch/updater-actors/src/test/resources/test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/test.conf
@@ -134,3 +134,45 @@ sharding-dispatcher {
   # Set to 1 for as fair as possible.
   throughput = 5 # default is 5
 }
+
+blocked-namespaces-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}
+
+enforcer-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}

--- a/services/thingsearch/updater-actors/src/test/resources/test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/test.conf
@@ -146,18 +146,3 @@ blocked-namespaces-dispatcher {
   }
   throughput = 5
 }
-
-enforcer-dispatcher {
-  type = Dispatcher
-  executor = "fork-join-executor"
-  fork-join-executor {
-    # Min number of threads to cap factor-based parallelism number to
-    parallelism-min = 4
-    # Parallelism (threads) ... ceil(available processors * factor)
-    parallelism-factor = 3.0
-    # Max number of threads to cap factor-based parallelism number to
-    parallelism-max = 32
-    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
-  }
-  throughput = 5
-}

--- a/services/thingsearch/updater-actors/src/test/resources/test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/test.conf
@@ -136,11 +136,8 @@ sharding-dispatcher {
 }
 
 blocked-namespaces-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -150,18 +147,11 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 enforcer-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -171,8 +161,4 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }

--- a/services/utils/namespaces/src/main/java/org/eclipse/ditto/services/utils/namespaces/BlockedNamespaces.java
+++ b/services/utils/namespaces/src/main/java/org/eclipse/ditto/services/utils/namespaces/BlockedNamespaces.java
@@ -44,10 +44,12 @@ public final class BlockedNamespaces extends DistributedData<ORSet<String>> {
      */
     private static final Key<ORSet<String>> KEY = ORSetKey.create("BlockedNamespaces");
 
+    private static final String BLOCKED_NAMESPACES_DISPATCHER = "blocked-namespaces-dispatcher";
+
     private final Cluster node;
 
     private BlockedNamespaces(final DistributedDataConfigReader configReader, final ActorSystem system) {
-        super(configReader, system);
+        super(configReader, system, system.dispatchers().lookup(BLOCKED_NAMESPACES_DISPATCHER));
         node = Cluster.get(system);
     }
 

--- a/services/utils/namespaces/src/test/resources/test.conf
+++ b/services/utils/namespaces/src/test/resources/test.conf
@@ -11,11 +11,8 @@ akka {
 }
 
 blocked-namespaces-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -25,18 +22,11 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }
 
 enforcer-dispatcher {
-  # Dispatcher is the name of the event-based dispatcher
   type = Dispatcher
-  # What kind of ExecutionService to use
   executor = "fork-join-executor"
-  # Configuration for the fork join pool
   fork-join-executor {
     # Min number of threads to cap factor-based parallelism number to
     parallelism-min = 4
@@ -46,8 +36,4 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
-  # Throughput defines the maximum number of messages to be
-  # processed per actor before the thread jumps to the next actor.
-  # Set to 1 for as fair as possible.
-  throughput = 2
 }

--- a/services/utils/namespaces/src/test/resources/test.conf
+++ b/services/utils/namespaces/src/test/resources/test.conf
@@ -9,3 +9,45 @@ akka {
     bind.port = 0
   }
 }
+
+blocked-namespaces-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}
+
+enforcer-dispatcher {
+  # Dispatcher is the name of the event-based dispatcher
+  type = Dispatcher
+  # What kind of ExecutionService to use
+  executor = "fork-join-executor"
+  # Configuration for the fork join pool
+  fork-join-executor {
+    # Min number of threads to cap factor-based parallelism number to
+    parallelism-min = 4
+    # Parallelism (threads) ... ceil(available processors * factor)
+    parallelism-factor = 3.0
+    # Max number of threads to cap factor-based parallelism number to
+    parallelism-max = 32
+    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
+  }
+  # Throughput defines the maximum number of messages to be
+  # processed per actor before the thread jumps to the next actor.
+  # Set to 1 for as fair as possible.
+  throughput = 2
+}

--- a/services/utils/namespaces/src/test/resources/test.conf
+++ b/services/utils/namespaces/src/test/resources/test.conf
@@ -22,6 +22,7 @@ blocked-namespaces-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }
 
 enforcer-dispatcher {
@@ -36,4 +37,5 @@ enforcer-dispatcher {
     parallelism-max = 32
     parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
   }
+  throughput = 5
 }

--- a/services/utils/namespaces/src/test/resources/test.conf
+++ b/services/utils/namespaces/src/test/resources/test.conf
@@ -24,18 +24,3 @@ blocked-namespaces-dispatcher {
   }
   throughput = 5
 }
-
-enforcer-dispatcher {
-  type = Dispatcher
-  executor = "fork-join-executor"
-  fork-join-executor {
-    # Min number of threads to cap factor-based parallelism number to
-    parallelism-min = 4
-    # Parallelism (threads) ... ceil(available processors * factor)
-    parallelism-factor = 3.0
-    # Max number of threads to cap factor-based parallelism number to
-    parallelism-max = 32
-    parallelism-max = ${?DEFAULT_DISPATCHER_PARALLELISM_MAX}
-  }
-  throughput = 5
-}


### PR DESCRIPTION
Mainly in concierge-service a lot of "applyAsync" was done on CompletionStages without specifying a separate Executor.
This PR fixes that.