### PR TITLE
Enhanced json number api + performance improvements

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/AbstractJsonNumber.java
+++ b/json/src/main/java/org/eclipse/ditto/json/AbstractJsonNumber.java
@@ -47,7 +47,7 @@ abstract class AbstractJsonNumber<T extends Number> extends AbstractJsonValue im
         if (isInt()) {
             return value.intValue();
         }
-        return super.asInt();
+        throw new NumberFormatException("This JSON value is not an int: " + value);
     }
 
     @Override
@@ -60,7 +60,7 @@ abstract class AbstractJsonNumber<T extends Number> extends AbstractJsonValue im
         if (isLong()) {
             return value.longValue();
         }
-        return super.asLong();
+        throw new NumberFormatException("This JSON value is not a long: " + value);
     }
 
     @Override

--- a/json/src/main/java/org/eclipse/ditto/json/AbstractJsonValue.java
+++ b/json/src/main/java/org/eclipse/ditto/json/AbstractJsonValue.java
@@ -42,6 +42,21 @@ abstract class AbstractJsonValue implements JsonValue {
     }
 
     @Override
+    public boolean isInt() {
+        return false;
+    }
+
+    @Override
+    public boolean isLong() {
+        return false;
+    }
+
+    @Override
+    public boolean isDouble() {
+        return false;
+    }
+
+    @Override
     public boolean isString() {
         return false;
     }

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonArray.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonArray.java
@@ -285,7 +285,7 @@ final class ImmutableJsonArray extends AbstractJsonValue implements JsonArray {
         private List<JsonValue> values() {
             List<JsonValue> result = valuesReference.get();
             if (null == result) {
-                result = Collections.unmodifiableList(parseToList(jsonArrayStringRepresentation));
+                result = parseToList(jsonArrayStringRepresentation);
                 valuesReference = new SoftReference<>(result);
             }
             return result;
@@ -429,7 +429,7 @@ final class ImmutableJsonArray extends AbstractJsonValue implements JsonArray {
 
         @Override
         protected List<JsonValue> getValue() {
-            return Collections.unmodifiableList(value);
+            return value;
         }
 
     }

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonField.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonField.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -27,6 +28,7 @@ final class ImmutableJsonField implements JsonField {
     private final JsonKey key;
     private final JsonValue value;
     @Nullable private final JsonFieldDefinition definition;
+    @Nullable private String stringRepresentation;
 
     private ImmutableJsonField(final JsonKey theKey, final JsonValue theValue,
             @Nullable final JsonFieldDefinition theDefinition) {
@@ -34,6 +36,7 @@ final class ImmutableJsonField implements JsonField {
         key = requireNonNull(theKey, "The JSON key must not be null!");
         value = requireNonNull(theValue, "The JSON value must not be null!");
         definition = theDefinition;
+        stringRepresentation = null;
     }
 
     /**
@@ -44,7 +47,7 @@ final class ImmutableJsonField implements JsonField {
      * @return a new JSON field object.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static JsonField newInstance(final JsonKey key, final JsonValue value) {
+    public static ImmutableJsonField newInstance(final JsonKey key, final JsonValue value) {
         return newInstance(key, value, null);
     }
 
@@ -57,7 +60,7 @@ final class ImmutableJsonField implements JsonField {
      * @return a new JSON field object.
      * @throws NullPointerException if any argument but {@code definition} is {@code null}.
      */
-    public static JsonField newInstance(final JsonKey key, final JsonValue value,
+    public static ImmutableJsonField newInstance(final JsonKey key, final JsonValue value,
             @Nullable final JsonFieldDefinition definition) {
 
         return new ImmutableJsonField(key, value, definition);
@@ -108,22 +111,18 @@ final class ImmutableJsonField implements JsonField {
 
     @Override
     public String toString() {
-        final String valueAsString = value.toString();
-        final StringBuilder stringBuilder = new StringBuilder(key.length() + valueAsString.length() + 4);
-        escapeKeyName(stringBuilder);
-        stringBuilder.append(":");
-        stringBuilder.append(valueAsString);
-        return stringBuilder.toString();
+        // keep escaped string as escaping is expensive
+        String result = stringRepresentation;
+        if (null == result) {
+            result = getEscapedKeyName() + ":" + value;
+            stringRepresentation = result;
+        }
+        return result;
     }
 
-    private void escapeKeyName(final StringBuilder stringBuilder) {
-        stringBuilder.append("\"");
-        final String keyName = key.toString();
-        final JsonCharEscaper jsonStringEscaper = JsonCharEscaper.getInstance();
-        for (final char c : keyName.toCharArray()) {
-            stringBuilder.append(jsonStringEscaper.apply(c));
-        }
-        stringBuilder.append("\"");
+    private String getEscapedKeyName() {
+        final UnaryOperator<String> javaStringToEscapeJsonString = JavaStringToEscapedJsonString.getInstance();
+        return javaStringToEscapeJsonString.apply(key.toString());
     }
 
 }

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
@@ -15,6 +15,7 @@ import static java.util.Objects.requireNonNull;
 import java.lang.ref.SoftReference;
 import java.text.MessageFormat;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.Iterator;
@@ -73,16 +74,22 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
      * @throws NullPointerException if {@code fields} is {@code null}.
      */
     public static ImmutableJsonObject of(final Map<String, JsonField> fields) {
+        return of(fields, null);
+    }
+
+    /**
+     * Returns a new {@code ImmutableJsonObject} instance which contains the given fields.
+     *
+     * @param fields the fields of the new JSON object.
+     * @param stringRepresentation the already known string representation of the returned object or {@code null}.
+     * @return a new JSON object containing the {@code fields}.
+     * @throws NullPointerException if {@code fields} is {@code null}.
+     */
+    public static ImmutableJsonObject of(final Map<String, JsonField> fields,
+            @Nullable final String stringRepresentation) {
+
         requireNonNull(fields, "The fields of JSON object must not be null!");
-        return new ImmutableJsonObject(SoftReferencedFieldMap.of(fields));
-    }
-
-    private static void checkPointer(final JsonPointer pointer) {
-        requireNonNull(pointer, "The JSON pointer must not be null!");
-    }
-
-    private static void checkFieldDefinition(final JsonFieldDefinition fieldDefinition) {
-        requireNonNull(fieldDefinition, "The JSON field definition which supplies the pointer must not be null!");
+        return new ImmutableJsonObject(SoftReferencedFieldMap.of(fields, stringRepresentation));
     }
 
     @Override
@@ -253,6 +260,10 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         return getValueForPointer(fieldDefinition.getPointer()).map(fieldDefinition::mapValue);
     }
 
+    private static void checkFieldDefinition(final JsonFieldDefinition fieldDefinition) {
+        requireNonNull(fieldDefinition, "The JSON field definition which supplies the pointer must not be null!");
+    }
+
     @Override
     public <T> T getValueOrThrow(final JsonFieldDefinition<T> fieldDefinition) {
         return getValue(fieldDefinition).orElseThrow(() -> new JsonMissingFieldException(fieldDefinition));
@@ -303,6 +314,10 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         return result;
+    }
+
+    private static void checkPointer(final JsonPointer pointer) {
+        requireNonNull(pointer, "The JSON pointer must not be null!");
     }
 
     @Override
@@ -495,28 +510,44 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
     static final class SoftReferencedFieldMap {
 
         private final String jsonObjectStringRepresentation;
-        private final int hashCode;
+        private int hashCode;
         private SoftReference<Map<String, JsonField>> fieldsReference;
 
-        private SoftReferencedFieldMap(final Map<String, JsonField> jsonFieldMap) {
-            jsonObjectStringRepresentation = createStringRepresentation(jsonFieldMap);
+        private SoftReferencedFieldMap(final Map<String, JsonField> jsonFieldMap, final String stringRepresentation) {
+            jsonObjectStringRepresentation = stringRepresentation;
             fieldsReference = new SoftReference<>(Collections.unmodifiableMap(new LinkedHashMap<>(jsonFieldMap)));
-            hashCode = Objects.hash(jsonObjectStringRepresentation, jsonFieldMap);
-        }
-
-        private static String createStringRepresentation(final Map<String, JsonField> jsonFieldMap) {
-            return jsonFieldMap.values()
-                    .stream()
-                    .map(JsonField::toString)
-                    .collect(Collectors.joining(",", "{", "}"));
+            hashCode = 0;
         }
 
         static SoftReferencedFieldMap empty() {
-            return new SoftReferencedFieldMap(Collections.emptyMap());
+            return of(Collections.emptyMap(), "{}");
         }
 
         static SoftReferencedFieldMap of(final Map<String, JsonField> fieldMap) {
-            return new SoftReferencedFieldMap(fieldMap);
+            return of(fieldMap, null);
+        }
+
+        static SoftReferencedFieldMap of(final Map<String, JsonField> jsonFieldMap,
+                @Nullable final String stringRepresentation) {
+
+            if (null != stringRepresentation) {
+                return new SoftReferencedFieldMap(jsonFieldMap, stringRepresentation);
+            }
+            return new SoftReferencedFieldMap(jsonFieldMap, createStringRepresentation(jsonFieldMap));
+        }
+
+        private static String createStringRepresentation(final Map<String, JsonField> jsonFieldMap) {
+            final StringBuilder stringBuilder = new StringBuilder(512);
+            stringBuilder.append('{');
+            String delimiter = "";
+            for (final JsonField jsonField : jsonFieldMap.values()) {
+                stringBuilder.append(delimiter);
+                stringBuilder.append(jsonField);
+                delimiter = ",";
+            }
+            stringBuilder.append('}');
+
+            return stringBuilder.toString();
         }
 
         int getSize() {
@@ -539,7 +570,7 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         SoftReferencedFieldMap put(final String key, final JsonField value) {
             final Map<String, JsonField> fieldsCopy = copyFields();
             fieldsCopy.put(key, value);
-            return new SoftReferencedFieldMap(fieldsCopy);
+            return of(fieldsCopy);
         }
 
         private Map<String, JsonField> copyFields() {
@@ -549,13 +580,13 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         SoftReferencedFieldMap putAll(final Iterable<JsonField> jsonFields) {
             final Map<String, JsonField> fieldsCopy = copyFields();
             jsonFields.forEach(jsonField -> fieldsCopy.put(jsonField.getKeyName(), jsonField));
-            return new SoftReferencedFieldMap(fieldsCopy);
+            return of(fieldsCopy);
         }
 
         SoftReferencedFieldMap remove(final String key) {
             final Map<String, JsonField> fieldsCopy = copyFields();
             fieldsCopy.remove(key);
-            return new SoftReferencedFieldMap(fieldsCopy);
+            return of(fieldsCopy);
         }
 
         Stream<JsonField> getStream() {
@@ -600,7 +631,12 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
 
         @Override
         public int hashCode() {
-            return hashCode;
+            int result = hashCode;
+            if (0 == result) {
+                result = fields().hashCode();
+                hashCode = result;
+            }
+            return result;
         }
 
         String asJsonObjectString() {
@@ -620,11 +656,11 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
      */
     @NotThreadSafe
     static final class FieldMapJsonHandler
-            extends DittoJsonHandler<JsonArrayBuilder, Map<String, JsonField>, Map<String, JsonField>> {
+            extends DittoJsonHandler<List<JsonValue>, List<JsonField>, Map<String, JsonField>> {
 
         private final DefaultDittoJsonHandler defaultHandler;
         private Map<String, JsonField> value;
-        private final Deque<JsonObjectBuilder> jsonObjectBuilders; // for nested JsonObjects
+        private final Deque<List<JsonField>> jsonObjectBuilders; // for nested JsonObjects
         private int level;
 
         /**
@@ -638,16 +674,16 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         @Override
-        public JsonArrayBuilder startArray() {
+        public List<JsonValue> startArray() {
             return defaultHandler.startArray();
         }
 
         @Override
-        public Map<String, JsonField> startObject() {
+        public List<JsonField> startObject() {
             if (0 < level) {
                 jsonObjectBuilders.push(defaultHandler.startObject());
             }
-            final Map<String, JsonField> result = new LinkedHashMap<>();
+            final List<JsonField> result = new ArrayList<>();
             level++;
             return result;
         }
@@ -673,32 +709,36 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         @Override
-        public void endArray(final JsonArrayBuilder array) {
-            defaultHandler.endArray(array);
+        public void endArray(final List<JsonValue> jsonValues) {
+            defaultHandler.endArray(jsonValues);
         }
 
         @Override
-        public void endArrayValue(final JsonArrayBuilder arrayBuilder) {
-            defaultHandler.endArrayValue(arrayBuilder);
+        public void endArrayValue(final List<JsonValue> jsonValues) {
+            defaultHandler.endArrayValue(jsonValues);
         }
 
         @Override
-        public void endObjectValue(final Map<String, JsonField> fieldMap, final String name) {
-            final JsonObjectBuilder jsonObjectBuilder = jsonObjectBuilders.peek();
+        public void endObjectValue(final List<JsonField> jsonFields, final String name) {
+            final List<JsonField> jsonObjectBuilder = jsonObjectBuilders.peek();
             if (null != jsonObjectBuilder) {
                 defaultHandler.endObjectValue(jsonObjectBuilder, name);
             } else {
-                fieldMap.put(name, JsonField.newInstance(name, defaultHandler.getValue()));
+                jsonFields.add(JsonField.newInstance(name, defaultHandler.getValue()));
             }
         }
 
         @Override
-        public void endObject(final Map<String, JsonField> fieldMap) {
-            final JsonObjectBuilder jsonObjectBuilder = jsonObjectBuilders.poll();
+        public void endObject(final List<JsonField> jsonFields) {
+            final List<JsonField> jsonObjectBuilder = jsonObjectBuilders.poll();
             if (null != jsonObjectBuilder) {
                 defaultHandler.endObject(jsonObjectBuilder);
             } else {
-                value = new LinkedHashMap<>(fieldMap);
+                final Map<String, JsonField> linkedHashMap = new LinkedHashMap<>(jsonFields.size());
+                for (final JsonField jsonField : jsonFields) {
+                    linkedHashMap.put(jsonField.getKeyName(), jsonField);
+                }
+                value = linkedHashMap;
             }
             level--;
         }

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
@@ -705,7 +705,7 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
 
         @Override
         protected Map<String, JsonField> getValue() {
-            return Collections.unmodifiableMap(value);
+            return value;
         }
 
     }

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonString.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonString.java
@@ -68,7 +68,7 @@ final class ImmutableJsonString extends AbstractJsonValue {
 
     @Override
     public int hashCode() {
-        return Objects.hash(value);
+        return value.hashCode();
     }
 
     @Override
@@ -83,22 +83,8 @@ final class ImmutableJsonString extends AbstractJsonValue {
     }
 
     private String createStringRepresentation() {
-        final StringBuilder stringBuilder = new StringBuilder(value.length() + 4);
-        stringBuilder.append("\"");
-        escapeValue(stringBuilder);
-        stringBuilder.append("\"");
-        return stringBuilder.toString();
-    }
-
-    private void escapeValue(final StringBuilder stringBuilder) {
-        for (final char c : value.toCharArray()) {
-            stringBuilder.append(getReplacementOrKeep(c));
-        }
-    }
-
-    private static String getReplacementOrKeep(final char c) {
-        final JsonCharEscaper jsonStringEscaper = JsonCharEscaper.getInstance();
-        return jsonStringEscaper.apply(c);
+        final JavaStringToEscapedJsonString javaStringToEscapedJsonString = JavaStringToEscapedJsonString.getInstance();
+        return javaStringToEscapedJsonString.apply(value);
     }
 
 }

--- a/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JavaStringToEscapedJsonString.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.json;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * This class converts a Java String into an escaped JSON string.
+ * The JSON string is surrounded by {@code "} and escaped with the help of
+ * {@link org.eclipse.ditto.json.JsonCharEscaper}.
+ */
+@Immutable
+final class JavaStringToEscapedJsonString implements UnaryOperator<String> {
+
+    private static final JavaStringToEscapedJsonString INSTANCE =
+            new JavaStringToEscapedJsonString(JsonCharEscaper.getInstance());
+
+    private static final char QUOTE = '\"';
+
+    private final Function<Character, String> jsonCharEscaper;
+
+    private JavaStringToEscapedJsonString(final Function<Character, String> theJsonCharEscaper) {
+        jsonCharEscaper = theJsonCharEscaper;
+    }
+
+    /**
+     * Returns an instance of {@code JavaStringToEscapedJsonString}.
+     *
+     * @return the instance.
+     */
+    public static JavaStringToEscapedJsonString getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public String apply(final String javaString) {
+        requireNonNull(javaString, "The Java String to be converted must not be null");
+        final StringBuilder stringBuilder = new StringBuilder(javaString.length() + 2);
+        stringBuilder.append(QUOTE);
+        stringBuilder.append(javaString);
+        int i = 1; // offset of starting " char
+        for (final char c : javaString.toCharArray()) {
+            @Nullable final String replacement = jsonCharEscaper.apply(c);
+            if (null != replacement) {
+                stringBuilder.replace(i, i + 1, replacement);
+                i += replacement.length();
+            } else {
+                i++;
+            }
+        }
+        stringBuilder.append(QUOTE);
+        return stringBuilder.toString();
+    }
+
+}

--- a/json/src/main/java/org/eclipse/ditto/json/JsonCharEscaper.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonCharEscaper.java
@@ -10,10 +10,6 @@
  */
 package org.eclipse.ditto.json;
 
-import static java.util.Objects.requireNonNull;
-
-import java.util.HashMap;
-import java.util.Map;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
@@ -29,25 +25,22 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 final class JsonCharEscaper implements Function<Character, String> {
 
+    private static final JsonCharEscaper INSTANCE = new JsonCharEscaper();
+
     // All chars up to this char (inclusive) are control characters.
     private static final int LAST_CONTROL_CHARACTER = 0x001F;
 
-    @Nullable private static JsonCharEscaper instance = null;
-
-    // Known two-character sequence escape representations of some popular characters.
-    private final Map<Character, String> replacements;
+    private static final String QUOT_CHARS = new String(new char[]{'\\', '"'});
+    private static final String BACKSLASH_CHARS = new String(new char[]{'\\', '\\'});
+    private static final String LF_CHARS = new String(new char[]{'\\', 'n'});
+    private static final String CR_CHARS = new String(new char[]{'\\', 'r'});
+    private static final String BACKSPACE_CHARS = new String(new char[]{'\\', 'b'});
+    private static final String TAB_CHARS = new String(new char[]{'\\', 't'});
+    private static final String UNICODE_2028_CHARS = new String(new char[]{'\\', 'u', '2', '0', '2', '8'});
+    private static final String UNICODE_2029_CHARS = new String(new char[]{'\\', 'u', '2', '0', '2', '9'});
 
     private JsonCharEscaper() {
-        replacements = new HashMap<>();
-        replacements.put('"', "\\\"");
-        replacements.put('\\', "\\\\");
-        replacements.put('\b', "\\b");
-        replacements.put('\f', "\\f");
-        replacements.put('\n', "\\n");
-        replacements.put('\r', "\\r");
-        replacements.put('\t', "\\t");
-        replacements.put('\u2028', "\\u2028");
-        replacements.put('\u2029', "\\u2029");
+        super();
     }
 
     /**
@@ -56,23 +49,46 @@ final class JsonCharEscaper implements Function<Character, String> {
      * @return the instance.
      */
     public static JsonCharEscaper getInstance() {
-        JsonCharEscaper result = instance;
-        if (null == result) {
-            result = new JsonCharEscaper();
-            instance = result;
-        }
-        return result;
+        return INSTANCE;
     }
 
+    /**
+     * Escapes the given char if necessary.
+     *
+     * @param c the character to be escaped.
+     * @return the replacement for {@code c} or {@code null} if {@code c} does not have to be escaped.
+     */
+    @SuppressWarnings("OverlyComplexMethod")
+    @Nullable
     @Override
     public String apply(final Character c) {
-        final String replacement = replacements.get(requireNonNull(c));
-        if (null != replacement) {
-            return replacement;
+        @Nullable final String result;
+
+        if ('"' == c) {
+            result = QUOT_CHARS;
+        } else if ('\n' == c) {
+            result = LF_CHARS;
+        } else if ('\r' == c) {
+            result = CR_CHARS;
+        } else if ('\\' == c) {
+            result = BACKSLASH_CHARS;
+        } else if ('\b' == c) {
+            result = BACKSPACE_CHARS;
+        } else if ('\t' == c) {
+            result = TAB_CHARS;
+        } else if ('\f' == c) {
+            result = "\\f";
+        } else if ('\u2028' == c) {
+            result = UNICODE_2028_CHARS;
+        } else if ('\u2029' == c) {
+            result = UNICODE_2029_CHARS;
         } else if (isControlCharacter(c)) {
-            return "\\" + c;
+            result = new String(new char[]{'\\', c});
+        } else {
+            result = null;
         }
-        return String.valueOf(c);
+
+        return result;
     }
 
     private static boolean isControlCharacter(final char c) {

--- a/json/src/main/java/org/eclipse/ditto/json/JsonNumber.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonNumber.java
@@ -15,25 +15,4 @@ package org.eclipse.ditto.json;
  */
 public interface JsonNumber extends JsonValue {
 
-    /**
-     * Indicates whether this number is an integer.
-     *
-     * @return {@code true} if an only if this number is an integer.
-     */
-    boolean isInt();
-
-    /**
-     * Indicates whether this number is of type long.
-     *
-     * @return {@code true} if an only if this number is of type long.
-     */
-    boolean isLong();
-
-    /**
-     * Indicates whether this number is of type double.
-     *
-     * @return {@code true} if an only if this number is of type double.
-     */
-    boolean isDouble();
-
 }

--- a/json/src/main/java/org/eclipse/ditto/json/JsonValue.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonValue.java
@@ -126,6 +126,27 @@ public interface JsonValue {
     boolean isNumber();
 
     /**
+     * Indicates whether this value is an integer.
+     *
+     * @return {@code true} if an only if this value is an integer.
+     */
+    boolean isInt();
+
+    /**
+     * Indicates whether this value is of type long.
+     *
+     * @return {@code true} if an only if this value is of type long.
+     */
+    boolean isLong();
+
+    /**
+     * Indicates whether this value is of type double.
+     *
+     * @return {@code true} if an only if this value is of type double.
+     */
+    boolean isDouble();
+
+    /**
      * Indicates whether this value represents a JSON string.
      *
      * @return {@code true} if this value represents a JSON string, {@code false} else.

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonArrayTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonArrayTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.ditto.json;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.eclipse.ditto.json.JsonFactory.newValue;
 import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -124,6 +125,9 @@ public final class ImmutableJsonArrayTest {
         assertThat(underTest).isNotNumber();
         assertThat(underTest).isNotString();
         assertThat(underTest).isNotObject();
+        assertThat(underTest.isInt()).isFalse();
+        assertThat(underTest.isLong()).isFalse();
+        assertThat(underTest.isDouble()).isFalse();
     }
 
     @Test

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonBooleanTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonBooleanTest.java
@@ -73,6 +73,9 @@ public final class ImmutableJsonBooleanTest {
     @Test
     public void isNotNumber() {
         assertThat(underTest.isNumber()).isFalse();
+        assertThat(underTest.isInt()).isFalse();
+        assertThat(underTest.isLong()).isFalse();
+        assertThat(underTest.isDouble()).isFalse();
     }
 
     @Test

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonDoubleTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonDoubleTest.java
@@ -207,7 +207,7 @@ public final class ImmutableJsonDoubleTest {
         if (underTest.isInt()) {
             assertThat(underTest.asInt()).isEqualTo(Double.valueOf(doubleValue).intValue());
         } else {
-            assertThatExceptionOfType(UnsupportedOperationException.class)
+            assertThatExceptionOfType(NumberFormatException.class)
                     .isThrownBy(() -> underTest.asInt())
                     .withMessage("This JSON value is not an int: %s", underTest)
                     .withNoCause();
@@ -219,7 +219,7 @@ public final class ImmutableJsonDoubleTest {
         if (underTest.isLong()) {
             assertThat(underTest.asLong()).isEqualTo(Double.valueOf(doubleValue).longValue());
         } else {
-            assertThatExceptionOfType(UnsupportedOperationException.class)
+            assertThatExceptionOfType(NumberFormatException.class)
                     .isThrownBy(() -> underTest.asLong())
                     .withMessage("This JSON value is not a long: %s", underTest)
                     .withNoCause();

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonFieldTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonFieldTest.java
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
+import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
@@ -51,6 +52,7 @@ public final class ImmutableJsonFieldTest {
     public void assertImmutability() {
         assertInstancesOf(ImmutableJsonField.class,
                 areImmutable(),
+                assumingFields("stringRepresentation").areModifiedAsPartOfAnUnobservableCachingStrategy(),
                 provided(JsonKey.class, JsonValue.class, JsonField.class,
                         JsonFieldDefinition.class).areAlsoImmutable());
     }
@@ -59,7 +61,7 @@ public final class ImmutableJsonFieldTest {
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(ImmutableJsonField.class)
                 .usingGetClass()
-                .withIgnoredFields("definition")
+                .withIgnoredFields("definition", "stringRepresentation")
                 .verify();
     }
 

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonLongTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonLongTest.java
@@ -174,7 +174,7 @@ public final class ImmutableJsonLongTest {
         if (isLongValueWithinIntegerRange()) {
             assertThat(underTest.asInt()).isEqualTo(Long.valueOf(longValue).intValue());
         } else {
-            assertThatExceptionOfType(UnsupportedOperationException.class)
+            assertThatExceptionOfType(NumberFormatException.class)
                     .isThrownBy(() -> underTest.asInt())
                     .withMessage("This JSON value is not an int: %s", underTest)
                     .withNoCause();

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.ditto.json;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
@@ -152,6 +153,9 @@ public final class ImmutableJsonObjectTest {
         assertThat(underTest).isNotNumber();
         assertThat(underTest).isNotString();
         assertThat(underTest).isNotArray();
+        assertThat(underTest.isInt()).isFalse();
+        assertThat(underTest.isLong()).isFalse();
+        assertThat(underTest.isDouble()).isFalse();
     }
 
     @Test

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonStringTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonStringTest.java
@@ -63,6 +63,9 @@ public final class ImmutableJsonStringTest {
         assertThat(underTest).isNotNumber();
         assertThat(underTest).isNotArray();
         assertThat(underTest).isNotObject();
+        assertThat(underTest.isInt()).isFalse();
+        assertThat(underTest.isLong()).isFalse();
+        assertThat(underTest.isDouble()).isFalse();
         assertThat(underTest).doesNotSupport(JsonValue::asBoolean);
         assertThat(underTest).doesNotSupport(JsonValue::asInt);
         assertThat(underTest).doesNotSupport(JsonValue::asLong);

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonStringTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonStringTest.java
@@ -42,6 +42,7 @@ public final class ImmutableJsonStringTest {
                 .usingGetClass()
                 .withRedefinedSuperclass()
                 .withIgnoredFields("stringRepresentation")
+                .withNonnullFields("value")
                 .verify();
     }
 

--- a/json/src/test/java/org/eclipse/ditto/json/JavaStringToEscapedJsonStringTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/JavaStringToEscapedJsonStringTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.json;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.util.function.Function;
+
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link org.eclipse.ditto.json.JavaStringToEscapedJsonString}.
+ */
+public final class JavaStringToEscapedJsonStringTest {
+    
+    private JavaStringToEscapedJsonString underTest;
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(JavaStringToEscapedJsonString.class,
+                areImmutable(),
+                provided(Function.class).isAlsoImmutable());
+    }
+
+    @Before
+    public void setUp() {
+        underTest = JavaStringToEscapedJsonString.getInstance();
+    }
+
+    @Test
+    public void convertJavaStringWithoutSpecialChars() {
+        final String javaString = "Auf der Wiese blueht ein kleines Bluemelein.";
+        final String expected = "\"" + javaString + "\"";
+
+        final String actual = underTest.apply(javaString);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    public void convertJavaStringWithSpecialChars() {
+        final String javaString = "Auf der Wiese\n blueht ein kleines \"Blümelein\".";
+        final String expected = "\"" + "Auf der Wiese\\n blueht ein kleines \\\"Blümelein\\\"." + "\"";
+
+        final String actual = underTest.apply(javaString);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+}

--- a/json/src/test/java/org/eclipse/ditto/json/JsonCharEscaperTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/JsonCharEscaperTest.java
@@ -47,14 +47,14 @@ public final class JsonCharEscaperTest {
     public void doNotEscapeSpace() {
         final String unescapedSpace = underTest.apply((char) 0x0020);
 
-        assertThat(unescapedSpace).isEqualTo(" ");
+        assertThat(unescapedSpace).isNull();
     }
 
     @Test
     public void doNotEscapeExclamationMark() {
         final String unescapedExclamationMark = underTest.apply((char) 0x0021);
 
-        assertThat(unescapedExclamationMark).isEqualTo("!");
+        assertThat(unescapedExclamationMark).isNull();
     }
 
     @Test
@@ -65,9 +65,8 @@ public final class JsonCharEscaperTest {
         IntStream.range(start, end)
                 .mapToObj(i -> (char) i)
                 .forEach(character -> {
-                    final String expected = String.valueOf(character);
                     final String notEscaped = underTest.apply(character);
-                    assertThat(notEscaped).isEqualTo(expected);
+                    assertThat(notEscaped).isNull();
                 });
     }
 
@@ -80,11 +79,10 @@ public final class JsonCharEscaperTest {
                 .filter(i -> '\u2028' != i && '\u2029' != i)
                 .mapToObj(i -> (char) i)
                 .forEach(character -> {
-                    final String expected = String.valueOf(character);
                     final String notEscaped = underTest.apply(character);
                     assertThat(notEscaped)
                             .describedAs("Do not escape character %s", Integer.toHexString(character))
-                            .isEqualTo(expected);
+                            .isNull();
                 });
     }
 
@@ -128,12 +126,6 @@ public final class JsonCharEscaperTest {
         final String escapedTab = underTest.apply('\t');
 
         assertThat(escapedTab).isEqualTo("\\t");
-    }
-
-    @Test
-    public void escapeCancel() {
-        final String escapedCancel = underTest.apply((char) 24);
-        System.out.println(escapedCancel);
     }
 
     @Test

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/things/ThingPredicatePredicateVisitor.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/things/ThingPredicatePredicateVisitor.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 import org.eclipse.ditto.model.things.Thing;
@@ -187,11 +186,10 @@ public final class ThingPredicatePredicateVisitor implements PredicateVisitor<Fu
         } else if (jsonValue.isNull()) {
             result = null;
         } else if (jsonValue.isNumber()) {
-            final JsonNumber jsonNumber = (JsonNumber) jsonValue;
-            if (jsonNumber.isInt() || jsonNumber.isLong()) {
-                result = jsonNumber.asLong();
+            if (jsonValue.isLong()) {
+                result = jsonValue.asLong();
             } else {
-                result = jsonNumber.asDouble();
+                result = jsonValue.asDouble();
             }
         } else if (jsonValue.isArray()) {
             result = null; // filtering arrays is not supported

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableAttributes.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableAttributes.java
@@ -84,6 +84,21 @@ final class ImmutableAttributes implements Attributes {
     }
 
     @Override
+    public boolean isInt() {
+        return wrapped.isInt();
+    }
+
+    @Override
+    public boolean isLong() {
+        return wrapped.isLong();
+    }
+
+    @Override
+    public boolean isDouble() {
+        return wrapped.isDouble();
+    }
+
+    @Override
     public boolean isString() {
         return wrapped.isString();
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableFeatureProperties.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableFeatureProperties.java
@@ -83,6 +83,21 @@ final class ImmutableFeatureProperties implements FeatureProperties {
     }
 
     @Override
+    public boolean isInt() {
+        return wrapped.isInt();
+    }
+
+    @Override
+    public boolean isLong() {
+        return wrapped.isLong();
+    }
+
+    @Override
+    public boolean isDouble() {
+        return wrapped.isDouble();
+    }
+
+    @Override
     public boolean isString() {
         return wrapped.isString();
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/NullAttributes.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/NullAttributes.java
@@ -67,6 +67,21 @@ final class NullAttributes implements Attributes {
     }
 
     @Override
+    public boolean isInt() {
+        return false;
+    }
+
+    @Override
+    public boolean isLong() {
+        return false;
+    }
+
+    @Override
+    public boolean isDouble() {
+        return false;
+    }
+
+    @Override
     public boolean isString() {
         return false;
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/NullFeatureProperties.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/NullFeatureProperties.java
@@ -65,6 +65,21 @@ final class NullFeatureProperties implements FeatureProperties {
     }
 
     @Override
+    public boolean isInt() {
+        return false;
+    }
+
+    @Override
+    public boolean isLong() {
+        return false;
+    }
+
+    @Override
+    public boolean isDouble() {
+        return false;
+    }
+
+    @Override
     public boolean isString() {
         return false;
     }

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/AttributesDocumentBuilder.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/AttributesDocumentBuilder.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bson.Document;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.things.Attributes;
 import org.eclipse.ditto.services.thingsearch.common.util.KeyEscapeUtil;
@@ -142,11 +141,10 @@ final class AttributesDocumentBuilder {
     }
 
     private void addNumberAttribute(final String path, final JsonValue jsonValue) {
-        final JsonNumber jsonNumber = (JsonNumber) jsonValue;
-        if (jsonNumber.isLong()) {
-            attributeInternally(path, jsonNumber.asLong());
+        if (jsonValue.isLong()) {
+            attributeInternally(path, jsonValue.asLong());
         } else {
-            attributeInternally(path, jsonNumber.asDouble());
+            attributeInternally(path, jsonValue.asDouble());
         }
     }
 

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/FeaturesDocumentBuilder.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/FeaturesDocumentBuilder.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.bson.Document;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.things.Features;
 import org.eclipse.ditto.services.thingsearch.common.util.KeyEscapeUtil;
@@ -114,11 +113,10 @@ final class FeaturesDocumentBuilder {
     }
 
     private void addNumberFeature(final String path, final JsonValue jsonValue, final String featureId) {
-        final JsonNumber jsonNumber = (JsonNumber) jsonValue;
-        if (jsonNumber.isLong()) {
-            featureInternally(path, jsonNumber.asLong(), featureId);
+        if (jsonValue.isLong()) {
+            featureInternally(path, jsonValue.asLong(), featureId);
         } else {
-            featureInternally(path, jsonNumber.asDouble(), featureId);
+            featureInternally(path, jsonValue.asDouble(), featureId);
         }
     }
 

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/ThingDocumentMapper.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/mapping/ThingDocumentMapper.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 import org.bson.Document;
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.services.thingsearch.common.util.KeyEscapeUtil;
@@ -107,13 +106,12 @@ public final class ThingDocumentMapper {
     private static Object handleNumberAttribute(final JsonValue jsonValue) {
         final Number result;
 
-        final JsonNumber jsonNumber = (JsonNumber) jsonValue;
-        if (jsonNumber.isInt()) {
-            result = jsonNumber.asInt();
-        } else if (jsonNumber.isLong()) {
-            result = jsonNumber.asLong();
+        if (jsonValue.isInt()) {
+            result = jsonValue.asInt();
+        } else if (jsonValue.isLong()) {
+            result = jsonValue.asLong();
         } else {
-            result = jsonNumber.asDouble();
+            result = jsonValue.asDouble();
         }
 
         return result;

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/AttributesUpdateFactory.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/AttributesUpdateFactory.java
@@ -18,7 +18,6 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonKey;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -173,9 +172,8 @@ final class AttributesUpdateFactory {
         } else if (value.isBoolean()) {
             flatAttributes.add(createFlatSubDocument(path, value.asBoolean()));
         } else if (value.isNumber()) {
-            final JsonNumber jsonNumber = (JsonNumber) value;
-            if (jsonNumber.isInt() || jsonNumber.isLong()) {
-                flatAttributes.add(createFlatSubDocument(path, jsonNumber.asLong()));
+            if (value.isLong()) {
+                flatAttributes.add(createFlatSubDocument(path, value.asLong()));
             } else {
                 flatAttributes.add(createFlatSubDocument(path, value.asDouble()));
             }

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/FeaturesUpdateFactory.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/impl/FeaturesUpdateFactory.java
@@ -19,7 +19,6 @@ import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
@@ -328,11 +327,10 @@ final class FeaturesUpdateFactory {
         } else if (value.isBoolean()) {
             flatFeatures.add(createFlatSubDocument(path, featureId, value.asBoolean()));
         } else if (value.isNumber()) {
-            final JsonNumber jsonNumber = (JsonNumber) value;
-            if (jsonNumber.isLong()) {
-                flatFeatures.add(createFlatSubDocument(path, featureId, jsonNumber.asLong()));
+            if (value.isLong()) {
+                flatFeatures.add(createFlatSubDocument(path, featureId, value.asLong()));
             } else {
-                flatFeatures.add(createFlatSubDocument(path, featureId, jsonNumber.asDouble()));
+                flatFeatures.add(createFlatSubDocument(path, featureId, value.asDouble()));
             }
         } else if (value.isNull()) {
             flatFeatures.add(createFlatSubDocument(path, featureId, null));

--- a/services/utils/jwt/src/main/java/org/eclipse/ditto/services/utils/jwt/JjwtDeserializer.java
+++ b/services/utils/jwt/src/main/java/org/eclipse/ditto/services/utils/jwt/JjwtDeserializer.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.common.ConditionChecker;
@@ -92,13 +91,12 @@ public final class JjwtDeserializer implements Deserializer {
         } else if (jsonValue.isBoolean()) {
             result = jsonValue.asBoolean();
         } else if (jsonValue.isNumber()) {
-            final JsonNumber jsonNumber = (JsonNumber) jsonValue;
-            if (jsonNumber.isInt()) {
-                result = jsonNumber.asInt();
-            } else if (jsonNumber.isLong()) {
-                result = jsonNumber.asLong();
+            if (jsonValue.isInt()) {
+                result = jsonValue.asInt();
+            } else if (jsonValue.isLong()) {
+                result = jsonValue.asLong();
             } else {
-                result = jsonNumber.asDouble();
+                result = jsonValue.asDouble();
             }
         } else if (jsonValue.isObject()) {
             result = toJavaMap(jsonValue.asObject());

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/JsonValueToDbEntityMapper.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/JsonValueToDbEntityMapper.java
@@ -19,7 +19,6 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonKey;
-import org.eclipse.ditto.json.JsonNumber;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.utils.jsr305.annotations.AllParametersAndReturnValuesAreNonnullByDefault;
@@ -137,13 +136,12 @@ final class JsonValueToDbEntityMapper {
     private static Number mapJsonNumberToJavaNumber(final JsonValue jsonNumberValue) {
         final Number result;
 
-        final JsonNumber jsonNumber = (JsonNumber) jsonNumberValue;
-        if (jsonNumber.isInt()) {
-            result = jsonNumber.asInt();
-        } else if (jsonNumber.isLong()) {
-            result = jsonNumber.asLong();
+        if (jsonNumberValue.isInt()) {
+            result = jsonNumberValue.asInt();
+        } else if (jsonNumberValue.isLong()) {
+            result = jsonNumberValue.asLong();
         } else {
-            result = jsonNumber.asDouble();
+            result = jsonNumberValue.asDouble();
         }
 
         return result;


### PR DESCRIPTION
This PR with commits from @jufickel-b 
* enhances the number API of ditto-json by adding methods like `isInt` on `JsonValue` level
* improves the parsing and JSON string building performance of ditto-json a lot by doing clever pre-calculations of JSON strings during parsing