### PR TITLE
split /status route into /overall and /status route.

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRoute.java
@@ -24,10 +24,7 @@ import java.util.function.Supplier;
 
 import org.eclipse.ditto.services.gateway.health.StatusAndHealthProvider;
 import org.eclipse.ditto.services.utils.health.cluster.ClusterStatus;
-import org.eclipse.ditto.services.utils.health.routes.StatusRoute;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpResponse;
 import akka.http.javadsl.model.StatusCodes;
@@ -41,31 +38,26 @@ public final class OverallStatusRoute {
     /**
      * Public endpoint of overall status.
      */
-    public static final String PATH_STATUS = "status";
+    public static final String PATH_OVERALL = "overall";
 
+    static final String PATH_STATUS = "status";
     static final String PATH_HEALTH = "health";
     static final String PATH_CLUSTER = "cluster";
-    static final String PATH_OWN = "own";
+
 
     private final Supplier<ClusterStatus> clusterStateSupplier;
     private final StatusAndHealthProvider statusHealthProvider;
 
-    private final StatusRoute ownStatusRoute;
-
     /**
      * Constructs the {@code /status} route builder.
      *
-     * @param actorSystem the Actor System.
      * @param clusterStateSupplier the supplier to get the cluster state.
-     * @param healthCheckingActor the actor for checking the gateways own health.
      * @param statusHealthProvider the provider for retrieving health status of the cluster.
      */
-    public OverallStatusRoute(final ActorSystem actorSystem, final Supplier<ClusterStatus> clusterStateSupplier,
-            final ActorRef healthCheckingActor, final StatusAndHealthProvider statusHealthProvider) {
+    public OverallStatusRoute(final Supplier<ClusterStatus> clusterStateSupplier,
+            final StatusAndHealthProvider statusHealthProvider) {
         this.clusterStateSupplier = clusterStateSupplier;
         this.statusHealthProvider = statusHealthProvider;
-
-        ownStatusRoute = new StatusRoute(clusterStateSupplier, healthCheckingActor, actorSystem);
     }
 
     /**
@@ -73,14 +65,13 @@ public final class OverallStatusRoute {
      *
      * @return the {@code /status} route.
      */
-    public Route buildStatusRoute() {
-        return rawPathPrefix(mergeDoubleSlashes().concat(PATH_STATUS), () -> // /status/*
+    public Route buildOverallStatusRoute() {
+        return rawPathPrefix(mergeDoubleSlashes().concat(PATH_OVERALL), () -> // /overall/*
                 get(() -> // GET
-                        route(
-                                // /status/own/status
-                                // /status/own/status/health
-                                // /status/own/status/cluster
-                                rawPathPrefix(mergeDoubleSlashes().concat(PATH_OWN), ownStatusRoute::buildStatusRoute),
+                        // /overall/status
+                        // /overall/status/health
+                        // /overall/status/cluster
+                        rawPathPrefix(mergeDoubleSlashes().concat(PATH_STATUS), () ->
                                 route(
                                         // /status
                                         pathEndOrSingleSlash(
@@ -93,10 +84,9 @@ public final class OverallStatusRoute {
                                                         .withEntity(ContentTypes.APPLICATION_JSON,
                                                                 clusterStateSupplier.get().toJson().toString()))
                                         )
-                                )
-                        )
-                )
-        );
+                                ))
+
+                ));
     }
 
     private CompletionStage<HttpResponse> createOverallStatusResponse() {

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRoute.java
@@ -18,6 +18,8 @@ import static akka.http.javadsl.server.Directives.pathEndOrSingleSlash;
 import static akka.http.javadsl.server.Directives.rawPathPrefix;
 import static akka.http.javadsl.server.Directives.route;
 import static org.eclipse.ditto.services.gateway.endpoints.directives.CustomPathMatchers.mergeDoubleSlashes;
+import static org.eclipse.ditto.services.gateway.endpoints.directives.DevopsBasicAuthenticationDirective.REALM_DEVOPS;
+import static org.eclipse.ditto.services.gateway.endpoints.directives.DevopsBasicAuthenticationDirective.authenticateDevopsBasic;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -67,7 +69,7 @@ public final class OverallStatusRoute {
      */
     public Route buildOverallStatusRoute() {
         return rawPathPrefix(mergeDoubleSlashes().concat(PATH_OVERALL), () -> // /overall/*
-                get(() -> // GET
+                authenticateDevopsBasic(REALM_DEVOPS, get(() -> // GET
                         // /overall/status
                         // /overall/status/health
                         // /overall/status/cluster
@@ -86,7 +88,7 @@ public final class OverallStatusRoute {
                                         )
                                 ))
 
-                ));
+                )));
     }
 
     private CompletionStage<HttpResponse> createOverallStatusResponse() {

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -52,7 +52,7 @@ public final class RootRouteTest extends EndpointTestBase {
             ROOT_PATH + OverallStatusRoute.PATH_OVERALL + "/" + STATUS_SUB_PATH;
     private static final String HEALTH_PATH = ROOT_PATH + CachingHealthRoute.PATH_HEALTH;
     private static final String STATUS_CLUSTER_PATH = ROOT_PATH + STATUS_SUB_PATH + "/" + CLUSTER_SUB_PATH;
-    private static final String STATUS_HEALTH_PATH = ROOT_PATH + "/" + STATUS_SUB_PATH + "/" + HEALTH_SUB_PATH;
+    private static final String STATUS_HEALTH_PATH = ROOT_PATH + STATUS_SUB_PATH + "/" + HEALTH_SUB_PATH;
     private static final String THINGS_1_PATH = ROOT_PATH + RootRoute.HTTP_PATH_API_PREFIX + "/" +
             JsonSchemaVersion.V_1.toInt() + "/" + ThingsRoute.PATH_THINGS;
     private static final String THINGS_2_PATH = ROOT_PATH + RootRoute.HTTP_PATH_API_PREFIX + "/" +
@@ -116,6 +116,38 @@ public final class RootRouteTest extends EndpointTestBase {
     @Test
     public void getStatusUrlWithoutHttps() {
         final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(OVERALL_STATUS_PATH));
+        result.assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void getStatusHealth() {
+        // If the endpoint /status/health should be secured do it via webserver for example
+        final TestRouteResult result =
+                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_HEALTH_PATH)));
+        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
+    }
+
+    @Test
+    public void getStatusHealthWithoutHttps() {
+        final TestRouteResult result =
+                rootTestRoute.run(HttpRequest.GET(STATUS_HEALTH_PATH));
+        result.assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void getStatusCluster() {
+
+        // If the endpoint /status/cluster should be secured do it via webserver for example
+        final TestRouteResult result =
+                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_CLUSTER_PATH)));
+        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
+    }
+
+    @Test
+    public void getStatusClusterWithoutHttps() {
+
+        final TestRouteResult result =
+                rootTestRoute.run(HttpRequest.GET(STATUS_CLUSTER_PATH));
         result.assertStatusCode(StatusCodes.NOT_FOUND);
     }
 
@@ -217,22 +249,6 @@ public final class RootRouteTest extends EndpointTestBase {
     public void getWithInvalidEncoding() {
         final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(PATH_WITH_INVALID_ENCODING));
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
-    }
-
-    @Test
-    public void getStatusHealth() {
-        // we don't need credentials here, because nginx denies all requests to /status/health
-        final TestRouteResult result =
-                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_HEALTH_PATH)));
-        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
-    }
-
-    @Test
-    public void getStatusCluster() {
-        // we don't need credentials here, because nginx denies all requests to /status/health
-        final TestRouteResult result =
-                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_CLUSTER_PATH)));
-        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     protected HttpRequest withHttps(final HttpRequest httpRequest) {

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -45,8 +45,14 @@ import akka.http.javadsl.testkit.TestRouteResult;
 public final class RootRouteTest extends EndpointTestBase {
 
     private static final String ROOT_PATH = "/";
-    private static final String STATUS_PATH = ROOT_PATH + OverallStatusRoute.PATH_STATUS;
+    private static final String STATUS_SUB_PATH = "status";
+    private static final String HEALTH_SUB_PATH = "health";
+    private static final String CLUSTER_SUB_PATH = "cluster";
+    private static final String OVERALL_STATUS_PATH =
+            ROOT_PATH + OverallStatusRoute.PATH_OVERALL + "/" + STATUS_SUB_PATH;
     private static final String HEALTH_PATH = ROOT_PATH + CachingHealthRoute.PATH_HEALTH;
+    private static final String STATUS_CLUSTER_PATH = ROOT_PATH + STATUS_SUB_PATH + "/" + CLUSTER_SUB_PATH;
+    private static final String STATUS_HEALTH_PATH = ROOT_PATH + "/" + STATUS_SUB_PATH + "/" + HEALTH_SUB_PATH;
     private static final String THINGS_1_PATH = ROOT_PATH + RootRoute.HTTP_PATH_API_PREFIX + "/" +
             JsonSchemaVersion.V_1.toInt() + "/" + ThingsRoute.PATH_THINGS;
     private static final String THINGS_2_PATH = ROOT_PATH + RootRoute.HTTP_PATH_API_PREFIX + "/" +
@@ -60,7 +66,8 @@ public final class RootRouteTest extends EndpointTestBase {
     private static final String WS_2_PATH = ROOT_PATH + RootRoute.WS_PATH_PREFIX + "/" + JsonSchemaVersion.V_2.toInt();
 
     private static final String PATH_WITH_INVALID_ENCODING = ROOT_PATH + RootRoute.HTTP_PATH_API_PREFIX + "/" +
-            JsonSchemaVersion.V_1.toInt() + "/" + ThingsRoute.PATH_THINGS + "/:bumlux/features?fields=feature-1%2properties";
+            JsonSchemaVersion.V_1.toInt() + "/" + ThingsRoute.PATH_THINGS +
+            "/:bumlux/features?fields=feature-1%2properties";
 
     private static final String HTTPS = "https";
 
@@ -96,19 +103,19 @@ public final class RootRouteTest extends EndpointTestBase {
     @Test
     public void getStatusWithAuth() {
         final TestRouteResult result =
-                rootTestRoute.run(withHttps(withDevopsCredentials(HttpRequest.GET(STATUS_PATH))));
+                rootTestRoute.run(withHttps(withDevopsCredentials(HttpRequest.GET(OVERALL_STATUS_PATH))));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
     public void getStatusWithoutAuth() {
-        final TestRouteResult result = rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_PATH)));
+        final TestRouteResult result = rootTestRoute.run(withHttps(HttpRequest.GET(OVERALL_STATUS_PATH)));
         result.assertStatusCode(StatusCodes.UNAUTHORIZED);
     }
 
     @Test
     public void getStatusUrlWithoutHttps() {
-        final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(STATUS_PATH));
+        final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(OVERALL_STATUS_PATH));
         result.assertStatusCode(StatusCodes.NOT_FOUND);
     }
 
@@ -168,7 +175,6 @@ public final class RootRouteTest extends EndpointTestBase {
                 withHttps(withDummyAuthentication(HttpRequest.GET(THING_SEARCH_2_PATH)));
 
         final TestRouteResult result = rootTestRoute.run(request);
-
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
@@ -178,7 +184,6 @@ public final class RootRouteTest extends EndpointTestBase {
                 withHttps(withDummyAuthentication(HttpRequest.GET(UNKNOWN_SEARCH_PATH)));
 
         final TestRouteResult result = rootTestRoute.run(request);
-
         result.assertStatusCode(StatusCodes.NOT_FOUND);
     }
 
@@ -212,6 +217,22 @@ public final class RootRouteTest extends EndpointTestBase {
     public void getWithInvalidEncoding() {
         final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(PATH_WITH_INVALID_ENCODING));
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
+    }
+
+    @Test
+    public void getStatusHealth() {
+        // we don't need credentials here, because nginx denies all requests to /status/health
+        final TestRouteResult result =
+                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_HEALTH_PATH)));
+        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
+    }
+
+    @Test
+    public void getStatusCluster() {
+        // we don't need credentials here, because nginx denies all requests to /status/health
+        final TestRouteResult result =
+                rootTestRoute.run(withHttps(HttpRequest.GET(STATUS_CLUSTER_PATH)));
+        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     protected HttpRequest withHttps(final HttpRequest httpRequest) {

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRouteTest.java
@@ -53,33 +53,40 @@ public class OverallStatusRouteTest extends EndpointTestBase {
 
     @Test
     public void getOverallStatusWithAuth() {
-        // we need credentials here, because nginx allows all requests to /overall/*
-        final TestRouteResult result =
-                statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(OVERALL_STATUS_PATH)));
-        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
-    }
-
-    @Test
-    public void getStatusOwnStatusWithAuth() {
-        // we need credentials here, because nginx allows all requests to /overall/*
         final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(OVERALL_STATUS_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
-    public void getStatusOwnStatusHealthWithAuth() {
-        // we need credentials here, because nginx allows all requests to /overall/*
+    public void getOverallStatusWithoutAuth() {
+        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(OVERALL_STATUS_PATH));
+        result.assertStatusCode(StatusCodes.UNAUTHORIZED);
+    }
+
+    @Test
+    public void getOverallStatusHealthWithAuth() {
         final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(
                 OVERALL_STATUS_HEALTH_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
-    public void getStatusOwnStatusClusterWithAuth() {
-        // we need credentials here, because nginx allows all requests to /overall/*
+    public void getOverallStatusHealthWithoutAuth() {
+        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(OVERALL_STATUS_HEALTH_PATH));
+        result.assertStatusCode(StatusCodes.UNAUTHORIZED);
+    }
+
+    @Test
+    public void getOverallStatusClusterWithAuth() {
         final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(
                 OVERALL_STATUS_CLUSTER_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
+    }
+
+    @Test
+    public void getOverallStatusClusterWithoutAuth() {
+        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(OVERALL_STATUS_CLUSTER_PATH));
+        result.assertStatusCode(StatusCodes.UNAUTHORIZED);
     }
 
     @Test

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/status/OverallStatusRouteTest.java
@@ -22,7 +22,6 @@ import org.eclipse.ditto.services.utils.health.cluster.ClusterStatus;
 import org.junit.Before;
 import org.junit.Test;
 
-import akka.actor.ActorRef;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.StatusCodes;
 import akka.http.javadsl.testkit.TestRoute;
@@ -33,67 +32,53 @@ import akka.http.javadsl.testkit.TestRouteResult;
  */
 public class OverallStatusRouteTest extends EndpointTestBase {
 
-    private static final String STATUS_PATH = "/" + OverallStatusRoute.PATH_STATUS;
-    private static final String STATUS_OWN_PATH = STATUS_PATH + "/" + OverallStatusRoute.PATH_OWN;
-    private static final String STATUS_OWN_STATUS_PATH = STATUS_OWN_PATH + STATUS_PATH;
-    private static final String STATUS_OWN_STATUS_HEALTH_PATH =
-            STATUS_OWN_STATUS_PATH + "/" + OverallStatusRoute.PATH_HEALTH;
-    private static final String STATUS_OWN_STATUS_CLUSTER_PATH =
-            STATUS_OWN_STATUS_PATH + "/" + OverallStatusRoute.PATH_CLUSTER;
-    private static final String STATUS_HEALTH_PATH = STATUS_PATH + "/" + OverallStatusRoute.PATH_HEALTH;
-    private static final String STATUS_CLUSTER_PATH = STATUS_PATH + "/" + OverallStatusRoute.PATH_CLUSTER;
+    private static final String OVERALL_PATH = "/" + OverallStatusRoute.PATH_OVERALL;
+    private static final String OVERALL_STATUS_PATH = OVERALL_PATH + "/" + OverallStatusRoute.PATH_STATUS;
+    private static final String OVERALL_STATUS_HEALTH_PATH =
+            OVERALL_STATUS_PATH + "/" + OverallStatusRoute.PATH_HEALTH;
+    private static final String OVERALL_STATUS_CLUSTER_PATH =
+            OVERALL_STATUS_PATH + "/" + OverallStatusRoute.PATH_CLUSTER;
 
     private TestRoute statusTestRoute;
 
     @Before
     public void setUp() {
-        final ActorRef healthCheckingActor = createHealthCheckingActorMock();
         final Supplier<ClusterStatus> clusterStateSupplier = createClusterStatusSupplierMock();
-        final StatusAndHealthProvider statusHealthProvider = DittoStatusAndHealthProviderFactory.of(system(), clusterStateSupplier);
+        final StatusAndHealthProvider statusHealthProvider =
+                DittoStatusAndHealthProviderFactory.of(system(), clusterStateSupplier);
         final OverallStatusRoute statusRoute =
-                new OverallStatusRoute(system(), clusterStateSupplier, healthCheckingActor, statusHealthProvider);
-        statusTestRoute = testRoute(statusRoute.buildStatusRoute());
+                new OverallStatusRoute(clusterStateSupplier, statusHealthProvider);
+        statusTestRoute = testRoute(statusRoute.buildOverallStatusRoute());
     }
 
     @Test
-    public void getStatusWithAuth() {
+    public void getOverallStatusWithAuth() {
+        // we need credentials here, because nginx allows all requests to /overall/*
         final TestRouteResult result =
-                statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(STATUS_PATH)));
+                statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(OVERALL_STATUS_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
-    public void getStatusOwnStatus() {
-        // we don't need credentials here, because nginx denies all requests to /status/own*
-        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(STATUS_OWN_STATUS_PATH));
+    public void getStatusOwnStatusWithAuth() {
+        // we need credentials here, because nginx allows all requests to /overall/*
+        final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(OVERALL_STATUS_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
-    public void getStatusOwnStatusHealth() {
-        // we don't need credentials here, because nginx denies all requests to /status/own*
-        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(STATUS_OWN_STATUS_HEALTH_PATH));
+    public void getStatusOwnStatusHealthWithAuth() {
+        // we need credentials here, because nginx allows all requests to /overall/*
+        final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(
+                OVERALL_STATUS_HEALTH_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 
     @Test
-    public void getStatusOwnStatusCluster() {
-        // we don't need credentials here, because nginx denies all requests to /status/own*
-        final TestRouteResult result = statusTestRoute.run(HttpRequest.GET(STATUS_OWN_STATUS_CLUSTER_PATH));
-        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
-    }
-
-    @Test
-    public void getStatusHealthWithAuth() {
-        final TestRouteResult result =
-                statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(STATUS_HEALTH_PATH)));
-        result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
-    }
-
-    @Test
-    public void getStatusClusterWithAuth() {
-        final TestRouteResult result =
-                statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(STATUS_CLUSTER_PATH)));
+    public void getStatusOwnStatusClusterWithAuth() {
+        // we need credentials here, because nginx allows all requests to /overall/*
+        final TestRouteResult result = statusTestRoute.run(withDevopsCredentials(HttpRequest.GET(
+                OVERALL_STATUS_CLUSTER_PATH)));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
     }
 

--- a/services/gateway/endpoints/src/test/resources/test.conf
+++ b/services/gateway/endpoints/src/test/resources/test.conf
@@ -174,7 +174,7 @@ ditto {
     enablecors = false
 
     redirect-to-https = true
-    redirect-to-https-blacklist-pattern = "/cr.*|/api.*|/ws.*|/status.*"
+    redirect-to-https-blacklist-pattern = "/cr.*|/api.*|/ws.*|/status.*|/overall.*"
 
     cache {
       publickeys {

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -126,7 +126,7 @@ ditto {
 
     redirect-to-https = false
     redirect-to-https = ${?REDIRECT_TO_HTTPS}
-    redirect-to-https-blacklist-pattern = "/api.*|/ws.*|/status.*"
+    redirect-to-https-blacklist-pattern = "/cr.*|/api.*|/ws.*|/status.*|/overall.*"
 
     cache {
       publickeys {


### PR DESCRIPTION
Add unsecured /status/health route to gateway service in order to use it for Kubernetes livenessProbe.

