### PR TITLE
Add configuration for measuring integration test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,10 @@
         <release.scm.developerConnection>scm:git:https://github.com/eclipse/ditto.git</release.scm.developerConnection>
         <release.scm.url>https://github.com/eclipse/ditto.git</release.scm.url>
 
+        <ditto.it.report.path>${user.dir}/target/jacoco-it.exec</ditto.it.report.path>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.jacoco.reportPaths>target/jacoco.exec, ${ditto.it.report.path}</sonar.jacoco.reportPaths>
+
         <argLine>-Dfile.encoding=${project.build.sourceEncoding}</argLine>
 
         <!-- globally set version for checking binary compatibility against -->
@@ -569,16 +573,30 @@
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>pre-test</id>
+                        <id>prepare-agent-test</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
                     </execution>
                     <execution>
-                        <id>post-test</id>
-                        <phase>test</phase>
+                        <id>prepare-agent-it</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${ditto.it.report.path}</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>report-test</id>
                         <goals>
                             <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report-it</id>
+                        <goals>
+                            <goal>report-integration</goal>
                         </goals>
                     </execution>
                 </executions>


### PR DESCRIPTION
- add executions for goals "prepare-agent-integration" and "report-integration" to config of jacoco-maven-plugin
- give meaningful ids for all executions of jacoco-maven-plugin
- explicitly set "sonar.java.coveragePlugin" to jacoco
- aggregate it-coverage in file "${user.dir}/target/jacoco-it.exec" (${user.dir} is the path of the top-level module - using ${maven.multiModuleProjectDirectory} currently does not work due to https://issues.apache.org/jira/browse/MNG-5830)