### PR TITLE
Accelerate build by not copying dependencies in each service

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -184,10 +184,6 @@
                         <id>copy-legal-docs</id>
                         <phase>none</phase>
                     </execution>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>none</phase>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/legal/pom.xml
+++ b/legal/pom.xml
@@ -82,10 +82,6 @@
                         <id>copy-legal-docs</id>
                         <phase>none</phase>
                     </execution>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>none</phase>
-                    </execution>
                 </executions>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -516,20 +516,6 @@
                             <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>install</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>runtime</includeScope>
-                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
             <!-- in order to gather all dependencies which are used in Ditto, execute following bash command:

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,10 @@
 
         <maven.skins.fluido.version>1.7</maven.skins.fluido.version>
         <doxia.markdown.version>1.8</doxia.markdown.version>
+
+        <ditto.thirdPartyLicences.excludedGroups>
+            (org\.eclipse\.ditto.*)|(com\.lihaoyi.*)
+        </ditto.thirdPartyLicences.excludedGroups>
     </properties>
 
     <build>
@@ -650,15 +654,14 @@
                                 </goals>
                                 <configuration>
                                     <outputDirectory>${project.build.outputDirectory}/META-INF</outputDirectory>
-                                    <excludedGroups>org.eclipse.ditto.*</excludedGroups>
+                                    <excludedGroups>${ditto.thirdPartyLicences.excludedGroups}</excludedGroups>
                                     <includedScopes>compile</includedScopes>
                                     <failOnMissing>true</failOnMissing>
                                     <fileTemplate>${maven.multiModuleProjectDirectory}/legal/templates/third-party-file.ftl
                                     </fileTemplate>
                                     <thirdPartyFilename>NOTICE-THIRD-PARTY.md</thirdPartyFilename>
-                                    <licenseMergesFile>${maven.multiModuleProjectDirectory}/legal/templates/licenses-merges-file
-                                    </licenseMergesFile>
-                                    <excludedGroups>com\.lihaoyi.*</excludedGroups>
+                                    <licenseMerges>${maven.multiModuleProjectDirectory}/legal/templates/licenses-merges-file
+                                    </licenseMerges>
                                 </configuration>
                             </execution>
                         </executions>
@@ -683,13 +686,12 @@
                                 </goals>
                                 <configuration>
                                     <outputDirectory>./legal</outputDirectory>
-                                    <excludedGroups>org.eclipse.ditto.*</excludedGroups>
+                                    <excludedGroups>${ditto.thirdPartyLicences.excludedGroups}</excludedGroups>
                                     <includedScopes>compile</includedScopes>
                                     <failOnMissing>true</failOnMissing>
                                     <fileTemplate>./legal/templates/third-party-file.ftl</fileTemplate>
                                     <thirdPartyFilename>NOTICE-THIRD-PARTY.md</thirdPartyFilename>
-                                    <licenseMergesFile>./legal/templates/licenses-merges-file</licenseMergesFile>
-                                    <excludedGroups>com\.lihaoyi.*</excludedGroups>
+                                    <licenseMerges>./legal/templates/licenses-merges-file</licenseMerges>
                                 </configuration>
                             </execution>
                         </executions>

--- a/services/connectivity/mapping/src/test/assembly/assembly.xml
+++ b/services/connectivity/mapping/src/test/assembly/assembly.xml
@@ -20,7 +20,7 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>true</unpack>
             <scope>test</scope>

--- a/services/connectivity/mapping/src/test/assembly/assembly.xml
+++ b/services/connectivity/mapping/src/test/assembly/assembly.xml
@@ -29,7 +29,7 @@
     <fileSets>
         <fileSet>
             <directory>${project.build.directory}/test-classes</directory>
-            <outputDirectory>/</outputDirectory>
+            <outputDirectory/>
             <includes>
                 <include>**/*</include>
             </includes>

--- a/services/connectivity/starter/pom.xml
+++ b/services/connectivity/starter/pom.xml
@@ -178,27 +178,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>runtime</includeScope>
-                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>

--- a/services/legal/pom.xml
+++ b/services/legal/pom.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+  ~
+  ~ All rights reserved. This program and the accompanying materials
+  ~ are made available under the terms of the Eclipse Public License v2.0
+  ~ which accompanies this distribution, and is available at
+  ~ https://www.eclipse.org/org/documents/epl-2.0/index.php
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ditto</groupId>
+        <artifactId>ditto-services</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <!-- Aggregates the dependencies of all services in the target/dependencies folder -->
+    <artifactId>ditto-services-legal</artifactId>
+    <name>Eclipse Ditto :: Services :: Legal</name>
+    <packaging>pom</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-policies-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-things-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-thingsearch-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-concierge-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-gateway-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-services-connectivity-starter</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-legal-docs</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeScope>runtime</includeScope>
+                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/services/models/connectivity/pom.xml
+++ b/services/models/connectivity/pom.xml
@@ -91,26 +91,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>copy-dependencies</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>copy-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeScope>runtime</includeScope>
-                            <outputDirectory>${project.build.directory}/dependencies</outputDirectory>
-                            <overWriteReleases>false</overWriteReleases>
-                            <overWriteSnapshots>false</overWriteSnapshots>
-                            <overWriteIfNewer>true</overWriteIfNewer>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
             </plugin>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -34,6 +34,7 @@
         <module>things</module>
         <module>thingsearch</module>
         <module>utils</module>
+        <module>legal</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
In order to scan our used dependencies, we copied them in each "-starter" module.
This was replaced by copying them now only once in a new module `services/legal`.
After a Ditto build with `mvn package` all used 3rd party dependencies can now be found in the following directory:
`services/legal/target/dependencies`