### PR TITLE
Kubernetes deployment

### DIFF
--- a/deployment/kubernetes/mongodb/mongodb.yaml
+++ b/deployment/kubernetes/mongodb/mongodb.yaml
@@ -5,9 +5,9 @@ metadata:
 spec:
   clusterIP: None
   ports:
-  - port: 27017
-    targetPort: 27017
-    protocol: TCP
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
   selector:
     app: mongodb
 ---
@@ -22,15 +22,17 @@ spec:
         app: mongodb
     spec:
       containers:
-      - name: mongodb
-        image: docker.io/mongo:3.6
-        command:
-          - mongod
-          - --storageEngine
-          - wiredTiger
-          - --noscripting
-        ports:
-          - containerPort: 27017
-        env:
-        - name: TZ
-          value: Europe/Berlin
+        - name: mongodb
+          image: docker.io/mongo:3.6
+          command:
+            - mongod
+            - --storageEngine
+            - wiredTiger
+            - --noscripting
+            - --bind_ip
+            - "0.0.0.0"
+          ports:
+            - containerPort: 27017
+          env:
+            - name: TZ
+              value: Europe/Berlin

--- a/deployment/kubernetes/nginx/nginx.conf
+++ b/deployment/kubernetes/nginx/nginx.conf
@@ -25,11 +25,6 @@ http {
       index index.html;
     }
 
-    location /status {
-      proxy_pass                    http://gateway:8080/status;
-      proxy_http_version            1.1;
-    }
-
     # api
     location /api {
       include nginx-cors.conf;
@@ -68,6 +63,42 @@ http {
       proxy_set_header              Connection          "upgrade";
       proxy_read_timeout            1d;
       proxy_send_timeout            1d;
+    }
+
+    # health
+    location /health {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/health;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
+    }
+
+    # status
+    location /status {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/status;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
+    }
+
+    # devops
+    location /devops {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/devops;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
     }
 
     # swagger


### PR DESCRIPTION
Hi,

while using your Kubernetes deployment I found a few things:

- MongoDB is on default bind_ip which means it will only accept connections on 127.0.0.1 interface. At least on my local as well as cloud setup that ain't working.
- Kubernetes compared to the ditto docker swarm setup does not provide devOps and health interfaces. Also the header config was a bit different compared to swarm for status.
- My editor prettified the indentation a bit. I hope you do not mind :)

I thought you might be interested in my changes. Tested on Azure Kubernetes Service as well as Docker Desktop for Mac.

Another bigger issue I had is that the Kubernetes stuff is a bit inflexible to work with. I would volunteer to create a Helm setup, let me know if you are interested and if yes if this should go extra or replace the Kubernetes deployment you already have. I would go for option two but let me know what you think.

Kai