### PR TITLE
[WIP] Range-based paging for things-search

### DIFF
--- a/model/query/src/main/java/org/eclipse/ditto/model/query/Query.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/Query.java
@@ -11,6 +11,7 @@
 package org.eclipse.ditto.model.query;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.ditto.model.query.criteria.Criteria;
 
@@ -39,4 +40,8 @@ public interface Query {
      */
     int getSkip();
 
+    /**
+     * @return key to the next page.
+     */
+    Optional<String> getNextPageKey();
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/QueryBuilder.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/QueryBuilder.java
@@ -43,6 +43,14 @@ public interface QueryBuilder {
     QueryBuilder skip(long n);
 
     /**
+     * Set the key to the next page.
+     *
+     * @param nextPageKey key to the next page.
+     * @return this builder.
+     */
+    QueryBuilder nextPageKey(String nextPageKey);
+
+    /**
      * Builds the Query.
      *
      * @return the Query

--- a/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/ImmutableSearchResultBuilder.java
+++ b/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/ImmutableSearchResultBuilder.java
@@ -12,6 +12,7 @@ package org.eclipse.ditto.model.thingsearch;
 
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonArray;
@@ -66,7 +67,7 @@ final class ImmutableSearchResultBuilder implements SearchResultBuilder {
     }
 
     @Override
-    public SearchResultBuilder nextPageKey(final String nextPageKey) {
+    public SearchResultBuilder nextPageKey(@Nullable final String nextPageKey) {
         this.nextPageKey = nextPageKey;
         return this;
     }

--- a/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/ImmutableSearchResultBuilder.java
+++ b/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/ImmutableSearchResultBuilder.java
@@ -27,6 +27,7 @@ final class ImmutableSearchResultBuilder implements SearchResultBuilder {
 
     private final JsonArrayBuilder jsonArrayBuilder;
     private long offset;
+    private String nextPageKey;
 
     private ImmutableSearchResultBuilder(final JsonArrayBuilder theJsonArrayBuilder, final long theOffset) {
         jsonArrayBuilder = theJsonArrayBuilder;
@@ -65,6 +66,12 @@ final class ImmutableSearchResultBuilder implements SearchResultBuilder {
     }
 
     @Override
+    public SearchResultBuilder nextPageKey(final String nextPageKey) {
+        this.nextPageKey = nextPageKey;
+        return this;
+    }
+
+    @Override
     public SearchResultBuilder add(final JsonValue value, final JsonValue... furtherValues) {
         jsonArrayBuilder.add(value, furtherValues);
         return this;
@@ -85,7 +92,7 @@ final class ImmutableSearchResultBuilder implements SearchResultBuilder {
     @Override
     public SearchResult build() {
         final JsonArray searchResultsJsonArray = jsonArrayBuilder.build();
-        return ImmutableSearchResult.of(searchResultsJsonArray, offset);
+        return new ImmutableSearchResult(searchResultsJsonArray, offset, nextPageKey);
     }
 
 }

--- a/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResult.java
+++ b/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResult.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.ditto.model.thingsearch;
 
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
@@ -70,6 +71,13 @@ public interface SearchResult extends Iterable<JsonValue>, Jsonifiable.WithField
      * @return the offset of the next page or {@link #NO_NEXT_PAGE}, if there is no next page.
      */
     long getNextPageOffset();
+
+    /**
+     * Get the key to scroll to the next page without skipping results.
+     *
+     * @return the key to the next page.
+     */
+    Optional<String> getNextPageKey();
 
     /**
      * Returns {@code true} if there is a next page and thus {@link #getNextPageOffset()} does not equal
@@ -140,6 +148,13 @@ public interface SearchResult extends Iterable<JsonValue>, Jsonifiable.WithField
          */
         public static final JsonFieldDefinition<Long> NEXT_PAGE_OFFSET =
                 JsonFactory.newLongFieldDefinition("nextPageOffset", FieldType.REGULAR, JsonSchemaVersion.V_1,
+                        JsonSchemaVersion.V_2);
+
+        /**
+         * JSON field containing key of the next page for range-based paging.
+         */
+        public static final JsonFieldDefinition<String> NEXT_PAGE_KEY =
+                JsonFactory.newStringFieldDefinition("nextPageKey", FieldType.REGULAR, JsonSchemaVersion.V_1,
                         JsonSchemaVersion.V_2);
 
         private JsonFields() {

--- a/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResultBuilder.java
+++ b/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResultBuilder.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.ditto.model.thingsearch;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonValue;
@@ -35,7 +36,7 @@ public interface SearchResultBuilder {
      * @param nextPageKey the offset of the next page.
      * @return this builder to allow method chaining.
      */
-    SearchResultBuilder nextPageKey(String nextPageKey);
+    SearchResultBuilder nextPageKey(@Nullable String nextPageKey);
 
     /**
      * Adds at least one {@link JsonValue} to the {@code SearchResult} to be built.

--- a/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResultBuilder.java
+++ b/model/thingsearch/src/main/java/org/eclipse/ditto/model/thingsearch/SearchResultBuilder.java
@@ -30,6 +30,14 @@ public interface SearchResultBuilder {
     SearchResultBuilder nextPageOffset(long nextPageOffset);
 
     /**
+     * Set the key to the next page.
+     *
+     * @param nextPageKey the offset of the next page.
+     * @return this builder to allow method chaining.
+     */
+    SearchResultBuilder nextPageKey(String nextPageKey);
+
+    /**
      * Adds at least one {@link JsonValue} to the {@code SearchResult} to be built.
      *
      * @param item the item to add to the results.

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/thingsearch/ThingSearchParameter.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/thingsearch/ThingSearchParameter.java
@@ -33,7 +33,9 @@ public enum ThingSearchParameter {
     /**
      * Request parameter for namespaces to apply.
      */
-    NAMESPACES("namespaces");
+    NAMESPACES("namespaces"),
+
+    NEXT_PAGE_KEY("nextPageKey");
 
     private final String parameterValue;
 

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
@@ -121,6 +121,8 @@ final class QueryThingsPerRequestActor extends AbstractActor {
                                 QueryThingsResponse.of(SearchResult.newBuilder()
                                                 .addAll(rtr.getEntity(rtr.getImplementedSchemaVersion()).asArray())
                                                 .nextPageOffset(queryThingsResponse.getSearchResult().getNextPageOffset())
+                                                .nextPageKey(
+                                                        queryThingsResponse.getSearchResult().getNextPageKey().orElse(null))
                                                 .build(),
                                         rtr.getDittoHeaders()
                                 );

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQuery.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQuery.java
@@ -16,7 +16,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.bson.conversions.Bson;
@@ -40,6 +42,31 @@ public final class MongoQuery implements Query {
     private final int limit;
     private final int skip;
 
+    @Nullable
+    private final String nextPageKey;
+
+    /**
+     * Constructor.
+     *
+     * @param criteria the criteria
+     * @param sortOptions the SortOptions
+     * @param limit the limit param
+     * @param skip the skip param
+     */
+    public MongoQuery(final Criteria criteria,
+            final List<SortOption> sortOptions,
+            final int limit,
+            final int skip,
+            @Nullable final String nextPageKey) {
+
+
+        this.criteria = checkNotNull(criteria, "criterion");
+        this.sortOptions = Collections.unmodifiableList(new ArrayList<>(sortOptions));
+        this.limit = limit;
+        this.skip = skip;
+        this.nextPageKey = nextPageKey;
+    }
+
     /**
      * Constructor.
      *
@@ -53,10 +80,7 @@ public final class MongoQuery implements Query {
             final int limit,
             final int skip) {
 
-        this.criteria = checkNotNull(criteria, "criterion");
-        this.sortOptions = Collections.unmodifiableList(new ArrayList<>(sortOptions));
-        this.limit = limit;
-        this.skip = skip;
+        this(criteria, sortOptions, limit, skip, null);
     }
 
     @Override
@@ -77,6 +101,11 @@ public final class MongoQuery implements Query {
     @Override
     public int getSkip() {
         return skip;
+    }
+
+    @Override
+    public Optional<String> getNextPageKey() {
+        return Optional.ofNullable(nextPageKey);
     }
 
     /**
@@ -111,12 +140,13 @@ public final class MongoQuery implements Query {
         return limit == that.limit &&
                 skip == that.skip &&
                 Objects.equals(criteria, that.criteria) &&
-                Objects.equals(sortOptions, that.sortOptions);
+                Objects.equals(sortOptions, that.sortOptions) &&
+                Objects.equals(nextPageKey, that.nextPageKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(criteria, sortOptions, limit, skip);
+        return Objects.hash(criteria, sortOptions, limit, skip, nextPageKey);
     }
 
     @Override
@@ -126,6 +156,7 @@ public final class MongoQuery implements Query {
                 ", sortOptions=" + sortOptions +
                 ", limit=" + limit +
                 ", skip=" + skip +
+                ", nextPageKey=" + nextPageKey +
                 "]";
     }
 

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilder.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilder.java
@@ -45,6 +45,7 @@ final class MongoQueryBuilder implements QueryBuilder {
     private int limit;
     private int skip;
     private List<SortOption> sortOptions;
+    private String nextPageKey;
 
     private MongoQueryBuilder(final Criteria criteria, final int maxLimit, final int defaultLimit) {
         this.criteria = checkNotNull(criteria, "criteria");
@@ -52,6 +53,7 @@ final class MongoQueryBuilder implements QueryBuilder {
         limit = defaultLimit;
         skip = DEFAULT_SKIP;
         sortOptions = new ArrayList<>();
+        nextPageKey = null;
     }
 
     /**
@@ -95,8 +97,14 @@ final class MongoQueryBuilder implements QueryBuilder {
     }
 
     @Override
+    public QueryBuilder nextPageKey(final String nextPageKey) {
+        this.nextPageKey = nextPageKey;
+        return this;
+    }
+
+    @Override
     public Query build() {
-        return new MongoQuery(criteria, sortOptions, limit, skip);
+        return new MongoQuery(criteria, sortOptions, limit, skip, nextPageKey);
     }
 
 }

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/CountThings.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/CountThings.java
@@ -145,6 +145,11 @@ public final class CountThings extends AbstractCommand<CountThings> implements T
     }
 
     @Override
+    public Optional<String> getNextPageKey() {
+        return Optional.empty();
+    }
+
+    @Override
     public Optional<Set<String>> getNamespaces() {
         return Optional.ofNullable(namespaces);
     }

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/QueryThings.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/QueryThings.java
@@ -71,14 +71,21 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
             JsonFactory.newJsonArrayFieldDefinition("namespaces", FieldType.REGULAR, JsonSchemaVersion.V_1,
                     JsonSchemaVersion.V_2);
 
+
+    static final JsonFieldDefinition<String> JSON_NEXT_PAGE_KEY =
+            JsonFactory.newStringFieldDefinition("nextPageKey", FieldType.REGULAR, JsonSchemaVersion.V_1,
+                    JsonSchemaVersion.V_2);
+
     @Nullable private final String filter;
     @Nullable private final List<String> options;
     @Nullable private final JsonFieldSelector fields;
     @Nullable private final Set<String> namespaces;
+    @Nullable private final String nextPageKey;
 
     private QueryThings(final DittoHeaders dittoHeaders, @Nullable final String filter,
             @Nullable final List<String> options, @Nullable final JsonFieldSelector fields,
-            @Nullable final Collection<String> namespaces) {
+            @Nullable final Collection<String> namespaces,
+            @Nullable final String nextPageKey) {
         super(TYPE, dittoHeaders);
         this.filter = filter;
         if (options != null) {
@@ -92,6 +99,24 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
         } else {
             this.namespaces = null;
         }
+        this.nextPageKey = nextPageKey;
+    }
+
+    /**
+     * Returns a new instance of {@code QueryThings}.
+     *
+     * @param filter the optional query filter string
+     * @param options the optional query options
+     * @param fields the optional fields
+     * @param nextPageKey the key to the next page
+     * @param dittoHeaders the headers of the command.
+     * @return a new command for searching Things.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public static QueryThings of(@Nullable final String filter, @Nullable final List<String> options,
+            @Nullable final JsonFieldSelector fields, @Nullable final Set<String> namespaces,
+            @Nullable final String nextPageKey, final DittoHeaders dittoHeaders) {
+        return new QueryThings(dittoHeaders, filter, options, fields, namespaces, nextPageKey);
     }
 
     /**
@@ -107,7 +132,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
     public static QueryThings of(@Nullable final String filter, @Nullable final List<String> options,
             @Nullable final JsonFieldSelector fields, @Nullable final Set<String> namespaces,
             final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, filter, options, fields, namespaces);
+        return new QueryThings(dittoHeaders, filter, options, fields, namespaces, null);
     }
 
     /**
@@ -121,7 +146,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      */
     public static QueryThings of(final String filter, final List<String> options, final Set<String> namespaces,
             final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, filter, options, null, namespaces);
+        return new QueryThings(dittoHeaders, filter, options, null, namespaces, null);
     }
 
     /**
@@ -135,7 +160,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      */
     public static QueryThings of(final String filter, final JsonFieldSelector fields, final Set<String> namespaces,
             final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, filter, null, fields, namespaces);
+        return new QueryThings(dittoHeaders, filter, null, fields, namespaces, null);
     }
 
     /**
@@ -147,7 +172,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static QueryThings of(final String filter, final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, filter, null, null, null);
+        return new QueryThings(dittoHeaders, filter, null, null, null, null);
     }
 
     /**
@@ -161,7 +186,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      */
     public static QueryThings of(final List<String> options, final JsonFieldSelector fields,
             final Set<String> namespaces, final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, null, options, fields, namespaces);
+        return new QueryThings(dittoHeaders, null, options, fields, namespaces, null);
     }
 
     /**
@@ -173,7 +198,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static QueryThings of(final JsonFieldSelector fields, final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, null, null, fields, null);
+        return new QueryThings(dittoHeaders, null, null, fields, null, null);
     }
 
     /**
@@ -185,7 +210,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static QueryThings of(final List<String> options, final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, null, options, null, null);
+        return new QueryThings(dittoHeaders, null, options, null, null, null);
     }
 
     /**
@@ -197,7 +222,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static QueryThings of(final Set<String> namespaces, final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, null, null, null, namespaces);
+        return new QueryThings(dittoHeaders, null, null, null, namespaces, null);
     }
 
     /**
@@ -208,7 +233,7 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
      * @throws NullPointerException if any argument is {@code null}.
      */
     public static QueryThings of(final DittoHeaders dittoHeaders) {
-        return new QueryThings(dittoHeaders, null, null, null, null);
+        return new QueryThings(dittoHeaders, null, null, null, null, null);
     }
 
     /**
@@ -258,13 +283,21 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
                             .collect(Collectors.toSet()))
                     .orElse(null);
 
-            return new QueryThings(dittoHeaders, extractedFilter, extractedOptions, extractedFieldSelector, extractedNamespaces);
+            final String nextPageKey = jsonObject.getValue(JSON_NEXT_PAGE_KEY).orElse(null);
+
+            return new QueryThings(dittoHeaders, extractedFilter, extractedOptions, extractedFieldSelector,
+                    extractedNamespaces, nextPageKey);
         });
     }
 
     @Override
     public Optional<String> getFilter() {
         return Optional.ofNullable(filter);
+    }
+
+    @Override
+    public Optional<String> getNextPageKey() {
+        return Optional.ofNullable(nextPageKey);
     }
 
     /**
@@ -292,26 +325,28 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
 
     @Override
     public QueryThings setNamespaces(@Nullable final Collection<String> namespaces) {
-        return new QueryThings(getDittoHeaders(), filter, options, fields, namespaces);
+        return new QueryThings(getDittoHeaders(), filter, options, fields, namespaces, nextPageKey);
     }
 
     @Override
     protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
             final Predicate<JsonField> thePredicate) {
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
-        getFilter().ifPresent(presentFilter -> jsonObjectBuilder.set(JSON_FILTER, presentFilter, predicate));
+        final Predicate<JsonField> predicateAndNonNull = predicate.and(field -> !field.getValue().isNull());
+        jsonObjectBuilder.set(JSON_FILTER, filter, predicateAndNonNull)
+                .set(JSON_NEXT_PAGE_KEY, nextPageKey, predicateAndNonNull);
         getOptions().ifPresent(presentOptions -> jsonObjectBuilder.set(JSON_OPTIONS, presentOptions.stream()
-                        .map(JsonValue::of)
-                        .collect(JsonCollectors.valuesToArray()), predicate));
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray()), predicate));
         getFields().ifPresent(presentFields -> jsonObjectBuilder.set(JSON_FIELDS, presentFields.toString(), predicate));
         getNamespaces().ifPresent(presentOptions -> jsonObjectBuilder.set(JSON_NAMESPACES, presentOptions.stream()
-                        .map(JsonValue::of)
-                        .collect(JsonCollectors.valuesToArray()), predicate));
+                .map(JsonValue::of)
+                .collect(JsonCollectors.valuesToArray()), predicate));
     }
 
     @Override
     public QueryThings setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return of(filter, options, fields, namespaces, dittoHeaders);
+        return new QueryThings(dittoHeaders, filter, options, fields, namespaces, nextPageKey);
     }
 
     @Override
@@ -326,17 +361,18 @@ public final class QueryThings extends AbstractCommand<QueryThings> implements T
         return Objects.equals(filter, that.filter) &&
                 Objects.equals(options, that.options) &&
                 Objects.equals(fields, that.fields) &&
-                Objects.equals(namespaces, that.namespaces);
+                Objects.equals(namespaces, that.namespaces) &&
+                Objects.equals(nextPageKey, that.nextPageKey);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), filter, options, fields, namespaces);
+        return Objects.hash(super.hashCode(), filter, options, fields, namespaces, nextPageKey);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + "[" + "filter='" + filter + "', options=" + options + ", fields=" + fields
-                + ", namespaces=" + namespaces + ']';
+                + ", namespaces=" + namespaces + ", nextPageKey=" + nextPageKey + +']';
     }
 }

--- a/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/ThingSearchQueryCommand.java
+++ b/signals/commands/thingsearch/src/main/java/org/eclipse/ditto/signals/commands/thingsearch/query/ThingSearchQueryCommand.java
@@ -34,6 +34,7 @@ public interface ThingSearchQueryCommand<T extends ThingSearchQueryCommand> exte
 
     /**
      * Sets the given namespaces on a copy of this command and returns it.
+     *
      * @param namespaces the namespaces.
      * @return the created command.
      */
@@ -45,6 +46,13 @@ public interface ThingSearchQueryCommand<T extends ThingSearchQueryCommand> exte
      * @return the optional filter string.
      */
     Optional<String> getFilter();
+
+    /**
+     * Get the optional key to the next page.
+     *
+     * @return the optional key to the next page.
+     */
+    Optional<String> getNextPageKey();
 
     @Override
     default Category getCategory() {


### PR DESCRIPTION
I'd like to add range-based paging for things-search so that Ditto supports paging through large numbers of things without putting excessive memory pressure on the persistence.

- Added a parameter "nextPageKey" to encode position of a search.
- TODO: Interpret "nextPageKey" in things-search so that paging is possible without large skip values.