### PR TITLE
Fix processing of websocket protocol messages

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractor.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.routes.websocket;
+
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.START_SEND_EVENTS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.START_SEND_LIVE_COMMANDS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.START_SEND_LIVE_EVENTS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.START_SEND_MESSAGES;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.STOP_SEND_EVENTS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.STOP_SEND_LIVE_COMMANDS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.STOP_SEND_LIVE_EVENTS;
+import static org.eclipse.ditto.services.gateway.endpoints.routes.websocket.ProtocolMessages.STOP_SEND_MESSAGES;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.services.gateway.streaming.StartStreaming;
+import org.eclipse.ditto.services.gateway.streaming.StopStreaming;
+import org.eclipse.ditto.services.models.concierge.streaming.StreamingType;
+
+/**
+ * Extracts WebSocket Protocol message from the given payload string and returns a {@link StartStreaming},
+ * {@link StopStreaming} instance or {@code null} if the payload did not contain one of the defined
+ * {@link ProtocolMessages}.
+ */
+final class ProtocolMessageExtractor implements Function<String, Object> {
+
+    private static final String PARAM_FILTER = "filter";
+    private static final String PARAM_NAMESPACES = "namespaces";
+
+    private final AuthorizationContext connectionAuthContext;
+    private final String connectionCorrelationId;
+
+    /**
+     * Instantiates a new {@link ProtocolMessageExtractor}.
+     *
+     * @param connectionAuthContext the {@link AuthorizationContext} of the connection
+     * @param connectionCorrelationId the correlation id of the connection
+     */
+    ProtocolMessageExtractor(final AuthorizationContext connectionAuthContext, final String connectionCorrelationId) {
+        this.connectionAuthContext = connectionAuthContext;
+        this.connectionCorrelationId = connectionCorrelationId;
+    }
+
+    @Override
+    public Object apply(final String protocolMessage) {
+        // twin events
+        if (START_SEND_EVENTS.matches(protocolMessage)) {
+            return buildStartStreaming(START_SEND_EVENTS, protocolMessage);
+        } else if (STOP_SEND_EVENTS.matches(protocolMessage)) {
+            return new StopStreaming(StreamingType.EVENTS, connectionCorrelationId);
+        }
+        // live events
+        else if (START_SEND_LIVE_EVENTS.matches(protocolMessage)) {
+            return buildStartStreaming(START_SEND_LIVE_EVENTS, protocolMessage);
+        } else if (STOP_SEND_LIVE_EVENTS.matches(protocolMessage)) {
+            return new StopStreaming(StreamingType.LIVE_EVENTS, connectionCorrelationId);
+        }
+        // live commands
+        else if (START_SEND_LIVE_COMMANDS.matches(protocolMessage)) {
+            return buildStartStreaming(START_SEND_LIVE_COMMANDS, protocolMessage);
+        } else if (STOP_SEND_LIVE_COMMANDS.matches(protocolMessage)) {
+            return new StopStreaming(StreamingType.LIVE_COMMANDS, connectionCorrelationId);
+        }
+        // messages
+        else if (START_SEND_MESSAGES.matches(protocolMessage)) {
+            return buildStartStreaming(START_SEND_MESSAGES, protocolMessage);
+        } else if (STOP_SEND_MESSAGES.matches(protocolMessage)) {
+            return new StopStreaming(StreamingType.MESSAGES, connectionCorrelationId);
+        } else {
+            return null;
+        }
+    }
+
+    private StartStreaming buildStartStreaming(final ProtocolMessages message, final String protocolMessage) {
+        if (message.matchesWithParameters(protocolMessage)) {
+            final Map<String, String> params = determineParams(protocolMessage);
+            final List<String> namespaces = Optional.ofNullable(params.get(PARAM_NAMESPACES))
+                    .filter(ids -> !ids.isEmpty())
+                    .map(ids -> ids.split(","))
+                    .map(Arrays::asList)
+                    .orElse(Collections.emptyList());
+            final String filter = params.get(PARAM_FILTER);
+            return new StartStreaming(message.getStreamingType(), connectionCorrelationId, connectionAuthContext,
+                    namespaces, filter);
+        } else {
+            return new StartStreaming(message.getStreamingType(), connectionCorrelationId, connectionAuthContext,
+                    Collections.emptyList(), null);
+        }
+    }
+
+    /**
+     * Parses the passed {@code protocolMessage} for an optional parameters string (e.g. containing a "filter") and
+     * creating a Map from it.
+     *
+     * @param protocolMessage the protocolMessage containing parameters, e.g.: {@code
+     * START-SEND-EVENTS?filter=eq(foo,1)}
+     * @return the map containing the resolved params
+     */
+    private static Map<String, String> determineParams(final String protocolMessage) {
+        if (protocolMessage.contains(ProtocolMessages.PARAMETER_SEPARATOR)) {
+            final String parametersString =
+                    protocolMessage.split(Pattern.quote(ProtocolMessages.PARAMETER_SEPARATOR), 2)[1];
+            return Arrays.stream(parametersString.split("&"))
+                    .map(paramWithValue -> paramWithValue.split("=", 2))
+                    .collect(Collectors.toMap(pv -> urlDecode(pv[0]), pv -> urlDecode(pv[1])));
+        } else {
+            return Collections.emptyMap();
+        }
+    }
+
+    private static String urlDecode(final String value) {
+        try {
+            return URLDecoder.decode(value, StandardCharsets.UTF_8.name());
+        } catch (final UnsupportedEncodingException e) {
+            return URLDecoder.decode(value);
+        }
+    }
+}

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessages.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessages.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.routes.websocket;
+
+import org.eclipse.ditto.services.models.concierge.streaming.StreamingType;
+
+/**
+ * Defines the protocol messages used to control emitting of events and messages via WebSocket.
+ */
+enum ProtocolMessages {
+
+    /**
+     * Message indicating that the Websocket should start emitting twin events.
+     */
+    START_SEND_EVENTS("START-SEND-EVENTS", StreamingType.EVENTS),
+    /**
+     * Message indicating that the Websocket should stop emitting twin events.
+     */
+    STOP_SEND_EVENTS("STOP-SEND-EVENTS", StreamingType.EVENTS),
+
+    /**
+     * Message indicating that the Websocket should start emitting live messages.
+     */
+    START_SEND_MESSAGES("START-SEND-MESSAGES", StreamingType.MESSAGES),
+    /**
+     * Message indicating that the Websocket should stop emitting live messages.
+     */
+    STOP_SEND_MESSAGES("STOP-SEND-MESSAGES", StreamingType.MESSAGES),
+
+    /**
+     * Message indicating that the Websocket should start emitting live commands.
+     */
+    START_SEND_LIVE_COMMANDS("START-SEND-LIVE-COMMANDS", StreamingType.LIVE_COMMANDS),
+    /**
+     * Message indicating that the Websocket should stop emitting live commands.
+     */
+    STOP_SEND_LIVE_COMMANDS("STOP-SEND-LIVE-COMMANDS", StreamingType.LIVE_COMMANDS),
+
+    /**
+     * Message indicating that the Websocket should start emitting live events.
+     */
+    START_SEND_LIVE_EVENTS("START-SEND-LIVE-EVENTS", StreamingType.LIVE_EVENTS),
+    /**
+     * Message indicating that the Websocket should stop emitting live events.
+     */
+    STOP_SEND_LIVE_EVENTS("STOP-SEND-LIVE-EVENTS", StreamingType.LIVE_EVENTS);
+
+    static final String PARAMETER_SEPARATOR = "?";
+
+    private final String identifier;
+    private final StreamingType streamingType;
+
+    /**
+     * Constructor.
+     * @param identifier the string identifier that is sent over the wire
+     * @param streamingType the associated {@link StreamingType}
+     */
+    ProtocolMessages(final String identifier, final StreamingType streamingType) {
+        this.identifier = identifier;
+        this.streamingType = streamingType;
+    }
+
+    String getIdentifier() {
+        return identifier;
+    }
+
+    StreamingType getStreamingType() {
+        return streamingType;
+    }
+
+    /**
+     * @param message message to be checked for a protocol message
+     * @return {@code true} if the given message starts with the protocol message identifier
+     */
+    boolean matches(final String message) {
+        return message != null && message.startsWith(getIdentifier());
+    }
+
+    /**
+     * @param message message to be checked for a protocol message
+     * @return {@code true} if the given message starts with the protocol message identifier incl. parameter separator
+     */
+    boolean matchesWithParameters(final String message) {
+        return message != null && message.startsWith(getIdentifier() + PARAMETER_SEPARATOR);
+    }
+
+    @Override
+    public String toString() {
+        return getIdentifier();
+    }
+}

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractorTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.routes.websocket;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.services.gateway.streaming.StartStreaming;
+import org.eclipse.ditto.services.gateway.streaming.StopStreaming;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+/**
+ * Tests {@link ProtocolMessageExtractor}.
+ */
+public class ProtocolMessageExtractorTest {
+
+    private String correlationId;
+    private AuthorizationContext authorizationContext;
+    private ProtocolMessageExtractor extractor;
+
+    @Before
+    public void setUp() {
+        authorizationContext = Mockito.mock(AuthorizationContext.class);
+        correlationId = UUID.randomUUID().toString();
+        extractor = new ProtocolMessageExtractor(authorizationContext, correlationId);
+    }
+
+    @Test
+    public void startSending() {
+        testStartSending("", Collections.emptyList(), null);
+    }
+
+    @Test
+    public void startSendingWithNamespaces() {
+        testStartSending("?namespaces=eclipse,ditto,is,awesome",
+                asList("eclipse", "ditto","is", "awesome"), null);
+    }
+    @Test
+    public void startSendingWithFilter() {
+        testStartSending("?filter=eq(foo,1)", Collections.emptyList(), "eq(foo,1)");
+    }
+
+    @Test
+    public void startSendingWithNamespacesAndFilter() {
+        testStartSending("?filter=eq(foo,1)&namespaces=eclipse,ditto,is,awesome",
+                asList("eclipse", "ditto","is", "awesome"), "eq(foo,1)");
+    }
+
+    @Test
+    public void startSendingWithEmptyFilter() {
+        testStartSending("?filter=", Collections.emptyList(), "");
+    }
+    @Test
+    public void startSendingWithEmptyNamespace() {
+        testStartSending("?namespaces=", Collections.emptyList(), null);
+    }
+
+    @Test
+    public void startSendingWithStrangeAppendix() {
+        testStartSending("thisShouldNotBeBreakAnything", Collections.emptyList(), null);
+    }
+
+    @Test
+    public void startSendingWithUnknownParameters() {
+        testStartSending("?eclipse=ditto", Collections.emptyList(), null);
+    }
+
+    private void testStartSending(final String parameters, final List<String> expectedNamespaces,
+            @Nullable final String expectedFilter) {
+        Stream.of(ProtocolMessages.values())
+                .filter(protocolMessage -> protocolMessage.getIdentifier().startsWith("START"))
+                .forEach(protocolMessage -> {
+                    final Object extracted = extractor.apply(protocolMessage.getIdentifier() + parameters);
+                    assertThat(extracted).isInstanceOfAny(StartStreaming.class);
+                    final StartStreaming start = ((StartStreaming) extracted);
+                    assertThat(start.getStreamingType()).isEqualTo(protocolMessage.getStreamingType());
+                    assertThat(start.getConnectionCorrelationId()).isEqualTo(correlationId);
+                    assertThat(start.getAuthorizationContext()).isEqualTo(authorizationContext);
+                    assertThat(start.getNamespaces()).isEqualTo(expectedNamespaces);
+                    assertThat(start.getFilter()).isEqualTo(Optional.ofNullable(expectedFilter));
+                });
+    }
+
+    @Test
+    public void testStopSending() {
+        Stream.of(ProtocolMessages.values())
+                .filter(protocolMessage -> protocolMessage.getIdentifier().startsWith("STOP"))
+                .forEach(protocolMessage -> {
+                    final Object extracted = extractor.apply(protocolMessage.getIdentifier());
+                    assertThat(extracted).isInstanceOfAny(StopStreaming.class);
+                    final StopStreaming stop = ((StopStreaming) extracted);
+                    assertThat(stop.getStreamingType()).isEqualTo(protocolMessage.getStreamingType());
+                    assertThat(stop.getConnectionCorrelationId()).isEqualTo(correlationId);
+                });
+    }
+
+    @Test
+    public void noneProtocolMessagesMappedToNull() {
+        assertThat(extractor.apply(null)).isNull();
+        assertThat(extractor.apply("")).isNull();
+        assertThat(extractor.apply("{\"some\":\"json\"}")).isNull();
+    }
+}


### PR DESCRIPTION
Any `?` was interpreted as parameter separator. Moved the extraction logic to a separate class and added tests.