### PR TITLE
Configurable helm templates

### DIFF
--- a/deployment/helm/eclipse-ditto/Chart.yaml
+++ b/deployment/helm/eclipse-ditto/Chart.yaml
@@ -2,4 +2,5 @@ apiVersion: v1
 appVersion: "0.8.0"
 description: A basic helm chart for Eclipse Ditto and K8s
 name: eclipse-ditto
+fullname: org.eclipse.ditto
 version: 0.8.0

--- a/deployment/helm/eclipse-ditto/files/nginx/nginx.conf
+++ b/deployment/helm/eclipse-ditto/files/nginx/nginx.conf
@@ -25,11 +25,6 @@ http {
       index index.html;
     }
 
-    location /status {
-      proxy_pass                    http://gateway:8080/status;
-      proxy_http_version            1.1;
-    }
-
     # api
     location /api {
       include nginx-cors.conf;
@@ -68,6 +63,42 @@ http {
       proxy_set_header              Connection          "upgrade";
       proxy_read_timeout            1d;
       proxy_send_timeout            1d;
+    }
+
+    # health
+    location /health {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/health;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
+    }
+
+    # status
+    location /status {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/status;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
+    }
+
+    # devops
+    location /devops {
+      include nginx-cors.conf;
+
+      proxy_pass                    http://gateway:8080/devops;
+      proxy_http_version            1.1;
+      proxy_set_header              Host                $http_host;
+      proxy_set_header              X-Real-IP           $remote_addr;
+      proxy_set_header              X-Forwarded-For     $proxy_add_x_forwarded_for;
+      proxy_set_header              X-Forwarded-User    $remote_user;
     }
 
     # swagger

--- a/deployment/helm/eclipse-ditto/templates/NOTES.txt
+++ b/deployment/helm/eclipse-ditto/templates/NOTES.txt
@@ -1,4 +1,12 @@
 1. Access ditto in your browser by running one of these commands:
+
+{{- if contains "NodePort" .Values.service.type }}
 - minikube service ditto (browser is automatically redirected)
 OR
-- kubectl port-forward svc/ditto 8080 (localhost:8080)
+- kubectl port-forward svc/ditto 8080 --namespace {{ .Release.Namespace }} (localhost:8080)
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w ditto --namespace {{ .Release.Namespace }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} ditto -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- end }}

--- a/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
+++ b/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
@@ -5,6 +5,12 @@ metadata:
   name: concierge
   labels:
     app: concierge
+    app.kubernetes.io/name: concierge
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -14,47 +20,56 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - name: concierge
-        image: docker.io/eclipse/ditto-concierge:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: concierge
+          image: "{{ .Values.concierge.image.repository }}:{{ .Values.concierge.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"           
+            - name: MONGO_DB_SSL_ENABLED
+              value: "{{ .Values.mongodb.apps.concierge.ssl }}"
+            - name: MONGO_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: concierge-uri
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -62,6 +77,12 @@ metadata:
   name: connectivity
   labels:
     app: connectivity
+    app.kubernetes.io/name: connectivity
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -71,47 +92,56 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - name: connectivity
-        image: docker.io/eclipse/ditto-connectivity:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: connectivity
+          image: "{{ .Values.connectivity.image.repository }}:{{ .Values.connectivity.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"         
+            - name: MONGO_DB_SSL_ENABLED
+              value: "{{ .Values.mongodb.apps.connectivity.ssl }}"
+            - name: MONGO_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: connectivity-uri
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -119,6 +149,12 @@ metadata:
   name: things
   labels:
     app: things
+    app.kubernetes.io/name: things
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -128,47 +164,56 @@ spec:
     spec:
       restartPolicy: Always
       containers:
-      - name: things
-        image: docker.io/eclipse/ditto-things:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: things
+          image: "{{ .Values.things.image.repository }}:{{ .Values.things.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+            - name: MONGO_DB_SSL_ENABLED
+              value: "{{ .Values.mongodb.apps.things.ssl }}"
+            - name: MONGO_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: things-uri
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -176,6 +221,12 @@ metadata:
   name: things-search
   labels:
     app: things-search
+    app.kubernetes.io/name: things-search
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -184,47 +235,56 @@ spec:
         actorSystemName: ditto-cluster
     spec:
       containers:
-      - name: things-search
-        image: docker.io/eclipse/ditto-things-search:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: things-search
+          image: "{{ .Values.search.image.repository }}:{{ .Values.search.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+            - name: MONGO_DB_SSL_ENABLED
+              value: "{{ .Values.mongodb.apps.searchDB.ssl }}"
+            - name: MONGO_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: searchDB-uri
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -232,6 +292,12 @@ metadata:
   name: policies
   labels:
     app: policies
+    app.kubernetes.io/name: policies
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -240,47 +306,56 @@ spec:
         actorSystemName: ditto-cluster
     spec:
       containers:
-      - name: policies
-        image: docker.io/eclipse/ditto-policies:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: policies
+          image: "{{ .Values.policies.image.repository }}:{{ .Values.policies.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+            - name: MONGO_DB_SSL_ENABLED
+              value: "{{ .Values.mongodb.apps.policies.ssl }}"
+            - name: MONGO_DB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: mongodb
+                  key: policies-uri
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -288,6 +363,12 @@ metadata:
   name: gateway
   labels:
     app: gateway
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -296,59 +377,68 @@ spec:
         actorSystemName: ditto-cluster
     spec:
       containers:
-      - name: gateway
-        image: docker.io/eclipse/ditto-gateway:{{.Chart.Version}}
-        imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
-        ports:
-        - name: akka-remoting
-          containerPort: 2551
-          protocol: TCP
-        - name: akka-mgmt-http
-          containerPort: 8558
-          protocol: TCP
-        readinessProbe:
-          tcpSocket:
-            port: 8558
-          initialDelaySeconds: 45
-          periodSeconds: 10
-        livenessProbe:
-          tcpSocket:
-            port: 2551
-          initialDelaySeconds: 180
-          periodSeconds: 10
-          timeoutSeconds: 3
-          failureThreshold: 4
-        env:
-        - name: ENABLE_DUMMY_AUTH
-          value: "true"
-        - name: INSTANCE_INDEX
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: status.podIP
-        - name: DISCOVERY_METHOD
-          value: "kubernetes-api"
-        - name: TZ
-          value: "Europe/Berlin"
-        - name: IBM_JAVA_OPTIONS
-          value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
+        - name: gateway
+          image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
+          imagePullPolicy: IfNotPresent
+          command: ["java"]
+          args: ["-jar", "/opt/ditto/starter.jar"]
+          ports:
+            - name: akka-remoting
+              containerPort: {{ .Values.akka.remoting.port }}
+              protocol: TCP
+            - name: akka-mgmt-http
+              containerPort: {{ .Values.akka.mgmthttp.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.mgmthttp.port }}
+            initialDelaySeconds: 45
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.akka.remoting.port }}
+            initialDelaySeconds: 180
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 4
+          env:
+            - name: K8S_NAMESPACE
+              value: {{.Release.Namespace}}
+            - name: ENABLE_DUMMY_AUTH
+              value: "true"
+            - name: INSTANCE_INDEX
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+            - name: DISCOVERY_METHOD
+              value: "kubernetes-api"
+            - name: TZ
+              value: "Europe/Berlin"
+            - name: IBM_JAVA_OPTIONS
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: gateway
+  labels:
+    app.kubernetes.io/name: gateway
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{.Chart.Version}}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   clusterIP: None
   ports:
-  - port: 8080
-    targetPort: 8080
-    protocol: TCP
+    - port: 8080
+      targetPort: 8080
+      protocol: TCP
   selector:
     app: gateway

--- a/deployment/helm/eclipse-ditto/templates/mongodb.yaml
+++ b/deployment/helm/eclipse-ditto/templates/mongodb.yaml
@@ -1,7 +1,34 @@
+{{-  $conciergeUri := printf "%s?ssl=%s" .Values.mongodb.apps.concierge.uri .Values.mongodb.apps.concierge.ssl -}}
+{{-  $connectivityUri := printf "%s?ssl=%s" .Values.mongodb.apps.connectivity.uri .Values.mongodb.apps.connectivity.ssl -}}
+{{-  $thingsUri := printf "%s?ssl=%s" .Values.mongodb.apps.things.uri .Values.mongodb.apps.things.ssl -}}
+{{-  $searchDBUri := printf "%s?ssl=%s" .Values.mongodb.apps.searchDB.uri .Values.mongodb.apps.searchDB.ssl -}}
+{{-  $policiesUri := printf "%s?ssl=%s" .Values.mongodb.apps.policies.uri .Values.mongodb.apps.policies.ssl -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mongodb
+type: Opaque
+data:
+  concierge-uri: {{$conciergeUri | b64enc | quote}}  
+  connectivity-uri: {{$connectivityUri | b64enc | quote}}  
+  things-uri: {{$thingsUri | b64enc | quote}}  
+  searchDB-uri: {{$searchDBUri | b64enc | quote}}  
+  policies-uri: {{$policiesUri | b64enc | quote}}  
+---
+{{- if .Values.mongodb.embedded.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
   name: mongodb
+  labels:
+    app.kubernetes.io/name: mongodb
+    app.kubernetes.io/component: database
+    app.kubernetes.io/version: "{{ .Values.mongodb.embedded.version }}"
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   clusterIP: None
   ports:
@@ -20,10 +47,17 @@ spec:
     metadata:
       labels:
         app: mongodb
+        app.kubernetes.io/name: mongodb
+        app.kubernetes.io/component: database
+        app.kubernetes.io/version: "{{ .Values.mongodb.embedded.version }}"
+        app.kubernetes.io/part-of: {{ .Chart.Name }}
+        helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       containers:
       - name: mongodb
-        image: docker.io/mongo:3.6
+        image: docker.io/mongo:{{ .Values.mongodb.embedded.version }}
         command:
           - mongod
           - --bind_ip
@@ -36,3 +70,4 @@ spec:
         env:
         - name: TZ
           value: Europe/Berlin
+{{- end }}

--- a/deployment/helm/eclipse-ditto/templates/nginx.yaml
+++ b/deployment/helm/eclipse-ditto/templates/nginx.yaml
@@ -2,12 +2,18 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ditto
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{ .Values.nginx.version }}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   ports:
-  - port: 8080
-    targetPort: 80
-    protocol: TCP
-  type: NodePort
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+      protocol: TCP
+  type: {{ .Values.service.type }}
   selector:
     app: nginx
 ---
@@ -15,6 +21,14 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: nginx
+  labels:
+    app: nginx
+    app.kubernetes.io/name: nginx
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{ .Values.nginx.version }}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:
@@ -22,31 +36,31 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: docker.io/nginx:1.15-alpine
-        volumeMounts:
-        - name: nginx-conf
-          mountPath: /etc/nginx/nginx.conf
-          subPath: nginx.conf
-        - name: nginx-htpasswd
-          mountPath: /etc/nginx/nginx.htpasswd
-          subPath: nginx.htpasswd
-        - name: nginx-cors
-          mountPath: /etc/nginx/nginx-cors.conf
-          subPath: nginx-cors.conf
-        - name: nginx-index
-          mountPath: /etc/nginx/html/index.html
-          subPath: index.html
+        - name: nginx
+          image: docker.io/nginx:{{ .Values.nginx.version }}-alpine
+          volumeMounts:
+            - name: nginx-conf
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+            - name: nginx-htpasswd
+              mountPath: /etc/nginx/nginx.htpasswd
+              subPath: nginx.htpasswd
+            - name: nginx-cors
+              mountPath: /etc/nginx/nginx-cors.conf
+              subPath: nginx-cors.conf
+            - name: nginx-index
+              mountPath: /etc/nginx/html/index.html
+              subPath: index.html
       volumes:
-      - name: nginx-conf
-        configMap:
-          name: nginx-conf
-      - name: nginx-htpasswd
-        configMap:
-          name: nginx-htpasswd
-      - name: nginx-cors
-        configMap:
-          name: nginx-cors
-      - name: nginx-index
-        configMap:
-          name: nginx-index
+        - name: nginx-conf
+          configMap:
+            name: nginx-conf
+        - name: nginx-htpasswd
+          configMap:
+            name: nginx-htpasswd
+        - name: nginx-cors
+          configMap:
+            name: nginx-cors
+        - name: nginx-index
+          configMap:
+            name: nginx-index

--- a/deployment/helm/eclipse-ditto/templates/pod-reader-role.yaml
+++ b/deployment/helm/eclipse-ditto/templates/pod-reader-role.yaml
@@ -22,7 +22,7 @@ subjects:
 # Note the `name` line below. The first default refers to the namespace. The second refers to the service account name.
 # For instance, `name: system:serviceaccount:myns:default` would refer to the default service account in namespace `myns`
 - kind: User
-  name: system:serviceaccount:default:default
+  name: system:serviceaccount:{{.Release.Namespace}}:default
 roleRef:
   kind: Role
   name: pod-reader

--- a/deployment/helm/eclipse-ditto/values.yaml
+++ b/deployment/helm/eclipse-ditto/values.yaml
@@ -1,3 +1,63 @@
 # Default values for eclipse-ditto.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
+service:
+  type: NodePort
+  port: 8080
+
+akka:
+  remoting:
+    port: 2551
+  mgmthttp:
+    port: 8558
+
+concierge:
+  image:
+    repository: docker.io/eclipse/ditto-concierge
+    tag: 0.8.0
+connectivity:
+  image:
+    repository: docker.io/eclipse/ditto-connectivity
+    tag: 0.8.0
+things:
+  image:
+    repository: docker.io/eclipse/ditto-things
+    tag: 0.8.0
+search:
+  image:
+    repository: docker.io/eclipse/ditto-things-search
+    tag: 0.8.0
+policies:
+  image:
+    repository: docker.io/eclipse/ditto-policies
+    tag: 0.8.0
+gateway:
+  image:
+    repository: docker.io/eclipse/ditto-gateway
+    tag: 0.8.0
+
+nginx:
+  version: 1.15
+
+mongodb:
+  # Deployed as part of chart.
+  embedded:
+    version: 3.6
+    enabled: true
+  apps:
+    concierge:
+      uri: mongodb://mongodb:27017/concierge
+      ssl: "false"
+    connectivity:
+      uri: mongodb://mongodb:27017/connectivity
+      ssl: "false"
+    things:
+      uri: mongodb://mongodb:27017/things
+      ssl: "false"
+    searchDB:
+      uri: mongodb://mongodb:27017/searchDB
+      ssl: "false"
+    policies:
+      uri: mongodb://mongodb:27017/policies
+      ssl: "false"


### PR DESCRIPTION
Hi,

I added a few options to the template to have flexibility on the environment.

- Support for namespace deployment.
- Support for other service types then `NodePort`.
- Support for external MongoDB including SSL support.
- Added [recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/).
- Support for other Docker repositories or tags.
- Internal akka ports are centrally set as well.

In addition I enabled DevOps and health API.

My editor also corrected the yaml indentation a bit, let me know if that bugs you. I can revert that.

Kai

Signed-off-by: Kai Zimmermann <kai.zimmermann@microsoft.com>