### PR TITLE
Fix error when duplicate header fields are send

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -94,7 +94,7 @@
         <jmh.version>1.4.1</jmh.version>
 
         <scalatest.version>3.0.0</scalatest.version>
-        <flapdoodle.version>2.2.0</flapdoodle.version>
+        <flapdoodle.version>2.0.0</flapdoodle.version>
     </properties>
 
     <dependencyManagement>

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -13,6 +13,8 @@ package org.eclipse.ditto.services.gateway.endpoints.routes;
 import static org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants.KNOWN_DOMAIN;
 import static org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants.UNKNOWN_PATH;
 
+import java.util.UUID;
+
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestBase;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants;
@@ -268,6 +270,17 @@ public final class RootRouteTest extends EndpointTestBase {
     @Test
     public void getWithInvalidEncoding() {
         final TestRouteResult result = rootTestRoute.run(HttpRequest.GET(PATH_WITH_INVALID_ENCODING));
+        result.assertStatusCode(StatusCodes.BAD_REQUEST);
+    }
+
+    @Test
+    public void getExceptionForDuplicateHeaderFields() {
+        final TestRouteResult result =
+                rootTestRoute.run(withHttps(withDummyAuthentication(HttpRequest.GET(THINGS_1_PATH_WITH_IDS)
+                        .addHeader(RawHeader.create(HttpHeader.X_CORRELATION_ID.getName(), UUID.randomUUID().toString()))
+                        .addHeader(RawHeader.create(HttpHeader.X_CORRELATION_ID.getName(), UUID.randomUUID().toString()))
+                        ))
+                );
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
     }
 

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayDuplicateHeaderException.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/exceptions/GatewayDuplicateHeaderException.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2017-2018 Bosch Software Innovations GmbH.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v2.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/epl-2.0/index.php
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.signals.commands.base.exceptions;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+/**
+ * This exception indicates that a request with duplicate header fields was sent.
+ */
+@Immutable
+@JsonParsableException(errorCode = GatewayDuplicateHeaderException.ERROR_CODE)
+public final class GatewayDuplicateHeaderException extends DittoRuntimeException implements GatewayException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "duplicate.header.field";
+
+    private static final String DEFAULT_MESSAGE =
+            "The send request contains headers which include a duplicate header field!";
+
+    private static final String DEFAULT_DESCRIPTION =
+            "A request must not contain multiple header fields with the same field name. " +
+                    "For more information see RFC 7230 section 3.2.2.";
+
+    private static final String DEFAULT_HREF = "https://tools.ietf.org/rfc/rfc7230.txt";
+
+    private static final long serialVersionUID = -1141581276920590766L;
+
+    private GatewayDuplicateHeaderException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for a {@code GatewayDuplicateHeaderException}.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a new {@code GatewayDuplicateHeaderException} object with given message.
+     *
+     * @param message detail message. This message can be later retrieved by the {@link #getMessage()} method.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayDuplicateHeaderException.
+     */
+    public static GatewayDuplicateHeaderException fromMessage(final String message,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code GatewayDuplicateHeaderException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new GatewayDuplicateHeaderException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field.
+     */
+    public static GatewayDuplicateHeaderException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link org.eclipse.ditto.signals.commands.base.exceptions.GatewayDuplicateHeaderException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<GatewayDuplicateHeaderException> {
+
+        private Builder() {
+            description(DEFAULT_DESCRIPTION);
+            message(DEFAULT_MESSAGE);
+            try {
+                href(new URI(DEFAULT_HREF));
+            } catch (final URISyntaxException e) {
+                // Will not happen. DEFAULT_HREF is valid URI.
+            }
+        }
+
+        @Override
+        protected GatewayDuplicateHeaderException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new GatewayDuplicateHeaderException(dittoHeaders, message, description, cause, href);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes Internal Server Error which is raised when to header fields with the same name are send.
Now a technical error response with Http status code 400 is send .