### PR TITLE
Fix *NamespaceOpsITs after upgrade to MongoDB 3.6.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
       mavenLocalRepo: theMvnRepo) {
 
       sh "mvn clean deploy javadoc:jar source:jar" +
-              " -T16 --batch-mode --errors" +
+              " --batch-mode --errors" +
               " -Pbuild-documentation,internal-repos -DcreateJavadoc=true" +
               " -Drevision=${theVersion}"
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ node {
       mavenLocalRepo: theMvnRepo) {
 
       sh "mvn clean deploy javadoc:jar source:jar" +
-              " --batch-mode --errors" +
+              " -T16 --batch-mode --errors" +
               " -Pbuild-documentation,internal-repos -DcreateJavadoc=true" +
               " -Drevision=${theVersion}"
     }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -94,7 +94,7 @@
         <jmh.version>1.4.1</jmh.version>
 
         <scalatest.version>3.0.0</scalatest.version>
-        <flapdoodle.version>2.0.0</flapdoodle.version>
+        <flapdoodle.version>2.2.0</flapdoodle.version>
     </properties>
 
     <dependencyManagement>

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractConditionalHeadersCheckingCommandStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractConditionalHeadersCheckingCommandStrategy.java
@@ -61,7 +61,8 @@ public abstract class AbstractConditionalHeadersCheckingCommandStrategy<C extend
                 .flatMap(EntityTag::fromEntity)
                 .orElse(null);
 
-        context.getLog().debug("Validating conditional headers with currentETagValue <{}> on command <{}>.");
+        context.getLog().debug("Validating conditional headers with currentETagValue <{}> on command <{}>.",
+                currentETagValue, command);
         try {
             VALIDATOR.checkConditionalHeaders(command, currentETagValue);
             context.getLog().debug("Validating conditional headers succeeded.");

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/strategies/AbstractReceiveStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/strategies/AbstractReceiveStrategy.java
@@ -53,12 +53,13 @@ public abstract class AbstractReceiveStrategy<T> implements ReceiveStrategy<T> {
         preApply(message);
     }
 
-    protected void preApply(final T message) {
+    private void preApply(final T message) {
         if (message instanceof Command) {
             final Command command = (Command) message;
             LogUtil.enhanceLogWithCorrelationId(logger, command.getDittoHeaders().getCorrelationId());
             if (logger.isDebugEnabled()) {
-                logger.debug("Applying command <{}>: {}", command.getType(), command.toJsonString());
+                logger.debug("Applying command <{}> with strategy <{}>: {}",
+                        command.getType(), this.getClass().getSimpleName(), command.toJsonString());
             }
         }
         doApply(message);

--- a/services/things/starter/src/main/resources/things.conf
+++ b/services/things/starter/src/main/resources/things.conf
@@ -3,7 +3,7 @@ ditto {
   cluster-downing.role = "things"
 
   things {
-    # Logs for all incoming messages minimal information to enable message tracing troughout the system
+    # Logs for all incoming messages minimal information to enable message tracing throughout the system
     log-incoming-messages = true
     log-incoming-messages = ${?LOG_INCOMING_MESSAGES}
 

--- a/services/things/starter/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingNamespaceOpsActorIT.java
+++ b/services/things/starter/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ThingNamespaceOpsActorIT.java
@@ -82,8 +82,8 @@ public final class ThingNamespaceOpsActorIT extends EventSourceNamespaceOpsActor
     protected ActorRef startActorUnderTest(final ActorSystem actorSystem, final ActorRef pubSubMediator,
             final Config config) {
 
-        final Props nanmespaceOpsActorProps = ThingNamespaceOpsActor.props(pubSubMediator, config);
-        return actorSystem.actorOf(nanmespaceOpsActorProps, ThingNamespaceOpsActor.ACTOR_NAME);
+        final Props namespaceOpsActorProps = ThingNamespaceOpsActor.props(pubSubMediator, config);
+        return actorSystem.actorOf(namespaceOpsActorProps, ThingNamespaceOpsActor.ACTOR_NAME);
     }
 
     @Override

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/namespace/EventSourceNamespaceOpsActorTestCases.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/namespace/EventSourceNamespaceOpsActorTestCases.java
@@ -111,10 +111,12 @@ public abstract class EventSourceNamespaceOpsActorTestCases {
         // - do not log dead letters (i. e., events for which there is no subscriber)
         // - bind to random available port
         // - do not attempt to join an Akka cluster
+        // - do not shutdown jvm on exit (breaks unit tests)
         // - make Mongo URI known to the persistence plugin and to the NamespaceOps actor
         final String testConfig = "akka.log-dead-letters=0\n" +
                 "akka.remote.artery.bind.port=0\n" +
                 "akka.cluster.seed-nodes=[]\n" +
+                "akka.coordinated-shutdown.exit-jvm=off\n" +
                 "akka.contrib.persistence.mongodb.mongo.mongouri=" + mongoUriValue +
                 "ditto.services-utils-config.mongodb.uri=" + mongoUriValue;
 

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/namespace/EventSourceNamespaceOpsActorTestCases.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/namespace/EventSourceNamespaceOpsActorTestCases.java
@@ -47,7 +47,6 @@ import akka.testkit.javadsl.TestKit;
  */
 public abstract class EventSourceNamespaceOpsActorTestCases {
 
-    private static final Logger MONGOD_LOGGER = LoggerFactory.getLogger("mongod");
     private static final Random RANDOM = new Random();
 
     /**
@@ -60,7 +59,7 @@ public abstract class EventSourceNamespaceOpsActorTestCases {
 
     @BeforeClass
     public static void startMongoDb() {
-        mongoDbResource = new MongoDbResource("localhost", MONGOD_LOGGER);
+        mongoDbResource = new MongoDbResource("localhost");
         mongoDbResource.start();
     }
 
@@ -117,6 +116,7 @@ public abstract class EventSourceNamespaceOpsActorTestCases {
                 "akka.remote.artery.bind.port=0\n" +
                 "akka.cluster.seed-nodes=[]\n" +
                 "akka.coordinated-shutdown.exit-jvm=off\n" +
+                "ditto.things.log-incoming-messages=true\n" +
                 "akka.contrib.persistence.mongodb.mongo.mongouri=" + mongoUriValue +
                 "ditto.services-utils-config.mongodb.uri=" + mongoUriValue;
 

--- a/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
+++ b/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
@@ -174,7 +174,7 @@ public final class MongoDbResource extends ExternalResource {
 
         return mongodStarter.prepare(new MongodConfigBuilder()
                 .net(new Net(bindIp, mongoDbPort, false))
-                .version(Version.Main.PRODUCTION)
+                .version(Version.Main.V3_6)
                 .cmdOptions(new MongoCmdOptionsBuilder()
                         .useStorageEngine("wiredTiger")
                         .useNoJournal(false)

--- a/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
+++ b/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
@@ -174,7 +174,7 @@ public final class MongoDbResource extends ExternalResource {
 
         return mongodStarter.prepare(new MongodConfigBuilder()
                 .net(new Net(bindIp, mongoDbPort, false))
-                .version(Version.Main.V3_4)
+                .version(Version.Main.V3_6)
                 .cmdOptions(new MongoCmdOptionsBuilder()
                         .useStorageEngine("wiredTiger")
                         .useNoJournal(false)

--- a/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
+++ b/services/utils/test/src/test/java/org/eclipse/ditto/services/utils/test/mongo/MongoDbResource.java
@@ -174,7 +174,7 @@ public final class MongoDbResource extends ExternalResource {
 
         return mongodStarter.prepare(new MongodConfigBuilder()
                 .net(new Net(bindIp, mongoDbPort, false))
-                .version(Version.Main.V3_6)
+                .version(Version.Main.V3_4)
                 .cmdOptions(new MongoCmdOptionsBuilder()
                         .useStorageEngine("wiredTiger")
                         .useNoJournal(false)


### PR DESCRIPTION
The tests *NamespaceOpsITs became unstable after using MongoDB version 3.6 for the integration tests. This PR stabilizes the tests by stopping the actorsystem started in the tests and better separating the databases used for the test runs.