### PR TITLE
Fix publishing of command responses in absence of a target

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/MqttClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/MqttClientActor.java
@@ -151,8 +151,8 @@ public final class MqttClientActor extends BaseClientActor {
     }
 
     @Override
-    protected Optional<ActorRef> getPublisherActor() {
-        return Optional.ofNullable(mqttPublisherActor);
+    protected ActorRef getPublisherActor() {
+        return mqttPublisherActor;
     }
 
     @Override
@@ -271,10 +271,10 @@ public final class MqttClientActor extends BaseClientActor {
 
     @Override
     protected void cleanupResourcesForConnection() {
-
         pendingStatusReportsFromStreams.clear();
         activateConsumerKillSwitch();
         stopCommandConsumers();
+        stopMessageMappingProcessorActor();
         stopMqttPublisher();
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/MqttClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/MqttClientActorTest.java
@@ -312,9 +312,6 @@ public class MqttClientActorTest {
             LOGGER.info("Sending thing modified message: {}", thingModifiedEvent);
             final OutboundSignal.WithExternalMessage mappedSignal =
                     Mockito.mock(OutboundSignal.WithExternalMessage.class);
-            final ExternalMessage externalMessage =
-                    ExternalMessageFactory.newExternalMessageBuilder(new HashMap<>()).withText(expectedJson).build();
-            when(mappedSignal.getExternalMessage()).thenReturn(externalMessage);
             when(mappedSignal.getTargets()).thenReturn(singletonList(TARGET));
             when(mappedSignal.getSource()).thenReturn(thingModifiedEvent);
             underTest.tell(mappedSignal, getRef());

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryActorTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryActorTest.java
@@ -45,7 +45,7 @@ import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.testkit.JavaTestKit;
+import akka.testkit.javadsl.TestKit;
 
 /**
  * Unit test for {@link QueryActor}.
@@ -82,7 +82,7 @@ public final class QueryActorTest {
     private Criteria criteriaMock;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         final Config config = ConfigFactory.load("test");
         actorSystem = ActorSystem.create("AkkaTestSystem", config);
 
@@ -102,14 +102,16 @@ public final class QueryActorTest {
     }
 
     @After
-    public void tearDown() throws Exception {
-        JavaTestKit.shutdownActorSystem(actorSystem);
-        actorSystem = null;
+    public void tearDown() {
+        if (actorSystem != null) {
+            TestKit.shutdownActorSystem(actorSystem);
+            actorSystem = null;
+        }
     }
 
     @Test
     public void countThingsToQuery() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createQueryActor();
 
@@ -124,7 +126,7 @@ public final class QueryActorTest {
 
     @Test
     public void queryThingsToQuery() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createQueryActor();
 
@@ -138,7 +140,7 @@ public final class QueryActorTest {
 
     @Test
     public void queryThingsToQueryWithOptions() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createQueryActor();
 
@@ -154,7 +156,7 @@ public final class QueryActorTest {
 
     @Test
     public void queryThingsToQueryWithInvalidFilter() {
-        new JavaTestKit(actorSystem) {
+        new TestKit(actorSystem) {
             {
                 final ActorRef underTest = createQueryActor();
 


### PR DESCRIPTION
Currently command responses are only published if a target was specified for the connection (amqp 1.0 and 0.9.1 connections, mqtt works fine).