### PR TITLE
Recover from closed JMS AMQP message producer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ ajcore.*.txt
 *.mdb
 .env
 .DS_Store
+.factorypath

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -24,14 +24,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
-
 import javax.annotation.Nullable;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
-
 import org.apache.qpid.jms.JmsConnection;
 import org.apache.qpid.jms.JmsConnectionListener;
 import org.apache.qpid.jms.message.JmsInboundMessageDispatch;
@@ -53,7 +51,6 @@ import org.eclipse.ditto.services.connectivity.messaging.internal.ImmutableConne
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.config.ConfigUtil;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionFailedException;
-
 import akka.actor.ActorRef;
 import akka.actor.FSM;
 import akka.actor.Props;
@@ -429,6 +426,9 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
                         }
                     });
         }
+        
+        statusReport.getClosedProducer().ifPresent(p -> amqpPublisherActor.tell(statusReport, ActorRef.noSender()));
+        
         return stay().using(data);
     }
 
@@ -489,71 +489,6 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
 
         JmsDisconnected(@Nullable final ActorRef origin) {
             super(origin);
-        }
-    }
-
-    /**
-     * Message for status reporter.
-     */
-    private static final class StatusReport {
-
-        private final boolean consumedMessage;
-        private final boolean connectionRestored;
-        @Nullable private final ConnectionFailure failure;
-        @Nullable private final MessageConsumer closedConsumer;
-        @Nullable private final MessageProducer closedProducer;
-
-        private StatusReport(
-                final boolean consumedMessage,
-                final boolean connectionRestored,
-                @Nullable final ConnectionFailure failure,
-                @Nullable final MessageConsumer closedConsumer,
-                @Nullable final MessageProducer closedProducer) {
-            this.consumedMessage = consumedMessage;
-            this.connectionRestored = connectionRestored;
-            this.failure = failure;
-            this.closedConsumer = closedConsumer;
-            this.closedProducer = closedProducer;
-        }
-
-        private static StatusReport connectionRestored() {
-            return new StatusReport(false, true, null, null, null);
-        }
-
-        private static StatusReport failure(final ConnectionFailure failure) {
-            return new StatusReport(false, false, failure, null, null);
-        }
-
-        private static StatusReport consumedMessage() {
-            return new StatusReport(true, false, null, null, null);
-        }
-
-        private static StatusReport consumerClosed(final MessageConsumer consumer) {
-            return new StatusReport(false, false, null, consumer, null);
-        }
-
-        private static StatusReport producerClosed(final MessageProducer producer) {
-            return new StatusReport(false, false, null, null, producer);
-        }
-
-        private boolean hasConsumedMessage() {
-            return consumedMessage;
-        }
-
-        private boolean isConnectionRestored() {
-            return connectionRestored;
-        }
-
-        private Optional<ConnectionFailure> getFailure() {
-            return Optional.ofNullable(failure);
-        }
-
-        private Optional<MessageConsumer> getClosedConsumer() {
-            return Optional.ofNullable(closedConsumer);
-        }
-
-        private Optional<MessageProducer> getClosedProducer() {
-            return Optional.ofNullable(closedProducer);
         }
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/JMSConnectionHandlingActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/JMSConnectionHandlingActor.java
@@ -239,6 +239,10 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
      */
     private JmsConnection createJmsConnection() {
         try {
+            if (log.isDebugEnabled()) {
+                log.debug("Attempt to create connection {} for URI [{}]", connection.getId(), 
+                        ConnectionBasedJmsConnectionFactory.buildAmqpConnectionUriFromConnection(connection));
+            }
             return jmsConnectionFactory.createConnection(connection, exceptionListener);
         } catch (final JMSException | NamingException e) {
             throw ConnectionFailedException.newBuilder(connection.getId())

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/StatusReport.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/StatusReport.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.messaging.amqp;
+
+import java.util.Optional;
+import javax.annotation.Nullable;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import org.eclipse.ditto.services.connectivity.messaging.internal.ConnectionFailure;
+
+/**
+ * Message for status reporter.
+ */
+final class StatusReport {
+
+    private final boolean consumedMessage;
+    private final boolean connectionRestored;
+    @Nullable private final ConnectionFailure failure;
+    @Nullable private final MessageConsumer closedConsumer;
+    @Nullable private final MessageProducer closedProducer;
+
+    private StatusReport(
+            final boolean consumedMessage,
+            final boolean connectionRestored,
+            @Nullable final ConnectionFailure failure,
+            @Nullable final MessageConsumer closedConsumer,
+            @Nullable final MessageProducer closedProducer) {
+        this.consumedMessage = consumedMessage;
+        this.connectionRestored = connectionRestored;
+        this.failure = failure;
+        this.closedConsumer = closedConsumer;
+        this.closedProducer = closedProducer;
+    }
+
+    static StatusReport connectionRestored() {
+        return new StatusReport(false, true, null, null, null);
+    }
+
+    static StatusReport failure(final ConnectionFailure failure) {
+        return new StatusReport(false, false, failure, null, null);
+    }
+
+    static StatusReport consumedMessage() {
+        return new StatusReport(true, false, null, null, null);
+    }
+
+    static StatusReport consumerClosed(final MessageConsumer consumer) {
+        return new StatusReport(false, false, null, consumer, null);
+    }
+
+    static StatusReport producerClosed(final MessageProducer producer) {
+        return new StatusReport(false, false, null, null, producer);
+    }
+
+    private boolean hasConsumedMessage() {
+        return consumedMessage;
+    }
+
+    boolean isConnectionRestored() {
+        return connectionRestored;
+    }
+
+    Optional<ConnectionFailure> getFailure() {
+        return Optional.ofNullable(failure);
+    }
+
+    Optional<MessageConsumer> getClosedConsumer() {
+        return Optional.ofNullable(closedConsumer);
+    }
+
+    Optional<MessageProducer> getClosedProducer() {
+        return Optional.ofNullable(closedProducer);
+    }
+}

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
@@ -75,14 +75,7 @@ public abstract class AbstractPublisherActorTest {
             when(source.getId()).thenReturn(TestConstants.Things.THING_ID);
             when(source.getDittoHeaders()).thenReturn(DittoHeaders.empty());
             when(outboundSignal.getSource()).thenReturn(source);
-            final Target target =
-                    ConnectivityModelFactory.newTargetBuilder()
-                            .address(getOutboundAddress())
-                            .originalAddress(getOutboundAddress())
-                            .authorizationContext(TestConstants.Authorization.AUTHORIZATION_CONTEXT)
-                            .headerMapping(TestConstants.HEADER_MAPPING)
-                            .topics(Topic.TWIN_EVENTS)
-                            .build();
+            final Target target = createTestTarget();
             when(outboundSignal.getTargets()).thenReturn(Collections.singletonList(decorateTarget(target)));
 
 
@@ -102,6 +95,18 @@ public abstract class AbstractPublisherActorTest {
             verifyPublishedMessage();
         }};
 
+        
+
+    }
+        
+    protected Target createTestTarget() {
+        return ConnectivityModelFactory.newTargetBuilder()
+            .address(getOutboundAddress())
+            .originalAddress(getOutboundAddress())
+            .authorizationContext(TestConstants.Authorization.AUTHORIZATION_CONTEXT)
+            .headerMapping(TestConstants.HEADER_MAPPING)
+            .topics(Topic.TWIN_EVENTS)
+            .build();
     }
 
     protected abstract String getOutboundAddress();

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
@@ -17,11 +17,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
-
+import java.util.Optional;
 import javax.jms.CompletionListener;
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -32,16 +33,25 @@ import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.message.JmsMessage;
 import org.apache.qpid.jms.message.JmsTextMessage;
 import org.apache.qpid.jms.provider.amqp.message.AmqpJmsTextMessageFacade;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.Target;
+import org.eclipse.ditto.model.connectivity.Topic;
 import org.eclipse.ditto.services.connectivity.messaging.AbstractPublisherActorTest;
 import org.eclipse.ditto.services.connectivity.messaging.TestConstants;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
+import org.eclipse.ditto.services.models.connectivity.OutboundSignal;
+import org.eclipse.ditto.services.models.connectivity.OutboundSignalFactory;
+import org.eclipse.ditto.signals.base.Signal;
+import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.Answer;
-
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
 
 public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
 
@@ -60,6 +70,45 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             jmsTextMessage.setText(argument);
             return jmsTextMessage;
         });
+    }
+    
+    @Test
+    public void testRecoverPublisher() throws Exception {
+
+        new TestKit(actorSystem) {{
+            final TestProbe probe = new TestProbe(actorSystem);
+            setupMocks(probe);
+            
+            final OutboundSignal outboundSignal = mock(OutboundSignal.class);
+            final Signal source = mock(Signal.class);
+            when(source.getId()).thenReturn(TestConstants.Things.THING_ID);
+            when(source.getDittoHeaders()).thenReturn(DittoHeaders.empty());
+            when(outboundSignal.getSource()).thenReturn(source);
+            final Target target = createTestTarget();
+            when(outboundSignal.getTargets()).thenReturn(Collections.singletonList(decorateTarget(target)));
+
+
+            final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().putHeader("device_id", "ditto:thing").build();
+            final ExternalMessage externalMessage =
+                    ExternalMessageFactory.newExternalMessageBuilder(dittoHeaders).withText("payload").build();
+            final OutboundSignal.WithExternalMessage mappedOutboundSignal =
+                    OutboundSignalFactory.newMappedOutboundSignal(outboundSignal, externalMessage);
+
+            final Props props = getPublisherActorProps();
+            final ActorRef publisherActor = actorSystem.actorOf(props);
+
+            publisherActor.tell(mappedOutboundSignal, getRef());
+            publisherActor.tell(mappedOutboundSignal, getRef());
+            // producer is cache so created only once
+            verify(session, timeout(1_000)).createProducer(ArgumentMatchers.any(Destination.class));
+            
+            publisherActor.tell(StatusReport.producerClosed(messageProducer), getRef());
+            
+            publisherActor.tell(mappedOutboundSignal, getRef());
+            // second producer created as first one was removed from cache
+            verify(session, timeout(1_000).times(2)).createProducer(ArgumentMatchers.any(Destination.class));            
+        }};
+
     }
 
     @Override


### PR DESCRIPTION
Hi,

ditto is currently caching the MessageProducers in its AMQP 1.0 connector. However, producers might be closed by the server. In fact Azure Service Bus is doing so after 10 minutes of idle time. Other servers might have something similar.

I think there are multiple approaches to solve this:
* Put a static invalidation on the cache, e.g. 5 minutes.
* Recover from the IllegalStateException the closed producer is throwing when attempting to send through it.
* React to the clients connection listener which actually informs about a closed producer.

I decided to go for the later option as it is the cleanest one imho. However, for maximum robustness it might make sense to implement all three.

Be aware this is my first code contribution to Ditto or any Akka based app at all, so please let me know if I got it completely wrong here 😈 

Kai

Signed-off-by: Kai Zimmermann <kai.zimmermann@microsoft.com>