### PR TITLE
MongoDbResource: set the listening port

### DIFF
--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/AbstractThingSearchPersistenceITBase.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/AbstractThingSearchPersistenceITBase.java
@@ -116,12 +116,8 @@ public abstract class AbstractThingSearchPersistenceITBase {
 
     private MongoThingsSearchPersistence provideReadPersistence() {
         final MongoThingsSearchPersistence result = new MongoThingsSearchPersistence(mongoClient, actorSystem);
-        try {
-            // explicitly trigger CompletableFuture to make sure that indices are created before test runs
-            result.initializeIndices().toCompletableFuture().get();
-        } catch (final InterruptedException | ExecutionException e) {
-            throw new IllegalStateException(e);
-        }
+        // explicitly trigger CompletableFuture to make sure that indices are created before test runs
+        result.initializeIndices().toCompletableFuture().join();
         return result;
     }
 


### PR DESCRIPTION
Allow setting listening port of embedded MongoDB to enable tests involving MongoDB downtime.