### PR TITLE
Fix Nginx connectivity after Helm update

### DIFF
--- a/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
+++ b/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
@@ -62,7 +62,7 @@ spec:
             - name: TZ
               value: "{{ .Values.global.timezone }}"
             - name: IBM_JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"           
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
             - name: MONGO_DB_SSL_ENABLED
               value: "{{ .Values.mongodb.apps.concierge.ssl }}"
             - name: MONGO_DB_URI
@@ -134,7 +134,7 @@ spec:
             - name: TZ
               value: "{{ .Values.global.timezone }}"
             - name: IBM_JAVA_OPTIONS
-              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"         
+              value: "-XX:MaxRAMPercentage=80 -XX:InitialRAMPercentage=40 -XX:+ExitOnOutOfMemoryError"
             - name: MONGO_DB_SSL_ENABLED
               value: "{{ .Values.mongodb.apps.connectivity.ssl }}"
             - name: MONGO_DB_URI
@@ -435,7 +435,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  clusterIP: None
   ports:
     - port: 8080
       targetPort: 8080

--- a/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
+++ b/deployment/helm/eclipse-ditto/templates/ditto-cluster.yaml
@@ -12,6 +12,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.concierge.replicaCount }}
   template:
     metadata:
       labels:
@@ -84,6 +85,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.connectivity.replicaCount }}
   template:
     metadata:
       labels:
@@ -156,6 +158,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.things.replicaCount }}
   template:
     metadata:
       labels:
@@ -228,6 +231,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.search.replicaCount }}
   template:
     metadata:
       labels:
@@ -299,6 +303,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.policies.replicaCount }}
   template:
     metadata:
       labels:
@@ -370,6 +375,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.gateway.replicaCount }}
   template:
     metadata:
       labels:

--- a/deployment/helm/eclipse-ditto/templates/mongodb-uris-secret.yaml
+++ b/deployment/helm/eclipse-ditto/templates/mongodb-uris-secret.yaml
@@ -1,17 +1,11 @@
-{{-  $conciergeUri := printf "%s?ssl=%s" .Values.mongodb.apps.concierge.uri .Values.mongodb.apps.concierge.ssl -}}
-{{-  $connectivityUri := printf "%s?ssl=%s" .Values.mongodb.apps.connectivity.uri .Values.mongodb.apps.connectivity.ssl -}}
-{{-  $thingsUri := printf "%s?ssl=%s" .Values.mongodb.apps.things.uri .Values.mongodb.apps.things.ssl -}}
-{{-  $searchDBUri := printf "%s?ssl=%s" .Values.mongodb.apps.searchDB.uri .Values.mongodb.apps.searchDB.ssl -}}
-{{-  $policiesUri := printf "%s?ssl=%s" .Values.mongodb.apps.policies.uri .Values.mongodb.apps.policies.ssl -}}
-
 apiVersion: v1
 kind: Secret
 metadata:
   name: mongodb
 type: Opaque
 data:
-  concierge-uri: {{$conciergeUri | b64enc | quote}}  
-  connectivity-uri: {{$connectivityUri | b64enc | quote}}  
-  things-uri: {{$thingsUri | b64enc | quote}}  
-  searchDB-uri: {{$searchDBUri | b64enc | quote}}  
-  policies-uri: {{$policiesUri | b64enc | quote}}  
+  concierge-uri: {{ .Values.mongodb.apps.concierge.uri | b64enc | quote}}
+  connectivity-uri: {{ .Values.mongodb.apps.connectivity.uri  | b64enc | quote}}
+  things-uri: {{ .Values.mongodb.apps.things.uri  | b64enc | quote}}
+  searchDB-uri: {{ .Values.mongodb.apps.searchDB.uri  | b64enc | quote}}
+  policies-uri: {{ .Values.mongodb.apps.policies.uri  | b64enc | quote}}

--- a/deployment/helm/eclipse-ditto/templates/nginx.yaml
+++ b/deployment/helm/eclipse-ditto/templates/nginx.yaml
@@ -30,6 +30,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.nginx.replicaCount }}
   template:
     metadata:
       labels:

--- a/deployment/helm/eclipse-ditto/templates/swagger.yaml
+++ b/deployment/helm/eclipse-ditto/templates/swagger.yaml
@@ -29,6 +29,7 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
+  replicas: {{ .Values.swagger.replicaCount }}
   template:
     metadata:
       labels:
@@ -36,7 +37,7 @@ spec:
     spec:
       containers:
       - name: swagger-ui
-        image: docker.io/swaggerapi/swagger-ui:3.17.4
+        image: docker.io/swaggerapi/swagger-ui:{{ .Values.swagger.version }}
         volumeMounts:
         - name: swagger-ui-api
           mountPath: /usr/share/nginx/html/openapi

--- a/deployment/helm/eclipse-ditto/templates/swagger.yaml
+++ b/deployment/helm/eclipse-ditto/templates/swagger.yaml
@@ -2,8 +2,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: swagger-ui
+  labels:
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{ .Values.nginx.version }}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
-  clusterIP: None
   ports:
   - port: 8080
     targetPort: 8080
@@ -15,6 +20,14 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: swagger-ui
+  labels:
+    app: swagger-ui
+    app.kubernetes.io/name: swagger-ui
+    app.kubernetes.io/part-of: {{ .Chart.Name }}
+    app.kubernetes.io/version: "{{ .Values.nginx.version }}"
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   template:
     metadata:

--- a/deployment/helm/eclipse-ditto/values.yaml
+++ b/deployment/helm/eclipse-ditto/values.yaml
@@ -15,52 +15,51 @@ akka:
 global:
   timezone: Europe/Berlin
 
-
 concierge:
   name: concierge
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-concierge
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 connectivity:
   name: connectivity
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-connectivity
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 things:
   name: things
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-things
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 search:
   name: things-search
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-things-search
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 policies:
   name: policies
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-policies
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 gateway:
   name: gateway
-  replicaCount: 2
+  replicaCount: 1
   image:
     repository: docker.io/eclipse/ditto-gateway
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 
 nginx:
-  replicaCount: 2
+  replicaCount: 1
   version: 1.15
 swagger:
   replicaCount: 1

--- a/deployment/helm/eclipse-ditto/values.yaml
+++ b/deployment/helm/eclipse-ditto/values.yaml
@@ -15,45 +15,57 @@ akka:
 global:
   timezone: Europe/Berlin
 
+
 concierge:
   name: concierge
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-concierge
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 connectivity:
   name: connectivity
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-connectivity
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 things:
   name: things
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-things
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 search:
   name: things-search
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-things-search
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 policies:
   name: policies
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-policies
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 gateway:
   name: gateway
+  replicaCount: 2
   image:
     repository: docker.io/eclipse/ditto-gateway
     imagePullPolicy: IfNotPresent
     tag: 0.9.0-M1
 
 nginx:
+  replicaCount: 2
   version: 1.15
+swagger:
+  replicaCount: 1
+  version: 3.17.4
+
 
 ##
 ## MongoDB chart configuration


### PR DESCRIPTION
Hi,

I fixed an issue where the reverse proxy was no longer able the access the gateway after a (pod) update. The reason was that no ClusterIP was used and the pod IP changed as a result of the update.

In addition I improved the boolean flag for MongoDB SSL a bit, introduced replicaCount as a setting for the pods, a version setting for Swagger-UI and added a few missing labels.

Kai