### PR TITLE
added missing OSGi imports for "org.atteo.classindex"

### DIFF
--- a/signals/base/pom.xml
+++ b/signals/base/pom.xml
@@ -51,6 +51,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
+                            org.atteo.classindex,
                             !org.eclipse.ditto.utils.jsr305.annotations,
                             org.eclipse.ditto.*
                         </Import-Package>

--- a/signals/commands/base/pom.xml
+++ b/signals/commands/base/pom.xml
@@ -51,6 +51,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
+                            org.atteo.classindex,
                             !org.eclipse.ditto.utils.jsr305.annotations,
                             org.eclipse.ditto.*
                         </Import-Package>

--- a/signals/events/base/pom.xml
+++ b/signals/events/base/pom.xml
@@ -51,6 +51,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
+                            org.atteo.classindex,
                             !org.eclipse.ditto.utils.jsr305.annotations,
                             org.eclipse.ditto.*
                         </Import-Package>


### PR DESCRIPTION
The added registries require that import during runtime.