### PR TITLE
Handle the case that the audience field is an array

### DIFF
--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJsonWebToken.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJsonWebToken.java
@@ -20,11 +20,13 @@ import java.security.Key;
 import java.text.MessageFormat;
 import java.util.Base64;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonParseException;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.services.utils.jwt.JjwtDeserializer;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
 import org.eclipse.ditto.signals.commands.base.exceptions.GatewayJwtInvalidException;
@@ -138,6 +140,12 @@ public abstract class AbstractJsonWebToken implements JsonWebToken {
     }
 
     @Override
+    public Audience getAudience() {
+        final Optional<JsonValue> audience = body.getValue(JsonFields.AUDIENCE);
+        return audience.map(Audience::fromJson).orElseGet(Audience::empty);
+    }
+
+    @Override
     public CompletableFuture<BinaryValidationResult> validate(final PublicKeyProvider publicKeyProvider) {
         final String issuer = getIssuer();
         final String keyId = getKeyId();
@@ -165,10 +173,10 @@ public abstract class AbstractJsonWebToken implements JsonWebToken {
     private BinaryValidationResult validatePublicKey(final Key publicKey) {
         final JwtParser jwtParser = Jwts.parser();
         jwtParser.deserializeJsonWith(JjwtDeserializer.getInstance())
-                    .setSigningKey(publicKey)
-                    .parse(getToken());
+                .setSigningKey(publicKey)
+                .parse(getToken());
 
-            return BinaryValidationResult.valid();
+        return BinaryValidationResult.valid();
     }
 
     @Override

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/Audience.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/Audience.java
@@ -1,0 +1,96 @@
+ /*
+  * Copyright (c) 2019 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collections;
+ import java.util.List;
+ import java.util.Optional;
+ import java.util.stream.Collectors;
+
+ import org.eclipse.ditto.json.JsonArray;
+ import org.eclipse.ditto.json.JsonValue;
+
+ /**
+  * Java representation of the audience field specified by:
+  * <a href="https://tools.ietf.org/html/rfc7519#section-4.1.3">rfc7519</a>.
+  */
+ public final class Audience {
+
+     private final List<String> principles;
+
+     private Audience(final List<String> principles) {
+         this.principles = Collections.unmodifiableList(new ArrayList<>(principles));
+     }
+
+     /**
+      * Builds an audience based on the given json value.
+      *
+      * @param audValue the value of the "aud" field of a JWT.
+      * @return the built audience.
+      * @throws JwtAudienceInvalidException if the aud field is neither an array nor a single string.
+      */
+     static Audience fromJson(final JsonValue audValue) {
+         final JsonArray principles;
+
+         if (audValue.isArray()) {
+             principles = audValue.asArray();
+         } else if (audValue.isString()) {
+             principles = JsonArray.of(audValue);
+         } else {
+             throw JwtAudienceInvalidException
+                     .newBuilder(audValue)
+                     .build();
+         }
+
+         final List<String> stringPrinciples = principles.stream()
+                 .map(JsonValue::asString)
+                 .distinct()
+                 .collect(Collectors.toList());
+
+         return new Audience(stringPrinciples);
+     }
+
+     /**
+      * builds and Audience without any principles.
+      *
+      * @return the empty audience.
+      */
+     static Audience empty() {
+         return new Audience(Collections.emptyList());
+     }
+
+     /**
+      * Returns the single principle if this audience does contain only a single principle.
+      *
+      * @return Optional of a principle. Optional is empty if either the principles are empty or the principles
+      * contain more than one principle.
+      */
+     public Optional<String> getSinglePrinciple() {
+         if (principles.size() != 1) {
+             return Optional.empty();
+         } else {
+             return Optional.of(principles.get(0));
+         }
+     }
+
+     /**
+      * Returns the principles of this audience.
+      *
+      * @return the principles of this audience.
+      */
+     public List<String> getPrinciples() {
+         return principles;
+     }
+ }

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JsonWebToken.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JsonWebToken.java
@@ -20,6 +20,7 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.json.FieldType;
 
 /**
@@ -79,6 +80,13 @@ public interface JsonWebToken {
     List<String> getSubjects();
 
     /**
+     * Returns the audience of a JWT.
+     *
+     * @return the audience.
+     */
+    Audience getAudience();
+
+    /**
      * Checks if this JSON web token is valid in terms of not expired, well formed and correctly signed.
      *
      * @param publicKeyProvider the public key provider to provide the public key that should be used to sign this JSON
@@ -114,8 +122,8 @@ public interface JsonWebToken {
         /**
          * JSON field containing the audience.
          */
-        public static final JsonFieldDefinition<String> AUDIENCE =
-                JsonFactory.newStringFieldDefinition("aud", FieldType.REGULAR);
+        public static final JsonFieldDefinition<JsonValue> AUDIENCE =
+                JsonFactory.newJsonValueFieldDefinition("aud", FieldType.REGULAR);
 
         private JsonFields() {
             throw new AssertionError();

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtAudienceInvalidException.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtAudienceInvalidException.java
@@ -1,0 +1,113 @@
+ /*
+  * Copyright (c) 2019 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+ import java.net.URI;
+ import java.text.MessageFormat;
+
+ import javax.annotation.Nullable;
+ import javax.annotation.concurrent.NotThreadSafe;
+
+ import org.eclipse.ditto.json.JsonObject;
+ import org.eclipse.ditto.json.JsonValue;
+ import org.eclipse.ditto.model.base.common.HttpStatusCode;
+ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+ import org.eclipse.ditto.model.base.headers.DittoHeaders;
+ import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+ @JsonParsableException(errorCode = JwtAudienceInvalidException.ERROR_CODE)
+ public final class JwtAudienceInvalidException extends DittoRuntimeException implements JwtException {
+
+     /**
+      * Error code of this exception.
+      */
+     static final String ERROR_CODE = ERROR_CODE_PREFIX + "audience.invalid";
+
+     private static final String MESSAGE = "The value for the <aud> field is not valid.";
+     private static final String DESCRIPTION_TEMPLATE = "The <aud> field was expected to be either a string or an " +
+             "array of strings. The actual value was <{0}>.";
+
+     private static final long serialVersionUID = -7613054868240460649L;
+
+     private JwtAudienceInvalidException(final DittoHeaders dittoHeaders,
+             @Nullable final String message,
+             @Nullable final String description,
+             @Nullable final Throwable cause,
+             @Nullable final URI href) {
+         super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+     }
+
+     /**
+      * A mutable builder for this exception.
+      *
+      * @param audValue the value the aud key.
+      * @return the builder.
+      */
+     public static Builder newBuilder(final JsonValue audValue) {
+         return new Builder(audValue);
+     }
+
+     /**
+      * A mutable builder for this exception.
+      *
+      * @return the builder.
+      */
+     public static Builder newBuilder() {
+         return new Builder();
+     }
+
+     /**
+      * Constructs a new {@code JwtAudienceInvalidException} object with the exception message extracted from the
+      * given JSON object.
+      *
+      * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+      * @param dittoHeaders the headers of the command which resulted in this exception.
+      * @return the new JwtAudienceInvalidException.
+      * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the
+      * {@link JsonFields#MESSAGE} field.
+      */
+     public static JwtAudienceInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+         return new Builder()
+                 .dittoHeaders(dittoHeaders)
+                 .message(readMessage(jsonObject))
+                 .description(readDescription(jsonObject).orElse(DESCRIPTION_TEMPLATE))
+                 .href(readHRef(jsonObject).orElse(null))
+                 .build();
+     }
+
+     /**
+      * A mutable builder with a fluent API for a {@link JwtAudienceInvalidException}.
+      */
+     @NotThreadSafe
+     public static final class Builder extends DittoRuntimeExceptionBuilder<JwtAudienceInvalidException> {
+
+         private Builder() {
+             message(MESSAGE);
+         }
+
+         private Builder(final JsonValue audValue) {
+             this();
+             description(MessageFormat.format(DESCRIPTION_TEMPLATE, audValue));
+         }
+
+         @Override
+         protected JwtAudienceInvalidException doBuild(final DittoHeaders dittoHeaders,
+                 @Nullable final String message,
+                 @Nullable final String description,
+                 @Nullable final Throwable cause,
+                 @Nullable final URI href) {
+             return new JwtAudienceInvalidException(dittoHeaders, message, description, cause, href);
+         }
+     }
+ }

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtException.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtException.java
@@ -1,0 +1,21 @@
+ /*
+  * Copyright (c) 2019 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+ public interface JwtException {
+
+     /**
+      * Error code prefix of errors related to JWT.
+      */
+     String ERROR_CODE_PREFIX = "jwt" + ":";
+ }

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AudienceTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AudienceTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonValue;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Audience}.
+ */
+public class AudienceTest {
+
+    @Test
+    public void fromJsonWithASingleString() {
+        final String principleName = "myAudience";
+        final JsonValue myAudience = JsonValue.of(principleName);
+        final Audience audience = Audience.fromJson(myAudience);
+        assertThat(audience.getSinglePrinciple()).contains(principleName);
+    }
+
+    @Test
+    public void fromJsonWithAJsonArray() {
+        final List<String> principles = Arrays.asList("myAudience1", "myAudience2");
+        final JsonValue jsonPrinciples = JsonArray.of(principles);
+        final Audience audience = Audience.fromJson(jsonPrinciples);
+        assertThat(audience.getPrinciples()).containsAll(principles);
+    }
+
+    @Test
+    public void empty() {
+        final Audience emptyAudience = Audience.empty();
+        assertThat(emptyAudience.getPrinciples()).isEmpty();
+    }
+
+    @Test
+    public void getSinglePrincipleContainsTheSinglePrinciple() {
+        final String principleName = "myAudience";
+        final JsonValue myAudience = JsonValue.of(principleName);
+        final Audience audience = Audience.fromJson(myAudience);
+        assertThat(audience.getSinglePrinciple()).contains(principleName);
+    }
+
+    @Test
+    public void getSinglePrincipleIsNotPresentForEmptyAudience() {
+        final Audience audience = Audience.empty();
+        assertThat(audience.getSinglePrinciple()).isNotPresent();
+    }
+
+    @Test
+    public void getSinglePrincipleIsNotPresentForMultiplePrincipleAudience() {
+        final List<String> principles = Arrays.asList("myAudience1", "myAudience2");
+        final JsonValue jsonPrinciples = JsonArray.of(principles);
+        final Audience audience = Audience.fromJson(jsonPrinciples);
+        assertThat(audience.getSinglePrinciple()).isNotPresent();
+    }
+
+    @Test
+    public void getPrinciplesContainsAllPrinciples() {
+        final List<String> principles = Arrays.asList("myAudience1", "myAudience2");
+        final JsonValue jsonPrinciples = JsonArray.of(principles);
+        final Audience audience = Audience.fromJson(jsonPrinciples);
+        assertThat(audience.getPrinciples()).containsAll(principles);
+    }
+
+    @Test
+    public void fromJsonThrowsJwtAudienceInvalidException() {
+        assertThatExceptionOfType(JwtAudienceInvalidException.class)
+                .isThrownBy(() -> Audience.fromJson(JsonValue.of(4711)));
+    }
+}

--- a/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
+++ b/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
@@ -22,6 +22,7 @@ import org.eclipse.ditto.model.placeholders.PlaceholderFunctionSignatureInvalidE
 import org.eclipse.ditto.model.policies.PolicyEntryInvalidException;
 import org.eclipse.ditto.model.things.AclEntryInvalidException;
 import org.eclipse.ditto.protocoladapter.UnknownCommandException;
+import org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtAudienceInvalidException;
 import org.eclipse.ditto.services.utils.test.GlobalErrorRegistryTestCases;
 import org.eclipse.ditto.signals.base.JsonTypeNotParsableException;
 import org.eclipse.ditto.signals.commands.base.CommandNotSupportedException;
@@ -51,7 +52,8 @@ public final class GatewayServiceGlobalErrorRegistryTest extends GlobalErrorRegi
                 BatchAlreadyExecutingException.class,
                 InvalidNamespacesException.class,
                 NamespaceBlockedException.class,
-                PlaceholderFunctionSignatureInvalidException.class
+                PlaceholderFunctionSignatureInvalidException.class,
+                JwtAudienceInvalidException.class
         ));
     }
 }


### PR DESCRIPTION
RFC7519 says that "aud" is either a string or an array of strings. Currently only a single string is expected. (see https://tools.ietf.org/html/rfc7519#section-4.1.3 )

This pr can handle both