### PR TITLE
Make signal headers available for publisher actors

### DIFF
--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
@@ -88,7 +88,7 @@ public final class DittoMessageMapper implements MessageMapper {
                         .withText(jsonString)
                         .asResponse(isResponse)
                         .asError(isError)
-                .build());
+                        .build());
     }
 
     private static String extractPayloadAsString(final ExternalMessage message) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.services.connectivity.mapping.DittoMessageMapper;
 import org.eclipse.ditto.services.connectivity.mapping.MessageMapper;
 import org.eclipse.ditto.services.connectivity.mapping.MessageMapperRegistry;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
+import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
 import org.eclipse.ditto.services.models.connectivity.InboundExternalMessage;
 import org.eclipse.ditto.services.models.connectivity.MappedInboundExternalMessage;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
@@ -120,7 +121,8 @@ public final class MessageMappingProcessor {
     Optional<ExternalMessage> process(final Signal<?> signal) {
         final StartedTimer overAllProcessingTimer = startNewTimer().tag(DIRECTION_TAG_NAME, OUTBOUND);
         return withTimer(overAllProcessingTimer,
-                () -> convertToExternalMessage(() -> protocolAdapter.toAdaptable(signal), overAllProcessingTimer));
+                () -> convertToExternalMessage(signal, () -> protocolAdapter.toAdaptable(signal),
+                        overAllProcessingTimer));
     }
 
     private Optional<InboundExternalMessage> convertMessage(final ExternalMessage message,
@@ -151,7 +153,9 @@ public final class MessageMappingProcessor {
         }
     }
 
-    private Optional<ExternalMessage> convertToExternalMessage(final Supplier<Adaptable> adaptableSupplier,
+    private Optional<ExternalMessage> convertToExternalMessage(
+            final Signal signal,
+            final Supplier<Adaptable> adaptableSupplier,
             final StartedTimer overAllProcessingTimer) {
         checkNotNull(adaptableSupplier);
 
@@ -164,7 +168,10 @@ public final class MessageMappingProcessor {
             return withTimer(overAllProcessingTimer.startNewSegment(PAYLOAD_SEGMENT_NAME),
                     () -> getMapper(adaptable)
                             .map(adaptable)
-                            .map(em -> em.withTopicPath(adaptable.getTopicPath()))
+                            .map(em -> ExternalMessageFactory.newExternalMessageBuilder(em)
+                                    .withTopicPath(adaptable.getTopicPath())
+                                    .withInternalHeaders(signal.getDittoHeaders())
+                                    .build())
             );
         } catch (final DittoRuntimeException e) {
             throw e;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -167,7 +167,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
                 log.warning("No producer for destination {} available.", publishTarget);
                 final MessageSendingFailedException sendFailedException = MessageSendingFailedException.newBuilder()
                         .message("Failed to send message, no producer available.")
-                        .dittoHeaders(DittoHeaders.of(message.getHeaders()))
+                        .dittoHeaders(DittoHeaders.of(message.getInternalHeaders()))
                         .build();
                 getSender().tell(sendFailedException, getSelf());
             }
@@ -181,7 +181,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
         log.info("Failed to send JMS message: [{}] {}", e.getClass().getSimpleName(), e.getMessage());
         final MessageSendingFailedException sendFailedException = MessageSendingFailedException.newBuilder()
                 .cause(e)
-                .dittoHeaders(DittoHeaders.of(message.getHeaders()))
+                .dittoHeaders(DittoHeaders.of(message.getInternalHeaders()))
                 .build();
         publishedCounter.recordFailure();
         sender.tell(sendFailedException, getSelf());

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/ExternalMessage.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/ExternalMessage.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.HeaderMapping;
 import org.eclipse.ditto.model.placeholders.EnforcementFilter;
 import org.eclipse.ditto.protocoladapter.TopicPath;
@@ -141,6 +142,12 @@ public interface ExternalMessage {
      * @return optional source address, where this message was received
      */
     Optional<String> getSourceAddress();
+
+    /**
+     * @return Ditto headers of the signal that created this external message if any.
+     * Use those headers when sending error back into the Ditto cluster.
+     */
+    DittoHeaders getInternalHeaders();
 
     /**
      * The known payload types of ExternalMessages.

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/ExternalMessageBuilder.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/ExternalMessageBuilder.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.Enforcement;
 import org.eclipse.ditto.model.connectivity.HeaderMapping;
 import org.eclipse.ditto.model.placeholders.EnforcementFilter;
@@ -143,6 +144,15 @@ public interface ExternalMessageBuilder {
      * @return this builder in order to enable method chaining
      */
     ExternalMessageBuilder asError(boolean error);
+
+    /**
+     * Attach headers of the signal that created the external message for generation of errors to send back
+     * into the Ditto cluster.
+     *
+     * @param internalHeaders headers of the signal.
+     * @return this builder.
+     */
+    ExternalMessageBuilder withInternalHeaders(DittoHeaders internalHeaders);
 
     /**
      * Builds the ExternalMessage.

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessage.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessage.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.HeaderMapping;
 import org.eclipse.ditto.model.placeholders.EnforcementFilter;
 import org.eclipse.ditto.protocoladapter.TopicPath;
@@ -45,6 +46,8 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
     @Nullable private final HeaderMapping headerMapping;
     @Nullable private final String sourceAddress;
 
+    private final DittoHeaders internalHeaders;
+
     UnmodifiableExternalMessage(final Map<String, String> headers,
             final boolean response,
             final boolean error,
@@ -55,7 +58,8 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
             @Nullable final TopicPath topicPath,
             @Nullable final EnforcementFilter<String> enforcementFilter,
             @Nullable final HeaderMapping headerMapping,
-            @Nullable final String sourceAddress) {
+            @Nullable final String sourceAddress,
+            final DittoHeaders internalHeaders) {
 
         this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
         this.response = response;
@@ -68,6 +72,7 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
         this.enforcementFilter = enforcementFilter;
         this.headerMapping = headerMapping;
         this.sourceAddress = sourceAddress;
+        this.internalHeaders = internalHeaders;
     }
 
     @Override
@@ -164,6 +169,11 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
     }
 
     @Override
+    public DittoHeaders getInternalHeaders() {
+        return internalHeaders;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -182,13 +192,14 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
                 Objects.equals(sourceAddress, that.sourceAddress) &&
                 Objects.equals(response, that.response) &&
                 Objects.equals(error, that.error) &&
-                payloadType == that.payloadType;
+                payloadType == that.payloadType &&
+                Objects.equals(internalHeaders, that.internalHeaders);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(headers, textPayload, bytePayload, payloadType, response, error, authorizationContext,
-                topicPath, enforcementFilter, headerMapping, sourceAddress);
+                topicPath, enforcementFilter, headerMapping, sourceAddress, internalHeaders);
     }
 
     @Override
@@ -206,6 +217,7 @@ final class UnmodifiableExternalMessage implements ExternalMessage {
                 ", textPayload=" + textPayload +
                 ", bytePayload=" +
                 (bytePayload == null ? "null" : ("<binary> (size :" + bytePayload.array().length + ")")) + "'" +
+                ", internalHeaders=" + internalHeaders +
                 "]";
     }
 }

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessageBuilder.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessageBuilder.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.common.ConditionChecker;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.HeaderMapping;
 import org.eclipse.ditto.model.placeholders.EnforcementFilter;
 import org.eclipse.ditto.protocoladapter.TopicPath;
@@ -41,6 +42,7 @@ final class UnmodifiableExternalMessageBuilder implements ExternalMessageBuilder
     @Nullable private EnforcementFilter<String> enforcementFilter;
     @Nullable private HeaderMapping headerMapping;
     @Nullable private String sourceAddress;
+    private DittoHeaders internalHeaders = DittoHeaders.empty();
 
     /**
      * Constructs a new MutableExternalMessageBuilder initialized with the passed {@code message}.
@@ -59,6 +61,7 @@ final class UnmodifiableExternalMessageBuilder implements ExternalMessageBuilder
         this.enforcementFilter = message.getEnforcementFilter().orElse(null);
         this.headerMapping = message.getHeaderMapping().orElse(null);
         this.sourceAddress = message.getSourceAddress().orElse(null);
+        this.internalHeaders = message.getInternalHeaders();
     }
 
     /**
@@ -164,9 +167,15 @@ final class UnmodifiableExternalMessageBuilder implements ExternalMessageBuilder
     }
 
     @Override
+    public ExternalMessageBuilder withInternalHeaders(final DittoHeaders internalHeaders) {
+        this.internalHeaders = internalHeaders;
+        return this;
+    }
+
+    @Override
     public ExternalMessage build() {
         return new UnmodifiableExternalMessage(headers, response, error, payloadType, textPayload, bytePayload,
-                authorizationContext, topicPath, enforcementFilter, headerMapping, sourceAddress);
+                authorizationContext, topicPath, enforcementFilter, headerMapping, sourceAddress, internalHeaders);
     }
 
 }

--- a/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessageTest.java
+++ b/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/UnmodifiableExternalMessageTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.services.models.connectivity;
 import java.nio.ByteBuffer;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.HeaderMapping;
 import org.eclipse.ditto.model.placeholders.EnforcementFilter;
 import org.eclipse.ditto.protocoladapter.Adaptable;
@@ -36,6 +37,7 @@ public final class UnmodifiableExternalMessageTest {
         // The field "bytePayload" is mutable.
         // Assume the user never modifies it.
         MutabilityAssert.assertInstancesOf(UnmodifiableExternalMessage.class, MutabilityMatchers.areImmutable(),
+                AllowedReason.provided(DittoHeaders.class).isAlsoImmutable(),
                 AllowedReason.assumingFields("bytePayload").areNotModifiedAndDoNotEscape(),
                 AllowedReason.provided(ByteBuffer.class, AuthorizationContext.class, Adaptable.class,
                         EnforcementFilter.class, HeaderMapping.class, TopicPath.class).areAlsoImmutable());


### PR DESCRIPTION
Sometimes publisher actors fail to send messages into an external connection. They  would report the error to the original sender. That error's header should have all the internal Ditto headers intact so that the protocol adapter processes it correctly. That is not the case; publisher actors had only the stripped headers of the external messages to send.

This patch adds the Ditto headers of the original signal into {{ExternalMessage}}. Those headers are used only when a publisher actor sends something back into the Ditto cluster.