### PR TITLE
fix WebSocket wrongly applied backpressure on errors

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -313,8 +313,9 @@ public final class WebsocketRoute {
 
     private Jsonifiable.WithPredicate<JsonObject, JsonField> publishResponsePublishedEvent(
             final Jsonifiable.WithPredicate<JsonObject, JsonField> jsonifiable) {
-        if (jsonifiable instanceof CommandResponse) {
-            // only create ResponsePublished for CommandResponses, not for Events with the same correlationId
+        if (jsonifiable instanceof CommandResponse || jsonifiable instanceof DittoRuntimeException) {
+            // only create ResponsePublished for CommandResponses and DittoRuntimeExceptions
+            //  not for Events with the same correlationId
             ((WithDittoHeaders) jsonifiable).getDittoHeaders()
                     .getCorrelationId()
                     .map(ResponsePublished::new)


### PR DESCRIPTION
 fixed that DittoRuntimeExceptions encountered as a result from protocol messages via WS triggered the backpressure mechanism so that effectively each websocket did block after receiving100 DittoRuntimeExceptions
