### PR TITLE
Remove "back-to-sleep" feature of SudoRetrieveThing

### DIFF
--- a/services/models/things/pom.xml
+++ b/services/models/things/pom.xml
@@ -89,6 +89,13 @@
             <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes>
+                            <exclude>org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThing</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/services/models/things/src/main/java/org/eclipse/ditto/services/models/things/commands/sudo/SudoRetrieveThing.java
+++ b/services/models/things/src/main/java/org/eclipse/ditto/services/models/things/commands/sudo/SudoRetrieveThing.java
@@ -54,13 +54,6 @@ public final class SudoRetrieveThing extends AbstractCommand<SudoRetrieveThing>
      */
     public static final String TYPE = TYPE_PREFIX + NAME;
 
-    /**
-     * Header to tell the recipient to go back to sleep.
-     */
-    public static final String BACK_TO_SLEEP_HEADER = "x-ditto-back-to-sleep";
-
-    private static final String BACK_TO_SLEEP_VALUE = "true";
-
     static final JsonFieldDefinition<Boolean> JSON_USE_ORIGINAL_SCHEMA_VERSION =
             JsonFactory.newBooleanFieldDefinition("payload/useOriginalSchemaVersion", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
@@ -198,22 +191,6 @@ public final class SudoRetrieveThing extends AbstractCommand<SudoRetrieveThing>
      */
     public Optional<JsonFieldSelector> getSelectedFields() {
         return Optional.ofNullable(selectedFields);
-    }
-
-    /**
-     * @return a copy of this command with an extra header telling the recipient to go back to sleep.
-     */
-    public SudoRetrieveThing goBackToSleep() {
-        final DittoHeaders newHeaders =
-                getDittoHeaders().toBuilder().putHeader(BACK_TO_SLEEP_HEADER, BACK_TO_SLEEP_VALUE).build();
-        return setDittoHeaders(newHeaders);
-    }
-
-    /**
-     * @return if the recipient should go back to sleep after handling this command.
-     */
-    public static boolean shouldGoBackToSleep(final DittoHeaders dittoHeaders) {
-        return BACK_TO_SLEEP_VALUE.equals(dittoHeaders.get(BACK_TO_SLEEP_HEADER));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/ThingPersistenceActor.java
@@ -108,8 +108,6 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
     private Cancellable activityChecker;
     private Thing thing;
 
-    private int firstMessageCounter = 0;
-
     ThingPersistenceActor(final String thingId, final ActorRef pubSubMediator,
             final ThingSnapshotter.Create thingSnapshotterCreate) {
 
@@ -132,7 +130,7 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
         final Runnable becomeDeletedRunnable = this::becomeThingDeletedHandler;
         defaultContext =
                 DefaultContext.getInstance(thingId, log, thingSnapshotter, becomeCreatedRunnable,
-                        becomeDeletedRunnable, this::stopThisActor, this::isFirstMessage);
+                        becomeDeletedRunnable);
 
         handleThingEvents = ReceiveBuilder.create()
                 .match(ThingEvent.class, event -> {
@@ -220,10 +218,6 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
         return thingId;
     }
 
-    private boolean isFirstMessage() {
-        return firstMessageCounter <= 1;
-    }
-
     private void scheduleCheckForThingActivity(final long intervalInSeconds) {
         log.debug("Scheduling for Activity Check in <{}> seconds.", intervalInSeconds);
         // if there is a previous activity checker, cancel it
@@ -280,13 +274,17 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
         return new StrategyAwareReceiveBuilder(receiveBuilder, log)
                 .match(new CheckForActivityStrategy())
                 .matchAny(new MatchAnyDuringInitializeStrategy())
-                .setPeekConsumer(getPeekConsumer())
+                .setPeekConsumer(getIncomingMessagesLoggerOrNull())
                 .build();
     }
 
     @Nullable
-    private Consumer<Object> getPeekConsumer() {
-        return new PeekConsumer(isLogIncomingMessages());
+    private Consumer<Object> getIncomingMessagesLoggerOrNull() {
+        if (isLogIncomingMessages()) {
+            return new LogIncomingMessagesConsumer();
+        } else {
+            return null;
+        }
     }
 
     @Override
@@ -389,7 +387,7 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
                 .matchEach(thingSnapshotter.strategies())
                 .match(new CheckForActivityStrategy())
                 .matchAny(new ThingNotFoundStrategy())
-                .setPeekConsumer(getPeekConsumer())
+                .setPeekConsumer(getIncomingMessagesLoggerOrNull())
                 .build();
 
         getContext().become(receive, true);
@@ -517,24 +515,6 @@ public final class ThingPersistenceActor extends AbstractPersistentActor impleme
     // stop the supervisor (otherwise it'd restart this actor) which causes this actor to stop, too.
     private void stopThisActor() {
         getContext().getParent().tell(ThingSupervisorActor.Control.PASSIVATE, getSelf());
-    }
-
-    /**
-     * This consumer sets firstMessageCounter and calls other peek consumers as needed.
-     */
-    private final class PeekConsumer implements Consumer<Object> {
-
-        private final Consumer<Object> furtherConsumers;
-
-        private PeekConsumer(final boolean logIncomingMessages) {
-            furtherConsumers = logIncomingMessages ? new LogIncomingMessagesConsumer() : object -> {};
-        }
-
-        @Override
-        public void accept(final Object o) {
-            firstMessageCounter = Math.min(2, firstMessageCounter + 1);
-            furtherConsumers.accept(o);
-        }
     }
 
     /**

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CommandStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CommandStrategy.java
@@ -121,15 +121,6 @@ public interface CommandStrategy<T extends Command> {
          */
         Runnable getBecomeDeletedRunnable();
 
-        /**
-         * @return the runnable to stop this actor.
-         */
-        Runnable getStopThisActorRunnable();
-
-        /**
-         * @return if this is the first message.
-         */
-        boolean isFirstMessage();
     }
 
 }

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DefaultContext.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DefaultContext.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.services.things.persistence.actors.strategies.commands
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.util.Objects;
-import java.util.function.Supplier;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -34,24 +33,18 @@ public final class DefaultContext implements CommandStrategy.Context {
     private final ThingSnapshotter<?, ?> thingSnapshotter;
     private final Runnable becomeCreatedRunnable;
     private final Runnable becomeDeletedRunnable;
-    private final Runnable stopThisActorRunnable;
-    private final Supplier<Boolean> isFirstMessageSupplier;
 
     private DefaultContext(final String theThingId,
             final DiagnosticLoggingAdapter theLog,
             final ThingSnapshotter<?, ?> theThingSnapshotter,
             final Runnable becomeCreatedRunnable,
-            final Runnable becomeDeletedRunnable,
-            final Runnable stopThisActorRunnable,
-            final Supplier<Boolean> isFirstMessageSupplier) {
+            final Runnable becomeDeletedRunnable) {
 
         thingId = checkNotNull(theThingId, "Thing ID");
         log = checkNotNull(theLog, "DiagnosticLoggingAdapter");
         thingSnapshotter = checkNotNull(theThingSnapshotter, "ThingSnapshotter");
         this.becomeCreatedRunnable = checkNotNull(becomeCreatedRunnable, "becomeCreatedRunnable");
         this.becomeDeletedRunnable = checkNotNull(becomeDeletedRunnable, "becomeDeletedRunnable");
-        this.stopThisActorRunnable = checkNotNull(stopThisActorRunnable, "stopThisActorRunnable");
-        this.isFirstMessageSupplier = checkNotNull(isFirstMessageSupplier, "isFirstMessageSupplier");
     }
 
     /**
@@ -62,7 +55,6 @@ public final class DefaultContext implements CommandStrategy.Context {
      * @param thingSnapshotter the snapshotter to be used.
      * @param becomeCreatedRunnable the runnable to be called in case a Thing is created.
      * @param becomeDeletedRunnable the runnable to be called in case a Thing is deleted.
-     * @param isFirstMessageSupplier whether this message is the first.
      * @return the instance.
      * @throws NullPointerException if any argument is {@code null}.
      */
@@ -70,12 +62,10 @@ public final class DefaultContext implements CommandStrategy.Context {
             final DiagnosticLoggingAdapter log,
             final ThingSnapshotter<?, ?> thingSnapshotter,
             final Runnable becomeCreatedRunnable,
-            final Runnable becomeDeletedRunnable,
-            final Runnable stopThisActorRunnable,
-            final Supplier<Boolean> isFirstMessageSupplier) {
+            final Runnable becomeDeletedRunnable) {
 
-        return new DefaultContext(thingId, log, thingSnapshotter, becomeCreatedRunnable, becomeDeletedRunnable,
-                stopThisActorRunnable, isFirstMessageSupplier);
+        return new DefaultContext(thingId, log, thingSnapshotter, becomeCreatedRunnable, becomeDeletedRunnable
+        );
     }
 
     @Override
@@ -104,16 +94,6 @@ public final class DefaultContext implements CommandStrategy.Context {
     }
 
     @Override
-    public Runnable getStopThisActorRunnable() {
-        return stopThisActorRunnable;
-    }
-
-    @Override
-    public boolean isFirstMessage() {
-        return isFirstMessageSupplier.get();
-    }
-
-    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -126,15 +106,12 @@ public final class DefaultContext implements CommandStrategy.Context {
                 Objects.equals(log, that.log) &&
                 Objects.equals(thingSnapshotter, that.thingSnapshotter) &&
                 Objects.equals(becomeCreatedRunnable, that.becomeCreatedRunnable) &&
-                Objects.equals(becomeDeletedRunnable, that.becomeDeletedRunnable) &&
-                Objects.equals(stopThisActorRunnable, that.stopThisActorRunnable) &&
-                Objects.equals(isFirstMessageSupplier, that.isFirstMessageSupplier);
+                Objects.equals(becomeDeletedRunnable, that.becomeDeletedRunnable);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(thingId, log, thingSnapshotter, becomeCreatedRunnable, becomeDeletedRunnable,
-                stopThisActorRunnable, isFirstMessageSupplier);
+        return Objects.hash(thingId, log, thingSnapshotter, becomeCreatedRunnable, becomeDeletedRunnable);
     }
 
     @Override
@@ -145,8 +122,6 @@ public final class DefaultContext implements CommandStrategy.Context {
                 ", thingSnapshotter=" + thingSnapshotter +
                 ", becomeCreatedRunnable=" + becomeCreatedRunnable +
                 ", becomeDeletedRunnable=" + becomeDeletedRunnable +
-                ", stopThisActorRunnable=" + stopThisActorRunnable +
-                ", isFirstMessageSupplier=" + isFirstMessageSupplier +
                 "]";
     }
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactory.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactory.java
@@ -25,7 +25,6 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTag;
 import org.eclipse.ditto.model.things.Thing;
-import org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThing;
 import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
 import org.eclipse.ditto.signals.commands.things.modify.ThingModifyCommand;
@@ -65,10 +64,6 @@ final class ResultFactory {
             @Nullable final ETagEntityProvider<C, E> eTagEntityProvider) {
 
         return new InfoResult<>(command, completeThing, response, eTagEntityProvider);
-    }
-
-    static CommandStrategy.Result newSudoRetrieveThingResult(final WithDittoHeaders response) {
-        return new SudoRetrieveThingResult(response);
     }
 
     static CommandStrategy.Result emptyResult() {
@@ -206,36 +201,6 @@ final class ResultFactory {
                     ", response=" + response +
                     ", completeThing=" + completeThing +
                     ", eTagEntityProvider=" + eTagEntityProvider +
-                    ']';
-        }
-    }
-
-    private static final class SudoRetrieveThingResult implements CommandStrategy.Result {
-
-        private final WithDittoHeaders response;
-
-        private SudoRetrieveThingResult(final WithDittoHeaders response) {
-            this.response = response;
-        }
-
-        @Override
-        public void apply(final CommandStrategy.Context context,
-                final BiConsumer<ThingModifiedEvent, BiConsumer<ThingModifiedEvent, Thing>> persistConsumer,
-                final Consumer<WithDittoHeaders> notifyConsumer) {
-
-            notifyConsumer.accept(response);
-
-            // actor woke up due to SudoRetrieveThing; stop it
-            final boolean requestedToGoBackToSleep = SudoRetrieveThing.shouldGoBackToSleep(response.getDittoHeaders());
-            if (requestedToGoBackToSleep && context.isFirstMessage()) {
-                context.getStopThisActorRunnable().run();
-            }
-        }
-
-        @Override
-        public String toString() {
-            return this.getClass().getSimpleName() + " [" +
-                    "response=" + response +
                     ']';
         }
     }

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategy.java
@@ -61,8 +61,8 @@ final class SudoRetrieveThingStrategy
                 .map(selectedFields -> theThing.toJson(jsonSchemaVersion, selectedFields, FieldType.regularOrSpecial()))
                 .orElseGet(() -> theThing.toJson(jsonSchemaVersion, FieldType.regularOrSpecial()));
 
-        return ResultFactory.newSudoRetrieveThingResult(
-                SudoRetrieveThingResponse.of(thingJson, command.getDittoHeaders()));
+        return ResultFactory.newQueryResult(command, thing,
+                SudoRetrieveThingResponse.of(thingJson, command.getDittoHeaders()), this);
     }
 
     private static JsonSchemaVersion determineSchemaVersion(final SudoRetrieveThing command, final Thing thing) {
@@ -74,7 +74,7 @@ final class SudoRetrieveThingStrategy
     @Override
     protected Result unhandled(final Context context, @Nullable final Thing thing,
             final long nextRevision, final SudoRetrieveThing command) {
-        return ResultFactory.newSudoRetrieveThingResult(
+        return ResultFactory.newErrorResult(
                 new ThingNotAccessibleException(context.getThingId(), command.getDittoHeaders()));
     }
 

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ETagTestUtils.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/ETagTestUtils.java
@@ -82,12 +82,10 @@ public abstract class ETagTestUtils {
         return ModifyThingResponse.modified(modifiedThing.getId().get(), dittoHeadersWithETag);
     }
 
-    /*
-     * SudoRetrieveThingResponse does not include ETag handling.
-     */
-    public static SudoRetrieveThingResponse sudoRetrieveThingResponse(final JsonObject expectedJsonRepresentation,
-            final DittoHeaders dittoHeaders) {
-        return SudoRetrieveThingResponse.of(expectedJsonRepresentation, dittoHeaders);
+    public static SudoRetrieveThingResponse sudoRetrieveThingResponse(final Thing expectedThing,
+            final JsonObject expectedJsonRepresentation, final DittoHeaders dittoHeaders) {
+        final DittoHeaders dittoHeadersWithETag = appendETagToDittoHeaders(expectedThing, dittoHeaders);
+        return SudoRetrieveThingResponse.of(expectedJsonRepresentation, dittoHeadersWithETag);
     }
 
     // Features

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
@@ -67,7 +67,7 @@ public abstract class AbstractCommandStrategyTest {
         final Runnable becomeCreatedRunnable = mock(Runnable.class);
         final Runnable becomeDeletedRunnable = mock(Runnable.class);
         return DefaultContext.getInstance(THING_ID, logger, thingSnapshotter, becomeCreatedRunnable,
-                becomeDeletedRunnable, () -> {}, () -> false);
+                becomeDeletedRunnable);
     }
 
     protected static void assertModificationResult(final CommandStrategy underTest, @Nullable final Thing thing,

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactoryTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactoryTest.java
@@ -121,7 +121,7 @@ public final class ResultFactoryTest {
         final ThingSnapshotter snapshotter = mock(ThingSnapshotter.class);
 
         return DefaultContext.getInstance("org.example:my-thing", log, snapshotter,
-                mock(Runnable.class), mock(Runnable.class), () -> {}, () -> false);
+                mock(Runnable.class), mock(Runnable.class));
     }
 
     interface Dummy {

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategyTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategyTest.java
@@ -16,10 +16,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.model.things.TestConstants.Thing.THING_ID;
 import static org.eclipse.ditto.model.things.TestConstants.Thing.THING_V2;
 import static org.eclipse.ditto.services.things.persistence.actors.ETagTestUtils.sudoRetrieveThingResponse;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
@@ -31,8 +27,6 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThing;
 import org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThingResponse;
-import org.eclipse.ditto.signals.commands.base.Command;
-import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import org.eclipse.ditto.signals.commands.things.exceptions.ThingNotAccessibleException;
 import org.junit.Before;
 import org.junit.Test;
@@ -94,9 +88,9 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
         final JsonObject expectedThingJson = THING_V2.toJson(command.getImplementedSchemaVersion(),
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                sudoRetrieveThingResponse(expectedThingJson, dittoHeaders);
+                sudoRetrieveThingResponse(THING_V2, expectedThingJson, dittoHeaders);
 
-        assertSudoRetrieveThingResult(underTest, command, expectedResponse);
+        assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
 
     @Test
@@ -107,9 +101,9 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
         final JsonObject expectedThingJson = THING_V2.toJson(THING_V2.getImplementedSchemaVersion(),
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                sudoRetrieveThingResponse(expectedThingJson, DittoHeaders.empty());
+                sudoRetrieveThingResponse(THING_V2, expectedThingJson, DittoHeaders.empty());
 
-        assertSudoRetrieveThingResult(underTest, command, expectedResponse);
+        assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
 
     @Test
@@ -124,9 +118,9 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
         final JsonObject expectedThingJson = THING_V2.toJson(command.getImplementedSchemaVersion(), fieldSelector,
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                sudoRetrieveThingResponse(expectedThingJson, dittoHeaders);
+                sudoRetrieveThingResponse(THING_V2, expectedThingJson, dittoHeaders);
 
-        assertSudoRetrieveThingResult(underTest, command, expectedResponse);
+        assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
 
     @Test
@@ -138,9 +132,9 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
         final JsonObject expectedThingJson = THING_V2.toJson(THING_V2.getImplementedSchemaVersion(), fieldSelector,
                 FieldType.regularOrSpecial());
         final SudoRetrieveThingResponse expectedResponse =
-                sudoRetrieveThingResponse(expectedThingJson, DittoHeaders.empty());
+                sudoRetrieveThingResponse(THING_V2, expectedThingJson, DittoHeaders.empty());
 
-        assertSudoRetrieveThingResult(underTest, command, expectedResponse);
+        assertQueryResult(underTest, THING_V2, command, expectedResponse);
     }
 
     @Test
@@ -152,20 +146,4 @@ public final class SudoRetrieveThingStrategyTest extends AbstractCommandStrategy
 
         assertUnhandledResult(underTest, THING_V2, command, expectedException);
     }
-
-    private void assertSudoRetrieveThingResult(final CommandStrategy underTest, final Command command,
-            final CommandResponse expectedCommandResponse) {
-
-        final CommandStrategy.Context context = getDefaultContext();
-        final CommandStrategy.Result result = applyStrategy(underTest, context, THING_V2, command);
-
-        final DummyCommandHandler mock = mock(DummyCommandHandler.class);
-
-        result.apply(context, mock::persist, mock::notify);
-
-        verify(mock).notify(expectedCommandResponse);
-        verify(mock, never()).persist(any(), any());
-        verify(context.getBecomeDeletedRunnable(), never()).run();
-    }
-
 }

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
@@ -48,7 +48,7 @@ import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.dispatch.MessageDispatcher;
-import akka.pattern.PatternsCS;
+import akka.pattern.Patterns;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
 import akka.stream.javadsl.Source;
@@ -143,13 +143,11 @@ final class EnforcementFlow {
 
     private Source<SudoRetrieveThingResponse, NotUsed> sudoRetrieveThing(final String thingId) {
         if (!thingId.isEmpty()) {
-            // Request recipient to go back to sleep after handling this command because
-            // indexing activities should not keep inactive entities in memory.
             final SudoRetrieveThing command =
-                    SudoRetrieveThing.withOriginalSchemaVersion(thingId, DittoHeaders.empty()).goBackToSleep();
+                    SudoRetrieveThing.withOriginalSchemaVersion(thingId, DittoHeaders.empty());
             final CompletionStage<Source<SudoRetrieveThingResponse, NotUsed>> responseFuture =
                     // using default thread-pool for asking Things shard region
-                    PatternsCS.ask(thingsShardRegion, command, thingsTimeout)
+                    Patterns.ask(thingsShardRegion, command, thingsTimeout)
                             .handle((response, error) -> {
                                 if (response instanceof SudoRetrieveThingResponse) {
                                     return Source.single((SudoRetrieveThingResponse) response);


### PR DESCRIPTION
Reasons:
1. It did not work.
2. Things-service should scale enough to keep all things in memory.

This reverts ca711fdcc61b1154995abc664165f4932baae075 except the passivation of ThingPersistenceActor.