### PR TITLE
MongoSearchUpdaterFlow: Fix looping on unexpected MongoException.

### DIFF
--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/MongoSearchUpdaterFlow.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/MongoSearchUpdaterFlow.java
@@ -114,7 +114,7 @@ final class MongoSearchUpdaterFlow {
 
     private Source<BulkWriteResult, NotUsed> executeBulkWrite(final List<WriteModel<Document>> writeModel) {
         return Source.fromPublisher(collection.bulkWrite(writeModel, new BulkWriteOptions().ordered(false)))
-                .recoverWith(new PFBuilder<Throwable, Source<BulkWriteResult, NotUsed>>()
+                .recoverWithRetries(1, new PFBuilder<Throwable, Source<BulkWriteResult, NotUsed>>()
                         .match(MongoBulkWriteException.class, bulkWriteException -> {
                             log.info("Got MongoBulkWriteException; may ignore if all are duplicate key errors:",
                                     bulkWriteException);


### PR DESCRIPTION
Reason: 'recoverWith' calls the recovery partial function on the SAME error forever if the recovery partial function delivers a failed source with its argument as cause.