### PR TITLE
Cleanup after TestConnection command for AMQP 1.0

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
@@ -416,18 +416,24 @@ public final class ConnectionActor extends AbstractPersistentActor {
         final ActorRef self = getSelf();
         restoreConnection(command.getConnection());
 
-        final PerformTask stopSelfTask = new PerformTask("stop self after test", ConnectionActor::stopSelf);
-
-        askClientActor(command, response -> {
-            origin.tell(TestConnectionResponse.success(command.getConnectionId(), response.toString(),
-                    command.getDittoHeaders()), self);
-            // terminate this actor's supervisor after a connection test again:
-            self.tell(stopSelfTask, ActorRef.noSender());
-        }, error -> {
-            handleException("test", origin, error);
-            // terminate this actor's supervisor after a connection test again:
-            self.tell(stopSelfTask, ActorRef.noSender());
-        });
+        if (clientActorRouter != null) {
+            // client actor is already running, so either another TestConnection command is currently executed or the
+            // connection has been created in the meantime. In either case reject the new TestConnection command to
+            // prevent strange behavior.
+            origin.tell(TestConnectionResponse.alreadyCreated(connectionId, command.getDittoHeaders()), self);
+        } else {
+            final PerformTask stopSelfTask = new PerformTask("stop self after test", ConnectionActor::stopSelf);
+            askClientActor(command, response -> {
+                origin.tell(TestConnectionResponse.success(command.getConnectionId(), response.toString(),
+                        command.getDittoHeaders()), self);
+                // terminate this actor's supervisor after a connection test again:
+                self.tell(stopSelfTask, ActorRef.noSender());
+            }, error -> {
+                handleException("test", origin, error);
+                // terminate this actor's supervisor after a connection test again:
+                self.tell(stopSelfTask, ActorRef.noSender());
+            });
+        }
     }
 
     private <T extends ConnectivityCommand> void validateAndForward(final T command, final Consumer<T> target) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -24,12 +24,14 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+
 import javax.annotation.Nullable;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageProducer;
 import javax.jms.Session;
+
 import org.apache.qpid.jms.JmsConnection;
 import org.apache.qpid.jms.JmsConnectionListener;
 import org.apache.qpid.jms.message.JmsInboundMessageDispatch;
@@ -51,13 +53,14 @@ import org.eclipse.ditto.services.connectivity.messaging.internal.ImmutableConne
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.config.ConfigUtil;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionFailedException;
+
 import akka.actor.ActorRef;
 import akka.actor.FSM;
 import akka.actor.Props;
 import akka.actor.Status;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.japi.pf.FSMStateFunctionBuilder;
-import akka.pattern.PatternsCS;
+import akka.pattern.Patterns;
 
 /**
  * Actor which manages a connection to an AMQP 1.0 server using the Qpid JMS client.
@@ -162,8 +165,22 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     @Override
     protected CompletionStage<Status.Status> doTestConnection(final Connection connection) {
         // delegate to child actor because the QPID JMS client is blocking until connection is opened/closed
-        return PatternsCS.ask(getTestConnectionHandler(connection),
+        return Patterns.ask(getTestConnectionHandler(connection),
                 new JmsConnect(getSender()), Duration.ofSeconds(TEST_CONNECTION_TIMEOUT))
+                // compose the disconnect because otherwise the actor hierarchy might be stopped too fast
+                .thenCompose(response -> {
+                    log.debug("Closing JMS connection after testing connection.");
+                    if (response instanceof JmsConnected) {
+                        final JmsConnection jmsConnection = ((JmsConnected) response).connection;
+                        final JmsDisconnect jmsDisconnect = new JmsDisconnect(ActorRef.noSender(), jmsConnection);
+                        return Patterns.ask(getDisconnectConnectionHandler(connection), jmsDisconnect,
+                                Duration.ofSeconds(TEST_CONNECTION_TIMEOUT))
+                                // replace jmsDisconnected message with original response
+                                .thenApply(jmsDisconnected -> response);
+                    } else {
+                        return CompletableFuture.completedFuture(response);
+                    }
+                })
                 .handle((response, throwable) -> {
                     if (throwable != null || response instanceof Status.Failure || response instanceof Throwable) {
                         final Throwable ex =
@@ -426,9 +443,9 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
                         }
                     });
         }
-        
+
         statusReport.getClosedProducer().ifPresent(p -> amqpPublisherActor.tell(statusReport, ActorRef.noSender()));
-        
+
         return stay().using(data);
     }
 


### PR DESCRIPTION
Connections created when testing an AMQP 1.0 connection were not closed and stayed open, potentially competing for messages with the actual connection. This PR also prevents execution of parallel test connection commands which might lead to strange behavior.