### PR TITLE
Make http request actor extensible

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
@@ -70,6 +70,11 @@ import akka.util.ByteString;
 import scala.concurrent.duration.Duration;
 import scala.util.Either;
 
+/**
+ * Abstract actor to handle one HTTP request. It is created with an HTTP request and a promise of an HTTP response that
+ * it should fulfill. When it receives a command response, exception, status or timeout message, it renders the message
+ * into an HTTP response and stops itself. Its behavior can be modified by overriding the protected instance methods.
+ */
 public abstract class AbstractHttpRequestActor extends AbstractActor {
 
     /**

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/DefaultHttpRequestActorPropsFactory.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/DefaultHttpRequestActorPropsFactory.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.actors;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.ditto.protocoladapter.HeaderTranslator;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+
+/**
+ * Default creator of Props of HTTP request actors.
+ */
+public final class DefaultHttpRequestActorPropsFactory implements HttpRequestActorPropsFactory {
+
+    @Override
+    public Props props(final ActorRef proxyActor, final HeaderTranslator headerTranslator,
+            final HttpRequest httpRequest,
+            final CompletableFuture<HttpResponse> httpResponseFuture) {
+
+        return HttpRequestActor.props(proxyActor, headerTranslator, httpRequest, httpResponseFuture);
+    }
+}

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.actors;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.ditto.protocoladapter.HeaderTranslator;
+import org.eclipse.ditto.signals.commands.base.Command;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+
+/**
+ * Every HTTP Request causes one new Actor instance of this one to be created.
+ * It holds the original sender of an issued {@link Command} and tells this one the completed HttpResponse.
+ */
+public final class HttpRequestActor extends AbstractHttpRequestActor {
+
+    private HttpRequestActor(final ActorRef proxyActor,
+            final HeaderTranslator headerTranslator,
+            final HttpRequest request,
+            final CompletableFuture<HttpResponse> httpResponseFuture) {
+        super(proxyActor, headerTranslator, request, httpResponseFuture);
+    }
+
+    /**
+     * Creates the Akka configuration object for this {@code HttpRequestActor} for the given {@code proxyActor}, {@code
+     * request}, and {@code httpResponseFuture} which will be completed with a {@link HttpResponse}.
+     *
+     * @param proxyActor the proxy actor which delegates commands.
+     * @param headerTranslator the {@link HeaderTranslator} used to map ditto headers to (external) Http headers.
+     * @param request the HTTP request
+     * @param httpResponseFuture the completable future which is completed with a HTTP response.
+     * @return the configuration object.
+     */
+    public static Props props(final ActorRef proxyActor,
+            final HeaderTranslator headerTranslator,
+            final HttpRequest request,
+            final CompletableFuture<HttpResponse> httpResponseFuture) {
+
+        return Props.create(HttpRequestActor.class,
+                () -> new HttpRequestActor(proxyActor, headerTranslator, request, httpResponseFuture));
+    }
+}

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorPropsFactory.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorPropsFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.actors;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.ditto.protocoladapter.HeaderTranslator;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+
+/**
+ * Factory of props of actors that handle HTTP requests.
+ */
+@FunctionalInterface
+public interface HttpRequestActorPropsFactory {
+
+    /**
+     * Create Props object of an actor to handle 1 HTTP request.
+     *
+     * @param proxyActor proxy actor to forward all commands.
+     * @param headerTranslator translator of Ditto headers.
+     * @param httpRequest the HTTP request.
+     * @param httpResponseFuture promise of an HTTP response to be fulfilled by the actor.
+     * @return Props of the actor.
+     */
+    Props props(ActorRef proxyActor, HeaderTranslator headerTranslator, HttpRequest httpRequest,
+            CompletableFuture<HttpResponse> httpResponseFuture);
+}

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/stats/StatsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/stats/StatsRoute.java
@@ -29,7 +29,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
-import org.eclipse.ditto.services.gateway.endpoints.HttpRequestActor;
+import org.eclipse.ditto.services.gateway.endpoints.actors.HttpRequestActor;
 import org.eclipse.ditto.services.gateway.endpoints.directives.CustomPathMatchers;
 import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.services.models.thingsearch.commands.sudo.SudoCountThings;

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/MessagesRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/MessagesRoute.java
@@ -42,7 +42,7 @@ import org.eclipse.ditto.model.messages.MessagesModelFactory;
 import org.eclipse.ditto.model.messages.SubjectInvalidException;
 import org.eclipse.ditto.model.messages.TimeoutInvalidException;
 import org.eclipse.ditto.protocoladapter.TopicPath;
-import org.eclipse.ditto.services.gateway.endpoints.HttpRequestActor;
+import org.eclipse.ditto.services.gateway.endpoints.actors.HttpRequestActor;
 import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.signals.commands.messages.MessageCommand;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandSizeValidator;

--- a/services/gateway/endpoints/src/test/resources/test.conf
+++ b/services/gateway/endpoints/src/test/resources/test.conf
@@ -93,6 +93,8 @@ ditto {
     http {
       schema-versions = [1, 2]
       # override schema-versions via system properties, e.g.: -Dditto.gateway.proxy.schema-versions.0=1 -Dditto.gateway.proxy.schema-versions.1=2
+
+      actor-props-factory = "org.eclipse.ditto.services.gateway.endpoints.actors.DefaultHttpRequestActorPropsFactory"
     }
 
     cluster {

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -14,6 +14,9 @@ ditto {
 
       schema-versions = [1, 2]
       # override schema-versions via system properties, e.g.: -Dditto.gateway.http.schema-versions.0=1 -Dditto.gateway.http.schema-versions.1=2
+
+      # Creator of props of HTTP request actors. Must implement HttpRequestActorPropsFactory.
+      actor-props-factory = "org.eclipse.ditto.services.gateway.endpoints.actors.DefaultHttpRequestActorPropsFactory"
     }
 
     cluster {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CreateThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CreateThingStrategy.java
@@ -63,7 +63,7 @@ public final class CreateThingStrategy
 
     @Override
     public boolean isDefined(final CreateThing command) {
-        return CreateThing.class.isAssignableFrom(command.getClass());
+        return true;
     }
 
     @Override

--- a/services/utils/akka/pom.xml
+++ b/services/utils/akka/pom.xml
@@ -68,6 +68,36 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>net.alchim31.maven</groupId>
+                <artifactId>scala-maven-plugin</artifactId>
+                <configuration>
+                    <scalaVersion>${scala.full.version}</scalaVersion>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>testCompile</goal>
+                        </goals>
+                        <phase>test-compile</phase>
+                    </execution>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>

--- a/services/utils/akka/src/main/scala/org/eclipse/ditto/services/utils/akka/AkkaClassLoader.scala
+++ b/services/utils/akka/src/main/scala/org/eclipse/ditto/services/utils/akka/AkkaClassLoader.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.akka
+
+import java.util.Collections
+
+import akka.actor.{ActorSystem, DynamicAccess, ExtendedActorSystem}
+
+import scala.collection.JavaConverters.asScalaBuffer
+import scala.collection.immutable
+import scala.reflect.ClassTag
+
+/**
+  * Java-friendly interface to load and instantiate classes inside an actor system.
+  */
+object AkkaClassLoader {
+
+  /**
+    * Dynamically instantiate a class with its zero-argument public constructor.
+    *
+    * @param actorSystem   Actor system to create the object in.
+    * @param superclass    A superclass of the instantiated class.
+    * @param canonicalName Canonical name of the class. Must have a zero-argument public constructor.
+    * @tparam T the superclass.
+    * @return The instantiated object.
+    */
+  def instantiate[T](actorSystem: ActorSystem, superclass: Class[T], canonicalName: String): T =
+    instantiate(actorSystem, superclass, canonicalName, Collections.emptyList(), Collections.emptyList())
+
+  /**
+    * Dynamically instantiate a class with a public constructor.
+    *
+    * @param actorSystem   Actor system to create the object in.
+    * @param superclass    A superclass of the instantiated class.
+    * @param canonicalName Canonical name of the class.
+    * @param argTypes      Classes of the constructor arguments.
+    * @param args          Constructor arguments.
+    * @tparam T the superclass.
+    * @return The instantiated object.
+    */
+  def instantiate[T](actorSystem: ActorSystem, superclass: Class[T],
+                     canonicalName: String,
+                     argTypes: java.util.List[Class[_]],
+                     args: java.util.List[AnyRef]): T = {
+
+    val dynamicAccess: DynamicAccess = actorSystem.asInstanceOf[ExtendedActorSystem].dynamicAccess
+    val argsAsScala: immutable.Seq[(Class[_], AnyRef)] = asScalaBuffer(argTypes).toList.zip(asScalaBuffer(args))
+    val classTag: ClassTag[T] = ClassTag(superclass)
+
+    dynamicAccess.createInstanceFor(canonicalName, argsAsScala)(classTag).get
+  }
+
+}

--- a/services/utils/cluster/src/main/java/org/eclipse/ditto/services/utils/cluster/MappingStrategies.java
+++ b/services/utils/cluster/src/main/java/org/eclipse/ditto/services/utils/cluster/MappingStrategies.java
@@ -12,19 +12,13 @@
  */
 package org.eclipse.ditto.services.utils.cluster;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
 import org.eclipse.ditto.model.base.json.Jsonifiable;
+import org.eclipse.ditto.services.utils.akka.AkkaClassLoader;
 
 import akka.actor.ActorSystem;
-import akka.actor.ExtendedActorSystem;
-import scala.Tuple2;
-import scala.collection.JavaConversions;
-import scala.reflect.ClassTag;
-import scala.util.Try;
 
 /**
  * Implementations define the mapping strategies for both persistence (JsonifiableSerializer) as well as Cluster
@@ -54,12 +48,7 @@ public interface MappingStrategies {
         // load via config the class implementing MappingStrategies:
         final String mappingStrategyClass =
                 actorSystem.settings().config().getString(CONFIGKEY_DITTO_MAPPING_STRATEGY_IMPLEMENTATION);
-        final ClassTag<MappingStrategies> tag = scala.reflect.ClassTag$.MODULE$.apply(MappingStrategies.class);
-        final List<Tuple2<Class<?>, Object>> constructorArgs = new ArrayList<>();
-        final Try<MappingStrategies> mappingStrategy =
-                ((ExtendedActorSystem) actorSystem).dynamicAccess().createInstanceFor(mappingStrategyClass,
-                        JavaConversions.asScalaBuffer(constructorArgs).toList(), tag);
-        return mappingStrategy.get();
+        return AkkaClassLoader.instantiate(actorSystem, MappingStrategies.class, mappingStrategyClass);
     }
 
 }


### PR DESCRIPTION
- Gave user complete freedom to choose HttpRequestActor implementations.
- Moved dynamic class loading from MappingStrategies to ditto-services-utils-akka as Scala object for Java API.
- Added the option of full HTTP logging to Gateway.
- Removed a tautology from CreateThingStrategy.