### PR TITLE
Guidance and template to run Ditto with Azure Cosmos DB's API for MongoDB

### DIFF
--- a/deployment/azure/README.md
+++ b/deployment/azure/README.md
@@ -16,8 +16,8 @@ As described [here](https://docs.microsoft.com/en-gb/azure/aks/kubernetes-servic
 
 ```bash
 service_principal=`az ad sp create-for-rbac --name http://dittoServicePrincipal --skip-assignment --output tsv`
-export app_id_principal=`echo $service_principal|cut -f1 -d ' '`
-export password_principal=`echo $service_principal|cut -f4 -d ' '`
+app_id_principal=`echo $service_principal|cut -f1 -d ' '`
+password_principal=`echo $service_principal|cut -f4 -d ' '`
 ```
 
 Note: it might take a few seconds until the principal is available to the cluster in the later steps. So maybe time to get up and stretch a bit.
@@ -57,7 +57,7 @@ helm init --service-account tiller
 kubectl apply -f managed-premium-retain.yaml
 ```
 
-Now install Ditto with helm
+Next we prepare the k8s environment and our chart for deployment.
 
 ```bash
 k8s_namespace=dittons
@@ -70,6 +70,10 @@ kubectl create namespace $k8s_namespace
 ```bash
 helm dependency update ../helm/eclipse-ditto/
 ```
+
+Now install Ditto with helm either with MongoDB as part of the deployment or [Azure Cosmos DB](https://docs.microsoft.com/en-gb/azure/cosmos-db/introduction) as persistence option.
+
+### Option 1: Embedded MongoDB
 
 ...either with persistent storage as part of the helm release (will be deleted with helm delete):
 
@@ -89,6 +93,34 @@ helm upgrade ditto ../helm/eclipse-ditto/ --namespace $k8s_namespace --set servi
 
 ```bash
 helm upgrade ditto ../helm/eclipse-ditto/ --namespace $k8s_namespace --set service.type=LoadBalancer --wait --install
+```
+
+### Option 2: Azure Cosmos DB's API for MongoDB
+
+Disclaimer: as of now Cosmos DB's API for MongoDB is supported by Ditto only for persistence cases. Ditto's search feature/service does not!
+
+First we have to provision the Cosmos DB. We will use the [Azure Resource Manager (ARM)](https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-group-overview) template from above to update our installation.
+
+Note: the provided template will create individual database per service. By default the template provides 400 [Request Units (RU)](https://docs.microsoft.com/en-us/azure/cosmos-db/request-units) for all collections of `Policies`, `Concierge`, `Things` and `Connectivity` and 800 for the Things journal collection. You can override by parameter as well as update RUs later at runtime.
+
+```bash
+az group deployment create --name DittoBasicInfrastructure --resource-group $resourcegroup_name --template-file arm/dittoInfrastructureDeployment.json --parameters uniqueSolutionPrefix=$unique_solution_prefix servicePrincipalClientId=$app_id_principal servicePrincipalClientSecret=$password_principal cosmosDB=true
+```
+
+The output of the command will provide you with the name of your Cosmos DB account which should be `YOUR_PREFIXdittocosmos`.
+
+Next we can retrieve the CosmosDB credentials:
+
+```bash
+cosmos_account_name=$unique_solution_prefix
+cosmos_account_name+="dittocosmos"
+cosmos_mongodb_primary_master_key=`az cosmosdb list-keys --name $cosmos_account_name --resource-group $resourcegroup_name --output tsv|cut  -f1|head -1`
+```
+
+Now install Ditto with Cosmos DB as persistence and Ditto search disabled.
+
+```bash
+helm upgrade ditto ../helm/eclipse-ditto/ --namespace $k8s_namespace --set search.enabled=false,mongodb.embedded.enabled=false,mongodb.apps.concierge.uri=mongodb://$cosmos_account_name:$cosmos_mongodb_primary_master_key@$cosmos_account_name.documents.azure.com:10255/concierge\?ssl=true\&replicaSet=globaldb\&maxIdleTimeMS=120000,mongodb.apps.concierge.ssl=true,mongodb.apps.connectivity.uri=mongodb://$cosmos_account_name:$cosmos_mongodb_primary_master_key@$cosmos_account_name.documents.azure.com:10255/connectivity\?ssl=true\&replicaSet=globaldb\&maxIdleTimeMS=120000,mongodb.apps.connectivity.ssl=true,mongodb.apps.things.uri=mongodb://$cosmos_account_name:$cosmos_mongodb_primary_master_key@$cosmos_account_name.documents.azure.com:10255/things\?ssl=true\&replicaSet=globaldb\&maxIdleTimeMS=120000,mongodb.apps.things.ssl=true,mongodb.apps.policies.uri=mongodb://$cosmos_account_name:$cosmos_mongodb_primary_master_key@$cosmos_account_name.documents.azure.com:10255/policies\?ssl=true\&replicaSet=globaldb\&maxIdleTimeMS=120000,mongodb.apps.policies.ssl=true,service.type=LoadBalancer --wait --install
 ```
 
 Have fun with Eclipse Ditto on Microsoft Azure!

--- a/deployment/azure/arm/dittoInfrastructureDeployment.json
+++ b/deployment/azure/arm/dittoInfrastructureDeployment.json
@@ -2,6 +2,20 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
+        "cosmosDB": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "CosmosDB deployment enabled."
+            }
+        },
+        "aks": {
+            "type": "bool",
+            "defaultValue": true,
+            "metadata": {
+                "description": "AKS deployment enabled."
+            }
+        },
         "uniqueSolutionPrefix": {
             "type": "string",
             "metadata": {
@@ -30,40 +44,67 @@
 
     },
     "variables": {
-        "clusterName": "[concat(parameters('uniqueSolutionPrefix'), 'dittoaks')]"
+        "clusterName": "[concat(parameters('uniqueSolutionPrefix'), 'dittoaks')]",
+        "accountName": "[concat(toLower(parameters('uniqueSolutionPrefix')), 'dittocosmos')]"
     },
     "resources": [{
-        "name": "dittoKubernetesDeployment",
-        "type": "Microsoft.Resources/deployments",
-        "apiVersion": "2018-05-01",
-        "properties": {
-            "mode": "Incremental",
-            "templateLink": {
-                "uri": "https://raw.githubusercontent.com/kaizimmerm/hawkbit-extensions/azure-arm-template/hawkbit-extended-runtimes/hawkbit-update-server-azure/arm/templates/kubernetesDeploy.json"
-            },
-            "parameters": {
-                "clusterName": {
-                    "value": "[variables('clusterName')]"
+            "condition": "[parameters('aks')]",
+            "name": "dittoKubernetesDeployment",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/eclipse/ditto/master/deployment/azure/arm/templates/kubernetesDeploy.json"
                 },
-                "location": {
-                    "value": "[parameters('location')]"
+                "parameters": {
+                    "clusterName": {
+                        "value": "[variables('clusterName')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    },
+                    "dnsPrefix": {
+                        "value": "[parameters('uniqueSolutionPrefix')]"
+                    },
+                    "servicePrincipalClientId": {
+                        "value": "[parameters('servicePrincipalClientId')]"
+                    },
+                    "servicePrincipalClientSecret": {
+                        "value": "[parameters('servicePrincipalClientSecret')]"
+                    }
+                }
+            }
+        },
+        {
+            "condition": "[parameters('cosmosDB')]",
+            "name": "dittoCosmosDBDeployment",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2018-05-01",
+            "properties": {
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/eclipse/ditto/master/deployment/azure/arm/templates/cosmosDBDeploy.json"
                 },
-                "dnsPrefix": {
-                    "value": "[parameters('uniqueSolutionPrefix')]"
-                },
-                "servicePrincipalClientId": {
-                    "value": "[parameters('servicePrincipalClientId')]"
-                },
-                "servicePrincipalClientSecret": {
-                    "value": "[parameters('servicePrincipalClientSecret')]"
+                "parameters": {
+                    "accountName": {
+                        "value": "[variables('accountName')]"
+                    },
+                    "location": {
+                        "value": "[parameters('location')]"
+                    }
                 }
             }
         }
-    }],
+    ],
     "outputs": {
         "aksClusterName": {
             "type": "string",
             "value": "[variables('clusterName')]"
+        },
+        "cosmosAccountName": {
+            "type": "string",
+            "value": "[variables('accountName')]"
         }
     }
 }

--- a/deployment/azure/arm/templates/cosmosDBDeploy.json
+++ b/deployment/azure/arm/templates/cosmosDBDeploy.json
@@ -1,0 +1,609 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "accountName": {
+            "type": "string",
+            "defaultValue": "[concat('mongodb-', uniqueString(resourceGroup().id))]",
+            "metadata": {
+                "description": "Cosmos DB account name"
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for the Cosmos DB account."
+            }
+        },
+        "defaultConsistencyLevel": {
+            "type": "string",
+            "defaultValue": "Session",
+            "allowedValues": ["Eventual", "ConsistentPrefix", "Session", "BoundedStaleness", "Strong"],
+            "metadata": {
+                "description": "The default consistency level of the Cosmos DB account."
+            }
+        },
+        "maxStalenessPrefix": {
+            "type": "int",
+            "defaultValue": 100000,
+            "minValue": 10,
+            "maxValue": 2147483647,
+            "metadata": {
+                "description": "Max stale requests. Required for BoundedStaleness. Valid ranges, Single Region: 10 to 1000000. Multi Region: 100000 to 1000000."
+            }
+        },
+        "maxIntervalInSeconds": {
+            "type": "int",
+            "defaultValue": 300,
+            "minValue": 5,
+            "maxValue": 86400,
+            "metadata": {
+                "description": "Max lag time (seconds). Required for BoundedStaleness. Valid ranges, Single Region: 5 to 84600. Multi Region: 300 to 86400."
+            }
+        },
+        "multipleWriteLocations": {
+            "type": "bool",
+            "defaultValue": false,
+            "allowedValues": [true, false],
+            "metadata": {
+                "description": "Enable multi-master to make all regions writable."
+            }
+        },
+        "throughputThingsJournal": {
+            "type": "int",
+            "defaultValue": 800,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB journal collection"
+            }
+        },
+        "throughputThingsSnaps": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB snapshot collection"
+            }
+        },
+        "throughputThingsMetadata": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB metadata collection"
+            }
+        },
+        "throughputConnectivityJournal": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB journal collection"
+            }
+        },
+        "throughputConnectivitySnaps": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB snapshots collection"
+            }
+        },
+        "throughputConnectivityMetadata": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB metadata collection"
+            }
+        },
+        "throughputPoliciesJournal": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB journal collection"
+            }
+        },
+        "throughputPoliciesMetadata": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB metadata collection"
+            }
+        },
+        "throughputPoliciesSnaps": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB snapshots collection"
+            }
+        },
+        "throughputConciergeJournal": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB journal collection"
+            }
+        },
+        "throughputConciergeSnaps": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB snapshots collection"
+            }
+        },
+        "throughputConciergeMetadata": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB metadata collection"
+            }
+        },
+        "throughputTest": {
+            "type": "int",
+            "defaultValue": 400,
+            "minValue": 400,
+            "maxValue": 1000000,
+            "metadata": {
+                "description": "The throughput for the Mongo DB test collections"
+            }
+        },
+        "collectionNameThingsJournal": {
+            "type": "string",
+            "defaultValue": "things_journal@org.eclipse.ditto",
+            "metadata": {
+                "description": "Name of the Mongo DB journal collection."
+            }
+        },
+        "collectionNameThingsSnaps": {
+            "type": "string",
+            "defaultValue": "things_snaps@org.eclipse.ditto",
+            "metadata": {
+                "description": "Name of the Mongo DB snapshots collection."
+            }
+        },
+        "collectionNameThingsMetadata": {
+            "type": "string",
+            "defaultValue": "things_metadata",
+            "metadata": {
+                "description": "Name of the Mongo DB metadata collection."
+            }
+        },
+        "collectionNameConnectivityJournal": {
+            "type": "string",
+            "defaultValue": "connection_journal",
+            "metadata": {
+                "description": "Name of the Mongo DB journal collection."
+            }
+        },
+        "collectionNameConnectivitySnaps": {
+            "type": "string",
+            "defaultValue": "connection_snaps",
+            "metadata": {
+                "description": "Name of the Mongo DB snapshots collection."
+            }
+        },
+        "collectionNameConnectivityMetadata": {
+            "type": "string",
+            "defaultValue": "connection_metadata",
+            "metadata": {
+                "description": "Name of the Mongo DB metadata collection."
+            }
+        },
+        "collectionNamePoliciesJournal": {
+            "type": "string",
+            "defaultValue": "policies_journal@org.eclipse.ditto",
+            "metadata": {
+                "description": "Name of the Mongo DB journal collection."
+            }
+        },
+        "collectionNamePoliciesMetadata": {
+            "type": "string",
+            "defaultValue": "policies_metadata",
+            "metadata": {
+                "description": "Name of the Mongo DB metadata collection."
+            }
+        },
+        "collectionNamePoliciesSnaps": {
+            "type": "string",
+            "defaultValue": "policies_snaps@org.eclipse.ditto",
+            "metadata": {
+                "description": "Name of the Mongo DB snapshots collection."
+            }
+        },
+        "collectionNameConciergeJournal": {
+            "type": "string",
+            "defaultValue": "batch_supervisor_journal",
+            "metadata": {
+                "description": "Name of the Mongo DB journal collection."
+            }
+        },
+        "collectionNameConciergeSnaps": {
+            "type": "string",
+            "defaultValue": "batch_supervisor_snaps",
+            "metadata": {
+                "description": "Name of the Mongo DB snapshots collection."
+            }
+        },
+        "collectionNameConciergeMetadata": {
+            "type": "string",
+            "defaultValue": "batch_supervisor_metadata",
+            "metadata": {
+                "description": "Name of the Mongo DB metadata collection."
+            }
+        },
+        "collectionNameTest": {
+            "type": "string",
+            "defaultValue": "test",
+            "metadata": {
+                "description": "Name of the Mongo DB test collections."
+            }
+        }
+
+
+
+
+
+
+    },
+    "variables": {
+        "accountName": "[toLower(parameters('accountName'))]",
+        "consistencyPolicy": {
+            "Eventual": {
+                "defaultConsistencyLevel": "Eventual"
+            },
+            "ConsistentPrefix": {
+                "defaultConsistencyLevel": "ConsistentPrefix"
+            },
+            "Session": {
+                "defaultConsistencyLevel": "Session"
+            },
+            "BoundedStaleness": {
+                "defaultConsistencyLevel": "BoundedStaleness",
+                "maxStalenessPrefix": "[parameters('maxStalenessPrefix')]",
+                "maxIntervalInSeconds": "[parameters('maxIntervalInSeconds')]"
+            },
+            "Strong": {
+                "defaultConsistencyLevel": "Strong"
+            }
+        }
+    },
+    "resources": [{
+            "type": "Microsoft.DocumentDB/databaseAccounts",
+            "name": "[variables('accountName')]",
+            "apiVersion": "2016-03-31",
+            "location": "[parameters('location')]",
+            "kind": "MongoDB",
+            "properties": {
+                "consistencyPolicy": "[variables('consistencyPolicy')[parameters('defaultConsistencyLevel')]]",
+                "databaseAccountOfferType": "Standard",
+                "enableMultipleWriteLocations": "[parameters('multipleWriteLocations')]"
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/apis/databases",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'concierge')]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('accountName'))]"],
+            "properties": {
+                "resource": {
+                    "id": "concierge"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'concierge/', parameters('collectionNameConciergeMetadata'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'concierge')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConciergeMetadata')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConciergeMetadata')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'concierge/', parameters('collectionNameConciergeJournal'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'concierge')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConciergeJournal')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConciergeJournal')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'concierge/', parameters('collectionNameConciergeSnaps'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'concierge')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConciergeSnaps')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConciergeSnaps')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'concierge/', parameters('collectionNameTest'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'concierge')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameTest')]"
+                },
+                "options": {
+                    "throughput": "[parameters('throughputTest')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/apis/databases",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'connectivity')]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('accountName'))]"],
+            "properties": {
+                "resource": {
+                    "id": "connectivity"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'connectivity/', parameters('collectionNameTest'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'connectivity')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameTest')]"
+                },
+                "options": {
+                    "throughput": "[parameters('throughputTest')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'connectivity/', parameters('collectionNameConnectivityJournal'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'connectivity')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConnectivityJournal')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConnectivityJournal')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'connectivity/', parameters('collectionNameConnectivityMetadata'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'connectivity')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConnectivityMetadata')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConnectivityMetadata')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'connectivity/', parameters('collectionNameConnectivitySnaps'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'connectivity')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameConnectivitySnaps')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputConnectivitySnaps')]"
+                }
+            }
+        },
+
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/apis/databases",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'policies')]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('accountName'))]"],
+            "properties": {
+                "resource": {
+                    "id": "policies"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'policies/', parameters('collectionNameTest'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'policies')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameTest')]"
+                },
+                "options": {
+                    "throughput": "[parameters('throughputTest')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'policies/', parameters('collectionNamePoliciesJournal'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'policies')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNamePoliciesJournal')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputPoliciesJournal')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'policies/', parameters('collectionNamePoliciesMetadata'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'policies')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNamePoliciesMetadata')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputPoliciesMetadata')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'policies/', parameters('collectionNamePoliciesSnaps'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'policies')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNamePoliciesSnaps')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputPoliciesSnaps')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDB/databaseAccounts/apis/databases",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'things')]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/', variables('accountName'))]"],
+            "properties": {
+                "resource": {
+                    "id": "things"
+                }
+            }
+        },
+
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'things/', parameters('collectionNameTest'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'things')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameTest')]"
+                },
+                "options": {
+                    "throughput": "[parameters('throughputTest')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'things/', parameters('collectionNameThingsJournal'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'things')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameThingsJournal')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputThingsJournal')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'things/', parameters('collectionNameThingsMetadata'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'things')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameThingsMetadata')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputThingsMetadata')]"
+                }
+            }
+        },
+        {
+            "type": "Microsoft.DocumentDb/databaseAccounts/apis/databases/collections",
+            "name": "[concat(variables('accountName'), '/mongodb/', 'things/', parameters('collectionNameThingsSnaps'))]",
+            "apiVersion": "2016-03-31",
+            "dependsOn": ["[resourceId('Microsoft.DocumentDB/databaseAccounts/apis/databases', variables('accountName'), 'mongodb', 'things')]"],
+            "properties": {
+                "resource": {
+                    "id": "[parameters('collectionNameThingsSnaps')]",
+                    "shardKey": {
+                        "pid": "Hash"
+                    }
+                },
+                "options": {
+                    "throughput": "[parameters('throughputThingsSnaps')]"
+                }
+            }
+        }
+    ]
+}

--- a/deployment/azure/arm/templates/kubernetesDeploy.json
+++ b/deployment/azure/arm/templates/kubernetesDeploy.json
@@ -4,7 +4,7 @@
   "parameters": {
     "kubernetesVersion": {
       "type": "string",
-      "defaultValue": "1.12.6",
+      "defaultValue": "1.13.5",
       "metadata": {
         "description": "Kubernetes version."
       }


### PR DESCRIPTION
Hi,

I extended the Azure deployment guide for a CosmosDB variant including an Azure Resource Manager template that provisions the CosmosDb account, the databases as well as the collections.

Note: this is done by template in order to provision [Request Units (RU)](https://docs.microsoft.com/en-us/azure/cosmos-db/request-units).

Kai