### PR TITLE
Stabilize persistence actor test for Travis more.

### DIFF
--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActor.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActor.java
@@ -127,7 +127,6 @@ import org.eclipse.ditto.signals.events.policies.SubjectsModified;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Cancellable;
-import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.cluster.pubsub.DistributedPubSubMediator;
 import akka.cluster.sharding.ClusterSharding;
@@ -246,10 +245,10 @@ public final class PolicyPersistenceActor extends AbstractPersistentActor {
 
                 // # Policy Entry Deletion Recovery
                 .match(PolicyEntryDeleted.class, ped -> null != policy, ped -> policy = policy.toBuilder()
-                            .remove(ped.getLabel())
-                            .setRevision(lastSequenceNr())
-                            .setModified(ped.getTimestamp().orElse(null))
-                            .build())
+                        .remove(ped.getLabel())
+                        .setRevision(lastSequenceNr())
+                        .setModified(ped.getTimestamp().orElse(null))
+                        .build())
 
                 // # Subjects Modification Recovery
                 .match(SubjectsModified.class, sm -> null != policy, sm -> policy.getEntryFor(sm.getLabel())
@@ -2188,10 +2187,10 @@ public final class PolicyPersistenceActor extends AbstractPersistentActor {
             }
         }
 
-        private void shutdown(final String shutdownLogTemplate, final String thingId) {
-            log.debug(shutdownLogTemplate, thingId);
+        private void shutdown(final String shutdownLogTemplate, final String policyId) {
+            log.debug(shutdownLogTemplate, policyId);
             // stop the supervisor (otherwise it'd restart this actor) which causes this actor to stop, too.
-            getContext().getParent().tell(PoisonPill.getInstance(), getSelf());
+            getContext().getParent().tell(PolicySupervisorActor.Control.PASSIVATE, getSelf());
         }
 
     }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicySupervisorActor.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicySupervisorActor.java
@@ -27,7 +27,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.services.base.actors.ShutdownBehaviour;
-import org.eclipse.ditto.services.base.config.DittoServiceConfig;
 import org.eclipse.ditto.services.base.config.supervision.ExponentialBackOffConfig;
 import org.eclipse.ditto.services.policies.common.config.DittoPoliciesConfig;
 import org.eclipse.ditto.services.policies.persistence.actors.AbstractReceiveStrategy;
@@ -42,9 +41,11 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorKilledException;
 import akka.actor.ActorRef;
 import akka.actor.OneForOneStrategy;
+import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.SupervisorStrategy;
 import akka.actor.Terminated;
+import akka.cluster.sharding.ShardRegion;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.japi.pf.DeciderBuilder;
 import scala.concurrent.duration.FiniteDuration;
@@ -69,7 +70,7 @@ public final class PolicySupervisorActor extends AbstractActor {
     @Nullable private ActorRef child;
     private long restartCount;
 
-    private final SupervisorStrategy supervisorStrategy =  new OneForOneStrategy(true, DeciderBuilder
+    private final SupervisorStrategy supervisorStrategy = new OneForOneStrategy(true, DeciderBuilder
             .match(NullPointerException.class, e -> SupervisorStrategy.restart())
             .match(ActorKilledException.class, e -> SupervisorStrategy.stop())
             .matchAny(e -> SupervisorStrategy.escalate())
@@ -137,7 +138,10 @@ public final class PolicySupervisorActor extends AbstractActor {
         receiveStrategies.forEach(strategyAwareReceiveBuilder::match);
         strategyAwareReceiveBuilder.matchAny(new MatchAnyStrategy());
 
-        return shutdownBehaviour.createReceive().build().orElse(strategyAwareReceiveBuilder.build());
+        return shutdownBehaviour.createReceive()
+                .matchEquals(Control.PASSIVATE, this::passivate)
+                .build()
+                .orElse(strategyAwareReceiveBuilder.build());
     }
 
     private void startChild() {
@@ -146,6 +150,10 @@ public final class PolicySupervisorActor extends AbstractActor {
             final ActorRef childRef = getContext().actorOf(persistenceActorProps, "pa");
             child = getContext().watch(childRef);
         }
+    }
+
+    private void passivate(final Control passivationTrigger) {
+        getContext().getParent().tell(new ShardRegion.Passivate(PoisonPill.getInstance()), getSelf());
     }
 
     /**
@@ -267,6 +275,10 @@ public final class PolicySupervisorActor extends AbstractActor {
             }
         }
 
+    }
+
+    enum Control {
+        PASSIVATE
     }
 
 }

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PersistenceActorTestBase.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PersistenceActorTestBase.java
@@ -51,7 +51,7 @@ import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
-import akka.event.Logging;
+import akka.stream.Attributes;
 import akka.testkit.JavaTestKit;
 import akka.testkit.TestProbe;
 
@@ -166,7 +166,7 @@ public abstract class PersistenceActorTestBase {
      * Disable logging for 1 test to hide stacktrace or other logs on level ERROR. Comment out to debug the test.
      */
     protected void disableLogging() {
-        actorSystem.eventStream().setLogLevel(Logging.levelFor("off").get().asInt());
+        actorSystem.eventStream().setLogLevel(Attributes.logLevelOff());
     }
 
 }

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
@@ -924,7 +924,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                 final RetrievePolicy retrievePolicy = RetrievePolicy.of(policy.getId().orElse(null), dittoHeadersV2);
 
                 final RetrievePolicyResponse expectedResponse =
-                        retrievePolicyResponse(policyExpected, retrievePolicy.getDittoHeaders())
+                        retrievePolicyResponse(policyExpected, retrievePolicy.getDittoHeaders());
 
                 Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
                     policyPersistenceActorRecovered.tell(retrievePolicy, getRef());
@@ -937,7 +937,6 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
     }
 
     @Test
-    @Ignore
     public void checkForActivityOfNonexistentPolicy() {
         new TestKit(actorSystem) {
             {

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/policy/PolicyPersistenceActorTest.java
@@ -24,8 +24,8 @@ import static org.eclipse.ditto.services.policies.persistence.testhelper.ETagTes
 import static org.eclipse.ditto.services.policies.persistence.testhelper.ETagTestUtils.retrieveResourceResponse;
 import static org.eclipse.ditto.services.policies.persistence.testhelper.ETagTestUtils.retrieveSubjectResponse;
 
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.awaitility.Awaitility;
 import org.eclipse.ditto.model.base.entity.Revision;
@@ -83,13 +83,20 @@ import org.eclipse.ditto.signals.commands.policies.query.RetrieveSubjectResponse
 import org.eclipse.ditto.signals.events.policies.PolicyCreated;
 import org.eclipse.ditto.signals.events.policies.PolicyEntryCreated;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
+import akka.actor.AbstractActor;
+import akka.actor.Actor;
 import akka.actor.ActorRef;
+import akka.actor.OneForOneStrategy;
+import akka.actor.PoisonPill;
 import akka.actor.Props;
+import akka.actor.SupervisorStrategy;
 import akka.cluster.pubsub.DistributedPubSubMediator;
+import akka.japi.pf.DeciderBuilder;
+import akka.japi.pf.ReceiveBuilder;
 import akka.testkit.TestActorRef;
+import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 import scala.PartialFunction;
 import scala.concurrent.duration.Duration;
@@ -115,7 +122,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
 
         new TestKit(actorSystem) {
             {
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policyId);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policyId);
                 policyPersistenceActor.tell(retrievePolicyCommand, getRef());
                 expectMsgClass(PolicyNotAccessibleException.class);
             }
@@ -151,7 +158,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
@@ -173,7 +180,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
 
         new TestKit(actorSystem) {
             {
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
                 underTest.tell(createPolicyCommand, getRef());
                 final CreatePolicyResponse createPolicyResponse = expectMsgClass(CreatePolicyResponse.class);
                 DittoPolicyAssertions.assertThat(createPolicyResponse.getPolicyCreated().get())
@@ -195,7 +202,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
 
         new TestKit(actorSystem) {
             {
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
                 underTest.tell(createPolicyCommand, getRef());
                 final CreatePolicyResponse createPolicy1Response = expectMsgClass(CreatePolicyResponse.class);
                 DittoPolicyAssertions.assertThat(createPolicy1Response.getPolicyCreated().get())
@@ -213,11 +220,11 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
 
         final SudoRetrievePolicy sudoRetrievePolicyCommand =
-                SudoRetrievePolicy.of(policy.getId().orElse(null), dittoHeadersV2);
+                SudoRetrievePolicy.of(policy.getId().orElseThrow(NoSuchElementException::new), dittoHeadersV2);
 
         new TestKit(actorSystem) {
             {
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
                 underTest.tell(createPolicyCommand, getRef());
                 final CreatePolicyResponse createPolicy1Response = expectMsgClass(CreatePolicyResponse.class);
                 DittoPolicyAssertions.assertThat(createPolicy1Response.getPolicyCreated().get())
@@ -234,17 +241,18 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
                 final CreatePolicyResponse createPolicy1Response = expectMsgClass(CreatePolicyResponse.class);
-                DittoPolicyAssertions.assertThat(createPolicy1Response.getPolicyCreated().get())
+                DittoPolicyAssertions.assertThat(createPolicy1Response.getPolicyCreated().orElse(null))
                         .isEqualEqualToButModified(policy);
 
-                final DeletePolicy deletePolicy = DeletePolicy.of(policy.getId().orElse(null), dittoHeadersV2);
+                final String policyId = policy.getId().orElseThrow(NoSuchElementException::new);
+                final DeletePolicy deletePolicy = DeletePolicy.of(policyId, dittoHeadersV2);
                 policyPersistenceActor.tell(deletePolicy, getRef());
-                expectMsgEquals(DeletePolicyResponse.of(policy.getId().orElse(null), dittoHeadersV2));
+                expectMsgEquals(DeletePolicyResponse.of(policyId, dittoHeadersV2));
             }
         };
     }
@@ -262,7 +270,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -296,7 +304,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -329,7 +337,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -366,7 +374,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
 
                 policy = policy.removeEntry("ENTRY-NO" + (i - 1));
 
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 // creating the Policy should be possible as we are below the limit:
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
@@ -403,7 +411,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -438,7 +446,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -467,7 +475,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -504,7 +512,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -541,7 +549,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -567,7 +575,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -608,7 +616,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -644,7 +652,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -677,7 +685,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         createDittoHeaders(JsonSchemaVersion.LATEST, AUTH_SUBJECT, UNAUTH_SUBJECT);
 
                 final String policyId = policy.getId().orElse(null);
-                final ActorRef underTest = createPersistenceActorFor(policy);
+                final ActorRef underTest = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 underTest.tell(createPolicyCommand, getRef());
@@ -708,7 +716,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
@@ -717,7 +725,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         .isEqualEqualToButModified(policy);
 
                 // restart
-                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(policy);
+                terminate(this, policyPersistenceActor);
+                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(this, policy);
                 final RetrievePolicy retrievePolicy =
                         RetrievePolicy.of(policy.getId().orElse(null), dittoHeadersV2);
 
@@ -739,7 +748,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
@@ -752,7 +761,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                 expectMsgEquals(DeletePolicyResponse.of(policy.getId().get(), dittoHeadersV2));
 
                 // restart
-                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(policy);
+                terminate(this, policyPersistenceActor);
+                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(this, policy);
 
                 // A deleted Policy cannot be retrieved anymore.
                 final RetrievePolicy retrievePolicy = RetrievePolicy.of(policy.getId().get(), dittoHeadersV2);
@@ -769,7 +779,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
@@ -800,7 +810,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                 assertThat(policyEntryModifiedPublish.msg()).isInstanceOf(PolicyEntryCreated.class);
 
                 // restart
-                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(policy);
+                terminate(this, policyPersistenceActor);
+                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(this, policy);
 
                 final Policy policyWithUpdatedPolicyEntry = policy.setEntry(policyEntry);
                 final RetrievePolicy retrievePolicy =
@@ -823,7 +834,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
                 policyPersistenceActor.tell(createPolicyCommand, getRef());
@@ -838,7 +849,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         dittoHeadersV2));
 
                 // restart
-                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(policy);
+                terminate(this, policyPersistenceActor);
+                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(this, policy);
 
                 final RetrievePolicy retrievePolicy =
                         RetrievePolicy.of(policy.getId().get(), dittoHeadersV2);
@@ -861,7 +873,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 // create the policy - results in sequence number 1
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
@@ -896,7 +908,7 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {
             {
                 final Policy policy = createPolicyWithRandomId();
-                final ActorRef policyPersistenceActor = createPersistenceActorFor(policy);
+                final ActorRef policyPersistenceActor = createPersistenceActorFor(this, policy);
 
                 // create the policy - results in sequence number 1
                 final CreatePolicy createPolicyCommand = CreatePolicy.of(policy, dittoHeadersV2);
@@ -920,7 +932,8 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                         .build();
 
                 // restart
-                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(policy);
+                terminate(this, policyPersistenceActor);
+                final ActorRef policyPersistenceActorRecovered = createPersistenceActorFor(this, policy);
                 final RetrievePolicy retrievePolicy = RetrievePolicy.of(policy.getId().orElse(null), dittoHeadersV2);
 
                 final RetrievePolicyResponse expectedResponse =
@@ -940,40 +953,69 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
     public void checkForActivityOfNonexistentPolicy() {
         new TestKit(actorSystem) {
             {
-                // GIVEN: props increments counter whenever a PolicyPersistenceActor is created
-                final AtomicInteger restartCounter = new AtomicInteger(0);
+                // GIVEN: a PolicyPersistenceActor is created in a parent that forwards all messages to us
                 final String policyId = "test.ns:nonexistent.policy";
-                final Props props = Props.create(PolicyPersistenceActor.class, () -> {
-                    restartCounter.incrementAndGet();
-                    return new PolicyPersistenceActor(policyId, new PolicyMongoSnapshotAdapter(), pubSubMediator);
+                final Props persistentActorProps =
+                        PolicyPersistenceActor.props(policyId, new PolicyMongoSnapshotAdapter(), pubSubMediator);
+
+                final TestProbe errorsProbe = TestProbe.apply(actorSystem);
+
+                final Props parentProps = Props.create(Actor.class, () -> new AbstractActor() {
+
+                    @Override
+                    public void preStart() {
+                        getContext().actorOf(persistentActorProps);
+                    }
+
+                    @Override
+                    public SupervisorStrategy supervisorStrategy() {
+                        return new OneForOneStrategy(true,
+                                DeciderBuilder.matchAny(throwable -> {
+                                    errorsProbe.ref().tell(throwable, getSelf());
+                                    return SupervisorStrategy.restart();
+                                }).build());
+                    }
+
+                    @Override
+                    public Receive createReceive() {
+                        return ReceiveBuilder.create()
+                                .matchAny(message -> {
+                                    if (getTestActor().equals(getSender())) {
+                                        getContext().actorSelection(getSelf().path().child("*"))
+                                                .forward(message, getContext());
+                                    } else {
+                                        getTestActor().forward(message, getContext());
+                                    }
+                                })
+                                .build();
+                    }
                 });
 
                 // WHEN: CheckForActivity is sent to a persistence actor of nonexistent policy after startup
-                final ActorRef underTest = actorSystem.actorOf(props);
-                watch(underTest);
+                final ActorRef underTest = actorSystem.actorOf(parentProps);
 
                 final Object checkForActivity = new PolicyPersistenceActor.CheckForActivity(1L, 1L);
-                underTest.tell(checkForActivity, ActorRef.noSender());
-                underTest.tell(checkForActivity, ActorRef.noSender());
-                underTest.tell(checkForActivity, ActorRef.noSender());
+                underTest.tell(checkForActivity, getRef());
+                underTest.tell(checkForActivity, getRef());
+                underTest.tell(checkForActivity, getRef());
 
-                // THEN: persistence actor shuts down parent (user guardian)
-                expectTerminated(Duration.create(10, TimeUnit.SECONDS), underTest);
+                // THEN: persistence actor requests shutdown
+                expectMsg(PolicySupervisorActor.Control.PASSIVATE);
 
-                // THEN: actor should not restart itself.
-                assertThat(restartCounter.get()).isEqualTo(1);
+                // THEN: persistence actor should not throw anything.
+                errorsProbe.expectNoMessage(Duration.create(3, TimeUnit.SECONDS));
             }
         };
     }
 
-    private ActorRef createPersistenceActorFor(final Policy policy) {
-        return createPersistenceActorFor(policy.getId().orElse(null));
+    private ActorRef createPersistenceActorFor(final TestKit testKit, final Policy policy) {
+        return createPersistenceActorFor(testKit, policy.getId().orElseThrow(NoSuchElementException::new));
     }
 
-    private ActorRef createPersistenceActorFor(final String policyId) {
+    private ActorRef createPersistenceActorFor(final TestKit testKit, final String policyId) {
         final SnapshotAdapter<Policy> snapshotAdapter = new PolicyMongoSnapshotAdapter();
         final Props props = PolicyPersistenceActor.props(policyId, snapshotAdapter, pubSubMediator);
-        return actorSystem.actorOf(props);
+        return testKit.watch(actorSystem.actorOf(props));
     }
 
     private static Policy incrementRevision(final Policy policy, final int n) {
@@ -986,6 +1028,11 @@ public final class PolicyPersistenceActorTest extends PersistenceActorTestBase {
                     .build();
         }
         return withIncrementedRevision;
+    }
+
+    private static void terminate(final TestKit testKit, final ActorRef actor) {
+        actor.tell(PoisonPill.getInstance(), ActorRef.noSender());
+        testKit.expectTerminated(actor);
     }
 
 }


### PR DESCRIPTION
- Add retries for more recovery scenarios where event flushing happened too slowly.

- Make tests safer by having PolicyPersistenceActor passivate parent instead of poisoning it (so that user guardian is not poisoned in test).

- When testing recovery, ensure events are flushed by waiting for the previous incarnation to terminate.