### PR TITLE
Fixes behaviour of ServiceSpecificEnvironmentConfigSupplier

### DIFF
--- a/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/HostingEnvironment.java
+++ b/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/HostingEnvironment.java
@@ -17,13 +17,28 @@ package org.eclipse.ditto.services.utils.config.raw;
  */
 enum HostingEnvironment {
 
-    // BIC...
+    /**
+     * Used when hosting environment is set to "cloud".
+     * This will use the config file $servicename-cloud.conf
+     */
     CLOUD("-cloud"),
 
+    /**
+     * Used when hosting environment is set to "docker".
+     * This will use the config file $servicename-docker.conf
+     */
     DOCKER("-docker"),
 
+    /**
+     * Used when no (known) hosting environment is specified.
+     * This will use the config file $servicename-dev.conf
+     */
     DEVELOPMENT("-dev"),
 
+    /**
+     * Used when hosting environment is set to "filebased".
+     * This will use the config file specified by the environment variable: HOSTING_ENVIRONMENT_FILE_LOCATION.
+     */
     FILE_BASED("");
 
     public static final String CONFIG_PATH = "hosting.environment";

--- a/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/HostingEnvironment.java
+++ b/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/HostingEnvironment.java
@@ -17,15 +17,14 @@ package org.eclipse.ditto.services.utils.config.raw;
  */
 enum HostingEnvironment {
 
-    CLOUD_NATIVE("-cloud"),
+    // BIC...
+    CLOUD("-cloud"),
 
     DOCKER("-docker"),
 
-    FILE_BASED_CONFIGURED(""),
+    DEVELOPMENT("-dev"),
 
-    FILE_BASED_SERVICE_NAME(""),
-
-    DEVELOPMENT("-dev");
+    FILE_BASED("");
 
     public static final String CONFIG_PATH = "hosting.environment";
 

--- a/services/utils/config/src/test/java/org/eclipse/ditto/services/utils/config/raw/ServiceSpecificEnvironmentConfigSupplierTest.java
+++ b/services/utils/config/src/test/java/org/eclipse/ditto/services/utils/config/raw/ServiceSpecificEnvironmentConfigSupplierTest.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.services.utils.config.raw;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.services.utils.config.raw.FileBasedConfigSupplier.HOSTING_ENV_FILE_LOCATION_ENV_VARIABLE_NAME;
-import static org.eclipse.ditto.services.utils.config.raw.ServiceSpecificEnvironmentConfigSupplier.CF_VCAP_SERVICES_ENV_VARIABLE_NAME;
 import static org.eclipse.ditto.services.utils.config.raw.ServiceSpecificEnvironmentConfigSupplier.HOSTING_ENVIRONMENT_ENV_VARIABLE_NAME;
 import static org.eclipse.ditto.services.utils.config.raw.VcapServicesStringSupplier.VCAP_LOCATION_ENV_VARIABLE_NAME;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
@@ -25,7 +24,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,9 +38,9 @@ public final class ServiceSpecificEnvironmentConfigSupplierTest {
 
     private static final String SERVICE_NAME = "test-service";
     private static final String KNOWN_CONFIG_FILE_NAME = "/vcap_services_test.json";
+    private static final String TEST_CONFIG_KEY = "test.value";
 
     private static Path vcapServicesFilePath;
-    private static JsonObject vcapServices;
 
     @Rule
     public EnvironmentVariables environmentVariables = new EnvironmentVariables();
@@ -51,8 +49,6 @@ public final class ServiceSpecificEnvironmentConfigSupplierTest {
     public static void initTestFixture() throws URISyntaxException {
         final URL vcapConfigFileUrl = VcapServicesStringSupplierTest.class.getResource(KNOWN_CONFIG_FILE_NAME);
         vcapServicesFilePath = Paths.get(vcapConfigFileUrl.toURI());
-        final VcapServicesStringSupplier vcapServicesStringSplr = VcapServicesStringSupplier.of(vcapServicesFilePath);
-        vcapServices = JsonObject.of(vcapServicesStringSplr.get().orElseThrow(IllegalStateException::new));
     }
 
     @Test
@@ -69,18 +65,24 @@ public final class ServiceSpecificEnvironmentConfigSupplierTest {
         final Config actualConfig = underTest.get();
 
         assertThat(actualConfig.getIsNull(HostingEnvironment.CONFIG_PATH)).isTrue();
+        assertThat(actualConfig.getString(TEST_CONFIG_KEY)).isEqualTo("dev");
+        assertThat(actualConfig.hasPath("vcap")).isFalse();
     }
 
     @Test
-    public void hostingEnvironmentIsCloudNativeIfVcapServicesIsSet() {
-        environmentVariables.set(CF_VCAP_SERVICES_ENV_VARIABLE_NAME, vcapServices.toString());
+    public void hostingEnvironmentIsCloudIfSet() {
+        environmentVariables.set(HOSTING_ENVIRONMENT_ENV_VARIABLE_NAME, "cloud");
+        environmentVariables.set(VCAP_LOCATION_ENV_VARIABLE_NAME, vcapServicesFilePath.toString());
 
         final ServiceSpecificEnvironmentConfigSupplier underTest =
                 ServiceSpecificEnvironmentConfigSupplier.of(SERVICE_NAME);
 
         final Config actualConfig = underTest.get();
 
-        assertThat(actualConfig.getIsNull(HostingEnvironment.CONFIG_PATH)).isTrue();
+        assertThat(actualConfig.getString(HostingEnvironment.CONFIG_PATH)).isEqualTo("cloud");
+        assertThat(actualConfig.getString(TEST_CONFIG_KEY)).isEqualTo("cloud");
+        assertThat(actualConfig.getString("vcap.MongoDB-Service.ditto-mongodb-staging.name"))
+                .isEqualTo("ditto-mongodb-staging");
     }
 
     @Test
@@ -93,12 +95,17 @@ public final class ServiceSpecificEnvironmentConfigSupplierTest {
         final Config actualConfig = underTest.get();
 
         assertThat(actualConfig.getString(HostingEnvironment.CONFIG_PATH)).isEqualTo("docker");
+        assertThat(actualConfig.getString(TEST_CONFIG_KEY)).isEqualTo("docker");
+        assertThat(actualConfig.hasPath("vcap")).isFalse();
     }
 
     @Test
-    public void hostingEnvironmentIsFilebasedIfSet() {
+    public void hostingEnvironmentIsFilebasedIfSet() throws URISyntaxException {
+        final String fileName = "/" + SERVICE_NAME + "-filebased.conf";
+        final URL fileUrl = VcapServicesStringSupplierTest.class.getResource(fileName);
+        final Path path = Paths.get(fileUrl.toURI());
+        environmentVariables.set(HOSTING_ENV_FILE_LOCATION_ENV_VARIABLE_NAME, path.toString());
         environmentVariables.set(HOSTING_ENVIRONMENT_ENV_VARIABLE_NAME, "filebased");
-        environmentVariables.set(HOSTING_ENV_FILE_LOCATION_ENV_VARIABLE_NAME, vcapServicesFilePath.toString());
         environmentVariables.set(VCAP_LOCATION_ENV_VARIABLE_NAME, vcapServicesFilePath.toString());
 
         final ServiceSpecificEnvironmentConfigSupplier underTest =
@@ -107,6 +114,9 @@ public final class ServiceSpecificEnvironmentConfigSupplierTest {
         final Config actualConfig = underTest.get();
 
         assertThat(actualConfig.getString(HostingEnvironment.CONFIG_PATH)).isEqualTo("filebased");
+        assertThat(actualConfig.getString(TEST_CONFIG_KEY)).isEqualTo("filebased");
+        assertThat(actualConfig.getString("vcap.MongoDB-Service.ditto-mongodb-staging.name"))
+                .isEqualTo("ditto-mongodb-staging");
     }
 
 }

--- a/services/utils/config/src/test/resources/test-service-cloud.conf
+++ b/services/utils/config/src/test/resources/test-service-cloud.conf
@@ -1,0 +1,3 @@
+test {
+  value = "cloud"
+}

--- a/services/utils/config/src/test/resources/test-service-dev.conf
+++ b/services/utils/config/src/test/resources/test-service-dev.conf
@@ -1,0 +1,3 @@
+test {
+  value = "dev"
+}

--- a/services/utils/config/src/test/resources/test-service-docker.conf
+++ b/services/utils/config/src/test/resources/test-service-docker.conf
@@ -1,0 +1,3 @@
+test {
+  value = "docker"
+}

--- a/services/utils/config/src/test/resources/test-service-filebased.conf
+++ b/services/utils/config/src/test/resources/test-service-filebased.conf
@@ -1,0 +1,3 @@
+test {
+  value = "filebased"
+}

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/config/PersistenceConfig.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/config/PersistenceConfig.java
@@ -46,7 +46,7 @@ public interface PersistenceConfig {
         /**
          * Determines whether the persistence health check should be enabled.
          */
-        ENABLED("enabled", false),
+        ENABLED("enabled", true),
 
         /**
          * The timeout of the health check for persistence.


### PR DESCRIPTION
With #421 we accidentally changed the way the config files are selected and read based on the host environment. This PR restores the previous behaviour.