### PR TITLE
Bugfix/resolve secret config

### DIFF
--- a/services/things/starter/src/main/resources/things.conf
+++ b/services/things/starter/src/main/resources/things.conf
@@ -5,6 +5,14 @@ ditto {
   persistence.operations.delay-after-persistence-actor-shutdown = 5s
   persistence.operations.delay-after-persistence-actor-shutdown = ${?DELAY_AFTER_PERSISTENCE_ACTOR_SHUTDOWN}
 
+  mongodb {
+    options {
+      ssl = false
+      ssl = ${?MONGO_DB_SSL_ENABLED}
+      w = 1
+    }
+  }
+
   things {
     # Logs for all incoming messages minimal information to enable message tracing throughout the system
     log-incoming-messages = true

--- a/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/SecretsAsConfigSupplier.java
+++ b/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/SecretsAsConfigSupplier.java
@@ -50,7 +50,7 @@ final class SecretsAsConfigSupplier implements Supplier<Config> {
 
     private SecretsAsConfigSupplier(final Path theSecretsDirPath, final Config theSecretsConfig) {
         secretsDirPath = theSecretsDirPath;
-        secretsConfig = theSecretsConfig;
+        secretsConfig = theSecretsConfig.resolve();
     }
 
     /**

--- a/services/utils/config/src/test/java/org/eclipse/ditto/services/utils/config/ConfigWithFallbackTest.java
+++ b/services/utils/config/src/test/java/org/eclipse/ditto/services/utils/config/ConfigWithFallbackTest.java
@@ -140,6 +140,29 @@ public final class ConfigWithFallbackTest {
     }
 
     @Test
+    public void ignoreFallBackValuesIfSetInOriginalConfig() {
+        final Map<String, Object> configValueMap = new HashMap<>();
+        configValueMap.put("foo", "bar");
+        configValueMap.put("baz", true);
+        configValueMap.put("bar", 2);
+        final Config config = ConfigFactory.parseMap(Collections.singletonMap(KNOWN_CONFIG_PATH, configValueMap));
+
+        final KnownConfigValue barFallbackValue = Mockito.mock(KnownConfigValue.class);
+        Mockito.when(barFallbackValue.getConfigPath()).thenReturn("bar");
+        Mockito.when(barFallbackValue.getDefaultValue()).thenReturn(1);
+
+        final ConfigWithFallback underTest =
+                ConfigWithFallback.newInstance(config, KNOWN_CONFIG_PATH, new KnownConfigValue[]{barFallbackValue});
+
+        assertThat(underTest.root()).satisfies(configObject -> {
+            assertThat(configObject).hasSize(3);
+        });
+        assertThat(underTest.getString("foo")).isEqualTo("bar");
+        assertThat(underTest.getInt("bar")).isEqualTo(2);
+        assertThat(underTest.getBoolean("baz")).isEqualTo(true);
+    }
+
+    @Test
     public void getConfigPathReturnsRelativePathIfConfigWithFallbackIsBuiltFromPlainConfig() {
         final ConfigWithFallback underTest =
                 ConfigWithFallback.newInstance(testConfig, "ditto", new KnownConfigValue[0]);


### PR DESCRIPTION
the config needs to be resolved because in [SecrectsAsConfigSupplier](https://github.com/bsinno/ditto/blob/916b03118b119d5c691c892300492f87f97a382e/services/utils/config/src/main/java/org/eclipse/ditto/services/utils/config/raw/SecretsAsConfigSupplier.java#L82) the config is read.