### PR TITLE
Fix concierge memory leak

### DIFF
--- a/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfig.java
+++ b/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfig.java
@@ -32,14 +32,11 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
     private final Duration askTimeout;
     private final int bufferSize;
     private final int parallelism;
-    private final int maxNamespacesSubstreams;
 
     private DefaultEnforcementConfig(final ConfigWithFallback configWithFallback) {
         askTimeout = configWithFallback.getDuration(EnforcementConfigValue.ASK_TIMEOUT.getConfigPath());
         bufferSize = configWithFallback.getInt(EnforcementConfigValue.BUFFER_SIZE.getConfigPath());
         parallelism = configWithFallback.getInt(EnforcementConfigValue.PARALLELISM.getConfigPath());
-        maxNamespacesSubstreams = configWithFallback.getInt(
-                EnforcementConfigValue.MAX_NAMESPACES_SUBSTREAMS.getConfigPath());
     }
 
     /**
@@ -69,10 +66,6 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
         return parallelism;
     }
 
-    @Override
-    public int getMaxNamespacesSubstreams() {
-        return maxNamespacesSubstreams;
-    }
 
     @Override
     public boolean equals(final Object o) {
@@ -85,13 +78,12 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
         final DefaultEnforcementConfig that = (DefaultEnforcementConfig) o;
         return bufferSize == that.bufferSize &&
                 parallelism == that.parallelism &&
-                maxNamespacesSubstreams == that.maxNamespacesSubstreams &&
                 askTimeout.equals(that.askTimeout);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(askTimeout, bufferSize, parallelism, maxNamespacesSubstreams);
+        return Objects.hash(askTimeout, bufferSize, parallelism);
     }
 
     @Override
@@ -100,7 +92,6 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
                 "askTimeout=" + askTimeout +
                 ", bufferSize=" + bufferSize +
                 ", parallelism=" + parallelism +
-                ", maxNamespacesSubstreams=" + maxNamespacesSubstreams +
                 "]";
     }
 

--- a/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/EnforcementConfig.java
+++ b/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/EnforcementConfig.java
@@ -46,15 +46,6 @@ public interface EnforcementConfig {
     int getParallelism();
 
     /**
-     * Returns the maximum of supported namespaces to start substreams for. Choose a high value as if the actual amount
-     * of substreams gets bigger than this maximum value, the whole enforcement stream will fail. But don't set too high
-     * as substreams require memory!
-     *
-     * @return the maximum of supported concurrently handled substreams.
-     */
-    int getMaxNamespacesSubstreams();
-
-    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code EnforcementConfig}.
      */
@@ -73,12 +64,7 @@ public interface EnforcementConfig {
         /**
          * The parallelism used for processing messages in parallel in enforcer actor.
          */
-        PARALLELISM("parallelism", 100),
-
-        /**
-         * The maximum of supported concurrently handled substreams.
-         */
-        MAX_NAMESPACES_SUBSTREAMS("max-namespaces-substreams", 100_000)
+        PARALLELISM("parallelism", 100)
         ;
 
         private final String path;

--- a/services/concierge/common/src/test/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfigTest.java
+++ b/services/concierge/common/src/test/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfigTest.java
@@ -70,9 +70,6 @@ public final class DefaultEnforcementConfigTest {
         softly.assertThat(underTest.getParallelism())
                 .as(EnforcementConfig.EnforcementConfigValue.PARALLELISM.getConfigPath())
                 .isEqualTo(EnforcementConfig.EnforcementConfigValue.PARALLELISM.getDefaultValue());
-        softly.assertThat(underTest.getMaxNamespacesSubstreams())
-                .as(EnforcementConfig.EnforcementConfigValue.MAX_NAMESPACES_SUBSTREAMS.getConfigPath())
-                .isEqualTo(EnforcementConfig.EnforcementConfigValue.MAX_NAMESPACES_SUBSTREAMS.getDefaultValue());
     }
 
     @Test
@@ -88,9 +85,6 @@ public final class DefaultEnforcementConfigTest {
         softly.assertThat(underTest.getParallelism())
                 .as(EnforcementConfig.EnforcementConfigValue.PARALLELISM.getConfigPath())
                 .isEqualTo(73);
-        softly.assertThat(underTest.getMaxNamespacesSubstreams())
-                .as(EnforcementConfig.EnforcementConfigValue.MAX_NAMESPACES_SUBSTREAMS.getConfigPath())
-                .isEqualTo(42);
     }
 
 }

--- a/services/concierge/common/src/test/resources/enforcement-test.conf
+++ b/services/concierge/common/src/test/resources/enforcement-test.conf
@@ -3,5 +3,4 @@ enforcement {
   ask-timeout = 30s
   buffer-size = 1337
   parallelism = 73
-  max-namespaces-substreams = 42
 }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcerActor.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcerActor.java
@@ -159,11 +159,6 @@ public abstract class AbstractEnforcerActor extends AbstractGraphActor<Contextua
     }
 
     @Override
-    protected int getMaxNamespacesSubstreams() {
-        return enforcementConfig.getMaxNamespacesSubstreams();
-    }
-
-    @Override
     protected Contextual<WithDittoHeaders> mapMessage(final WithDittoHeaders message) {
         return contextual.withReceivedMessage(message, getSender());
     }

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/DispatcherActor.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/DispatcherActor.java
@@ -109,11 +109,6 @@ public final class DispatcherActor extends AbstractGraphActor<DispatcherActor.Im
     }
 
     @Override
-    protected int getMaxNamespacesSubstreams() {
-        return enforcementConfig.getMaxNamespacesSubstreams();
-    }
-
-    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         // no-op
     }

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -30,12 +30,6 @@ ditto {
       # when configured too low, throughput of messages which perform blocking operations will be bad
       parallelism = 256
       parallelism = ${?ENFORCEMENT_PARALLELISM}
-
-      # the maximum of supported namespaces to start substreams for. Choose a high value as if the actual amount
-      # of substreams gets bigger than this maximum value, the whole enforcement stream will fail. But don't set too high
-      # as substreams require memory!
-      max-namespaces-substreams = 100000
-      max-namespaces-substreams = ${?ENFORCEMENT_MAX_NAMESPACES_SUBSTREAMS}
     }
 
     caches {

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/controlflow/AbstractGraphActor.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/controlflow/AbstractGraphActor.java
@@ -101,13 +101,6 @@ public abstract class AbstractGraphActor<T> extends AbstractActor {
      */
     protected abstract int getParallelism();
 
-    /**
-     * @return the maximum of supported namespaces to start substreams for. Choose a high value as if the actual amount
-     * of substreams gets bigger than this maximum value, the whole enforcement stream will fail. But don't set too high
-     * as substreams require memory!
-     */
-    protected abstract int getMaxNamespacesSubstreams();
-
     @Override
     public Receive createReceive() {
 
@@ -127,34 +120,12 @@ public abstract class AbstractGraphActor<T> extends AbstractActor {
                 );
         final ActorMaterializer materializer = ActorMaterializer.create(materializerSettings, getContext());
 
-        final int maxNamespacesSubstreams = getMaxNamespacesSubstreams();
-        final SourceQueueWithComplete<T> sourceQueue;
-        if (maxNamespacesSubstreams > 0) {
-            sourceQueue = Source.<T>queue(getBufferSize(), OverflowStrategy.backpressure())
-                    // first: create substreams by namespace of the messages
-                    .groupBy(maxNamespacesSubstreams, msg -> {
-                        if (msg instanceof WithId) {
-                            final String id = ((WithId) msg).getId();
-                            final int firstColon = id.indexOf(':');
-                            if (firstColon >= 0) {
-                                return id.substring(0, firstColon);
-                            }
-                        }
-                        return "";
-                    })
-                    .via(Flow.fromFunction(this::beforeProcessMessage))
-                    // second: partition by the message's ID in order to maintain order per ID
-                    .via(partitionById(processMessageFlow(), getParallelism()))
-                    .to(processedMessageSink())
-                    .run(materializer);
-        } else {
-            sourceQueue = Source.<T>queue(getBufferSize(), OverflowStrategy.backpressure())
-                    .via(Flow.fromFunction(this::beforeProcessMessage))
-                    // partition by the message's ID in order to maintain order per ID
-                    .via(partitionById(processMessageFlow(), getParallelism()))
-                    .to(processedMessageSink())
-                    .run(materializer);
-        }
+        final SourceQueueWithComplete<T> sourceQueue = Source.<T>queue(getBufferSize(), OverflowStrategy.backpressure())
+                .via(Flow.fromFunction(this::beforeProcessMessage))
+                // partition by the message's ID in order to maintain order per ID
+                .via(partitionById(processMessageFlow(), getParallelism()))
+                .to(processedMessageSink())
+                .run(materializer);
 
         final ReceiveBuilder receiveBuilder = ReceiveBuilder.create();
         preEnhancement(receiveBuilder);


### PR DESCRIPTION
Substream creation for each namespace causes a memory leak when using a lot of different namespaces.
This premature optimization seems not to be necessary for overall performance.