### PR TITLE
Fixes wrong status if connection contains no targets

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BasePublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BasePublisherActor.java
@@ -173,11 +173,6 @@ public abstract class BasePublisherActor<T extends PublishTarget> extends Abstra
     }
 
     private Collection<ResourceStatus> getCurrentTargetStatus() {
-        if (resourceStatusMap.isEmpty()) {
-            return Collections.singletonList(
-                    ConnectivityModelFactory.newTargetStatus(getInstanceIdentifier(), ConnectivityStatus.UNKNOWN, null,
-                            null));
-        }
         return resourceStatusMap.values();
     }
 


### PR DESCRIPTION
When getting the status of a connection, all actors that are part of a connection (`*ClientActor`, `*ConsumerActor` and `*PublisherActor`) are asked for their current status.

Since currently publishers are started even if there are no targets, also the publishers are asked for their status. This lead to false status since the publishers returned `UNKNOWN` if no target was defined. This PR will fix this issue