### PR TITLE
Statistics-actor improvements

### DIFF
--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
@@ -222,9 +222,13 @@ public final class StatisticsActor extends AbstractActorWithStashWithTimers {
     }
 
     private void tellShardRegionToSendClusterShardingStats(final String shardRegion) {
-        clusterSharding.shardRegion(shardRegion).tell(
-                new ShardRegion.GetClusterShardingStats(FiniteDuration.apply(10, TimeUnit.SECONDS)),
-                getSelf());
+        try {
+            clusterSharding.shardRegion(shardRegion).tell(
+                    new ShardRegion.GetClusterShardingStats(FiniteDuration.apply(10, TimeUnit.SECONDS)),
+                    getSelf());
+        } catch (final IllegalArgumentException e) {
+            // shard not started; there will not be any sharding stats.
+        }
     }
 
     private void initGauges() {

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/StatisticsActor.java
@@ -12,30 +12,42 @@
  */
 package org.eclipse.ditto.services.gateway.proxy.actors;
 
+import static io.jsonwebtoken.lang.Strings.capitalize;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
+import org.eclipse.ditto.services.gateway.proxy.config.StatisticsConfig;
+import org.eclipse.ditto.services.gateway.proxy.config.StatisticsShardConfig;
 import org.eclipse.ditto.services.models.policies.PoliciesMessagingConstants;
 import org.eclipse.ditto.services.models.things.ThingsMessagingConstants;
 import org.eclipse.ditto.services.models.thingsearch.ThingsSearchConstants;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
+import org.eclipse.ditto.services.utils.cluster.ClusterStatusSupplier;
+import org.eclipse.ditto.services.utils.health.cluster.ClusterRoleStatus;
 import org.eclipse.ditto.services.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.services.utils.metrics.instruments.gauge.Gauge;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatistics;
@@ -43,10 +55,11 @@ import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetails;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetailsResponse;
 import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsResponse;
 
-import akka.actor.AbstractActor;
+import akka.actor.AbstractActorWithTimers;
 import akka.actor.ActorRef;
 import akka.actor.Address;
 import akka.actor.Props;
+import akka.cluster.Cluster;
 import akka.cluster.pubsub.DistributedPubSubMediator;
 import akka.cluster.sharding.ClusterSharding;
 import akka.cluster.sharding.ShardRegion;
@@ -58,7 +71,7 @@ import scala.concurrent.duration.FiniteDuration;
 /**
  * Actor collecting statistics in the cluster.
  */
-public final class StatisticsActor extends AbstractActor {
+public final class StatisticsActor extends AbstractActorWithTimers {
 
     /**
      * The name of this Actor in the ActorSystem.
@@ -86,24 +99,25 @@ public final class StatisticsActor extends AbstractActor {
 
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
 
+    private final StatisticsConfig statisticsConfig;
+
     private final ActorRef pubSubMediator;
     private final ClusterSharding clusterSharding;
-    private Gauge hotThings;
-    private Gauge hotPolicies;
-    private Gauge hotSearchUpdaters;
+    private final ClusterStatusSupplier clusterStatusSupplier;
+    private List<NamedShardGauge> gauges;
     private Statistics currentStatistics;
     private StatisticsDetails currentStatisticsDetails;
 
     @SuppressWarnings("unused")
     private StatisticsActor(final ActorRef pubSubMediator) {
+        statisticsConfig = StatisticsConfig.forActor(getContext());
+
         this.pubSubMediator = pubSubMediator;
-        hotThings = DittoMetrics.gauge(Statistics.HOT_THINGS);
-        hotPolicies = DittoMetrics.gauge(Statistics.HOT_POLICIES);
-        hotSearchUpdaters = DittoMetrics.gauge(Statistics.HOT_SEARCH_UPDATERS);
+        this.gauges = initializeGaugesForHotEntities(statisticsConfig);
 
         clusterSharding = ClusterSharding.get(getContext().getSystem());
+        clusterStatusSupplier = new ClusterStatusSupplier(Cluster.get(getContext().getSystem()));
         scheduleInternalRetrieveHotEntities();
-
         subscribeForStatisticsCommands();
     }
 
@@ -119,35 +133,28 @@ public final class StatisticsActor extends AbstractActor {
     }
 
     private void scheduleInternalRetrieveHotEntities() {
-        initHotMetrics();
-        getContext().getSystem()
-                .scheduler()
-                .schedule(FiniteDuration.apply(WAIT_TIME_MS, TimeUnit.MILLISECONDS),
-                        FiniteDuration.apply(SCHEDULE_INTERNAL_RETRIEVE_COMMAND, TimeUnit.MILLISECONDS), getSelf(),
-                        InternalRetrieveStatistics.newInstance(), getContext().getSystem().dispatcher(),
-                        ActorRef.noSender());
+        initGauges();
+        final InternalRetrieveStatistics internalRetrieveStatistics = InternalRetrieveStatistics.newInstance();
+        getTimers().startPeriodicTimer(internalRetrieveStatistics, internalRetrieveStatistics,
+                Duration.ofMillis(SCHEDULE_INTERNAL_RETRIEVE_COMMAND));
+        getSelf().tell(internalRetrieveStatistics, getSelf());
     }
 
-    private static Map<String, ShardStatisticsWrapper> initShardStatisticsMap() {
-        final Map<String, ShardStatisticsWrapper> shardStatisticsMap = new HashMap<>();
-        shardStatisticsMap.put(SR_THING, new ShardStatisticsWrapper());
-        shardStatisticsMap.put(SR_POLICY, new ShardStatisticsWrapper());
-        shardStatisticsMap.put(SR_SEARCH_UPDATER, new ShardStatisticsWrapper());
-        return shardStatisticsMap;
+    private void updateGauges(final Map<String, ShardStatisticsWrapper> shardStatisticsWrapperMap) {
+        gauges.forEach(namedShardGauge ->
+                shardStatisticsWrapperMap.computeIfPresent(namedShardGauge.shard, (k, wrapper) -> {
+                    namedShardGauge.gauge.set(wrapper.count);
+                    return wrapper;
+                }));
     }
 
     @Override
     public Receive createReceive() {
-        // ignore - the message is too late
         return ReceiveBuilder.create()
                 .match(InternalRetrieveStatistics.class, unused -> {
                     tellShardRegionToSendClusterShardingStats();
 
-                    becomeStatisticsAwaiting(statistics -> {
-                        hotThings.set(statistics.hotThingsCount);
-                        hotPolicies.set(statistics.hotPoliciesCount);
-                        hotSearchUpdaters.set(statistics.hotSearchUpdatersCount);
-                    });
+                    becomeStatisticsAwaiting(statistics -> {});
                 })
                 .match(RetrieveStatistics.class, retrieveStatistics -> {
                     tellShardRegionToSendClusterShardingStats();
@@ -161,13 +168,15 @@ public final class StatisticsActor extends AbstractActor {
                 })
                 .match(RetrieveStatisticsDetails.class, retrieveStatistics -> {
 
-                    tellRootActorToRetrieveStatistics(THINGS_ROOT, retrieveStatistics);
-                    tellRootActorToRetrieveStatistics(POLICIES_ROOT, retrieveStatistics);
-                    tellRootActorToRetrieveStatistics(SEARCH_UPDATER_ROOT, retrieveStatistics);
-
                     final ActorRef self = getSelf();
                     final ActorRef sender = getSender();
-                    becomeStatisticsDetailsAwaiting(statistics ->
+                    final List<ClusterRoleStatus> relevantRoles = clusterStatusSupplier.get()
+                            .getRoles()
+                            .stream()
+                            .filter(this::hasRelevantRole)
+                            .collect(Collectors.toList());
+                    tellRelevantRootActorsToRetrieveStatistics(relevantRoles, retrieveStatistics);
+                    becomeStatisticsDetailsAwaiting(relevantRoles, statistics ->
                             sender.tell(RetrieveStatisticsResponse.of(statistics.toJson(),
                                     retrieveStatistics.getDittoHeaders()), self)
                     );
@@ -198,6 +207,16 @@ public final class StatisticsActor extends AbstractActor {
         tellShardRegionToSendClusterShardingStats(SR_SEARCH_UPDATER);
     }
 
+    private void tellRelevantRootActorsToRetrieveStatistics(final Collection<ClusterRoleStatus> relevantRoles,
+            final RetrieveStatisticsDetails command) {
+
+        relevantRoles.forEach(clusterRoleStatus ->
+                statisticsConfig.getShards()
+                        .stream()
+                        .filter(shardConfig -> haveEqualRole(shardConfig, clusterRoleStatus))
+                        .forEach(shardConfig -> tellRootActorToRetrieveStatistics(shardConfig.getRoot(), command)));
+    }
+
     private void tellRootActorToRetrieveStatistics(final String rootActorPath,
             final RetrieveStatisticsDetails retrieveStatistics) {
         pubSubMediator.tell(new DistributedPubSubMediator.SendToAll(rootActorPath, retrieveStatistics, false),
@@ -210,20 +229,16 @@ public final class StatisticsActor extends AbstractActor {
                 getSelf());
     }
 
-    private void initHotMetrics() {
-        hotThings.set(0L);
-        hotPolicies.set(0L);
-        hotSearchUpdaters.set(0L);
+    private void initGauges() {
+        gauges.forEach(namedShardGauge -> namedShardGauge.gauge.set(0L));
     }
 
     private void becomeStatisticsAwaiting(final Consumer<Statistics> statisticsConsumer) {
 
-        final Map<String, ShardStatisticsWrapper> shardStatisticsMap = initShardStatisticsMap();
+        final Map<String, ShardStatisticsWrapper> shardStatisticsMap = new HashMap<>();
 
-        getContext().getSystem()
-                .scheduler()
-                .scheduleOnce(FiniteDuration.apply(WAIT_TIME_MS, TimeUnit.MILLISECONDS), getSelf(),
-                        new AskTimeoutException("Timed out"), getContext().getSystem().dispatcher(), getSelf());
+        final AskTimeoutException askTimeoutException = new AskTimeoutException("Timed out");
+        getTimers().startSingleTimer(askTimeoutException, askTimeoutException, Duration.ofMillis(WAIT_TIME_MS));
 
         getContext().become(ReceiveBuilder.create()
                 .match(RetrieveStatistics.class, rs -> currentStatistics != null,
@@ -231,22 +246,30 @@ public final class StatisticsActor extends AbstractActor {
                                 currentStatistics.toJson(), retrieveStatistics.getDittoHeaders()), getSelf())
                 )
                 .match(ShardRegion.ClusterShardingStats.class, clusterShardingStats -> {
-                    final ShardStatisticsWrapper shardStatistics = getShardStatistics(shardStatisticsMap,
-                            getSender().path().name());
-                    final Map<Address, ShardRegion.ShardRegionStats> regions = clusterShardingStats.getRegions();
-                    shardStatistics.count = regions.isEmpty() ? 0 : regions.values().stream()
-                            .mapToInt(shardRegionStats -> shardRegionStats.getStats().isEmpty() ? 0 :
-                                    shardRegionStats.getStats().values().stream()
-                                            .mapToInt(o -> (Integer) o)
-                                            .sum())
-                            .sum();
+                    final Optional<ShardStatisticsWrapper> shardStatistics =
+                            getShardStatistics(shardStatisticsMap, getSender());
+
+                    if (shardStatistics.isPresent()) {
+                        final Map<Address, ShardRegion.ShardRegionStats> regions = clusterShardingStats.getRegions();
+                        shardStatistics.get().count = regions.isEmpty() ? 0 : regions.values().stream()
+                                .mapToInt(shardRegionStats -> shardRegionStats.getStats().isEmpty() ? 0 :
+                                        shardRegionStats.getStats().values().stream()
+                                                .mapToInt(o -> (Integer) o)
+                                                .sum())
+                                .sum();
+                    } else {
+                        log.warning("Got stats from unknown shard <{}>: <{}>", getSender(), clusterShardingStats);
+                    }
+
+                    // all shard statistics are present; no need to wait more.
+                    if (shardStatisticsMap.size() >= statisticsConfig.getShards().size()) {
+                        getTimers().cancel(askTimeoutException);
+                        getSelf().tell(askTimeoutException, getSelf());
+                    }
                 })
-                .match(AskTimeoutException.class, askTimeout -> {
-                    currentStatistics = new Statistics(
-                            shardStatisticsMap.get(SR_THING).count,
-                            shardStatisticsMap.get(SR_POLICY).count,
-                            shardStatisticsMap.get(SR_SEARCH_UPDATER).count
-                    );
+                .matchEquals(askTimeoutException, unit -> {
+                    updateGauges(shardStatisticsMap);
+                    currentStatistics = Statistics.fromGauges(gauges);
                     statisticsConsumer.accept(currentStatistics);
                     getContext().unbecome();
                 })
@@ -256,14 +279,21 @@ public final class StatisticsActor extends AbstractActor {
         );
     }
 
-    private void becomeStatisticsDetailsAwaiting(final Consumer<StatisticsDetails> statisticsDetailsConsumer) {
+    private void becomeStatisticsDetailsAwaiting(final Collection<ClusterRoleStatus> relevantRoles,
+            final Consumer<StatisticsDetails> statisticsDetailsConsumer) {
 
-        final Map<String, ShardStatisticsWrapper> shardStatisticsMap = initShardStatisticsMap();
+        final Map<String, ShardStatisticsWrapper> shardStatisticsMap = new HashMap<>();
+        final AskTimeoutException askTimeoutException = new AskTimeoutException("Timed out");
 
-        getContext().getSystem()
-                .scheduler()
-                .scheduleOnce(FiniteDuration.apply(WAIT_TIME_MS * 8L, TimeUnit.MILLISECONDS), getSelf(),
-                        new AskTimeoutException("Timed out"), getContext().getSystem().dispatcher(), getSelf());
+        getTimers().startSingleTimer(askTimeoutException, askTimeoutException,
+                Duration.ofMillis(WAIT_TIME_MS).multipliedBy(8L));
+
+        final int reachableMembers = relevantRoles.stream()
+                .mapToInt(clusterRoleStatus -> clusterRoleStatus.getReachable().size())
+                .sum();
+
+        final ShardStatisticsWrapper messageCounter = new ShardStatisticsWrapper();
+        messageCounter.count = 0L;
 
         getContext().become(ReceiveBuilder.create()
                 .match(RetrieveStatisticsDetails.class, rs -> currentStatisticsDetails != null,
@@ -279,7 +309,7 @@ public final class StatisticsActor extends AbstractActor {
 
                     if (shardRegion != null) {
                         final ShardStatisticsWrapper shardStatistics =
-                                getShardStatistics(shardStatisticsMap, shardRegion);
+                                shardStatisticsMap.computeIfAbsent(shardRegion, s -> new ShardStatisticsWrapper());
 
                         retrieveStatisticsDetailsResponse.getStatisticsDetails().getValue(shardRegion)
                                 .map(JsonValue::asObject)
@@ -288,14 +318,16 @@ public final class StatisticsActor extends AbstractActor {
                                         shardStatistics.hotnessMap
                                                 .merge(field.getKeyName(), field.getValue().asLong(), Long::sum)
                                 ));
+
+                        // all reachable members sent reply; stop waiting.
+                        if (++messageCounter.count >= reachableMembers) {
+                            getTimers().cancel(askTimeoutException);
+                            getSelf().tell(askTimeoutException, getSelf());
+                        }
                     }
                 })
                 .match(AskTimeoutException.class, askTimeout -> {
-                    currentStatisticsDetails = new StatisticsDetails(
-                            shardStatisticsMap.get(SR_THING).hotnessMap,
-                            shardStatisticsMap.get(SR_POLICY).hotnessMap,
-                            shardStatisticsMap.get(SR_SEARCH_UPDATER).hotnessMap
-                    );
+                    currentStatisticsDetails = StatisticsDetails.fromShardStatisticsWrappers(shardStatisticsMap);
                     statisticsDetailsConsumer.accept(currentStatisticsDetails);
                     getContext().unbecome();
                 })
@@ -305,20 +337,30 @@ public final class StatisticsActor extends AbstractActor {
         );
     }
 
-    private ShardStatisticsWrapper getShardStatistics(final Map<String, ShardStatisticsWrapper> shardStatisticsMap,
-            final String shardRegion) {
+    private boolean hasRelevantRole(final ClusterRoleStatus clusterRoleStatus) {
+        return statisticsConfig.getShards()
+                .stream()
+                .anyMatch(shardConfig -> haveEqualRole(shardConfig, clusterRoleStatus));
+    }
 
-        ShardStatisticsWrapper shardStatistics = shardStatisticsMap.get(shardRegion);
-        if (shardStatistics == null) {
-            if (getSender().path().toStringWithoutAddress().contains(SR_SEARCH_UPDATER)) {
-                shardStatistics = shardStatisticsMap.get(SR_SEARCH_UPDATER);
-            } else if (getSender().path().toStringWithoutAddress().contains(SR_POLICY)) {
-                shardStatistics = shardStatisticsMap.get(SR_POLICY);
-            } else if (getSender().path().toStringWithoutAddress().contains(SR_THING)) {
-                shardStatistics = shardStatisticsMap.get(SR_THING);
-            }
-        }
-        return shardStatistics;
+    private static boolean haveEqualRole(final StatisticsShardConfig shardConfig,
+            final ClusterRoleStatus clusterRoleStatus) {
+        return shardConfig.getRole().equals(clusterRoleStatus.getRole());
+    }
+
+    private Optional<ShardStatisticsWrapper> getShardStatistics(
+            final Map<String, ShardStatisticsWrapper> shardStatisticsMap,
+            final ActorRef sender) {
+
+        final String senderPath = sender.path().toStringWithoutAddress();
+        final Optional<StatisticsShardConfig> shardConfig = statisticsConfig.getShards()
+                .stream()
+                .filter(sc -> senderPath.contains(sc.getShard()))
+                .findFirst();
+        return shardConfig.map(sc ->
+                shardStatisticsMap.computeIfAbsent(sc.getShard(), s -> new ShardStatisticsWrapper())
+        );
+
     }
 
     private static final class ShardStatisticsWrapper {
@@ -327,36 +369,88 @@ public final class StatisticsActor extends AbstractActor {
         private long count = -1L;
     }
 
+    private static String simpleCamelCasePluralForm(final String singular, final boolean capitalize) {
+        final String[] words = singular.split("\\W");
+        if (words.length > 0) {
+            // capitalization by io.jsonwebtoken
+            for (int i = capitalize ? 0 : 1; i < words.length; ++i) {
+                words[i] = capitalize(words[i]);
+            }
+            // This simple pluralization rule needs only work on the configured shard region names.
+            // Exceptions such as "mothers-in-law" and "mitochondria" are not handled.
+            final int lastIndex = words.length - 1;
+            final String lastWord = words[lastIndex];
+            if (lastWord.endsWith("y")) {
+                words[lastIndex] = lastWord.substring(0, lastWord.length() - 1) + "ies";
+            } else {
+                words[lastIndex] += "s";
+            }
+            return String.join("", words);
+        } else {
+            // singular consists entirely of non-word characters
+            return capitalize(singular) + "s";
+        }
+    }
+
+    private static String hotPluralForm(final String singular) {
+        return "hot" + simpleCamelCasePluralForm(singular, true);
+    }
+
+    private static List<NamedShardGauge> initializeGaugesForHotEntities(final StatisticsConfig statisticsConfig) {
+        final List<NamedShardGauge> gauges = new ArrayList<>(statisticsConfig.getShards().size());
+        statisticsConfig.getShards().forEach(shardConfig -> {
+            final String hotStuffs = hotPluralForm(shardConfig.getShard());
+            gauges.add(new NamedShardGauge(hotStuffs, shardConfig.getShard(), DittoMetrics.gauge(hotStuffs)));
+        });
+        return gauges;
+    }
+
+    private static class InternalRetrieveStatistics {
+
+        private InternalRetrieveStatistics() {
+            // no-op
+        }
+
+        static InternalRetrieveStatistics newInstance() {
+            return new InternalRetrieveStatistics();
+        }
+    }
+
+    @Immutable
+    private static final class NamedShardGauge {
+
+        private final String name;
+        private final String shard;
+        private final Gauge gauge;
+
+        private NamedShardGauge(final String name, final String shard,
+                final Gauge gauge) {
+            this.name = name;
+            this.shard = shard;
+            this.gauge = gauge;
+        }
+    }
+
     /**
      * Representation publicly available statistics about hot entities within Ditto.
      */
     @Immutable
     private static final class Statistics implements Jsonifiable.WithPredicate<JsonObject, JsonField> {
 
-        private static final String HOT_THINGS = "hotThingsCount";
-        private static final String HOT_POLICIES = "hotPoliciesCount";
-        private static final String HOT_SEARCH_UPDATERS = "hotSearchUpdatersCount";
+        private final JsonObject hotEntitiesCount;
 
-        private static final JsonFieldDefinition<Long> HOT_THINGS_COUNT =
-                JsonFactory.newLongFieldDefinition(HOT_THINGS, FieldType.REGULAR);
+        private Statistics(final JsonObject hotEntitiesCount) {
+            this.hotEntitiesCount = hotEntitiesCount;
+        }
 
-        private static final JsonFieldDefinition<Long> HOT_POLICIES_COUNT =
-                JsonFactory.newLongFieldDefinition(HOT_POLICIES, FieldType.REGULAR);
-
-        private static final JsonFieldDefinition<Long> HOT_SEARCH_UPDATERS_COUNT =
-                JsonFactory.newLongFieldDefinition(HOT_SEARCH_UPDATERS, FieldType.REGULAR);
-
-        private final long hotThingsCount;
-        private final long hotPoliciesCount;
-        private final long hotSearchUpdatersCount;
-
-        private Statistics(final long hotThingsCount,
-                final long hotPoliciesCount,
-                final long hotSearchUpdatersCount) {
-
-            this.hotThingsCount = hotThingsCount;
-            this.hotPoliciesCount = hotPoliciesCount;
-            this.hotSearchUpdatersCount = hotSearchUpdatersCount;
+        private static Statistics fromGauges(final Collection<NamedShardGauge> gauges) {
+            return new Statistics(
+                    gauges.stream()
+                            .map(namedShardGauge ->
+                                    JsonFactory.newField(JsonKey.of(namedShardGauge.name),
+                                            JsonFactory.newValue(namedShardGauge.gauge.get())))
+                            .collect(JsonCollectors.fieldsToObject())
+            );
         }
 
         /**
@@ -366,17 +460,15 @@ public final class StatisticsActor extends AbstractActor {
          */
         @Override
         public JsonObject toJson() {
-            return toJson(FieldType.notHidden());
+            return hotEntitiesCount;
         }
 
         @Override
         public JsonObject toJson(@Nonnull final JsonSchemaVersion schemaVersion,
                 @Nonnull final Predicate<JsonField> predicate) {
-            return JsonFactory.newObjectBuilder()
-                    .set(HOT_THINGS_COUNT, hotThingsCount, predicate)
-                    .set(HOT_POLICIES_COUNT, hotPoliciesCount, predicate)
-                    .set(HOT_SEARCH_UPDATERS_COUNT, hotSearchUpdatersCount, predicate)
-                    .build();
+            return hotEntitiesCount.stream()
+                    .filter(predicate)
+                    .collect(JsonCollectors.fieldsToObject());
         }
 
         @SuppressWarnings("OverlyComplexMethod")
@@ -387,22 +479,18 @@ public final class StatisticsActor extends AbstractActor {
             }
             if (o == null || getClass() != o.getClass()) return false;
             final Statistics that = (Statistics) o;
-            return hotThingsCount == that.hotThingsCount &&
-                    hotPoliciesCount == that.hotPoliciesCount &&
-                    hotSearchUpdatersCount == that.hotSearchUpdatersCount;
+            return Objects.equals(hotEntitiesCount, that.hotEntitiesCount);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(hotThingsCount, hotPoliciesCount, hotSearchUpdatersCount);
+            return hotEntitiesCount.hashCode();
         }
 
         @Override
         public String toString() {
             return getClass().getSimpleName() + " [" +
-                    "hotThingsCount=" + hotThingsCount +
-                    ", hotPoliciesCount=" + hotPoliciesCount +
-                    ", hotSearchUpdatersCount=" + hotSearchUpdatersCount +
+                    "hotEntitiesCount=" + hotEntitiesCount +
                     "]";
         }
 
@@ -414,26 +502,26 @@ public final class StatisticsActor extends AbstractActor {
     @Immutable
     private static final class StatisticsDetails implements Jsonifiable.WithPredicate<JsonObject, JsonField> {
 
-        private static final JsonFieldDefinition<JsonObject> THINGS_NAMESPACE_HOTNESS =
-                JsonFactory.newJsonObjectFieldDefinition("thingsNamespacesHotness", FieldType.REGULAR);
+        private final JsonObject namespacesHotness;
 
-        private static final JsonFieldDefinition<JsonObject> POLICIES_NAMESPACE_HOTNESS =
-                JsonFactory.newJsonObjectFieldDefinition("policiesNamespacesHotness", FieldType.REGULAR);
+        private StatisticsDetails(final JsonObject namespacesHotness) {
+            this.namespacesHotness = namespacesHotness;
+        }
 
-        private static final JsonFieldDefinition<JsonObject> SEARCH_UPDATERS_NAMESPACE_HOTNESS =
-                JsonFactory.newJsonObjectFieldDefinition("searchUpdatersNamespacesHotness", FieldType.REGULAR);
+        private static StatisticsDetails fromShardStatisticsWrappers(
+                final Map<String, ShardStatisticsWrapper> shardStatisticsWrapperMap) {
 
-        private final Map<String, Long> thingsNamespacesHotness;
-        private final Map<String, Long> policiesNamespacesHotness;
-        private final Map<String, Long> searchUpdatersNamespacesHotness;
-
-        private StatisticsDetails(final Map<String, Long> thingsNamespacesHotness,
-                final Map<String, Long> policiesNamespacesHotness,
-                final Map<String, Long> searchUpdatersNamespacesHotness) {
-
-            this.thingsNamespacesHotness = thingsNamespacesHotness;
-            this.policiesNamespacesHotness = policiesNamespacesHotness;
-            this.searchUpdatersNamespacesHotness = searchUpdatersNamespacesHotness;
+            return new StatisticsDetails(
+                    shardStatisticsWrapperMap.entrySet()
+                            .stream()
+                            .map(entry -> {
+                                final String entitiesNamespacesHotness =
+                                        simpleCamelCasePluralForm(entry.getKey(), false) + "NamespacesHotness";
+                                return JsonFactory.newField(JsonKey.of(entitiesNamespacesHotness),
+                                        buildHotnessMapJson(entry.getValue().hotnessMap));
+                            })
+                            .collect(JsonCollectors.fieldsToObject())
+            );
         }
 
         private static JsonObject buildHotnessMapJson(final Map<String, Long> hotnessMap) {
@@ -469,18 +557,15 @@ public final class StatisticsActor extends AbstractActor {
          */
         @Override
         public JsonObject toJson() {
-            return toJson(FieldType.notHidden());
+            return namespacesHotness;
         }
 
         @Override
         public JsonObject toJson(@Nonnull final JsonSchemaVersion schemaVersion,
                 @Nonnull final Predicate<JsonField> predicate) {
-            return JsonFactory.newObjectBuilder()
-                    .set(THINGS_NAMESPACE_HOTNESS, buildHotnessMapJson(thingsNamespacesHotness), predicate)
-                    .set(POLICIES_NAMESPACE_HOTNESS, buildHotnessMapJson(policiesNamespacesHotness), predicate)
-                    .set(SEARCH_UPDATERS_NAMESPACE_HOTNESS, buildHotnessMapJson(searchUpdatersNamespacesHotness),
-                            predicate)
-                    .build();
+            return namespacesHotness.stream()
+                    .filter(predicate)
+                    .collect(JsonCollectors.fieldsToObject());
         }
 
         @SuppressWarnings("OverlyComplexMethod")
@@ -491,36 +576,21 @@ public final class StatisticsActor extends AbstractActor {
             }
             if (o == null || getClass() != o.getClass()) return false;
             final StatisticsDetails that = (StatisticsDetails) o;
-            return Objects.equals(thingsNamespacesHotness, that.thingsNamespacesHotness) &&
-                    Objects.equals(policiesNamespacesHotness, that.policiesNamespacesHotness) &&
-                    Objects.equals(searchUpdatersNamespacesHotness, that.searchUpdatersNamespacesHotness);
+            return Objects.equals(namespacesHotness, that.namespacesHotness);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(thingsNamespacesHotness, policiesNamespacesHotness, searchUpdatersNamespacesHotness);
+            return namespacesHotness.hashCode();
         }
 
         @Override
         public String toString() {
             return getClass().getSimpleName() + " [" +
-                    "thingsNamespacesHotness=" + thingsNamespacesHotness +
-                    ", policiesNamespacesHotness=" + policiesNamespacesHotness +
-                    ", searchUpdatersNamespacesHotness=" + searchUpdatersNamespacesHotness +
+                    "namespacesHotness=" + namespacesHotness +
                     "]";
         }
 
-    }
-
-    private static class InternalRetrieveStatistics {
-
-        private InternalRetrieveStatistics() {
-            // no-op
-        }
-
-        static InternalRetrieveStatistics newInstance() {
-            return new InternalRetrieveStatistics();
-        }
     }
 
 }

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.services.gateway.proxy.config;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.Immutable;
@@ -25,16 +27,19 @@ import com.typesafe.config.Config;
 
 /**
  * The implementation of statistics-config.
- * TODO: TESTS!
  */
 @Immutable
 final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath {
 
     private static final String CONFIG_PATH = "statistics";
 
+    private final Duration askTimeout;
+    private final Duration updateInterval;
     private final List<StatisticsShardConfig> shards;
 
     private DefaultStatisticsConfig(final ScopedConfig scopedConfig) {
+        askTimeout = scopedConfig.getDuration(ConfigValues.ASK_TIMEOUT.getConfigPath());
+        updateInterval = scopedConfig.getDuration(ConfigValues.UPDATE_INTERVAL.getConfigPath());
         shards = scopedConfig.getConfigList(ConfigValues.SHARDS.getConfigPath())
                 .stream()
                 .map(DefaultStatisticsShardConfig::of)
@@ -50,6 +55,16 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
      */
     static StatisticsConfig of(final Config config) {
         return new DefaultStatisticsConfig(ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValues.values()));
+    }
+
+    @Override
+    public Duration getAskTimeout() {
+        return askTimeout;
+    }
+
+    @Override
+    public Duration getUpdateInterval() {
+        return updateInterval;
     }
 
     @Override
@@ -74,18 +89,22 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
             return false;
         }
         final DefaultStatisticsConfig that = (DefaultStatisticsConfig) o;
-        return shards.equals(that.shards);
+        return askTimeout.equals(that.askTimeout) &&
+                updateInterval.equals(that.updateInterval) &&
+                shards.equals(that.shards);
     }
 
     @Override
     public int hashCode() {
-        return shards.hashCode();
+        return Objects.hash(askTimeout, updateInterval, shards);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "shards=" + shards +
+                "askTimeout=" + askTimeout +
+                ", updateInterval=" + updateInterval +
+                ", shards=" + shards +
                 "]";
     }
 

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.services.utils.config.ScopedConfig;
+import org.eclipse.ditto.services.utils.config.WithConfigPath;
+
+import com.typesafe.config.Config;
+
+/**
+ * The implementation of statistics-config.
+ * TODO: TESTS!
+ */
+@Immutable
+final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath {
+
+    private static final String CONFIG_PATH = "statistics";
+
+    private final List<StatisticsShardConfig> shards;
+
+    private DefaultStatisticsConfig(final ScopedConfig scopedConfig) {
+        shards = scopedConfig.getConfigList(ConfigValues.SHARDS.getConfigPath())
+                .stream()
+                .map(DefaultStatisticsShardConfig::of)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an instance of {@code StatisticsConfig} based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the authentication config at {@value #CONFIG_PATH}.
+     * @return the instance.
+     * @throws org.eclipse.ditto.services.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    static StatisticsConfig of(final Config config) {
+        return new DefaultStatisticsConfig(ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValues.values()));
+    }
+
+    @Override
+    public List<StatisticsShardConfig> getShards() {
+        return shards;
+    }
+
+    /**
+     * @return always {@value CONFIG_PATH}.
+     */
+    @Override
+    public String getConfigPath() {
+        return CONFIG_PATH;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultStatisticsConfig that = (DefaultStatisticsConfig) o;
+        return shards.equals(that.shards);
+    }
+
+    @Override
+    public int hashCode() {
+        return shards.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "shards=" + shards +
+                "]";
+    }
+
+}

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfig.java
@@ -35,11 +35,13 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
 
     private final Duration askTimeout;
     private final Duration updateInterval;
+    private final Duration detailsExpireAfter;
     private final List<StatisticsShardConfig> shards;
 
     private DefaultStatisticsConfig(final ScopedConfig scopedConfig) {
         askTimeout = scopedConfig.getDuration(ConfigValues.ASK_TIMEOUT.getConfigPath());
         updateInterval = scopedConfig.getDuration(ConfigValues.UPDATE_INTERVAL.getConfigPath());
+        detailsExpireAfter = scopedConfig.getDuration(ConfigValues.DETAILS_EXPIRE_AFTER.getConfigPath());
         shards = scopedConfig.getConfigList(ConfigValues.SHARDS.getConfigPath())
                 .stream()
                 .map(DefaultStatisticsShardConfig::of)
@@ -68,6 +70,11 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
     }
 
     @Override
+    public Duration getDetailsExpireAfter() {
+        return detailsExpireAfter;
+    }
+
+    @Override
     public List<StatisticsShardConfig> getShards() {
         return shards;
     }
@@ -91,12 +98,13 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
         final DefaultStatisticsConfig that = (DefaultStatisticsConfig) o;
         return askTimeout.equals(that.askTimeout) &&
                 updateInterval.equals(that.updateInterval) &&
+                detailsExpireAfter.equals(that.detailsExpireAfter) &&
                 shards.equals(that.shards);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(askTimeout, updateInterval, shards);
+        return Objects.hash(askTimeout, updateInterval, detailsExpireAfter, shards);
     }
 
     @Override
@@ -104,6 +112,7 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
         return getClass().getSimpleName() + " [" +
                 "askTimeout=" + askTimeout +
                 ", updateInterval=" + updateInterval +
+                ", detailsExpireAfter=" + updateInterval +
                 ", shards=" + shards +
                 "]";
     }

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
@@ -34,6 +34,13 @@ final class DefaultStatisticsShardConfig implements StatisticsShardConfig, WithC
     private final String role;
     private final String root;
 
+    // for test
+    DefaultStatisticsShardConfig(final String shard, final String role, final String root) {
+        this.shard = shard;
+        this.role = role;
+        this.root = root;
+    }
+
     private DefaultStatisticsShardConfig(final ScopedConfig scopedConfig) {
         shard = scopedConfig.getString(ConfigValues.SHARD.getConfigPath());
         role = scopedConfig.getString(ConfigValues.ROLE.getConfigPath());

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
@@ -42,7 +42,7 @@ final class DefaultStatisticsShardConfig implements StatisticsShardConfig, WithC
     }
 
     private DefaultStatisticsShardConfig(final ScopedConfig scopedConfig) {
-        shard = scopedConfig.getString(ConfigValues.SHARD.getConfigPath());
+        shard = scopedConfig.getString(ConfigValues.REGION.getConfigPath());
         role = scopedConfig.getString(ConfigValues.ROLE.getConfigPath());
         root = scopedConfig.getString(ConfigValues.ROOT.getConfigPath());
     }
@@ -60,7 +60,7 @@ final class DefaultStatisticsShardConfig implements StatisticsShardConfig, WithC
     }
 
     @Override
-    public String getShard() {
+    public String getRegion() {
         return shard;
     }
 

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfig.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.services.utils.config.ScopedConfig;
+import org.eclipse.ditto.services.utils.config.WithConfigPath;
+
+import com.typesafe.config.Config;
+
+/**
+ * The implementation of statistics-shard-config.
+ */
+@Immutable
+final class DefaultStatisticsShardConfig implements StatisticsShardConfig, WithConfigPath {
+
+    private static final String CONFIG_PATH = "shards";
+
+    private final String shard;
+    private final String role;
+    private final String root;
+
+    private DefaultStatisticsShardConfig(final ScopedConfig scopedConfig) {
+        shard = scopedConfig.getString(ConfigValues.SHARD.getConfigPath());
+        role = scopedConfig.getString(ConfigValues.ROLE.getConfigPath());
+        root = scopedConfig.getString(ConfigValues.ROOT.getConfigPath());
+    }
+
+    /**
+     * Returns an instance of {@code StatisticsShardConfig} based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the authentication config at root.
+     * @return the instance.
+     * @throws org.eclipse.ditto.services.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    static DefaultStatisticsShardConfig of(final Config config) {
+        return new DefaultStatisticsShardConfig(
+                ConfigWithFallback.newInstance(config.atKey(CONFIG_PATH), CONFIG_PATH, ConfigValues.values()));
+    }
+
+    @Override
+    public String getShard() {
+        return shard;
+    }
+
+    @Override
+    public String getRoot() {
+        return root;
+    }
+
+    @Override
+    public String getRole() {
+        return role;
+    }
+
+    /**
+     * @return always {@value CONFIG_PATH}.
+     */
+    @Override
+    public String getConfigPath() {
+        return CONFIG_PATH;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultStatisticsShardConfig that = (DefaultStatisticsShardConfig) o;
+        return shard.equals(that.shard) &&
+                role.equals(that.role) &&
+                root.equals(that.root);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shard, role, root);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "shard=" + shard +
+                ", role=" + role +
+                ", root=" + root +
+                "]";
+    }
+
+}

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
@@ -46,6 +46,13 @@ public interface StatisticsConfig {
     Duration getUpdateInterval();
 
     /**
+     * Returns the configured lifetime of statistics details.
+     *
+     * @return the lifetime.
+     */
+    Duration getDetailsExpireAfter();
+
+    /**
      * Returns the configuration settings of shards for which statistics are reported..
      *
      * @return the config.
@@ -79,6 +86,11 @@ public interface StatisticsConfig {
          * Configuration for update interval of public endpoint.
          */
         UPDATE_INTERVAL("update-interval", Duration.ofSeconds(15L)),
+
+        /**
+         * Configuration for expiry of statistics details.
+         */
+        DETAILS_EXPIRE_AFTER("details-expire-after", Duration.ofSeconds(1L)),
 
         /**
          * Configuration for individual shards.

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+import org.eclipse.ditto.services.utils.config.ScopedConfig;
+
+import com.typesafe.config.Config;
+
+import akka.actor.ActorContext;
+
+/**
+ * Provides configuration settings for the statistics actor.
+ */
+@Immutable
+public interface StatisticsConfig {
+
+    /**
+     * Returns the configuration settings of shards for which statistics are reported..
+     *
+     * @return the config.
+     */
+    List<StatisticsShardConfig> getShards();
+
+    /**
+     * Returns an instance of {@code StatisticsConfig} based on the settings of the actor system.
+     *
+     * @param context any actor context.
+     * @return the instance.
+     * @throws org.eclipse.ditto.services.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    static StatisticsConfig forActor(final ActorContext context) {
+        final Config systemConfig = context.system().settings().config();
+        final String configPath = String.format("%s.%s", ScopedConfig.DITTO_SCOPE, "gateway");
+        return DefaultStatisticsConfig.of(systemConfig.getConfig(configPath));
+    }
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values.
+     */
+    enum ConfigValues implements KnownConfigValue {
+
+        /**
+         * Configuration for individual shards.
+         */
+        SHARDS("shards", Collections.emptyList());
+
+        private final String path;
+        private final Object defaultValue;
+
+        ConfigValues(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+    }
+
+}

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsConfig.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.services.gateway.proxy.config;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -29,6 +30,20 @@ import akka.actor.ActorContext;
  */
 @Immutable
 public interface StatisticsConfig {
+
+    /**
+     * Returns the configured timeout when asking other cluster members for information.
+     *
+     * @return the ask-timeout.
+     */
+    Duration getAskTimeout();
+
+    /**
+     * Returns the configured interval for updating the public statistics.
+     *
+     * @return the update-interval.
+     */
+    Duration getUpdateInterval();
 
     /**
      * Returns the configuration settings of shards for which statistics are reported..
@@ -54,6 +69,16 @@ public interface StatisticsConfig {
      * An enumeration of the known config path expressions and their associated default values.
      */
     enum ConfigValues implements KnownConfigValue {
+
+        /**
+         * Configuration for ask timeout.
+         */
+        ASK_TIMEOUT("ask-timeout", Duration.ofSeconds(5L)),
+
+        /**
+         * Configuration for update interval of public endpoint.
+         */
+        UPDATE_INTERVAL("update-interval", Duration.ofSeconds(15L)),
 
         /**
          * Configuration for individual shards.

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+
+import com.typesafe.config.Config;
+
+/**
+ * Configuration for statistics of shard regions.
+ */
+public interface StatisticsShardConfig {
+
+    /**
+     * Returns the shard region name.
+     *
+     * @return the shard region name.
+     */
+    String getShard();
+
+    /**
+     * Returns the cluster role where the shard is started.
+     *
+     * @return the cluster role.
+     */
+    String getRole();
+
+    /**
+     * Returns the actor path of the actor who supervises the shard.
+     *
+     * @return actor path of the supervisor.
+     */
+    String getRoot();
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values.
+     */
+    enum ConfigValues implements KnownConfigValue {
+
+        /**
+         * The shard region name.
+         */
+        SHARD("shard", ""),
+
+        /**
+         * The cluster role of the shard.
+         */
+        ROLE("role", ""),
+
+        /**
+         * The actor path of the shard's supervisor.
+         */
+        ROOT("root", "");
+
+        private final String path;
+        private final Object defaultValue;
+
+        ConfigValues(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+    }
+}

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
@@ -24,7 +24,7 @@ public interface StatisticsShardConfig {
      *
      * @return the shard region name.
      */
-    String getShard();
+    String getRegion();
 
     /**
      * Returns the cluster role where the shard is started.
@@ -48,7 +48,7 @@ public interface StatisticsShardConfig {
         /**
          * The shard region name.
          */
-        SHARD("shard", ""),
+        REGION("region", ""),
 
         /**
          * The cluster role of the shard.

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/StatisticsShardConfig.java
@@ -14,8 +14,6 @@ package org.eclipse.ditto.services.gateway.proxy.config;
 
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
 
-import com.typesafe.config.Config;
-
 /**
  * Configuration for statistics of shard regions.
  */

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/package-info.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/config/package-info.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * This package provides functionality which lets the API Gateway act as a proxy for other services.
+ */
+@org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault
+package org.eclipse.ditto.services.gateway.proxy.config;

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfigTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfigTest.java
@@ -58,6 +58,10 @@ public final class DefaultStatisticsConfigTest {
                 .as(StatisticsConfig.ConfigValues.UPDATE_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(15L));
 
+        softly.assertThat(underTest.getDetailsExpireAfter())
+                .as(StatisticsConfig.ConfigValues.DETAILS_EXPIRE_AFTER.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(1L));
+
         softly.assertThat(underTest.getShards())
                 .as(StatisticsConfig.ConfigValues.SHARDS.getConfigPath())
                 .isEmpty();
@@ -74,6 +78,10 @@ public final class DefaultStatisticsConfigTest {
         softly.assertThat(underTest.getUpdateInterval())
                 .as(StatisticsConfig.ConfigValues.UPDATE_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofMinutes(5678L));
+
+        softly.assertThat(underTest.getDetailsExpireAfter())
+                .as(StatisticsConfig.ConfigValues.DETAILS_EXPIRE_AFTER.getConfigPath())
+                .isEqualTo(Duration.ofDays(9L));
 
         softly.assertThat(underTest.getShards())
                 .as(StatisticsConfig.ConfigValues.SHARDS.getConfigPath())

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfigTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsConfigTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.time.Duration;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Tests {@link org.eclipse.ditto.services.gateway.proxy.config.DefaultStatisticsConfig}.
+ */
+public final class DefaultStatisticsConfigTest {
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(DefaultStatisticsConfig.class,
+                areImmutable(),
+                assumingFields("shards").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultStatisticsConfig.class).verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final StatisticsConfig underTest = DefaultStatisticsConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.getAskTimeout())
+                .as(StatisticsConfig.ConfigValues.ASK_TIMEOUT.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(5L));
+
+        softly.assertThat(underTest.getUpdateInterval())
+                .as(StatisticsConfig.ConfigValues.UPDATE_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(15L));
+
+        softly.assertThat(underTest.getShards())
+                .as(StatisticsConfig.ConfigValues.SHARDS.getConfigPath())
+                .isEmpty();
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final StatisticsConfig underTest = DefaultStatisticsConfig.of(ConfigFactory.load("test-statistics.conf"));
+
+        softly.assertThat(underTest.getAskTimeout())
+                .as(StatisticsConfig.ConfigValues.ASK_TIMEOUT.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(1234L));
+
+        softly.assertThat(underTest.getUpdateInterval())
+                .as(StatisticsConfig.ConfigValues.UPDATE_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofMinutes(5678L));
+
+        softly.assertThat(underTest.getShards())
+                .as(StatisticsConfig.ConfigValues.SHARDS.getConfigPath())
+                .containsExactly(
+                        new DefaultStatisticsShardConfig("glass", "macbeth", "/user/ginger"),
+                        new DefaultStatisticsShardConfig("crystal", "hamlet", "/user/asparagus")
+                );
+    }
+
+}

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfigTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.proxy.config;
+
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Tests {@link org.eclipse.ditto.services.gateway.proxy.config.DefaultStatisticsShardConfig}.
+ */
+public final class DefaultStatisticsShardConfigTest {
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(DefaultStatisticsShardConfig.class, areImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultStatisticsShardConfig.class).verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final StatisticsShardConfig underTest = DefaultStatisticsShardConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.getShard())
+                .as(StatisticsShardConfig.ConfigValues.SHARD.getConfigPath())
+                .isEmpty();
+
+        softly.assertThat(underTest.getRole())
+                .as(StatisticsShardConfig.ConfigValues.ROLE.getConfigPath())
+                .isEmpty();
+
+        softly.assertThat(underTest.getRoot())
+                .as(StatisticsShardConfig.ConfigValues.ROOT.getConfigPath())
+                .isEmpty();
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final StatisticsShardConfig underTest =
+                DefaultStatisticsShardConfig.of(ConfigFactory.load("test-statistics-shard.conf"));
+
+        softly.assertThat(underTest.getShard())
+                .as(StatisticsShardConfig.ConfigValues.SHARD.getConfigPath())
+                .isEqualTo("metal");
+
+        softly.assertThat(underTest.getRole())
+                .as(StatisticsShardConfig.ConfigValues.ROLE.getConfigPath())
+                .isEqualTo("shylock");
+
+        softly.assertThat(underTest.getRoot())
+                .as(StatisticsShardConfig.ConfigValues.ROOT.getConfigPath())
+                .isEqualTo("/user/radish");
+
+    }
+
+}

--- a/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfigTest.java
+++ b/services/gateway/proxy/src/test/java/org/eclipse/ditto/services/gateway/proxy/config/DefaultStatisticsShardConfigTest.java
@@ -45,8 +45,8 @@ public final class DefaultStatisticsShardConfigTest {
     public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
         final StatisticsShardConfig underTest = DefaultStatisticsShardConfig.of(ConfigFactory.empty());
 
-        softly.assertThat(underTest.getShard())
-                .as(StatisticsShardConfig.ConfigValues.SHARD.getConfigPath())
+        softly.assertThat(underTest.getRegion())
+                .as(StatisticsShardConfig.ConfigValues.REGION.getConfigPath())
                 .isEmpty();
 
         softly.assertThat(underTest.getRole())
@@ -63,8 +63,8 @@ public final class DefaultStatisticsShardConfigTest {
         final StatisticsShardConfig underTest =
                 DefaultStatisticsShardConfig.of(ConfigFactory.load("test-statistics-shard.conf"));
 
-        softly.assertThat(underTest.getShard())
-                .as(StatisticsShardConfig.ConfigValues.SHARD.getConfigPath())
+        softly.assertThat(underTest.getRegion())
+                .as(StatisticsShardConfig.ConfigValues.REGION.getConfigPath())
                 .isEqualTo("metal");
 
         softly.assertThat(underTest.getRole())

--- a/services/gateway/proxy/src/test/resources/test-statistics-shard.conf
+++ b/services/gateway/proxy/src/test/resources/test-statistics-shard.conf
@@ -1,0 +1,3 @@
+shard = metal
+role = shylock
+root = /user/radish

--- a/services/gateway/proxy/src/test/resources/test-statistics-shard.conf
+++ b/services/gateway/proxy/src/test/resources/test-statistics-shard.conf
@@ -1,3 +1,3 @@
-shard = metal
+region = metal
 role = shylock
 root = /user/radish

--- a/services/gateway/proxy/src/test/resources/test-statistics.conf
+++ b/services/gateway/proxy/src/test/resources/test-statistics.conf
@@ -1,6 +1,7 @@
 statistics {
   ask-timeout = 1234s
   update-interval = 5678m
+  details-expire-after = 9d
   shards = [
     {
       shard = "glass"

--- a/services/gateway/proxy/src/test/resources/test-statistics.conf
+++ b/services/gateway/proxy/src/test/resources/test-statistics.conf
@@ -4,12 +4,12 @@ statistics {
   details-expire-after = 9d
   shards = [
     {
-      shard = "glass"
+      region = "glass"
       role = "macbeth"
       root = "/user/ginger"
     },
     {
-      shard = "crystal",
+      region = "crystal",
       role = "hamlet",
       root = "/user/asparagus"
     }

--- a/services/gateway/proxy/src/test/resources/test-statistics.conf
+++ b/services/gateway/proxy/src/test/resources/test-statistics.conf
@@ -1,0 +1,16 @@
+statistics {
+  ask-timeout = 1234s
+  update-interval = 5678m
+  shards = [
+    {
+      shard = "glass"
+      role = "macbeth"
+      root = "/user/ginger"
+    },
+    {
+      shard = "crystal",
+      role = "hamlet",
+      root = "/user/asparagus"
+    }
+  ]
+}

--- a/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
+++ b/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
@@ -165,18 +165,6 @@ final class GatewayRootActor extends AbstractActor {
         final ClusterConfig clusterConfig = gatewayConfig.getClusterConfig();
         final int numberOfShards = clusterConfig.getNumberOfShards();
 
-        // start the cluster sharding proxies for retrieving Statistics via StatisticActor about them:
-        ClusterSharding.get(actorSystem)
-                .startProxy(PoliciesMessagingConstants.SHARD_REGION,
-                        Optional.of(PoliciesMessagingConstants.CLUSTER_ROLE),
-                        ShardRegionExtractor.of(numberOfShards, actorSystem));
-        ClusterSharding.get(actorSystem)
-                .startProxy(ThingsMessagingConstants.SHARD_REGION, Optional.of(ThingsMessagingConstants.CLUSTER_ROLE),
-                        ShardRegionExtractor.of(numberOfShards, actorSystem));
-        ClusterSharding.get(actorSystem)
-                .startProxy(ThingsSearchConstants.SHARD_REGION, Optional.of(ThingsSearchConstants.CLUSTER_ROLE),
-                        ShardRegionExtractor.of(numberOfShards, actorSystem));
-
         log.info("Starting /user/{}", DevOpsCommandsActor.ACTOR_NAME);
         final ActorRef devOpsCommandsActor = actorSystem.actorOf(
                 DevOpsCommandsActor.props(LogbackLoggingFacade.newInstance(), GatewayService.SERVICE_NAME,

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -144,6 +144,9 @@ ditto {
       // how often to update hot entities count for the public
       update-interval = 15s
 
+      // minimum pause between computations of statistics details
+      details-expire-after = 3s
+
       // CAUTION: no shard name should be a part of another shard name, because statistics-actor identifies
       // messages from shard regions by checking whether the sender's actor path contains the shard name.
       // This restriction does not apply to cluster role names; it is okay for example to have both the role "things"

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -137,7 +137,14 @@ ditto {
     }
 
     statistics {
-      // CAUTION: no shard name should be the prefix of another shard name, because statistics-actor identifies
+
+      // how long to wait for messages from other cluster members
+      ask-timeout = 5s
+
+      // how often to update hot entities count for the public
+      update-interval = 15s
+
+      // CAUTION: no shard name should be a part of another shard name, because statistics-actor identifies
       // messages from shard regions by checking whether the sender's actor path contains the shard name.
       // This restriction does not apply to cluster role names; it is okay for example to have both the role "things"
       // and the role "things-search".

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -153,17 +153,17 @@ ditto {
       // and the role "things-search".
       shards: [
         {
-          shard: "thing"
+          region: "thing"
           role: "things"
           root: "/user/thingsRoot"
         },
         {
-          shard: "policy"
+          region: "policy"
           role: "policies"
           root: "/user/policiesRoot"
         },
         {
-          shard: "search-updater",
+          region: "search-updater",
           role: "things-search",
           root: "/user/thingsSearchRoot/searchUpdaterRoot"
         }

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -142,10 +142,12 @@ ditto {
       ask-timeout = 5s
 
       // how often to update hot entities count for the public
-      update-interval = 15s
+      update-interval = 30s
+      update-interval = ${?STATISTICS_UPDATE_INTERVAL}
 
       // minimum pause between computations of statistics details
-      details-expire-after = 3s
+      details-expire-after = 5s
+      details-expire-after = ${?STATISTICS_DETAILS_EXPIRE_AFTER}
 
       // CAUTION: no shard name should be a part of another shard name, because statistics-actor identifies
       // messages from shard regions by checking whether the sender's actor path contains the shard name.

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -135,6 +135,30 @@ ditto {
         expire-after-write = ${ditto.gateway.cache.publickeys.expiry}
       }
     }
+
+    statistics {
+      // CAUTION: no shard name should be the prefix of another shard name, because statistics-actor identifies
+      // messages from shard regions by checking whether the sender's actor path contains the shard name.
+      // This restriction does not apply to cluster role names; it is okay for example to have both the role "things"
+      // and the role "things-search".
+      shards: [
+        {
+          shard: "thing"
+          role: "things"
+          root: "/user/thingsRoot"
+        },
+        {
+          shard: "policy"
+          role: "policies"
+          root: "/user/policiesRoot"
+        },
+        {
+          shard: "search-updater",
+          role: "things-search",
+          root: "/user/thingsSearchRoot/searchUpdaterRoot"
+        }
+      ]
+    }
   }
 }
 

--- a/services/utils/akka/src/main/scala/org/eclipse/ditto/services/utils/akka/actors/AbstractActorWithStashWithTimers.scala
+++ b/services/utils/akka/src/main/scala/org/eclipse/ditto/services/utils/akka/actors/AbstractActorWithStashWithTimers.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.akka.actors
+
+import akka.actor.{AbstractActorWithTimers, Stash}
+
+/**
+  * Java's `Actor with Stash with Timers`.
+  */
+abstract class AbstractActorWithStashWithTimers extends AbstractActorWithTimers with Stash

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.signals.commands.devops;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
@@ -55,8 +56,8 @@ public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<Retri
     private RetrieveStatisticsDetails(final List<String> shardRegions, final List<String> namespaces,
             final DittoHeaders dittoHeaders) {
         super(TYPE, null, null, dittoHeaders);
-        this.shardRegions = shardRegions;
-        this.namespaces = namespaces;
+        this.shardRegions = Collections.unmodifiableList(new ArrayList<>(shardRegions));
+        this.namespaces = Collections.unmodifiableList(new ArrayList<>(namespaces));
     }
 
     /**

--- a/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
+++ b/signals/commands/devops/src/main/java/org/eclipse/ditto/signals/commands/devops/RetrieveStatisticsDetails.java
@@ -12,14 +12,21 @@
  */
 package org.eclipse.ditto.signals.commands.devops;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
@@ -42,18 +49,37 @@ public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<Retri
      */
     public static final String TYPE = TYPE_PREFIX + NAME;
 
-    private RetrieveStatisticsDetails(final DittoHeaders dittoHeaders) {
+    private final List<String> shardRegions;
+    private final List<String> namespaces;
+
+    private RetrieveStatisticsDetails(final List<String> shardRegions, final List<String> namespaces,
+            final DittoHeaders dittoHeaders) {
         super(TYPE, null, null, dittoHeaders);
+        this.shardRegions = shardRegions;
+        this.namespaces = namespaces;
     }
 
     /**
-     * Returns a Command for retrieving statistics.
+     * Returns a Command for retrieving statistics about all namespaces in all shard regions.
      *
      * @param dittoHeaders the optional command headers of the request.
      * @return a Command for retrieving statistics.
      */
     public static RetrieveStatisticsDetails of(final DittoHeaders dittoHeaders) {
-        return new RetrieveStatisticsDetails(dittoHeaders);
+        return new RetrieveStatisticsDetails(Collections.emptyList(), Collections.emptyList(), dittoHeaders);
+    }
+
+    /**
+     * Returns a Command for retrieving statistics about certain namespaces in certain shard regions.
+     *
+     * @param shardRegions shard regions to query, or an empty list to query all shard regions.
+     * @param namespaces namespaces to query, or an empty list to query all namespaces.
+     * @param dittoHeaders the optional command headers of the request.
+     * @return a Command for retrieving statistics.
+     */
+    public static RetrieveStatisticsDetails of(final List<String> shardRegions, final List<String> namespaces,
+            final DittoHeaders dittoHeaders) {
+        return new RetrieveStatisticsDetails(shardRegions, namespaces, dittoHeaders);
     }
 
     /**
@@ -82,7 +108,15 @@ public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<Retri
      */
     public static RetrieveStatisticsDetails fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<RetrieveStatisticsDetails>(TYPE, jsonObject)
-                .deserialize(() -> RetrieveStatisticsDetails.of(dittoHeaders));
+                .deserialize(() -> {
+                    final List<String> shardRegions = jsonObject.getValue(JsonFields.SHARD_REGIONS)
+                            .map(RetrieveStatisticsDetails::toStringListOrThrow)
+                            .orElseGet(Collections::emptyList);
+                    final List<String> namespaces = jsonObject.getValue(JsonFields.NAMESPACES)
+                            .map(RetrieveStatisticsDetails::toStringListOrThrow)
+                            .orElseGet(Collections::emptyList);
+                    return RetrieveStatisticsDetails.of(shardRegions, namespaces, dittoHeaders);
+                });
     }
 
     @Override
@@ -91,7 +125,32 @@ public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<Retri
 
         super.appendPayload(jsonObjectBuilder, schemaVersion, thePredicate);
 
-        jsonObjectBuilder.build();
+        if (!shardRegions.isEmpty()) {
+            jsonObjectBuilder.set(JsonFields.SHARD_REGIONS,
+                    shardRegions.stream().map(JsonFactory::newValue).collect(JsonCollectors.valuesToArray()));
+        }
+        if (!namespaces.isEmpty()) {
+            jsonObjectBuilder.set(JsonFields.NAMESPACES,
+                    namespaces.stream().map(JsonFactory::newValue).collect(JsonCollectors.valuesToArray()));
+        }
+    }
+
+    /**
+     * Return the shard regions to query for statistics-details, or an empty list to query all shard regions.
+     *
+     * @return the relevant shard regions.
+     */
+    public List<String> getShardRegions() {
+        return shardRegions;
+    }
+
+    /**
+     * Return the namespaces to query for statistics-details, or an empty list to query all namespaces.
+     *
+     * @return the relevant namespaces.
+     */
+    public List<String> getNamespaces() {
+        return namespaces;
     }
 
     @Override
@@ -106,7 +165,32 @@ public final class RetrieveStatisticsDetails extends AbstractDevOpsCommand<Retri
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + super.toString() + "]";
+        return getClass().getSimpleName() + " [" + super.toString() +
+                ", shardRegions=" + shardRegions +
+                ", namespaces=" + namespaces +
+                "]";
+    }
+
+    private static List<String> toStringListOrThrow(final JsonArray jsonArray) {
+        return jsonArray.stream().map(JsonValue::asString).collect(Collectors.toList());
+    }
+
+    /**
+     * JSON fields of this command.
+     */
+    public static final class JsonFields {
+
+        /**
+         * JSON fields to limit the shard regions to query.
+         */
+        public static final JsonFieldDefinition<JsonArray> SHARD_REGIONS =
+                JsonFactory.newJsonArrayFieldDefinition("shardRegions");
+
+        /**
+         * JSON fields to limit statistics details to the namespaces.
+         */
+        public static final JsonFieldDefinition<JsonArray> NAMESPACES =
+                JsonFactory.newJsonArrayFieldDefinition("namespaces");
     }
 
 }


### PR DESCRIPTION
Changes
- Make shard regions queried by the statistics-actor configurable.
- `RetrieveStatistics` are now always answered by the cached value, updated at a configured interval.
- Filters by shards and by namespaces are added to `RetrieveStatisticsDetails`.
- Cache statistics-details for a configured duration to reduce cluster traffic.
- Fixed discarding of previous behavior before `getContext().unbecome()`.
- Fixed timeout of queries during update of statistics.