### PR TITLE
Stop reconnecting deleted connections

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Connection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Connection.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.model.connectivity;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
@@ -195,6 +196,25 @@ public interface Connection extends Jsonifiable.WithFieldSelectorAndPredicate<Js
     Set<String> getTags();
 
     /**
+     * Returns the current lifecycle of this Connection.
+     *
+     * @return the current lifecycle of this Connection.
+     */
+    Optional<ConnectionLifecycle> getLifecycle();
+
+    /**
+     * Indicates whether this Connection has the given lifecycle.
+     *
+     * @param lifecycle the lifecycle to be checked for.
+     * @return {@code true} if this Connection has {@code lifecycle} as its lifecycle, {@code false} else.
+     */
+    default boolean hasLifecycle(final ConnectionLifecycle lifecycle) {
+        return getLifecycle()
+                .filter(actualLifecycle -> Objects.equals(actualLifecycle, lifecycle))
+                .isPresent();
+    }
+
+    /**
      * Returns a mutable builder with a fluent API for immutable {@code Connection}. The builder is initialised with the
      * entries of this instance.
      *
@@ -230,6 +250,13 @@ public interface Connection extends Jsonifiable.WithFieldSelectorAndPredicate<Js
          */
         public static final JsonFieldDefinition<Integer> SCHEMA_VERSION =
                 JsonFactory.newIntFieldDefinition(JsonSchemaVersion.getJsonKey(), FieldType.SPECIAL, FieldType.HIDDEN,
+                        JsonSchemaVersion.V_1, JsonSchemaVersion.V_2);
+
+        /**
+         * JSON field containing the Connection's lifecycle.
+         */
+        public static final JsonFieldDefinition<String> LIFECYCLE =
+                JsonFactory.newStringFieldDefinition("__lifecycle", FieldType.SPECIAL, FieldType.HIDDEN,
                         JsonSchemaVersion.V_1, JsonSchemaVersion.V_2);
 
         /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionBuilder.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionBuilder.java
@@ -178,6 +178,8 @@ public interface ConnectionBuilder {
      */
     ConnectionBuilder tag(String tag);
 
+    ConnectionBuilder lifecycle(@Nullable ConnectionLifecycle lifecycle);
+
     /**
      * Builds a new {@link Connection}.
      *

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionLifecycle.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionLifecycle.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.connectivity;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javax.annotation.Nullable;
+
+/**
+ * An enumeration of a Connection's lifecycle.
+ */
+public enum ConnectionLifecycle {
+
+    /**
+     * Signals that a Connection is active.
+     */
+    ACTIVE,
+
+    /**
+     * Signals that a Connection is deleted.
+     */
+    DELETED;
+
+    /**
+     * Returns the {@code ConnectionLifecycle} with the given name.
+     *
+     * @param name the name of the lifecycle to get.
+     * @return the lifecycle with the given name or an empty optional.
+     */
+    public static Optional<ConnectionLifecycle> forName(@Nullable final CharSequence name) {
+        return Stream.of(values())
+                .filter(l -> Objects.equals(l.name(), String.valueOf(name)))
+                .findAny();
+    }
+
+}

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActor.java
@@ -379,7 +379,9 @@ public final class ConnectionActor extends AbstractPersistentActorWithTimersAndC
     @Override
     protected long staleEventsKeptAfterCleanup() {
         final boolean isDesiredStateOpen =
-                connection != null && connection.getConnectionStatus() == ConnectivityStatus.OPEN;
+                connection != null &&
+                        connection.hasLifecycle(ConnectionLifecycle.ACTIVE) &&
+                        connection.getConnectionStatus() == ConnectivityStatus.OPEN;
         return isDesiredStateOpen ? 1 : 0;
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ConnectionConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ConnectionConfig.java
@@ -18,12 +18,13 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.services.base.config.supervision.WithSupervisorConfig;
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+import org.eclipse.ditto.services.utils.persistence.mongo.config.WithActivityCheckConfig;
 
 /**
  * Provides configuration settings for Connectivity service's connection behaviour.
  */
 @Immutable
-public interface ConnectionConfig extends WithSupervisorConfig {
+public interface ConnectionConfig extends WithSupervisorConfig, WithActivityCheckConfig {
 
     /**
      * Returns the delay between subscribing to Akka pub/sub and responding to the command that triggered the

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultConnectionConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultConnectionConfig.java
@@ -20,6 +20,8 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.services.base.config.supervision.DefaultSupervisorConfig;
 import org.eclipse.ditto.services.base.config.supervision.SupervisorConfig;
 import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.services.utils.persistence.mongo.config.ActivityCheckConfig;
+import org.eclipse.ditto.services.utils.persistence.mongo.config.DefaultActivityCheckConfig;
 
 import com.typesafe.config.Config;
 
@@ -38,6 +40,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     private final Amqp10Config amqp10Config;
     private final MqttConfig mqttConfig;
     private final KafkaConfig kafkaConfig;
+    private final ActivityCheckConfig activityCheckConfig;
 
     private DefaultConnectionConfig(final ConfigWithFallback config) {
         flushPendingResponsesTimeout =
@@ -48,6 +51,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
         amqp10Config = DefaultAmqp10Config.of(config);
         mqttConfig = DefaultMqttConfig.of(config);
         kafkaConfig = DefaultKafkaConfig.of(config);
+        activityCheckConfig = DefaultActivityCheckConfig.of(config);
     }
 
     /**
@@ -98,6 +102,11 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     }
 
     @Override
+    public ActivityCheckConfig getActivityCheckConfig() {
+        return activityCheckConfig;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -112,13 +121,14 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 Objects.equals(snapshotConfig, that.snapshotConfig) &&
                 Objects.equals(amqp10Config, that.amqp10Config) &&
                 Objects.equals(mqttConfig, that.mqttConfig) &&
+                Objects.equals(activityCheckConfig, that.activityCheckConfig) &&
                 Objects.equals(kafkaConfig, that.kafkaConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(flushPendingResponsesTimeout, clientActorAskTimeout, supervisorConfig, snapshotConfig,
-                amqp10Config, mqttConfig, kafkaConfig);
+                amqp10Config, mqttConfig, kafkaConfig, activityCheckConfig);
     }
 
     @Override
@@ -131,6 +141,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 ", amqp10Config=" + amqp10Config +
                 ", mqttConfig=" + mqttConfig +
                 ", kafkaConfig=" + kafkaConfig +
+                ", activityCheckConfig=" + activityCheckConfig +
                 "]";
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActorRecoveryTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionActorRecoveryTest.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.messaging;
+
+import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.INSTANT;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.Connection;
+import org.eclipse.ditto.model.connectivity.ConnectionLifecycle;
+import org.eclipse.ditto.services.connectivity.messaging.persistence.ConnectionMongoSnapshotAdapter;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionClosed;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionCreated;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionDeleted;
+import org.eclipse.ditto.signals.events.connectivity.ConnectivityEvent;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.cluster.pubsub.DistributedPubSub;
+import akka.japi.Creator;
+import akka.persistence.AbstractPersistentActor;
+import akka.persistence.RecoveryCompleted;
+import akka.persistence.SnapshotMetadata;
+import akka.persistence.SnapshotOffer;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Unit test for {@link ConnectionActor}.
+ */
+public final class ConnectionActorRecoveryTest extends WithMockServers {
+
+    private static final String PERSISTENCE_ID_PREFIX = "connection:";
+    private static final String JOURNAL_PLUGIN_ID = "akka-contrib-mongodb-persistence-connection-journal";
+    private static final String SNAPSHOT_PLUGIN_ID = "akka-contrib-mongodb-persistence-connection-snapshots";
+
+    private static ActorSystem actorSystem;
+    private static ActorRef pubSubMediator;
+    private static ActorRef conciergeForwarder;
+    private String connectionId;
+
+    private ConnectionCreated connectionCreated;
+    private ConnectionClosed connectionClosed;
+    private ConnectionDeleted connectionDeleted;
+
+    private static final ConnectionMongoSnapshotAdapter SNAPSHOT_ADAPTER = new ConnectionMongoSnapshotAdapter();
+
+    @BeforeClass
+    public static void setUp() {
+        actorSystem = ActorSystem.create("AkkaTestSystem", TestConstants.CONFIG);
+        pubSubMediator = DistributedPubSub.get(actorSystem).mediator();
+        conciergeForwarder = actorSystem.actorOf(TestConstants.ConciergeForwarderActorMock.props());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        TestKit.shutdownActorSystem(actorSystem, scala.concurrent.duration.Duration.apply(5, TimeUnit.SECONDS), false);
+    }
+
+    @Before
+    public void init() {
+        connectionId = TestConstants.createRandomConnectionId();
+        final Connection connection = TestConstants.createConnection(connectionId);
+        connectionCreated = ConnectionCreated.of(connection, INSTANT, DittoHeaders.empty());
+        connectionClosed = ConnectionClosed.of(connectionId, INSTANT, DittoHeaders.empty());
+        connectionDeleted = ConnectionDeleted.of(connectionId, INSTANT, DittoHeaders.empty());
+    }
+
+    /**
+     * This tests the behavior for connections that were deleted without saving a snapshot i.e the last stored event
+     * is a ConnectionDeleted event.
+     */
+    @Test
+    public void testRecoveryOfDeletedConnectionsWithoutSnapshot() {
+        new TestKit(actorSystem) {{
+
+            final Queue<ConnectivityEvent> existingEvents
+                    = new LinkedList<>(Arrays.asList(connectionCreated, connectionDeleted));
+            final Props fakeProps = FakePersistenceActor.props(connectionId, getRef(), existingEvents);
+
+            actorSystem.actorOf(fakeProps);
+            expectMsgEquals("persisted");
+
+            final ActorRef underTest = TestConstants.createConnectionSupervisorActor(connectionId, actorSystem,
+                    pubSubMediator, conciergeForwarder);
+            watch(underTest);
+
+            // expect termination because it was deleted (last event was ConnectionDeleted)
+            expectTerminated(underTest);
+
+            // verify snapshot was saved with DELETED lifecycle
+            final Connection deletedConnection = setLifecycleDeleted(connectionCreated.getConnection());
+            final SnapshotOffer snapshot = getSnapshotOffer(deletedConnection, 2); // created + deleted = 2
+            final Queue<Object> expected = new LinkedList<>(Arrays.asList(snapshot, RecoveryCompleted.getInstance()));
+            actorSystem.actorOf(RecoverActor.props(connectionId, getRef(), expected));
+            expectMsgEquals("recovered");
+        }};
+    }
+
+    private Connection setLifecycleDeleted(final Connection connection) {
+        return connection
+                .toBuilder()
+                .lifecycle(ConnectionLifecycle.DELETED)
+                .build();
+    }
+
+    private SnapshotOffer getSnapshotOffer(final Connection deletedConnection, final int sequenceNr) {
+        final SnapshotMetadata metadata = new SnapshotMetadata(PERSISTENCE_ID_PREFIX + connectionId, sequenceNr, 0);
+        return new SnapshotOffer(metadata, deletedConnection);
+    }
+
+    /**
+     * This actor verifies recovery of a persistence actor by checking if the events received during recovery matches
+     * the expected events.
+     */
+    static class RecoverActor extends AbstractPersistentActor {
+
+        private final String connectionId;
+        private final ActorRef ref;
+        private final Queue<Object> expected;
+
+        private RecoverActor(final String connectionId, final ActorRef ref,
+                final Queue<Object> expected) {
+            this.connectionId = connectionId;
+            this.ref = ref;
+            this.expected = expected;
+        }
+
+        static Props props(final String connectionId, final ActorRef probe,
+                final Queue<Object> expected) {
+            return Props.create(RecoverActor.class, new Creator<RecoverActor>() {
+                private static final long serialVersionUID = 1L;
+
+                @Override
+                public RecoverActor create() {
+                    return new RecoverActor(connectionId, probe, expected);
+                }
+            });
+        }
+
+        @Override
+        public Receive createReceiveRecover() {
+            return receiveBuilder()
+                    .match(SnapshotOffer.class, this::checkSnapshotOffer)
+                    .matchAny(this::check)
+                    .build();
+        }
+
+        private void check(final Object recovered) {
+            final Object next = expected.poll();
+            if (recovered.equals(next)) {
+                if (expected.isEmpty()) {
+                    ref.tell("recovered", getSelf());
+                }
+            } else {
+                fail("expected: " + next + " but got: " + recovered);
+            }
+        }
+
+        private void checkSnapshotOffer(final SnapshotOffer snapshotOffer) {
+            final Object next = expected.poll();
+            if (next instanceof SnapshotOffer) {
+                final SnapshotOffer expected = (SnapshotOffer) next;
+                if (expected.metadata().sequenceNr() != snapshotOffer.metadata().sequenceNr()) {
+                    fail("expected sequence nr: " + expected.metadata().sequenceNr() + " but got: " + snapshotOffer.metadata().sequenceNr());
+                }
+                if (!expected.snapshot().equals(SNAPSHOT_ADAPTER.fromSnapshotStore(snapshotOffer))) {
+                    fail("expected: " + expected.snapshot() + " but got: " + snapshotOffer.snapshot());
+                }
+            } else {
+                fail("expected snapshot offer");
+            }
+        }
+
+        private void fail(final String reason) {
+            ref.tell(reason, getSelf());
+            getContext().stop(getSelf());
+        }
+
+        @Override
+        public Receive createReceive() {
+            return receiveBuilder()
+                    .matchAny(m -> ref.forward(m, context())).build();
+        }
+
+        @Override
+        public String persistenceId() {
+            return PERSISTENCE_ID_PREFIX + connectionId;
+        }
+
+        @Override
+        public String journalPluginId() {
+            return JOURNAL_PLUGIN_ID;
+        }
+
+        @Override
+        public String snapshotPluginId() {
+            return SNAPSHOT_PLUGIN_ID;
+        }
+    }
+
+    /**
+     * This actor prepares the (in-memory) persistence with the given events.
+     */
+    static class FakePersistenceActor extends AbstractPersistentActor {
+
+        private final String connectionId;
+        private final ActorRef probe;
+        private final Queue<ConnectivityEvent> events;
+
+        private FakePersistenceActor(final String connectionId, final ActorRef probe,
+                final Queue<ConnectivityEvent> events) {
+            this.connectionId = connectionId;
+            this.probe = probe;
+            this.events = events;
+        }
+
+        static Props props(final String connectionId, final ActorRef probe,
+                final Queue<ConnectivityEvent> events) {
+            return Props.create(FakePersistenceActor.class,
+                    (Creator<FakePersistenceActor>) () -> new FakePersistenceActor(connectionId, probe, events));
+        }
+
+        @Override
+        public Receive createReceiveRecover() {
+            return receiveBuilder().build();
+        }
+
+        @Override
+        public Receive createReceive() {
+            return receiveBuilder()
+                    .match(ConnectivityEvent.class, e -> persist(e, persisted -> persistNextEvent()))
+                    .build();
+        }
+
+        private void persistNextEvent() {
+            final ConnectivityEvent next = events.poll();
+            if (next != null) {
+                getSelf().tell(next, getSelf());
+            } else {
+                probe.tell("persisted", getSelf());
+                getContext().stop(getSelf());
+            }
+        }
+
+        @Override
+        public void preStart() {
+            persistNextEvent();
+        }
+
+        @Override
+        public String persistenceId() {
+            return PERSISTENCE_ID_PREFIX + connectionId;
+        }
+
+        @Override
+        public String journalPluginId() {
+            return JOURNAL_PLUGIN_ID;
+        }
+
+        @Override
+        public String snapshotPluginId() {
+            return SNAPSHOT_PLUGIN_ID;
+        }
+    }
+}

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
@@ -51,6 +51,7 @@ import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.AddressMetric;
 import org.eclipse.ditto.model.connectivity.Connection;
+import org.eclipse.ditto.model.connectivity.ConnectionLifecycle;
 import org.eclipse.ditto.model.connectivity.ConnectionMetrics;
 import org.eclipse.ditto.model.connectivity.ConnectionType;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
@@ -495,6 +496,7 @@ public final class TestConstants {
         return ConnectivityModelFactory.newConnectionBuilder(connectionId, TYPE, status, getUriOfNewMockServer())
                 .sources(sources)
                 .targets(Targets.TARGETS)
+                .lifecycle(ConnectionLifecycle.ACTIVE)
                 .build();
     }
 

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -20,6 +20,14 @@ ditto {
         threshold = 5
       }
 
+      activity-check {
+        # the interval of how long to keep an "inactive" Connection in memory:
+        inactive-interval = 0 # keep active indefinitely
+
+        # the interval of how long to keep a deleted Connection in memory:
+        deleted-interval = 1s
+      }
+
       flush-pending-responses-timeout = 0s
 
       kafka.producer.internal { # internal configuration as needed by akka-stream-kafka library

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -24,6 +24,16 @@ ditto {
         threshold = 10
       }
 
+      activity-check {
+        # the interval of how long to keep an "inactive" Connection in memory:
+        inactive-interval = 0 # currently not used
+        inactive-interval = ${?CONNECTION_ACTIVITY_CHECK_INTERVAL} # may be overridden with this environment variable
+
+        # the interval of how long to keep a deleted Connection in memory:
+        deleted-interval = 5m
+        deleted-interval = ${?CONNECTION_ACTIVITY_CHECK_DELETED_INTERVAL}
+      }
+
       # how long for connection actor to wait between subscribing to pub/sub topics and sending response
       flush-pending-responses-timeout = 5s
       flush-pending-responses-timeout = ${?CONNECTIVITY_FLUSH_PENDING_RESPONSES_TIMEOUT}


### PR DESCRIPTION
…by making a snapshot for deleted connections, which eventually removes the connection from the reconnect-actor's watch list, namely connections with journalled events.