### PR TITLE
remove session tag from metrics

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/SseThingsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/SseThingsRoute.java
@@ -211,8 +211,7 @@ public class SseThingsRoute extends AbstractRoute {
 
         final Counter messageCounter = DittoMetrics.counter("streaming_messages")
                         .tag("type", "sse")
-                        .tag("direction", "out")
-                        .tag("session", connectionCorrelationId);
+                        .tag("direction", "out");
 
         if (filterString != null) {
             // will throw an InvalidRqlExpressionException if the RQL expression was not valid:

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -198,8 +198,7 @@ public final class WebsocketRoute {
 
         final Counter inCounter = DittoMetrics.counter("streaming_messages")
                 .tag("type", "ws")
-                .tag("direction", "in")
-                .tag("session", connectionCorrelationId);
+                .tag("direction", "in");
 
         final ProtocolMessageExtractor protocolMessageExtractor = new ProtocolMessageExtractor(connectionAuthContext,
                 connectionCorrelationId);
@@ -258,8 +257,7 @@ public final class WebsocketRoute {
 
         final Counter outCounter = DittoMetrics.counter("streaming_messages")
                 .tag("type", "ws")
-                .tag("direction", "out")
-                .tag("session", connectionCorrelationId);
+                .tag("direction", "out");
 
         final Source<Jsonifiable.WithPredicate<JsonObject, JsonField>, NotUsed> eventAndResponseSource =
                 Source.<Jsonifiable.WithPredicate<JsonObject, JsonField>>actorPublisher(


### PR DESCRIPTION
This reduces the amount of different counters because there will be too many different sessions and Kamon will create a separate counter for each tag.