### PR TITLE
MongoReadJournal: stop creating substreams per suffix.

### DIFF
--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -278,10 +278,7 @@ public class MongoReadJournal {
     private Source<JournalAndSnaps, NotUsed> listJournalsAndSnapshotStores() {
         final MongoDatabase database = mongoClient.getDefaultDatabase();
         return resolveCollectionNames(journalCollectionPrefix, snapsCollectionPrefix, database, log)
-                .map(this::toJournalAndSnaps)
-                .groupBy(Integer.MAX_VALUE, JournalAndSnaps::getSuffix)
-                .fold(new JournalAndSnaps(), JournalAndSnaps::merge)
-                .mergeSubstreams();
+                .map(this::toJournalAndSnaps);
     }
 
     private Source<MongoCollection<Document>, NotUsed> listJournals() {


### PR DESCRIPTION
Creating a substream for each suffixed journal or snapshot collection is too resource-intensive.