### PR TITLE
 Provide more information in Ditto protocol error messages

### DIFF
--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
@@ -252,12 +252,12 @@ abstract class AbstractAdapter<T extends Jsonifiable> implements Adapter<T> {
                 headerTranslator.fromExternalHeaders(externalHeaders),
                 externalAdaptable.getTopicPath());
 
-        final Adaptable adaptable = externalAdaptable.setDittoHeaders(filteredHeaders);
         final JsonifiableMapper<T> jsonifiableMapper = mappingStrategies.get(type);
         if (null == jsonifiableMapper) {
             throw UnknownTopicPathException.fromMessage(getUnknownTypeMessage(externalAdaptable), filteredHeaders);
         }
 
+        final Adaptable adaptable = externalAdaptable.setDittoHeaders(filteredHeaders);
         return DittoJsonException.wrapJsonRuntimeException(() -> jsonifiableMapper.map(adaptable));
     }
 

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
@@ -254,17 +254,12 @@ abstract class AbstractAdapter<T extends Jsonifiable> implements Adapter<T> {
 
         final JsonifiableMapper<T> jsonifiableMapper = mappingStrategies.get(type);
         if (null == jsonifiableMapper) {
-            throw UnknownTopicPathException.fromMessage(getUnknownTypeMessage(externalAdaptable), filteredHeaders);
+            throw UnknownTopicPathException.fromTopicAndPath(externalAdaptable.getTopicPath(),
+                    externalAdaptable.getPayload().getPath(), filteredHeaders);
         }
 
         final Adaptable adaptable = externalAdaptable.setDittoHeaders(filteredHeaders);
         return DittoJsonException.wrapJsonRuntimeException(() -> jsonifiableMapper.map(adaptable));
-    }
-
-    private String getUnknownTypeMessage(final Adaptable adaptable) {
-        final String topic = adaptable.getTopicPath().getPath();
-        final MessagePath path = adaptable.getPayload().getPath();
-        return String.format("The topic '%s' is not supported in combination with the path '%s'", topic, path);
     }
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 
 /**
@@ -58,13 +59,19 @@ final class ImmutableJsonifiableAdaptable implements JsonifiableAdaptable {
      * @throws org.eclipse.ditto.json.JsonMissingFieldException if {@code jsonObject} is missing required JSON fields.
      */
     public static ImmutableJsonifiableAdaptable fromJson(final JsonObject jsonObject) {
-        final TopicPath topicPath = jsonObject.getValue(JsonFields.TOPIC)
-                .map(ProtocolFactory::newTopicPath)
-                .orElseGet(ProtocolFactory::emptyTopicPath);
-
         final DittoHeaders headers = jsonObject.getValue(JsonFields.HEADERS)
                 .map(ProtocolFactory::newHeaders)
                 .orElse(DittoHeaders.empty());
+
+        TopicPath topicPath;
+
+        try {
+            topicPath = jsonObject.getValue(JsonFields.TOPIC)
+                    .map(ProtocolFactory::newTopicPath)
+                    .orElseGet(ProtocolFactory::emptyTopicPath);
+        } catch (final DittoRuntimeException e) {
+            throw e.setDittoHeaders(headers);
+        }
 
         return new ImmutableJsonifiableAdaptable(ImmutableAdaptable.of(topicPath,
                 ProtocolFactory.newPayload(jsonObject), headers));

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
@@ -63,7 +63,7 @@ final class ImmutableJsonifiableAdaptable implements JsonifiableAdaptable {
                 .map(ProtocolFactory::newHeaders)
                 .orElse(DittoHeaders.empty());
 
-        TopicPath topicPath;
+        final TopicPath topicPath;
 
         try {
             topicPath = jsonObject.getValue(JsonFields.TOPIC)

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathException.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.protocoladapter;
 import java.net.URI;
 import java.text.MessageFormat;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
@@ -37,6 +38,8 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
     public static final String ERROR_CODE = "things.protocol.adapter:unknown.topicpath";
 
     private static final String MESSAGE_TEMPLATE = "The topic path ''{0}'' is not supported.";
+
+    private static final String MESSAGE_TEMPLATE_WITH_PATH = "The topic ''{0}'' is not supported in combination with the path ''{1}''";
 
     private static final String DEFAULT_DESCRIPTION = "Check if the topic path is correct.";
 
@@ -100,6 +103,26 @@ public final class UnknownTopicPathException extends DittoRuntimeException {
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
                 .href(readHRef(jsonObject).orElse(null))
+                .build();
+    }
+
+    /**
+     * Constructs a new {@code UnknownTopicPathException} object for unknown combinations of topic path and message path.
+     *
+     * @param topicPath The topic path.
+     * @param path The message path.
+     * @param dittoHeaders the header of the command which resulted in this exception.
+     * @return the new UnknownTopicPathException.
+     */
+    static UnknownTopicPathException fromTopicAndPath(
+            @Nullable final TopicPath topicPath,
+            @Nullable final MessagePath path,
+            @Nonnull final DittoHeaders dittoHeaders) {
+        final String theTopicPath = null != topicPath ? topicPath.getPath() : "";
+        final String message = MessageFormat.format(MESSAGE_TEMPLATE_WITH_PATH, theTopicPath, path);
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(message)
                 .build();
     }
 

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
@@ -41,16 +41,15 @@ import org.junit.Test;
 /**
  * Unit test for {@link DittoProtocolAdapter}.
  */
-public final class DittoProtocolAdapterTest {
+public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
 
-    private DittoProtocolAdapter underTest;
+    private ProtocolAdapter underTest;
 
     @Before
     public void setUp() {
         underTest = DittoProtocolAdapter.newInstance();
     }
 
-    /** */
     @Test
     public void topicPathFromString() {
         final TopicPath expected = TopicPath.newBuilder(THING_ID)
@@ -66,7 +65,6 @@ public final class DittoProtocolAdapterTest {
         assertThat(actual).isEqualTo(expected);
     }
 
-    /** */
     @Test
     public void thingErrorResponseFromAdaptable() {
         final ThingNotAccessibleException thingNotAccessibleException =
@@ -92,7 +90,6 @@ public final class DittoProtocolAdapterTest {
         assertThat(actual.toJson()).isEqualTo(expected.toJson());
     }
 
-    /** */
     @Test
     public void thingModifyCommandFromAdaptable() {
         final ModifyThing modifyThing =
@@ -113,10 +110,9 @@ public final class DittoProtocolAdapterTest {
                 .build();
 
         final ThingModifyCommand actualCommand = (ThingModifyCommand) underTest.fromAdaptable(adaptable);
-        assertThat(actualCommand).isEqualTo(modifyThing);
+        assertWithExternalHeadersThat(actualCommand).isEqualTo(modifyThing);
     }
 
-    /** */
     @Test
     public void thingModifyCommandFromAdaptableWithPolicyToCopy() {
         final String policyIdToCopy = "someNameSpace:someId";
@@ -140,10 +136,9 @@ public final class DittoProtocolAdapterTest {
                 .build();
 
         final ThingModifyCommand actualCommand = (ThingModifyCommand) underTest.fromAdaptable(adaptable);
-        assertThat(actualCommand).isEqualTo(modifyThing);
+        assertWithExternalHeadersThat(actualCommand).isEqualTo(modifyThing);
     }
 
-    /** */
     @Test
     public void thingModifyCommandResponseFromAdaptable() {
         final ModifyThingResponse modifyThingResponseCreated =
@@ -167,7 +162,7 @@ public final class DittoProtocolAdapterTest {
                                 .build())
                         .withHeaders(TestConstants.HEADERS_V_2)
                         .build());
-        assertThat(actualCommandResponseCreated).isEqualTo(modifyThingResponseCreated);
+        assertWithExternalHeadersThat(actualCommandResponseCreated).isEqualTo(modifyThingResponseCreated);
 
         final ThingModifyCommandResponse actualCommandResponseModified =
                 (ThingModifyCommandResponse) underTest.fromAdaptable(Adaptable.newBuilder(topicPath)
@@ -176,10 +171,9 @@ public final class DittoProtocolAdapterTest {
                                 .build())
                         .withHeaders(TestConstants.HEADERS_V_2)
                         .build());
-        assertThat(actualCommandResponseModified).isEqualTo(modifyThingResponseModified);
+        assertWithExternalHeadersThat(actualCommandResponseModified).isEqualTo(modifyThingResponseModified);
     }
 
-    /** */
     @Test
     public void thingQueryCommandFromAdaptable() {
         final RetrieveThing retrieveThing = RetrieveThing.of(THING_ID, DITTO_HEADERS_V_2);
@@ -199,7 +193,7 @@ public final class DittoProtocolAdapterTest {
                         .withHeaders(TestConstants.HEADERS_V_2)
                         .build());
 
-        assertThat(actualCommand).isEqualTo(retrieveThing);
+        assertWithExternalHeadersThat(actualCommand).isEqualTo(retrieveThing);
 
         final JsonFieldSelector selectedFields = JsonFieldSelector.newInstance("thingId");
         final RetrieveThing retrieveThingWithFields = RetrieveThing.getBuilder(THING_ID, DITTO_HEADERS_V_2)
@@ -213,10 +207,9 @@ public final class DittoProtocolAdapterTest {
                                 .build())
                         .withHeaders(TestConstants.HEADERS_V_2)
                         .build());
-        assertThat(actualCommandWithFields).isEqualTo(retrieveThingWithFields);
+        assertWithExternalHeadersThat(actualCommandWithFields).isEqualTo(retrieveThingWithFields);
     }
 
-    /** */
     @Test
     public void thingQueryCommandResponseFromAdaptable() {
         final RetrieveThingResponse retrieveThingResponse =
@@ -239,10 +232,9 @@ public final class DittoProtocolAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = (ThingQueryCommandResponse) underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(retrieveThingResponse);
+        assertWithExternalHeadersThat(actual).isEqualTo(retrieveThingResponse);
     }
 
-    /** */
     @Test
     public void thingEventFromAdaptable() {
         final ThingModified expected =
@@ -265,10 +257,9 @@ public final class DittoProtocolAdapterTest {
                 .build();
         final ThingEvent actual = (ThingEvent) underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
-    /** */
     @Test
     public void modifyFeaturePropertyFromAdaptable() {
         final String topicPathString =
@@ -285,7 +276,6 @@ public final class DittoProtocolAdapterTest {
         assertThat(jsonifiable).isInstanceOf(ModifyFeatureProperty.class);
     }
 
-    /** */
     @Test
     public void thingMessageFromAdaptable() {
         final String subject = "this/is/all/part/of/subject";

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandAdapterTest.java
@@ -50,7 +50,7 @@ import org.junit.runners.Parameterized;
  * Unit test for {@link MessageCommandAdapter}.
  */
 @RunWith(Parameterized.class)
-public final class MessageCommandAdapterTest {
+public final class MessageCommandAdapterTest implements ProtocolAdapterTest {
 
     private static final String APPLICATION_JSON = "application/json";
     private static final String APPLICATION_OCTET_STREAM = "application/octet-stream";
@@ -135,7 +135,7 @@ public final class MessageCommandAdapterTest {
 
         final MessageCommand actualMessageCommand = underTest.fromAdaptable(adaptable);
 
-        assertThat(actualMessageCommand).isEqualTo(expectedMessageCommand);
+        assertWithExternalHeadersThat(actualMessageCommand).isEqualTo(expectedMessageCommand);
     }
 
     private MessageHeaders messageHeaders(final CharSequence subject, final CharSequence contentType) {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapterTest.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.protocoladapter.TestConstants.CORRELATION_ID;
 import static org.eclipse.ditto.protocoladapter.TestConstants.FEATURE_ID;
 
@@ -186,7 +185,7 @@ public final class MessageCommandResponseAdapterTest implements ProtocolAdapterT
 
         final Adaptable actual = underTest.toAdaptable(messageCommandResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     private MessageCommandResponse messageCommandResponse(final Message<Object> message, final DittoHeaders headers) {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapterTest.java
@@ -48,7 +48,7 @@ import org.junit.runners.Parameterized;
  * Unit test for {@link MessageCommandResponseAdapter}.
  */
 @RunWith(Parameterized.class)
-public final class MessageCommandResponseAdapterTest {
+public final class MessageCommandResponseAdapterTest implements ProtocolAdapterTest {
 
     private MessageCommandResponseAdapter underTest;
 
@@ -140,7 +140,7 @@ public final class MessageCommandResponseAdapterTest {
                 .build();
         final MessageCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     private String subject() {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ProtocolAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ProtocolAdapterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.protocoladapter;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
+
+/**
+ * Super class of protocol adapter tests.
+ */
+interface ProtocolAdapterTest {
+
+    /**
+     * Make equality assertions on {@link org.eclipse.ditto.model.base.headers.WithDittoHeaders} comparing only
+     * the external headers.
+     *
+     * @param actual a signal.
+     * @return an Assert object for the signal.
+     */
+    default AbstractObjectAssert<?, WithDittoHeaders> assertWithExternalHeadersThat(final WithDittoHeaders actual) {
+        return new WithFilteredHeadersAssert(actual, DittoProtocolAdapter.getHeaderTranslator(), true);
+    }
+
+    /**
+     * Assert for {@link org.eclipse.ditto.model.base.headers.WithDittoHeaders} comparing only the external headers.
+     */
+    final class WithFilteredHeadersAssert extends AbstractObjectAssert<WithFilteredHeadersAssert, WithDittoHeaders> {
+
+        private final HeaderTranslator headerTranslator;
+        private final boolean filterSelf;
+
+        private WithFilteredHeadersAssert(final WithDittoHeaders withDittoHeaders,
+                final HeaderTranslator headerTranslator, final boolean filterSelf) {
+            super(withDittoHeaders, WithFilteredHeadersAssert.class);
+            this.headerTranslator = headerTranslator;
+            this.filterSelf = filterSelf;
+        }
+
+        @Override
+        public WithFilteredHeadersAssert isEqualTo(final Object that) {
+            if (that instanceof WithDittoHeaders) {
+                if (filterSelf) {
+                    final DittoHeaders filteredHeaders =
+                            DittoHeaders.of(headerTranslator.toExternalHeaders(actual.getDittoHeaders()));
+                    final WithDittoHeaders actualWithFilteredHeaders = actual.setDittoHeaders(filteredHeaders);
+                    return new WithFilteredHeadersAssert(actualWithFilteredHeaders, headerTranslator, false)
+                            .isEqualTo(that);
+                } else {
+                    final WithDittoHeaders expected = (WithDittoHeaders) that;
+                    final DittoHeaders filteredHeaders =
+                            DittoHeaders.of(headerTranslator.toExternalHeaders(actual.getDittoHeaders()));
+                    return super.isEqualTo(expected.setDittoHeaders(filteredHeaders));
+                }
+            } else {
+                return super.isEqualTo(that);
+            }
+        }
+    }
+}

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingEventAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingEventAdapterTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Instant;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -65,7 +63,7 @@ import org.junit.Test;
 /**
  * Unit test for {@link ThingEventAdapter}.
  */
-public final class ThingEventAdapterTest {
+public final class ThingEventAdapterTest implements ProtocolAdapterTest {
 
     private static TopicPath topicPathCreated;
     private static TopicPath topicPathModified;
@@ -125,7 +123,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -143,10 +141,11 @@ public final class ThingEventAdapterTest {
                 .build();
 
         final ThingCreated thingCreated =
-                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, now, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
+                ThingCreated.of(TestConstants.THING, TestConstants.REVISION, now,
+                        TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(thingCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -165,7 +164,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -185,7 +184,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(thingModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -203,7 +202,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -222,7 +221,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(thingDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -241,7 +240,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -261,7 +260,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(aclModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -280,7 +279,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -299,7 +298,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(aclEntryCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -318,7 +317,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -337,7 +336,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(aclEntryModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -355,7 +354,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -373,7 +372,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.AUTHORIZATION_SUBJECT, TestConstants.REVISION, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(aclEntryDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -392,7 +391,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -412,7 +411,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributesCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -431,7 +430,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -450,7 +449,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.ATTRIBUTES, TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributesModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -468,7 +467,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -487,7 +486,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributesDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -506,7 +505,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -527,7 +526,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributeCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -546,7 +545,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -567,7 +566,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributeModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -585,7 +584,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -603,7 +602,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.ATTRIBUTE_POINTER, TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(attributeDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -622,7 +621,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -641,7 +640,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featuresCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -660,7 +659,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -679,7 +678,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featuresModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -697,7 +696,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -716,7 +715,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featuresDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -735,7 +734,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -754,7 +753,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -773,7 +772,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -792,7 +791,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -810,7 +809,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -828,7 +827,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -848,7 +847,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -869,7 +868,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertiesCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -889,7 +888,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -910,7 +909,7 @@ public final class ThingEventAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertiesModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -928,7 +927,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -946,7 +945,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertiesDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -967,7 +966,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -988,7 +987,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertyCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1009,7 +1008,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1030,7 +1029,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertyModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1051,7 +1050,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1071,7 +1070,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featurePropertyDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1091,7 +1090,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1111,7 +1110,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureDefinitionCreated);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1131,7 +1130,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1151,7 +1150,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureDefinitionModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1170,7 +1169,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1188,7 +1187,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(featureDefinitionDeleted);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1207,7 +1206,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1226,7 +1225,7 @@ public final class ThingEventAdapterTest {
                 .build();
         final ThingEvent actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1245,7 +1244,7 @@ public final class ThingEventAdapterTest {
                 TestConstants.REVISION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(policyIdModified);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     private static final class UnknownThingEvent implements ThingEvent {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingModifyCommandAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingModifyCommandAdapterTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
@@ -50,7 +48,7 @@ import org.junit.Test;
 /**
  * Unit test for {@link ThingModifyCommandAdapter}.
  */
-public final class ThingModifyCommandAdapterTest {
+public final class ThingModifyCommandAdapterTest implements ProtocolAdapterTest {
 
     private ThingModifyCommandAdapter underTest;
 
@@ -88,7 +86,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -111,7 +109,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -135,7 +133,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(createThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -160,7 +158,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -185,7 +183,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -212,7 +210,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -239,7 +237,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -265,7 +263,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -291,7 +289,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -313,7 +311,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -336,7 +334,7 @@ public final class ThingModifyCommandAdapterTest {
                 DeleteThing.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -360,7 +358,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -384,7 +382,7 @@ public final class ThingModifyCommandAdapterTest {
                 ModifyAcl.of(TestConstants.THING_ID, TestConstants.ACL, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyAcl);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -408,7 +406,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -433,7 +431,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyAclEntry);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -455,7 +453,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -477,7 +475,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.AUTHORIZATION_SUBJECT, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAclEntry);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -502,7 +500,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -527,7 +525,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyAttributes);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -550,7 +548,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -573,7 +571,7 @@ public final class ThingModifyCommandAdapterTest {
                 DeleteAttributes.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAttributes);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -597,7 +595,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -622,7 +620,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyAttribute);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -646,7 +644,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -670,7 +668,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAttribute);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -694,7 +692,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -719,7 +717,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyFeatures);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -741,7 +739,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -764,7 +762,7 @@ public final class ThingModifyCommandAdapterTest {
                 DeleteFeatures.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatures);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -788,7 +786,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -813,7 +811,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyFeature);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -836,7 +834,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -860,7 +858,7 @@ public final class ThingModifyCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeature);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -884,7 +882,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -908,7 +906,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.FEATURE_DEFINITION, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyFeatureDefinition);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -931,7 +929,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -954,7 +952,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatureDefinition);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -978,7 +976,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1002,7 +1000,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.FEATURE_PROPERTIES, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyFeatureProperties);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1025,7 +1023,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1048,7 +1046,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.FEATURE_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatureProperties);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1076,7 +1074,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1103,7 +1101,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyFeatureProperty);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1129,7 +1127,7 @@ public final class ThingModifyCommandAdapterTest {
                 .build();
         final ThingModifyCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1155,7 +1153,7 @@ public final class ThingModifyCommandAdapterTest {
                 TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatureProperty);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     private static class UnknownThingModifyCommand implements ThingModifyCommand {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingModifyCommandResponseAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingModifyCommandResponseAdapterTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
@@ -53,7 +51,7 @@ import org.junit.Test;
 /**
  * Unit test for {@link ThingModifyCommandResponseAdapter}.
  */
-public final class ThingModifyCommandResponseAdapterTest {
+public final class ThingModifyCommandResponseAdapterTest implements ProtocolAdapterTest {
 
     private ThingModifyCommandResponseAdapter underTest;
 
@@ -135,7 +133,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -160,7 +158,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 CreateThingResponse.of(TestConstants.THING, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(createThingResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -185,7 +183,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyThingResponse expectedModified =
                 ModifyThingResponse.modified(TestConstants.THING_ID, TestConstants.DITTO_HEADERS_V_2);
@@ -198,7 +196,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -223,7 +221,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 ModifyThingResponse.created(TestConstants.THING, TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyThingResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -236,7 +234,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 ModifyThingResponse.modified(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyThingResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -260,7 +258,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -284,7 +282,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 DeleteThingResponse.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteThingResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -309,7 +307,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -334,7 +332,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(modifyAclResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -360,7 +358,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyAclEntryResponse expectedModified =
                 ModifyAclEntryResponse.modified(TestConstants.THING_ID, TestConstants.ACL_ENTRY,
@@ -375,7 +373,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -401,7 +399,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_1);
         final Adaptable actualCreated = underTest.toAdaptable(modifyAclEntryResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -415,7 +413,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyAclEntryResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -440,7 +438,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -465,7 +463,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAclEntryResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -491,7 +489,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyAttributesResponse expectedModified =
                 ModifyAttributesResponse.modified(TestConstants.THING_ID, TestConstants.DITTO_HEADERS_V_2);
@@ -504,7 +502,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -530,7 +528,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyAttributesResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -544,7 +542,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 ModifyAttributesResponse.modified(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyAttributesResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -568,7 +566,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -592,7 +590,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 DeleteAttributesResponse.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAttributesResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -618,7 +616,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyAttributeResponse expectedModified =
                 ModifyAttributeResponse.modified(TestConstants.THING_ID, TestConstants.ATTRIBUTE_POINTER,
@@ -632,7 +630,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -658,7 +656,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyAttributeResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -672,7 +670,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyAttributeResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -697,7 +695,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -722,7 +720,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteAttributeResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -748,7 +746,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyFeaturesResponse expectedModified =
                 ModifyFeaturesResponse.modified(TestConstants.THING_ID, TestConstants.DITTO_HEADERS_V_2);
@@ -761,7 +759,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -787,7 +785,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyFeaturesResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -801,7 +799,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 ModifyFeaturesResponse.modified(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyFeaturesResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -825,7 +823,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -849,7 +847,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 DeleteFeaturesResponse.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeaturesResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -875,7 +873,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyFeatureResponse expectedModified =
                 ModifyFeatureResponse.modified(TestConstants.THING_ID, TestConstants.FEATURE_ID,
@@ -889,7 +887,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -915,7 +913,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyFeatureResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -930,7 +928,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyFeatureResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -955,7 +953,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -980,7 +978,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatureResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1006,7 +1004,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyFeatureDefinitionResponse expectedModified =
                 ModifyFeatureDefinitionResponse.modified(TestConstants.THING_ID, TestConstants.FEATURE_ID,
@@ -1020,7 +1018,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1046,7 +1044,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyFeatureDefinitionResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -1060,7 +1058,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyFeatureDefinitionResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1085,7 +1083,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1110,7 +1108,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeatureDefinitionResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1136,7 +1134,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyFeaturePropertiesResponse expectedModified =
                 ModifyFeaturePropertiesResponse.modified(TestConstants.THING_ID, TestConstants.FEATURE_ID,
@@ -1150,7 +1148,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1176,7 +1174,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyFeaturePropertiesResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -1190,7 +1188,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyFeaturePropertiesResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1215,7 +1213,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1240,7 +1238,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeaturePropertiesResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1268,7 +1266,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualCreated = underTest.fromAdaptable(adaptableCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final ModifyFeaturePropertyResponse expectedModified = ModifyFeaturePropertyResponse
                 .modified(TestConstants.THING_ID, TestConstants.FEATURE_ID, TestConstants.FEATURE_PROPERTY_POINTER,
@@ -1282,7 +1280,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actualModified = underTest.fromAdaptable(adaptableModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1310,7 +1308,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.FEATURE_PROPERTY_VALUE, TestConstants.DITTO_HEADERS_V_2);
         final Adaptable actualCreated = underTest.toAdaptable(modifyFeaturePropertyResponseCreated);
 
-        assertThat(actualCreated).isEqualTo(expectedCreated);
+        assertWithExternalHeadersThat(actualCreated).isEqualTo(expectedCreated);
 
         final Adaptable expectedModified = Adaptable.newBuilder(topicPath)
                 .withPayload(Payload.newBuilder(path)
@@ -1325,7 +1323,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actualModified = underTest.toAdaptable(modifyFeaturePropertyResponseModified);
 
-        assertThat(actualModified).isEqualTo(expectedModified);
+        assertWithExternalHeadersThat(actualModified).isEqualTo(expectedModified);
     }
 
     @Test
@@ -1351,7 +1349,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                 .build();
         final ThingModifyCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -1377,7 +1375,7 @@ public final class ThingModifyCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(deleteFeaturePropertyResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
 }

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingQueryCommandAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingQueryCommandAdapterTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -44,7 +42,7 @@ import org.junit.Test;
 /**
  * Unit test for {@link ThingQueryCommandAdapter}.
  */
-public final class ThingQueryCommandAdapterTest {
+public final class ThingQueryCommandAdapterTest implements ProtocolAdapterTest {
 
     private ThingQueryCommandAdapter underTest;
 
@@ -76,7 +74,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -103,7 +101,7 @@ public final class ThingQueryCommandAdapterTest {
         final JsonObject jsonObject = jsonifiableAdaptable.toJson();
         System.out.println(jsonObject.toString());
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -128,7 +126,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -153,7 +151,7 @@ public final class ThingQueryCommandAdapterTest {
                         .build();
         final Adaptable actual = underTest.toAdaptable(retrieveThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -174,7 +172,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -196,7 +194,7 @@ public final class ThingQueryCommandAdapterTest {
                 RetrieveAcl.of(TestConstants.THING_ID, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAcl);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -218,7 +216,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -241,7 +239,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAclEntry);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -265,7 +263,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -289,7 +287,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAclEntry);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -311,7 +309,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -333,7 +331,7 @@ public final class ThingQueryCommandAdapterTest {
                 RetrieveAttributes.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAttributes);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -355,7 +353,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -379,7 +377,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAttributes);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -401,7 +399,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -424,7 +422,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAttribute);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -446,7 +444,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -468,7 +466,7 @@ public final class ThingQueryCommandAdapterTest {
                 RetrieveFeatures.of(TestConstants.THING_ID, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatures);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -490,7 +488,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -513,7 +511,7 @@ public final class ThingQueryCommandAdapterTest {
                 RetrieveFeatures.of(TestConstants.THING_ID, selectedFields, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatures);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -535,7 +533,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -558,7 +556,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeature);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -581,7 +579,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -604,7 +602,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureDefinition);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -627,7 +625,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -650,7 +648,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureProperties);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -673,7 +671,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -697,7 +695,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureProperties);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -722,7 +720,7 @@ public final class ThingQueryCommandAdapterTest {
                 .build();
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -746,7 +744,7 @@ public final class ThingQueryCommandAdapterTest {
                         TestConstants.FEATURE_PROPERTY_POINTER, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureProperty);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -785,7 +783,7 @@ public final class ThingQueryCommandAdapterTest {
 
         final ThingQueryCommand actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -824,7 +822,7 @@ public final class ThingQueryCommandAdapterTest {
 
         final Adaptable actual = underTest.toAdaptable(retrieveThings);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     private static class UnknownThingQueryCommand implements ThingQueryCommand {

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingQueryCommandResponseAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/ThingQueryCommandResponseAdapterTest.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.protocoladapter;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.protocoladapter.TestConstants.DITTO_HEADERS_V_1;
 import static org.eclipse.ditto.protocoladapter.TestConstants.FEATURE_ID;
 import static org.eclipse.ditto.protocoladapter.TestConstants.THING_ID;
@@ -49,7 +48,7 @@ import org.junit.Test;
 /**
  * Unit test for {@link ThingQueryCommandResponseAdapter}.
  */
-public final class ThingQueryCommandResponseAdapterTest {
+public final class ThingQueryCommandResponseAdapterTest implements ProtocolAdapterTest {
 
     private ThingQueryCommandResponseAdapter underTest;
 
@@ -141,7 +140,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -167,7 +166,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 RetrieveThingResponse.of(THING_ID, TestConstants.THING, TestConstants.HEADERS_V_2_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveThing);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -205,7 +204,7 @@ public final class ThingQueryCommandResponseAdapterTest {
 
         final Adaptable actual = underTest.toAdaptable(retrieveThingsResponse);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -230,7 +229,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -256,7 +255,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 RetrieveAclResponse.of(THING_ID, TestConstants.ACL, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAcl);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -281,7 +280,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -308,7 +307,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAclEntry);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -333,7 +332,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -360,7 +359,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAttributes);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -386,7 +385,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -413,7 +412,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveAttribute);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -438,7 +437,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -465,7 +464,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatures);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -490,7 +489,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -517,7 +516,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeature);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -543,7 +542,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -570,7 +569,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureDefinition);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -596,7 +595,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -623,7 +622,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureProperties);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -650,7 +649,7 @@ public final class ThingQueryCommandResponseAdapterTest {
                 .build();
         final ThingQueryCommandResponse actual = underTest.fromAdaptable(adaptable);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
     @Test
@@ -678,16 +677,14 @@ public final class ThingQueryCommandResponseAdapterTest {
                         TestConstants.FEATURE_PROPERTY_VALUE, TestConstants.HEADERS_V_1_NO_CONTENT_TYPE);
         final Adaptable actual = underTest.toAdaptable(retrieveFeatureProperty);
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
-    /** */
     @Test
     public void retrieveThingsResponseFromAdaptable() {
         retrieveThingsResponseFromAdaptable(TestConstants.NAMESPACE);
     }
 
-    /** */
     @Test
     public void retrieveThingsResponseWithWildcardNamespaceFromAdaptable() {
         retrieveThingsResponseFromAdaptable(null);
@@ -718,7 +715,7 @@ public final class ThingQueryCommandResponseAdapterTest {
 
         System.out.println(actual.toJsonString());
 
-        assertThat(actual).isEqualTo(expected);
+        assertWithExternalHeadersThat(actual).isEqualTo(expected);
     }
 
 }

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathExceptionTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/UnknownTopicPathExceptionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.protocoladapter;
+
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.assertj.core.api.Assertions;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link UnknownTopicPathException}.
+ */
+public final class UnknownTopicPathExceptionTest {
+
+    @Test
+    public void fromTopicAndPath() {
+        final TopicPath topicPath = ImmutableTopicPath.of("ns", "id", TopicPath.Group.THINGS, TopicPath.Channel.TWIN,
+                TopicPath.Criterion.COMMANDS, TopicPath.Action.MODIFY);
+        final MessagePath messagePath = ImmutableMessagePath.of(JsonPointer.of("/policyId"));
+        final DittoHeaders dittoHeaders = DittoHeaders.empty();
+
+        final UnknownTopicPathException exception = UnknownTopicPathException.fromTopicAndPath(topicPath, messagePath, dittoHeaders);
+
+        Assertions.assertThat(exception)
+                .hasMessageContaining(topicPath.getPath())
+                .hasMessageContaining(messagePath.toString());
+    }
+
+    @Test
+    public void testImmutability() {
+        assertInstancesOf(UnknownTopicPathException.class, areImmutable());
+    }
+
+}

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
@@ -281,7 +281,8 @@ public final class MessageMappingProcessorActor extends AbstractActor {
          * instance due to cluster routing.
          */
         final DittoHeaders truncatedHeaders = mergedDittoHeaders.truncate(limitsConfig.getHeadersMaxSize());
-        return getThingId(exception).map(thingId -> ThingErrorResponse.of(thingId, exception, truncatedHeaders))
+        return getThingId(exception)
+                .map(thingId -> ThingErrorResponse.of(thingId, exception, truncatedHeaders))
                 .orElseGet(() -> ThingErrorResponse.of(exception, truncatedHeaders));
     }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/WebsocketRoute.java
@@ -38,7 +38,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
-import org.eclipse.ditto.model.messages.MessageHeaders;
+import org.eclipse.ditto.model.messages.MessageHeaderDefinition;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
 import org.eclipse.ditto.protocoladapter.ProtocolAdapter;
@@ -503,17 +503,14 @@ public final class WebsocketRoute {
         } else if (jsonifiable instanceof CommandResponse) {
             adaptable = adapter.toAdaptable((CommandResponse) jsonifiable, channel);
         } else if (jsonifiable instanceof DittoRuntimeException) {
-            final DittoHeaders enhancedHeaders = ((DittoRuntimeException) jsonifiable).getDittoHeaders().toBuilder()
+            final DittoRuntimeException dittoRuntimeException = (DittoRuntimeException) jsonifiable;
+            final DittoHeaders enhancedHeaders = dittoRuntimeException.getDittoHeaders().toBuilder()
                     .channel(channel.getName())
                     .build();
-            ThingErrorResponse errorResponse;
-            try {
-                errorResponse = ThingErrorResponse.of(MessageHeaders.of(enhancedHeaders).getThingId(),
-                        (DittoRuntimeException) jsonifiable, enhancedHeaders);
-            } catch (final IllegalStateException | IllegalArgumentException | DittoRuntimeException e) {
-                // thrown if headers did not contain the thing ID:
-                errorResponse = ThingErrorResponse.of((DittoRuntimeException) jsonifiable, enhancedHeaders);
-            }
+            final String nullableThingId = enhancedHeaders.get(MessageHeaderDefinition.THING_ID.getKey());
+            final ThingErrorResponse errorResponse = nullableThingId != null
+                    ? ThingErrorResponse.of(nullableThingId, dittoRuntimeException, enhancedHeaders)
+                    : ThingErrorResponse.of(dittoRuntimeException, enhancedHeaders);
             adaptable = adapter.toAdaptable(errorResponse, channel);
         } else {
             throw new IllegalArgumentException("Jsonifiable was neither Command nor CommandResponse nor"


### PR DESCRIPTION
- During deserialization:
  - Report headers on all valid JSON messages.
  - Report topic-path if the message has a valid topic-path.

- Add topic-path information to all Ditto-protocol messages
  with a valid topic-path. Note that this causes many errors,
  including ThingNotAccessibleException, to have the topic
  `/<namespace>/<thing-name>/things/<channel>/errors`, whereas
  their previous topic was `/unknown/unknown/things/<channel>/errors`.

- Improve the error message if a signal with valid topic-path
  could not be deserialized.

- Connectivity: Take advantage of topic-path information when
  reporting errors.

- Gateway: Fixed a bug where topic-path information is always
  discarded for error reporting in the twin channel, due to
  an attempt to construct MessageHeaders without the required
  header "direction".