### PR TITLE
Improve robustness of connections, especially of AMQP 1.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -79,7 +79,7 @@
             and update the code otherwise. see implementation of org.eclipse.ditto.services.connectivity.mapping.MessageMapper
         -->
         <js.long.version>3.2.0</js.long.version>
-        <caffeine.version>2.7.0</caffeine.version>
+        <caffeine.version>2.8.0</caffeine.version>
 
         <classindex.version>3.8</classindex.version>
 
@@ -806,6 +806,16 @@
                 <groupId>com.github.ben-manes.caffeine</groupId>
                 <artifactId>caffeine</artifactId>
                 <version>${caffeine.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-qual</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.google.errorprone</groupId>
+                        <artifactId>error_prone_annotations</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -79,7 +79,7 @@
             and update the code otherwise. see implementation of org.eclipse.ditto.services.connectivity.mapping.MessageMapper
         -->
         <js.long.version>3.2.0</js.long.version>
-        <caffeine.version>2.6.2</caffeine.version>
+        <caffeine.version>2.7.0</caffeine.version>
 
         <classindex.version>3.8</classindex.version>
 

--- a/legal/3rd-party-dependencies/compile.txt
+++ b/legal/3rd-party-dependencies/compile.txt
@@ -2,7 +2,7 @@
    ch.qos.logback:logback-core:jar:1.2.3:compile
    com.ajjpj.simple-akka-downing:simple-akka-downing_2.12:jar:0.9.2:compile
    com.eclipsesource.minimal-json:minimal-json:jar:0.9.5:compile
-   com.github.ben-manes.caffeine:caffeine:jar:2.6.2:compile
+   com.github.ben-manes.caffeine:caffeine:jar:2.8.0:compile
    com.github.jnr:jffi:jar:1.2.16:compile
    com.github.jnr:jnr-constants:jar:0.9.9:compile
    com.github.jnr:jnr-ffi:jar:2.1.7:compile
@@ -11,7 +11,7 @@
    com.github.scullxbones:akka-persistence-mongo-common_2.12:jar:2.2.9:compile
    com.github.scullxbones:akka-persistence-mongo-scala_2.12:jar:2.2.9:compile
    com.lightbend.akka:akka-stream-alpakka-mqtt_2.12:jar:1.0.0:compile
-   com.lightbend.akka.discovery:akka-discovery-kubernetes-api_2.12:jar:1.0.0:compile
+   com.lightbend.akka.discovery:akka-discovery-kubernetes-api_2.12:jar:1.0.1:compile
    com.lightbend.akka.management:akka-management_2.12:jar:1.0.1:compile
    com.lightbend.akka.management:akka-management-cluster-bootstrap_2.12:jar:1.0.1:compile
    com.lightbend.akka.management:akka-management-cluster-http_2.12:jar:1.0.1:compile
@@ -61,7 +61,7 @@
    org.apache.kafka:kafka-clients:jar:2.1.1:compile
    org.apache.qpid:proton-j:jar:0.33.0:compile
    org.apache.qpid:qpid-jms-client:jar:0.42.0:compile
-   org.atteo.classindex:classindex:jar:3.7:compile
+   org.atteo.classindex:classindex:jar:3.8:compile
    org.eclipse.paho:org.eclipse.paho.client.mqttv3:jar:1.2.0:compile
    org.hdrhistogram:HdrHistogram:jar:2.1.9:compile
    org.lmdbjava:lmdbjava:jar:0.6.1:compile

--- a/legal/3rd-party-dependencies/cqs.md
+++ b/legal/3rd-party-dependencies/cqs.md
@@ -8,7 +8,7 @@
 |ch.qos.logback|logback-core|1.2.3| [16305](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16305) |
 |com.ajjpj.simple-akka-downing|simple-akka-downing_2.12|0.9.2| [18601](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=18601) |
 |com.eclipsesource.minimal-json|minimal-json|0.9.5| [16296](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16296) |
-|com.github.ben-manes.caffeine|caffeine|2.6.2| [16300](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16300) |
+|com.github.ben-manes.caffeine|caffeine|2.8.0| [20651](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20651) |
 |com.github.jnr|jffi|1.2.16| [16301](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16301) |
 |com.github.jnr|jnr-constants|0.9.9| [16302](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16302) |
 |com.github.jnr|jnr-ffi|2.1.7| [16303](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16303) |
@@ -168,4 +168,4 @@ Manual step by sending mail to Eclipse IP team - this is a collection of depende
 
 | Group ID  | Artifact ID  | Version  | CQ |
 |-----------|--------------|----------|----|
-|           |              |          |    |
+|com.github.ben-manes.caffeine|caffeine|2.6.2| [16300](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=16300) |

--- a/legal/NOTICE-THIRD-PARTY.md
+++ b/legal/NOTICE-THIRD-PARTY.md
@@ -32,9 +32,9 @@
  * Source: https://github.com/ralfstx/minimal-json
 
 
-## Caffeine cache (2.7.0)
+## Caffeine cache (2.8.0)
 
- * Maven coordinates: `com.github.ben-manes.caffeine:caffeine:2.7.0`
+ * Maven coordinates: `com.github.ben-manes.caffeine:caffeine:2.8.0`
  * License: [Apache-2.0](licenses/Apache-2.0.txt)
  * Project: https://github.com/ben-manes/caffeine
  * Source: https://github.com/ben-manes/caffeine

--- a/legal/NOTICE-THIRD-PARTY.md
+++ b/legal/NOTICE-THIRD-PARTY.md
@@ -32,9 +32,9 @@
  * Source: https://github.com/ralfstx/minimal-json
 
 
-## Caffeine cache (2.6.2)
+## Caffeine cache (2.7.0)
 
- * Maven coordinates: `com.github.ben-manes.caffeine:caffeine:2.6.2`
+ * Maven coordinates: `com.github.ben-manes.caffeine:caffeine:2.7.0`
  * License: [Apache-2.0](licenses/Apache-2.0.txt)
  * Project: https://github.com/ben-manes/caffeine
  * Source: https://github.com/ben-manes/caffeine

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionBuilder.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionBuilder.java
@@ -131,6 +131,24 @@ public interface ConnectionBuilder {
     ConnectionBuilder targets(List<Target> targets);
 
     /**
+     * Set sources of connection.
+     *
+     * @param sources the new sources.
+     * @return this builder to allow method chaining.
+     * @throws NullPointerException if {@code sources} is {@code null}.
+     */
+    ConnectionBuilder setSources(List<Source> sources);
+
+    /**
+     * Set targets to the connection.
+     *
+     * @param targets the new targets.
+     * @return this builder to allow method chaining.
+     * @throws NullPointerException if {@code targets} is {@code null}.
+     */
+    ConnectionBuilder setTargets(List<Target> targets);
+
+    /**
      * Sets how many clients on different cluster nodes should establish the {@code Connection}.
      * <p>
      * If greater than 1, the connection is created in a HA mode, running on at least 2 cluster nodes.

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
@@ -547,6 +547,18 @@ final class ImmutableConnection implements Connection {
         }
 
         @Override
+        public ConnectionBuilder setSources(final List<Source> sources) {
+            this.sources.clear();
+            return sources(sources);
+        }
+
+        @Override
+        public ConnectionBuilder setTargets(final List<Target> targets) {
+            this.targets.clear();
+            return targets(targets);
+        }
+
+        @Override
         public ConnectionBuilder clientCount(final int clientCount) {
             checkArgument(clientCount, ps -> ps > 0, () -> "The client count must be > 0!");
             this.clientCount = clientCount;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -752,7 +752,7 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
                         String.format("Connection failed due to: {0}. Will reconnect after %s.", nextBackoff);
                 connectionLogger.failure(errorMessage, event.getFailureDescription());
                 log.info("Connection failed: {}. Reconnect after {}.", event, nextBackoff);
-                return goTo(CONNECTING).forMax(reconnectTimeoutStrategy.getNextBackoff()).using(data.resetSession()
+                return goTo(CONNECTING).forMax(nextBackoff).using(data.resetSession()
                         .setConnectionStatus(ConnectivityStatus.FAILED)
                         .setConnectionStatusDetails(event.getFailureDescription()));
             } else {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -471,7 +471,8 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
      * @return an FSM function builder
      */
     protected FSMStateFunctionBuilder<BaseClientState, BaseClientData> inConnectedState() {
-        return matchEvent(CloseConnection.class, BaseClientData.class, this::closeConnection);
+        return matchEvent(CloseConnection.class, BaseClientData.class, this::closeConnection)
+                .event(OpenConnection.class, BaseClientData.class, this::connectionAlreadyOpen);
     }
 
     /**
@@ -572,6 +573,13 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
                             .setConnectionStatusDetails(error.getMessage())
                             .resetSession());
         }
+    }
+
+    private FSM.State<BaseClientState, BaseClientData> connectionAlreadyOpen(final OpenConnection openConnection,
+            final BaseClientData data) {
+
+        getSender().tell(new Status.Success(CONNECTED), getSelf());
+        return stay();
     }
 
     private void reconnect(final BaseClientData data) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseConsumerActor.java
@@ -57,8 +57,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
         this.messageMappingProcessor = checkNotNull(messageMappingProcessor, "messageMappingProcessor");
         this.authorizationContext = checkNotNull(authorizationContext, "authorizationContext");
         this.headerMapping = headerMapping;
-        resourceStatus = ConnectivityModelFactory.newSourceStatus(getInstanceIdentifier(),
-                ConnectivityStatus.OPEN, sourceAddress, "Started at " + Instant.now());
+        resetResourceStatus();
 
         final MonitoringConfig monitoringConfig = DittoConnectivityConfig.of(
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
@@ -66,6 +65,11 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
 
         this.connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(monitoringConfig);
         inboundMonitor = connectionMonitorRegistry.forInboundConsumed(connectionId, sourceAddress);
+    }
+
+    protected void resetResourceStatus() {
+        resourceStatus = ConnectivityModelFactory.newSourceStatus(getInstanceIdentifier(),
+                ConnectivityStatus.OPEN, sourceAddress, "Started at " + Instant.now());
     }
 
     protected ResourceStatus getCurrentSourceStatus() {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -181,15 +181,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     @Override
     protected FSMStateFunctionBuilder<BaseClientState, BaseClientData> inConnectedState() {
         return super.inConnectedState()
-                .event(ConnectionFailure.class, this::handleConnectionFailureWhenConnected)
                 .event(JmsSessionRecovered.class, this::handleSessionRecovered);
-    }
-
-    private State<BaseClientState, BaseClientData> handleConnectionFailureWhenConnected(final ConnectionFailure failure,
-            final BaseClientData data) {
-        return goTo(BaseClientState.UNKNOWN)
-                .using(data.setConnectionStatus(ConnectivityStatus.FAILED)
-                        .setConnectionStatusDetails(failure.getFailureDescription()));
     }
 
     @Override

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -14,9 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging.amqp;
 
 import java.net.URI;
 import java.text.MessageFormat;
-import java.time.Instant;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -25,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import javax.jms.ExceptionListener;
 import javax.jms.JMSException;
 import javax.jms.MessageConsumer;
@@ -38,7 +37,6 @@ import org.apache.qpid.jms.message.JmsInboundMessageDispatch;
 import org.apache.qpid.jms.provider.ProviderFactory;
 import org.eclipse.ditto.model.connectivity.Connection;
 import org.eclipse.ditto.model.connectivity.ConnectionConfigurationInvalidException;
-import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.ConnectivityStatus;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientActor;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientData;
@@ -59,7 +57,6 @@ import org.eclipse.ditto.services.connectivity.messaging.internal.ImmutableConne
 import org.eclipse.ditto.services.connectivity.messaging.internal.RecoverSession;
 import org.eclipse.ditto.services.connectivity.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.services.connectivity.util.ConnectionLogUtil;
-import org.eclipse.ditto.services.utils.config.InstanceIdentifierSupplier;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionFailedException;
 
 import akka.actor.ActorRef;
@@ -81,7 +78,6 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     private static final String SPEC_CONFIG_RECOVER_ON_CONNECTION_RESTORED = "recover.on-connection-restored";
     private final JmsConnectionFactory jmsConnectionFactory;
     private final StatusReportingListener connectionListener;
-    private final List<ConsumerData> consumers;
 
     @Nullable private JmsConnection jmsConnection;
     @Nullable private Session jmsSession;
@@ -107,7 +103,6 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         super(connection, connectionStatus, conciergeForwarder);
         this.jmsConnectionFactory = jmsConnectionFactory;
         connectionListener = new StatusReportingListener(getSelf(), connection.getId(), log, connectionLogger);
-        consumers = new LinkedList<>();
         consumerByNamePrefix = new HashMap<>();
         recoverSessionOnSessionClosed = isRecoverSessionOnSessionClosedEnabled();
         recoverSessionOnConnectionRestored = isRecoverSessionOnConnectionRestoredEnabled();
@@ -256,18 +251,17 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     @Override
     protected void allocateResourcesOnConnection(final ClientConnected clientConnected) {
         if (clientConnected instanceof JmsConnected) {
+            final ActorRef jmsActor = getConnectConnectionHandler(connection());
             final JmsConnected c = (JmsConnected) clientConnected;
             log.info("Received JmsConnected");
             ensureJmsConnectionClosed();
             jmsConnection = c.connection;
             jmsConnection.addConnectionListener(connectionListener);
             jmsSession = c.session;
-            consumers.clear();
-            consumers.addAll(c.consumerList);
             // note: start order is important (publisher -> mapping -> consumer actor)
             startCommandProducer();
             startMessageMappingProcessorActor();
-            startCommandConsumers();
+            startCommandConsumers(c.consumerList, jmsActor);
         } else {
             log.info("ClientConnected was not JmsConnected as expected, ignoring as this probably was a reconnection");
         }
@@ -283,7 +277,6 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         ensureJmsConnectionClosed();
         jmsConnection = null;
         jmsSession = null;
-        consumers.clear();
     }
 
     /*
@@ -318,8 +311,15 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     }
 
     @Override
-    protected boolean isEventUpToDate(final Object event, final BaseClientState state, final ActorRef sender) {
+    protected boolean isEventUpToDate(final Object event, final BaseClientState state,
+            @Nullable final ActorRef sender) {
         switch (state) {
+            case CONNECTED:
+                // while connected, events from publisher or consumer child actors are relevant
+                return sender != null &&
+                        sender.path().toStringWithoutAddress().startsWith(getSelf().path().toStringWithoutAddress()) &&
+                        (sender.path().name().startsWith(AmqpConsumerActor.ACTOR_NAME_PREFIX) ||
+                                sender.path().name().startsWith(AmqpPublisherActor.ACTOR_NAME_PREFIX));
             case CONNECTING:
                 return Objects.equals(sender, connectConnectionHandler);
             case DISCONNECTING:
@@ -332,12 +332,12 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         }
     }
 
-    private void startCommandConsumers() {
+    private void startCommandConsumers(final List<ConsumerData> consumers, final ActorRef jmsActor) {
         final Optional<ActorRef> messageMappingProcessor = getMessageMappingProcessorActor();
         if (messageMappingProcessor.isPresent()) {
             if (isConsuming()) {
                 stopCommandConsumers();
-                consumers.forEach(consumer -> startCommandConsumer(consumer, messageMappingProcessor.get()));
+                consumers.forEach(consumer -> startCommandConsumer(consumer, messageMappingProcessor.get(), jmsActor));
                 connectionLogger.success("Subscriptions {0} initialized successfully.", consumers);
                 log.info("Subscribed Connection <{}> to sources: {}", connectionId(), consumers);
             } else {
@@ -348,11 +348,10 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         }
     }
 
-    private void startCommandConsumer(final ConsumerData consumer, final ActorRef messageMappingProcessor) {
+    private void startCommandConsumer(final ConsumerData consumer, final ActorRef messageMappingProcessor,
+            final ActorRef jmsActor) {
         final String namePrefix = consumer.getActorNamePrefix();
-        final Props props = AmqpConsumerActor.props(connectionId(), consumer.getAddress(),
-                consumer.getMessageConsumer(),
-                messageMappingProcessor, consumer.getSource());
+        final Props props = AmqpConsumerActor.props(connectionId(), consumer, messageMappingProcessor, jmsActor);
 
         final ActorRef child = startChildActorConflictFree(namePrefix, props);
         consumerByNamePrefix.put(namePrefix, child);
@@ -360,7 +359,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
 
     private void startCommandProducer() {
         stopCommandProducer();
-        final String namePrefix = AmqpPublisherActor.ACTOR_NAME;
+        final String namePrefix = AmqpPublisherActor.ACTOR_NAME_PREFIX;
         if (jmsSession != null) {
             final Props props = AmqpPublisherActor.props(connectionId(), getTargetsOrEmptyList(), jmsSession);
             amqpPublisherActor = startChildActorConflictFree(namePrefix, props);
@@ -467,22 +466,10 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     private FSM.State<BaseClientState, BaseClientData> handleConsumerClosed(
             final ConsumerClosedStatusReport statusReport,
             final BaseClientData currentData) {
-        final MessageConsumer consumer = statusReport.getMessageConsumer();
 
-        consumers.stream()
-                .filter(c -> c.getMessageConsumer().equals(consumer))
-                .findFirst()
-                .ifPresent(c -> {
-                    final ActorRef consumerActor = consumerByNamePrefix.get(c.getActorNamePrefix());
-                    if (consumerActor != null) {
-                        final Object message = ConnectivityModelFactory.newStatusUpdate(
-                                InstanceIdentifierSupplier.getInstance().get(),
-                                ConnectivityStatus.FAILED,
-                                c.getAddress(),
-                                "Consumer closed", Instant.now());
-                        consumerActor.tell(message, ActorRef.noSender());
-                    }
-                });
+        // broadcast event to consumers, who then decide whether the event is meant for them
+        consumerByNamePrefix.forEach((namePrefix, consumerActor) -> consumerActor.tell(statusReport, getSelf()));
+
         return stay().using(currentData);
     }
 
@@ -524,17 +511,16 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
             final BaseClientData currentData) {
 
         // make sure that we close any previous session
+        final ActorRef jmsActor = getConnectConnectionHandler(connection());
         if (jmsSession != null) {
-            getConnectConnectionHandler(connection()).tell(new JmsCloseSession(getSender(), jmsSession), getSelf());
+            jmsActor.tell(new JmsCloseSession(getSender(), jmsSession), getSelf());
         }
 
         jmsSession = sessionRecovered.getSession();
-        consumers.clear();
-        consumers.addAll(sessionRecovered.getConsumerList());
         // note: start order is important (publisher -> mapping -> consumer actor)
         startCommandProducer();
         startMessageMappingProcessorActor();
-        startCommandConsumers();
+        startCommandConsumers(sessionRecovered.getConsumerList(), jmsActor);
 
         connectionLogger.success("Session has been recovered successfully.");
 
@@ -544,17 +530,18 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     private boolean isRecoverSessionOnSessionClosedEnabled() {
         final String recoverOnSessionClosed =
                 connection().getSpecificConfig().getOrDefault(SPEC_CONFIG_RECOVER_ON_SESSION_CLOSED, "false");
-        return Boolean.valueOf(recoverOnSessionClosed);
+        return Boolean.parseBoolean(recoverOnSessionClosed);
     }
 
     private boolean isRecoverSessionOnConnectionRestoredEnabled() {
-        final String recoverOnConnectionRestored = connection().getSpecificConfig().getOrDefault(SPEC_CONFIG_RECOVER_ON_CONNECTION_RESTORED, "true");
-        return Boolean.valueOf(recoverOnConnectionRestored);
+        final String recoverOnConnectionRestored =
+                connection().getSpecificConfig().getOrDefault(SPEC_CONFIG_RECOVER_ON_CONNECTION_RESTORED, "true");
+        return Boolean.parseBoolean(recoverOnConnectionRestored);
     }
 
     @Override
     public void onException(final JMSException exception) {
-        connectionLogger.exception("Exception occured: {0}", exception.getMessage());
+        connectionLogger.exception("Exception occurred: {0}", exception.getMessage());
         log.warning("{} occurred: {}", exception.getClass().getName(), exception.getMessage());
     }
 
@@ -688,6 +675,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     /**
      * Listener updates connection status for metrics reporting. Do not alter actor state.
      */
+    @Immutable
     private static final class StatusReportingListener implements JmsConnectionListener {
 
         private final ActorRef self;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
@@ -251,6 +251,7 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
 
     private void messageConsumerCreated(final CreateMessageConsumerResponse response) throws JMSException {
         if (consumerData.equals(response.consumerData)) {
+            log.info("Consumer <{}> created", response.messageConsumer);
             destroyMessageConsumer();
             messageConsumer = response.messageConsumer;
             initMessageConsumer();

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
@@ -17,11 +17,14 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nullable;
@@ -41,26 +44,34 @@ import org.apache.qpid.proton.amqp.Symbol;
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
+import org.eclipse.ditto.model.connectivity.ConnectivityStatus;
 import org.eclipse.ditto.model.connectivity.Enforcement;
 import org.eclipse.ditto.model.connectivity.ResourceStatus;
-import org.eclipse.ditto.model.connectivity.Source;
 import org.eclipse.ditto.model.placeholders.EnforcementFactoryFactory;
 import org.eclipse.ditto.model.placeholders.EnforcementFilterFactory;
 import org.eclipse.ditto.model.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.services.connectivity.messaging.BaseConsumerActor;
+import org.eclipse.ditto.services.connectivity.messaging.amqp.status.ConsumerClosedStatusReport;
 import org.eclipse.ditto.services.connectivity.messaging.config.Amqp10Config;
+import org.eclipse.ditto.services.connectivity.messaging.config.ConnectionConfig;
 import org.eclipse.ditto.services.connectivity.messaging.config.DittoConnectivityConfig;
+import org.eclipse.ditto.services.connectivity.messaging.internal.ConnectionFailure;
+import org.eclipse.ditto.services.connectivity.messaging.internal.ImmutableConnectionFailure;
 import org.eclipse.ditto.services.connectivity.messaging.internal.RetrieveAddressStatus;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessageBuilder;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
 import org.eclipse.ditto.services.utils.akka.LogUtil;
 import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
+import org.eclipse.ditto.services.utils.config.InstanceIdentifierSupplier;
 
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.japi.pf.ReceiveBuilder;
+import akka.pattern.Patterns;
 import akka.routing.ConsistentHashingRouter;
 
 /**
@@ -75,7 +86,6 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
     private static final String RESTART_MESSAGE_CONSUMER = "restartMessageConsumer";
 
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
-    private final MessageConsumer messageConsumer;
     private final EnforcementFilterFactory<Map<String, String>, String> headerEnforcementFilterFactory;
 
     // the configured throttling interval
@@ -85,23 +95,37 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
     // the state for message throttling
     private final AtomicReference<ThrottleState> throttleState;
 
-    @SuppressWarnings("unused")
-    private AmqpConsumerActor(final String connectionId, final String sourceAddress,
-            final MessageConsumer messageConsumer,
-            final ActorRef messageMappingProcessor, final Source source) {
-        super(connectionId, sourceAddress, messageMappingProcessor, source.getAuthorizationContext(),
-                source.getHeaderMapping().orElse(null));
-        this.messageConsumer = checkNotNull(messageConsumer);
-        checkNotNull(source, "source");
+    // Access to the actor who performs JMS tasks in own thread
+    private final ActorRef jmsActor;
+    private final Duration jmsActorAskTimeout;
+    // data to reconstruct message consumer if something happens to it
+    private ConsumerData consumerData;
+    @Nullable
+    private MessageConsumer messageConsumer;
 
-        final Amqp10Config amqp10Config = DittoConnectivityConfig.of(
-                DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
-        ).getConnectionConfig().getAmqp10Config();
+    @SuppressWarnings("unused")
+    private AmqpConsumerActor(final String connectionId, final ConsumerData consumerData,
+            final ActorRef messageMappingProcessor, final ActorRef jmsActor) {
+        super(connectionId,
+                checkNotNull(consumerData, "consumerData").getAddress(),
+                messageMappingProcessor,
+                consumerData.getSource().getAuthorizationContext(),
+                consumerData.getSource().getHeaderMapping().orElse(null));
+        final ConnectionConfig connectionConfig =
+                DittoConnectivityConfig.of(
+                        DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config()))
+                        .getConnectionConfig();
+        final Amqp10Config amqp10Config = connectionConfig.getAmqp10Config();
+        this.messageConsumer = consumerData.getMessageConsumer();
+        this.consumerData = consumerData;
+        this.jmsActor = checkNotNull(jmsActor, "jmsActor");
+        jmsActorAskTimeout = connectionConfig.getClientActorAskTimeout();
+
         throttlingInterval = amqp10Config.getConsumerThrottlingInterval();
         throttlingLimit = amqp10Config.getConsumerThrottlingLimit();
         throttleState = new AtomicReference<>(new ThrottleState(0L, 0));
 
-        final Enforcement enforcement = source.getEnforcement().orElse(null);
+        final Enforcement enforcement = consumerData.getSource().getEnforcement().orElse(null);
 
         headerEnforcementFilterFactory = enforcement != null ? EnforcementFactoryFactory
                 .newEnforcementFilterFactory(enforcement, PlaceholderFactory.newHeadersPlaceholder()) :
@@ -112,18 +136,15 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
      * Creates Akka configuration object {@link Props} for this {@code AmqpConsumerActor}.
      *
      * @param connectionId the connection id
-     * @param sourceAddress the source address of messages
-     * @param messageConsumer the JMS message consumer
+     * @param consumerData the consumer data.
      * @param messageMappingProcessor the message mapping processor where received messages are forwarded to
-     * @param source the Source if the consumer
+     * @param jmsActor reference of the {@code JMSConnectionHandlingActor).
      * @return the Akka configuration Props object.
      */
-    static Props props(final String connectionId, final String sourceAddress,
-            final MessageConsumer messageConsumer,
-            final ActorRef messageMappingProcessor, final Source source) {
+    static Props props(final String connectionId, final ConsumerData consumerData,
+            final ActorRef messageMappingProcessor, final ActorRef jmsActor) {
 
-        return Props.create(AmqpConsumerActor.class, connectionId, sourceAddress, messageConsumer,
-                messageMappingProcessor, source);
+        return Props.create(AmqpConsumerActor.class, connectionId, consumerData, messageMappingProcessor, jmsActor);
     }
 
     @Override
@@ -133,6 +154,9 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
                 .match(JmsMessage.class, this::handleJmsMessage)
                 .match(ResourceStatus.class, this::handleAddressStatus)
                 .match(RetrieveAddressStatus.class, ras -> getSender().tell(getCurrentSourceStatus(), getSelf()))
+                .match(ConsumerClosedStatusReport.class, this::matchesOwnConsumer, this::handleConsumerClosed)
+                .match(CreateMessageConsumerResponse.class, this::messageConsumerCreated)
+                .match(Status.Failure.class, this::messageConsumerFailed)
                 .matchAny(m -> {
                     log.warning("Unknown message: {}", m);
                     unhandled(m);
@@ -141,19 +165,13 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
 
     @Override
     public void preStart() throws JMSException {
-        messageConsumer.setMessageListener(this);
+        initMessageConsumer();
     }
 
     @Override
     public void postStop() throws Exception {
         super.postStop();
-        try {
-            log.debug("Closing AMQP Consumer for '{}'", sourceAddress);
-            messageConsumer.close();
-        } catch (final JMSException jmsException) {
-            log.debug("Closing consumer failed (can be ignored if connection was closed already): {}",
-                    jmsException.getMessage());
-        }
+        destroyMessageConsumer();
     }
 
     @Override
@@ -164,8 +182,91 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
         }
     }
 
+    private void initMessageConsumer() throws JMSException {
+        if (messageConsumer != null) {
+            messageConsumer.setMessageListener(this);
+            consumerData = consumerData.withMessageConsumer(messageConsumer);
+        }
+    }
+
+    private void destroyMessageConsumer() {
+        if (messageConsumer != null) {
+            try {
+                log.debug("Closing AMQP Consumer for '{}'", sourceAddress);
+                messageConsumer.close();
+            } catch (final JMSException jmsException) {
+                log.debug("Closing consumer failed (can be ignored if connection was closed already): {}",
+                        jmsException.getMessage());
+            }
+            messageConsumer = null;
+        }
+    }
+
+    private void stopMessageConsumer() {
+        if (messageConsumer != null) {
+            ((JmsMessageConsumer) messageConsumer).stop();
+        }
+    }
+
+    private void startMessageConsumer() {
+        if (messageConsumer != null) {
+            ((JmsMessageConsumer) messageConsumer).start();
+        }
+    }
+
     private boolean isThrottlingEnabled() {
         return throttlingInterval.toMillis() > 0 && throttlingLimit > 0;
+    }
+
+    private boolean matchesOwnConsumer(final ConsumerClosedStatusReport event) {
+        return messageConsumer != null && messageConsumer.equals(event.getMessageConsumer());
+    }
+
+    private void handleConsumerClosed(final ConsumerClosedStatusReport event) {
+        // consumer closed
+        // update own status
+        final ResourceStatus addressStatus = ConnectivityModelFactory.newStatusUpdate(
+                InstanceIdentifierSupplier.getInstance().get(),
+                ConnectivityStatus.FAILED,
+                sourceAddress,
+                "Consumer closed", Instant.now());
+        handleAddressStatus(addressStatus);
+
+        // destroy current message consumer in any case
+        destroyMessageConsumer();
+
+        /* ask JMSConnectionHandlingActor for a new consumer */
+        final CreateMessageConsumer createMessageConsumer = new CreateMessageConsumer(consumerData);
+        final CompletionStage<Object> responseFuture =
+                Patterns.ask(jmsActor, createMessageConsumer, jmsActorAskTimeout)
+                        .thenApply(response -> {
+                            if (response instanceof Throwable) {
+                                // create failed future so that Patterns.pipe sends me Status.Failure
+                                throw new CompletionException((Throwable) response);
+                            }
+                            return response;
+                        });
+        Patterns.pipe(responseFuture, getContext().getDispatcher()).to(getSelf());
+    }
+
+    private void messageConsumerCreated(final CreateMessageConsumerResponse response) throws JMSException {
+        if (consumerData.equals(response.consumerData)) {
+            destroyMessageConsumer();
+            messageConsumer = response.messageConsumer;
+            initMessageConsumer();
+            resetResourceStatus();
+        } else {
+            // got an orphaned message consumer! this is an error.
+            log.error("RESOURCE_LEAK! Got created MessageConsumer <{}> for <{}>, while I have <{}> for <{}>",
+                    response.messageConsumer, response.consumerData, messageConsumer, consumerData);
+        }
+    }
+
+    private void messageConsumerFailed(final Status.Failure failure) {
+        // escalate to parent
+        final ConnectionFailure connectionFailed = new ImmutableConnectionFailure(getSelf(), failure.cause(),
+                "Failed to recreate closed message consumer");
+        getContext().getParent().tell(connectionFailed, getSelf());
     }
 
     /**
@@ -188,7 +289,7 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
             // TODO: add monitoring logs after merge
             log.info("Stopping message consumer, message limit of {}/{} exceeded.", throttlingLimit,
                     throttlingInterval);
-            ((JmsMessageConsumer) messageConsumer).stop();
+            stopMessageConsumer();
             // calculate timestamp of next interval when the consumer should be restarted
             final long restartConsumerAt = (interval + 1) * throttlingInterval.toMillis();
             getSelf().tell(new RestartMessageConsumer(restartConsumerAt), ActorRef.noSender());
@@ -204,7 +305,7 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
         final long delay = restartMessageConsumer.getRestartAt() - System.currentTimeMillis();
         if (delay <= 25) { // restart message consumer immediately if delay is negative or too small to schedule
             log.debug("Restarting message consumer.");
-            ((JmsMessageConsumer) messageConsumer).start();
+            startMessageConsumer();
         } else { // otherwise schedule restarting of consumer
             log.debug("Scheduling restart of message consumer after {}ms.", delay);
             getTimers().startSingleTimer(RESTART_MESSAGE_CONSUMER, restartMessageConsumer, Duration.ofMillis(delay));
@@ -361,6 +462,37 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
         private ThrottleState(final long currentInterval, final int currentMessagePerInterval) {
             this.currentInterval = currentInterval;
             this.currentMessagePerInterval = currentMessagePerInterval;
+        }
+    }
+
+    /**
+     * Demand a new message consumer be made for this actor.
+     */
+    static final class CreateMessageConsumer {
+
+        private final ConsumerData consumerData;
+
+        private CreateMessageConsumer(final ConsumerData consumerData) {
+            this.consumerData = consumerData;
+        }
+
+        ConsumerData getConsumerData() {
+            return consumerData;
+        }
+
+        Object toResponse(final MessageConsumer messageConsumer) {
+            return new CreateMessageConsumerResponse(consumerData, messageConsumer);
+        }
+    }
+
+    private static final class CreateMessageConsumerResponse {
+
+        private final ConsumerData consumerData;
+        private final MessageConsumer messageConsumer;
+
+        private CreateMessageConsumerResponse(final ConsumerData consumerData, final MessageConsumer messageConsumer) {
+            this.consumerData = consumerData;
+            this.messageConsumer = messageConsumer;
         }
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -60,7 +60,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
     /**
      * The name prefix of this Actor in the ActorSystem.
      */
-    static final String ACTOR_NAME = "amqpPublisherActor";
+    static final String ACTOR_NAME_PREFIX = "amqpPublisherActor";
 
     private static final Map<String, BiConsumer<Message, String>> JMS_HEADER_MAPPING = new HashMap<>();
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -229,7 +229,6 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
         } else {
             message = session.createMessage();
         }
-        // replace default destination of session by message's actual destination
 
         // some headers must be handled differently to be passed to amqp message
         final Map<String, String> headers = externalMessage.getHeaders();

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/ConsumerData.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/ConsumerData.java
@@ -28,12 +28,17 @@ public final class ConsumerData {
     private final String addressWithIndex;
     private final MessageConsumer messageConsumer;
 
-    ConsumerData(final Source source, final String address, final String addressWithIndex,
+    private ConsumerData(final Source source, final String address, final String addressWithIndex,
             final MessageConsumer messageConsumer) {
         this.source = source;
         this.address = address;
         this.addressWithIndex = addressWithIndex;
         this.messageConsumer = messageConsumer;
+    }
+
+    static ConsumerData of(final Source source, final String address, final String addressWithIndex,
+            final MessageConsumer messageConsumer) {
+        return new ConsumerData(source, address, addressWithIndex, messageConsumer);
     }
 
     Source getSource() {
@@ -54,6 +59,10 @@ public final class ConsumerData {
 
     String getActorNamePrefix() {
         return AmqpConsumerActor.ACTOR_NAME_PREFIX + source.getIndex() + "-" + addressWithIndex;
+    }
+
+    ConsumerData withMessageConsumer(final MessageConsumer messageConsumer) {
+        return new ConsumerData(source, address, addressWithIndex, messageConsumer);
     }
 
     @Override

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/JMSConnectionHandlingActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/JMSConnectionHandlingActor.java
@@ -32,7 +32,6 @@ import javax.naming.NamingException;
 
 import org.apache.qpid.jms.JmsConnection;
 import org.apache.qpid.jms.JmsQueue;
-import org.apache.qpid.jms.JmsSession;
 import org.eclipse.ditto.model.connectivity.Connection;
 import org.eclipse.ditto.model.connectivity.Source;
 import org.eclipse.ditto.services.connectivity.messaging.internal.ImmutableConnectionFailure;
@@ -43,6 +42,7 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.dispatch.MessageDispatcher;
 import akka.event.DiagnosticLoggingAdapter;
 
@@ -64,13 +64,15 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
     /**
      * Config key of the dispatcher for this actor.
      */
-    public static final String DISPATCHER_NAME = "jms-connection-handling-dispatcher";
+    private static final String DISPATCHER_NAME = "jms-connection-handling-dispatcher";
 
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
 
     private final Connection connection;
     private final ExceptionListener exceptionListener;
     private final JmsConnectionFactory jmsConnectionFactory;
+
+    @Nullable Session currentSession = null;
 
     @SuppressWarnings("unused")
     private JMSConnectionHandlingActor(final Connection connection, final ExceptionListener exceptionListener,
@@ -118,7 +120,31 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
                 .match(AmqpClientActor.JmsRecoverSession.class, this::handleRecoverSession)
                 .match(AmqpClientActor.JmsCloseSession.class, this::handleCloseSession)
                 .match(AmqpClientActor.JmsDisconnect.class, this::handleDisconnect)
+                .match(AmqpConsumerActor.CreateMessageConsumer.class, this::createMessageConsumer)
                 .build();
+    }
+
+    private void createMessageConsumer(final AmqpConsumerActor.CreateMessageConsumer command) {
+        final Throwable error;
+        if (currentSession != null) {
+            // create required consumer
+            final ConsumerData consumerData = command.getConsumerData();
+            final ConsumerData newConsumerData =
+                    createJmsConsumer(currentSession, new HashMap<>(), consumerData.getSource(),
+                            consumerData.getAddress(), consumerData.getAddressWithIndex());
+            if (newConsumerData != null) {
+                final Object response = command.toResponse(newConsumerData.getMessageConsumer());
+                getSender().tell(response, getSelf());
+                error = null;
+            } else {
+                error = new IllegalStateException("Failed to create message consumer");
+            }
+        } else {
+            error = new IllegalStateException("No session");
+        }
+        if (error != null) {
+            getSender().tell(new Status.Failure(error), getSelf());
+        }
     }
 
     private void handleCloseSession(final AmqpClientActor.JmsCloseSession closeSession) {
@@ -129,6 +155,9 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
                 session.close();
                 return null;
             });
+            if (Objects.equals(session, currentSession)) {
+                currentSession = null;
+            }
         } catch (final Exception e) {
             log.debug("Closing session failed: {}", e.getMessage());
         }
@@ -151,13 +180,14 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
         }
 
         if (recoverSession.getConnection().isPresent()) {
-            final JmsConnection jmsConnection = recoverSession.getConnection().map(c -> (JmsConnection)c).get();
+            final JmsConnection jmsConnection = recoverSession.getConnection().map(c -> (JmsConnection) c).get();
             try {
                 log.debug("Creating new JMS session.");
                 final Session session = createSession(jmsConnection);
                 log.debug("Creating consumers for new session.");
                 final List<ConsumerData> consumers = createConsumers(session);
-                final AmqpClientActor.JmsSessionRecovered r = new AmqpClientActor.JmsSessionRecovered(origin, session, consumers);
+                final AmqpClientActor.JmsSessionRecovered r =
+                        new AmqpClientActor.JmsSessionRecovered(origin, session, consumers);
                 sender.tell(r, self);
                 log.debug("Session of connection <{}> recovered successfully.", connection.getId());
             } catch (final ConnectionFailedException e) {
@@ -169,8 +199,8 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
             }
         } else {
             log.info("Recovering session failed, no connection available.");
-            sender.tell(new ImmutableConnectionFailure(origin,null,
-                            "Session recovery failed, no connection available."), self);
+            sender.tell(new ImmutableConnectionFailure(origin, null,
+                    "Session recovery failed, no connection available."), self);
         }
     }
 
@@ -223,8 +253,10 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
     }
 
     private Session createSession(final JmsConnection jmsConnection) {
-        return safelyExecuteJmsOperation(jmsConnection, "create session",
+        final Session session = safelyExecuteJmsOperation(jmsConnection, "create session",
                 () -> (jmsConnection.createSession(Session.CLIENT_ACKNOWLEDGE)));
+        currentSession = session;
+        return session;
     }
 
     private <T> T safelyExecuteJmsOperation(@Nullable final JmsConnection jmsConnection,
@@ -275,7 +307,7 @@ public final class JMSConnectionHandlingActor extends AbstractActor {
         final MessageConsumer messageConsumer;
         try {
             messageConsumer = session.createConsumer(destination);
-            return new ConsumerData(source, sourceAddress, addressWithIndex, messageConsumer);
+            return ConsumerData.of(source, sourceAddress, addressWithIndex, messageConsumer);
         } catch (final JMSException jmsException) {
             failedSources.put(addressWithIndex, jmsException);
             return null;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/Amqp10Config.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/Amqp10Config.java
@@ -41,11 +41,11 @@ public interface Amqp10Config {
     int getConsumerThrottlingLimit();
 
     /**
-     * Returns how many reply-to addresses to cache.
+     * Returns how many message producers to cache.
      *
-     * @return the reply-to cache size.
+     * @return the message producer cache size.
      */
-    int getReplyToCacheSize();
+    int getProducerCacheSize();
 
     /**
      * An enumeration of the known config path expressions and their associated default values for
@@ -66,9 +66,9 @@ public interface Amqp10Config {
         CONSUMER_THROTTLING_LIMIT("consumer.throttling.limit", 100),
 
         /**
-         * How many reply-to addresses to cache per client actor.
+         * How many message producers to cache per client actor.
          */
-        REPLY_TO_CACHE_SIZE("reply-to-cache-size", 10);
+        PRODUCER_CACHE_SIZE("producer-cache-size", 10);
 
         private final String path;
         private final Object defaultValue;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/Amqp10Config.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/Amqp10Config.java
@@ -41,6 +41,13 @@ public interface Amqp10Config {
     int getConsumerThrottlingLimit();
 
     /**
+     * Returns how many reply-to addresses to cache.
+     *
+     * @return the reply-to cache size.
+     */
+    int getReplyToCacheSize();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code Amqp10Config}.
      */
@@ -56,8 +63,12 @@ public interface Amqp10Config {
          * The consumer throttling limit defining processed messages per configured
          * {@link #CONSUMER_THROTTLING_INTERVAL interval}.
          */
-        CONSUMER_THROTTLING_LIMIT("consumer.throttling.limit", 100)
-        ;
+        CONSUMER_THROTTLING_LIMIT("consumer.throttling.limit", 100),
+
+        /**
+         * How many reply-to addresses to cache per client actor.
+         */
+        REPLY_TO_CACHE_SIZE("reply-to-cache-size", 10);
 
         private final String path;
         private final Object defaultValue;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ClientConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ClientConfig.java
@@ -14,14 +14,11 @@ package org.eclipse.ditto.services.connectivity.messaging.config;
 
 import java.time.Duration;
 
-import javax.annotation.concurrent.Immutable;
-
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
 
 /**
  * Provides configuration settings for Connectivity service's client.
  */
-@Immutable
 public interface ClientConfig {
 
     /**
@@ -36,6 +33,7 @@ public interface ClientConfig {
      * Initial timeout when connecting to a remote system. If the connection could not be established after this time, the
      * service will try to reconnect. If a failure happened during connecting, then the service will wait for at least this
      * time until it will try to reconnect. The max timeout is defined in {@link ClientConfig#getConnectingMaxTimeout()}.
+     *
      * @return the minimum connecting timeout.
      */
     Duration getConnectingMinTimeout();
@@ -43,15 +41,31 @@ public interface ClientConfig {
     /**
      * Max timeout (until reconnecting) when connecting to a remote system. See docs on {@link ClientConfig#getConnectingMinTimeout()}
      * for more information on the concept.
-     * @return the maximum connecting timeout.
+     *
+     * @return the maximum backoff.
      * @see ClientConfig#getConnectingMinTimeout()
      */
     Duration getConnectingMaxTimeout();
 
     /**
-     * How many times we will try to reconnect when connecting to a remote system.
+     * Minimum backoff duration after failure.
      *
+     * @return the minimum backoff.
+     */
+    Duration getMinBackoff();
+
+    /**
+     * Maximum backoff duration after failure.
+     *
+     * @return the maximum backoff.
+     */
+    Duration getMaxBackoff();
+
+    /**
+     * How many times we will try to reconnect when connecting to a remote system.
+     * <p>
      * The max time is about {@link ClientConfig#getConnectingMaxTimeout()} * this.
+     *
      * @return the maximum retries for connecting.
      */
     int getConnectingMaxTries();
@@ -59,6 +73,7 @@ public interface ClientConfig {
     /**
      * How long the service will wait for a successful connection when testing a new connection. If no response is
      * received after this duration, the test will be assumed a failure.
+     *
      * @return the testing timeout.
      */
     Duration getTestingTimeout();
@@ -91,7 +106,17 @@ public interface ClientConfig {
         /**
          * See documentation on {@link ClientConfig#getTestingTimeout()}.
          */
-        TESTING_TIMEOUT("testing-timeout", Duration.ofSeconds(10L));
+        TESTING_TIMEOUT("testing-timeout", Duration.ofSeconds(10L)),
+
+        /**
+         * See documentation on {@link ClientConfig#getConnectingMaxTimeout()}.
+         */
+        MIN_BACKOFF("min-backoff", Duration.ofSeconds(5L)),
+
+        /**
+         * See documentation on {@link ClientConfig#getConnectingMaxTries()}.
+         */
+        MAX_BACKOFF("max-backoff", Duration.ofHours(1L));
 
         private final String path;
         private final Object defaultValue;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultAmqp10Config.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultAmqp10Config.java
@@ -32,12 +32,12 @@ public final class DefaultAmqp10Config implements Amqp10Config {
 
     private final Duration consumerThrottlingInterval;
     private final int consumerThrottlingLimit;
-    private final int replyToCacheSize;
+    private final int producerCacheSize;
 
     private DefaultAmqp10Config(final ScopedConfig config) {
         consumerThrottlingInterval = config.getDuration(Amqp10ConfigValue.CONSUMER_THROTTLING_INTERVAL.getConfigPath());
         consumerThrottlingLimit = config.getInt(Amqp10ConfigValue.CONSUMER_THROTTLING_LIMIT.getConfigPath());
-        replyToCacheSize = config.getInt(Amqp10ConfigValue.REPLY_TO_CACHE_SIZE.getConfigPath());
+        producerCacheSize = config.getInt(Amqp10ConfigValue.PRODUCER_CACHE_SIZE.getConfigPath());
     }
 
     /**
@@ -62,8 +62,8 @@ public final class DefaultAmqp10Config implements Amqp10Config {
     }
 
     @Override
-    public int getReplyToCacheSize() {
-        return replyToCacheSize;
+    public int getProducerCacheSize() {
+        return producerCacheSize;
     }
 
     @Override
@@ -76,13 +76,13 @@ public final class DefaultAmqp10Config implements Amqp10Config {
         }
         final DefaultAmqp10Config that = (DefaultAmqp10Config) o;
         return consumerThrottlingLimit == that.consumerThrottlingLimit &&
-                replyToCacheSize == that.replyToCacheSize &&
+                producerCacheSize == that.producerCacheSize &&
                 Objects.equals(consumerThrottlingInterval, that.consumerThrottlingInterval);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(consumerThrottlingInterval, consumerThrottlingLimit, replyToCacheSize);
+        return Objects.hash(consumerThrottlingInterval, consumerThrottlingLimit, producerCacheSize);
     }
 
     @Override
@@ -90,7 +90,7 @@ public final class DefaultAmqp10Config implements Amqp10Config {
         return getClass().getSimpleName() + " [" +
                 "consumerThrottlingInterval=" + consumerThrottlingInterval +
                 ", consumerThrottlingLimit=" + consumerThrottlingLimit +
-                ", replyToCacheSize=" + replyToCacheSize +
+                ", producerCacheSize=" + producerCacheSize +
                 "]";
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultAmqp10Config.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultAmqp10Config.java
@@ -32,10 +32,12 @@ public final class DefaultAmqp10Config implements Amqp10Config {
 
     private final Duration consumerThrottlingInterval;
     private final int consumerThrottlingLimit;
+    private final int replyToCacheSize;
 
     private DefaultAmqp10Config(final ScopedConfig config) {
         consumerThrottlingInterval = config.getDuration(Amqp10ConfigValue.CONSUMER_THROTTLING_INTERVAL.getConfigPath());
         consumerThrottlingLimit = config.getInt(Amqp10ConfigValue.CONSUMER_THROTTLING_LIMIT.getConfigPath());
+        replyToCacheSize = config.getInt(Amqp10ConfigValue.REPLY_TO_CACHE_SIZE.getConfigPath());
     }
 
     /**
@@ -49,7 +51,6 @@ public final class DefaultAmqp10Config implements Amqp10Config {
         return new DefaultAmqp10Config(ConfigWithFallback.newInstance(config, CONFIG_PATH, Amqp10ConfigValue.values()));
     }
 
-
     @Override
     public Duration getConsumerThrottlingInterval() {
         return consumerThrottlingInterval;
@@ -58,6 +59,11 @@ public final class DefaultAmqp10Config implements Amqp10Config {
     @Override
     public int getConsumerThrottlingLimit() {
         return consumerThrottlingLimit;
+    }
+
+    @Override
+    public int getReplyToCacheSize() {
+        return replyToCacheSize;
     }
 
     @Override
@@ -70,20 +76,21 @@ public final class DefaultAmqp10Config implements Amqp10Config {
         }
         final DefaultAmqp10Config that = (DefaultAmqp10Config) o;
         return consumerThrottlingLimit == that.consumerThrottlingLimit &&
+                replyToCacheSize == that.replyToCacheSize &&
                 Objects.equals(consumerThrottlingInterval, that.consumerThrottlingInterval);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(consumerThrottlingInterval, consumerThrottlingLimit);
+        return Objects.hash(consumerThrottlingInterval, consumerThrottlingLimit, replyToCacheSize);
     }
-
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "consumerThrottlingInterval=" + consumerThrottlingInterval +
                 ", consumerThrottlingLimit=" + consumerThrottlingLimit +
+                ", replyToCacheSize=" + replyToCacheSize +
                 "]";
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfig.java
@@ -36,6 +36,8 @@ public final class DefaultClientConfig implements ClientConfig {
     private final Duration connectingMaxTimeout;
     private final int connectingMaxTries;
     private final Duration testingTimeout;
+    private final Duration minBackoff;
+    private final Duration maxBackoff;
 
     private DefaultClientConfig(final ScopedConfig config) {
         initTimeout = config.getDuration(ClientConfigValue.INIT_TIMEOUT.getConfigPath());
@@ -43,6 +45,8 @@ public final class DefaultClientConfig implements ClientConfig {
         connectingMaxTimeout = config.getDuration(ClientConfigValue.CONNECTING_MAX_TIMEOUT.getConfigPath());
         connectingMaxTries = config.getInt(ClientConfigValue.CONNECTING_MAX_TRIES.getConfigPath());
         testingTimeout = config.getDuration(ClientConfigValue.TESTING_TIMEOUT.getConfigPath());
+        minBackoff = config.getDuration(ClientConfigValue.MIN_BACKOFF.getConfigPath());
+        maxBackoff = config.getDuration(ClientConfigValue.MAX_BACKOFF.getConfigPath());
     }
 
     /**
@@ -82,6 +86,16 @@ public final class DefaultClientConfig implements ClientConfig {
     }
 
     @Override
+    public Duration getMinBackoff() {
+        return minBackoff;
+    }
+
+    @Override
+    public Duration getMaxBackoff() {
+        return maxBackoff;
+    }
+
+    @Override
     public boolean equals(@Nullable final Object o) {
         if (this == o) {
             return true;
@@ -94,12 +108,15 @@ public final class DefaultClientConfig implements ClientConfig {
                 Objects.equals(connectingMinTimeout, that.connectingMinTimeout) &&
                 Objects.equals(connectingMaxTimeout, that.connectingMaxTimeout) &&
                 Objects.equals(connectingMaxTries, that.connectingMaxTries) &&
-                Objects.equals(testingTimeout, that.testingTimeout);
+                Objects.equals(testingTimeout, that.testingTimeout) &&
+                Objects.equals(minBackoff, that.minBackoff) &&
+                Objects.equals(maxBackoff, that.maxBackoff);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(initTimeout, connectingMinTimeout, connectingMaxTimeout, connectingMaxTries, testingTimeout);
+        return Objects.hash(initTimeout, connectingMinTimeout, connectingMaxTimeout, connectingMaxTries,
+                testingTimeout, minBackoff, maxBackoff);
     }
 
     @Override
@@ -110,6 +127,8 @@ public final class DefaultClientConfig implements ClientConfig {
                 ", connectingMaxTimeout=" + connectingMaxTimeout +
                 ", connectingMaxTries=" + connectingMaxTries +
                 ", testingTimeout=" + testingTimeout +
+                ", minBackoff" + minBackoff +
+                ", maxBackoff" + maxBackoff +
                 "]";
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractConsumerActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractConsumerActorTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.disableLogging;
 import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.header;
 
 import java.util.Map;
@@ -84,6 +85,7 @@ public abstract class AbstractConsumerActorTest<M> {
 
     @Test
     public void testInboundMessageFails() {
+        disableLogging(actorSystem);
         testInboundMessage(header("device_id", "_invalid"), false, s -> {}, outboundSignal -> {
             final ConnectionSignalIdEnforcementFailedException exception =
                     ConnectionSignalIdEnforcementFailedException.fromMessage(
@@ -96,6 +98,7 @@ public abstract class AbstractConsumerActorTest<M> {
 
     @Test
     public void testInboundMessageFailsIfHeaderIsMissing() {
+        disableLogging(actorSystem);
         testInboundMessage(header("some", "header"), false, s -> {}, outboundSignal -> {
             final UnresolvedPlaceholderException exception =
                     UnresolvedPlaceholderException.fromMessage(
@@ -122,6 +125,7 @@ public abstract class AbstractConsumerActorTest<M> {
 
     @Test
     public void testInboundMessageWithHeaderMappingThrowsUnresolvedPlaceholderException() {
+        disableLogging(actorSystem);
         testInboundMessage(header("useless", "header"), false,
                 msg -> {},
                 response -> {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
@@ -44,7 +44,7 @@ import akka.testkit.javadsl.TestKit;
 
 public abstract class AbstractPublisherActorTest {
 
-    private static final Config CONFIG = ConfigFactory.load("test");
+    protected static final Config CONFIG = ConfigFactory.load("test");
     protected static ActorSystem actorSystem;
 
     @Rule
@@ -78,7 +78,6 @@ public abstract class AbstractPublisherActorTest {
             final Target target = createTestTarget();
             when(outboundSignal.getTargets()).thenReturn(Collections.singletonList(decorateTarget(target)));
 
-
             final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().putHeader("device_id", "ditto:thing").build();
             final ExternalMessage externalMessage =
                     ExternalMessageFactory.newExternalMessageBuilder(dittoHeaders).withText("payload").build();
@@ -95,23 +94,25 @@ public abstract class AbstractPublisherActorTest {
             verifyPublishedMessage();
         }};
 
-        
 
     }
-        
+
     protected Target createTestTarget() {
         return ConnectivityModelFactory.newTargetBuilder()
-            .address(getOutboundAddress())
-            .originalAddress(getOutboundAddress())
-            .authorizationContext(TestConstants.Authorization.AUTHORIZATION_CONTEXT)
-            .headerMapping(TestConstants.HEADER_MAPPING)
-            .topics(Topic.TWIN_EVENTS)
-            .build();
+                .address(getOutboundAddress())
+                .originalAddress(getOutboundAddress())
+                .authorizationContext(TestConstants.Authorization.AUTHORIZATION_CONTEXT)
+                .headerMapping(TestConstants.HEADER_MAPPING)
+                .topics(Topic.TWIN_EVENTS)
+                .build();
     }
 
     protected abstract String getOutboundAddress();
+
     protected abstract void setupMocks(final TestProbe probe) throws Exception;
+
     protected abstract Props getPublisherActorProps();
+
     protected abstract void publisherCreated(ActorRef publisherActor);
 
     protected abstract Target decorateTarget(Target target);

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
@@ -190,6 +190,23 @@ public final class BaseClientActorTest {
         }};
     }
 
+    @Test
+    public void connectsAutomaticallyAfterActorStart() {
+        new TestKit(actorSystem) {{
+            final String randomConnectionId = TestConstants.createRandomConnectionId();
+            final Connection connection =
+                    TestConstants.createConnection(randomConnectionId,new Target[0]);
+            final Props props = DummyClientActor.props(connection, getRef(), delegate);
+
+            final ActorRef dummyClientActor = actorSystem.actorOf(props);
+            watch(dummyClientActor);
+
+            thenExpectConnectClientCalledAfterTimeout(Duration.ofSeconds(5L));
+            Mockito.clearInvocations(delegate);
+            andConnectionSuccessful(dummyClientActor, getRef());
+        }};
+    }
+
     private void thenExpectConnectClientCalled() {
         thenExpectConnectClientCalledAfterTimeout(Duration.ZERO);
     }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
+import akka.actor.FSM;
 import akka.actor.Props;
 import akka.actor.Status;
 import akka.testkit.javadsl.TestKit;
@@ -134,7 +135,7 @@ public final class BaseClientActorTest {
             whenOpeningConnection(dummyClientActor, OpenConnection.of(randomConnectionId, DittoHeaders.empty()), getRef());
             thenExpectConnectClientCalled();
 
-            andNoResponseSent();
+            andStateTimeoutSent(dummyClientActor);
 
             expectMsgClass(Status.Failure.class);
 
@@ -238,13 +239,8 @@ public final class BaseClientActorTest {
                 clientActor);
     }
 
-    private void andNoResponseSent() {
-        try {
-            TimeUnit.SECONDS.sleep(connectivityConfig.getClientConfig().getConnectingMinTimeout().getSeconds());
-        } catch (InterruptedException e) {
-            System.out.println("Unexpected interruption while waiting until the connecting timeout takes place...");
-            e.printStackTrace();
-        }
+    private void andStateTimeoutSent(final ActorRef clientActor) {
+        clientActor.tell(FSM.StateTimeout$.MODULE$, clientActor);
     }
 
     private static final class DummyClientActor extends BaseClientActor {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
@@ -223,7 +223,7 @@ public final class TestConstants {
                 newTarget("target:{{ thing:namespace }}/{{thing:name}}@{{ topic:channel }}",
                         Authorization.AUTHORIZATION_CONTEXT, HEADER_MAPPING,
                         null, Topic.TWIN_EVENTS);
-        static final Target TWIN_TARGET =
+        public static final Target TWIN_TARGET =
                 newTarget("twinEventExchange/twinEventRoutingKey", Authorization.AUTHORIZATION_CONTEXT, HEADER_MAPPING,
                         null, Topic.TWIN_EVENTS);
         private static final Target TWIN_TARGET_UNAUTHORIZED =

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -20,6 +20,7 @@ import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.cr
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.timeout;
@@ -728,7 +729,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             amqpClientActor.connectionListener.onConsumerClosed(mockConsumer, error);
 
             // THEN: another consumer is created
-            verify(mockSession).createConsumer(any());
+            verify(mockSession, atLeastOnce()).createConsumer(any());
             final ArgumentCaptor<MessageListener> captor = ArgumentCaptor.forClass(MessageListener.class);
             verify(mockConsumer2, timeout(1000).atLeastOnce()).setMessageListener(captor.capture());
             final MessageListener messageListener = captor.getValue();

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -364,7 +364,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             expectMsg(CONNECTED_SUCCESS);
 
             amqpClientActor.tell(OpenConnection.of(CONNECTION_ID, DittoHeaders.empty()), getRef());
-            expectMsgClass(ConnectionSignalIllegalException.class);
+            expectMsg(CONNECTED_SUCCESS);
 
             // no reconnect happens
             Mockito.verify(mockConnection, Mockito.times(1)).start();

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -126,7 +126,8 @@ import akka.testkit.TestActorRef;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
-@RunWith(MockitoJUnitRunner.class)
+// TODO: investigate whether unnecessary stubbing is avoidable
+@RunWith(MockitoJUnitRunner.Silent.class)
 public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
     private static final Status.Success CONNECTED_SUCCESS = new Status.Success(BaseClientState.CONNECTED);

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -764,7 +764,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                 final Throwable error = new IllegalStateException("Forcibly detached");
                 final Status.Failure failure = new Status.Failure(new AskTimeoutException("Consumer creation timeout"));
                 amqpClientActor.connectionListener.onConsumerClosed(mockConsumer, error);
-                verify(mockSession).createConsumer(any());
+                verify(mockSession, atLeastOnce()).createConsumer(any());
                 amqpConsumerActor.tell(failure, amqpConsumerActor);
 
                 // THEN: connection gets restarted

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
@@ -31,28 +31,32 @@ import javax.jms.MessageProducer;
 import org.apache.qpid.jms.JmsSession;
 import org.apache.qpid.jms.message.JmsMessage;
 import org.apache.qpid.jms.message.JmsTextMessage;
+import org.apache.qpid.jms.provider.amqp.AmqpConnection;
 import org.apache.qpid.jms.provider.amqp.message.AmqpJmsTextMessageFacade;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.services.connectivity.messaging.AbstractPublisherActorTest;
 import org.eclipse.ditto.services.connectivity.messaging.TestConstants;
 import org.eclipse.ditto.services.connectivity.messaging.amqp.status.ProducerClosedStatusReport;
+import org.eclipse.ditto.services.connectivity.messaging.config.ConnectionConfig;
+import org.eclipse.ditto.services.connectivity.messaging.config.DittoConnectivityConfig;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
 import org.eclipse.ditto.services.models.connectivity.OutboundSignal;
 import org.eclipse.ditto.services.models.connectivity.OutboundSignalFactory;
+import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.signals.base.Signal;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.stubbing.Answer;
+
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
 public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
-
 
     private JmsSession session;
     private MessageProducer messageProducer;
@@ -64,19 +68,22 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
         when(session.createProducer(ArgumentMatchers.any(Destination.class))).thenReturn(messageProducer);
         when(session.createTextMessage(anyString())).thenAnswer((Answer<JmsMessage>) invocation -> {
             final String argument = invocation.getArgument(0);
-            final JmsTextMessage jmsTextMessage = new JmsTextMessage(new AmqpJmsTextMessageFacade());
+            final AmqpJmsTextMessageFacade facade = new AmqpJmsTextMessageFacade() {{
+                connection = mock(AmqpConnection.class);
+            }};
+            final JmsTextMessage jmsTextMessage = new JmsTextMessage(facade);
             jmsTextMessage.setText(argument);
             return jmsTextMessage;
         });
     }
-    
+
     @Test
     public void testRecoverPublisher() throws Exception {
 
         new TestKit(actorSystem) {{
             final TestProbe probe = new TestProbe(actorSystem);
             setupMocks(probe);
-            
+
             final OutboundSignal outboundSignal = mock(OutboundSignal.class);
             final Signal source = mock(Signal.class);
             when(source.getId()).thenReturn(TestConstants.Things.THING_ID);
@@ -85,33 +92,34 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             final Target target = createTestTarget();
             when(outboundSignal.getTargets()).thenReturn(Collections.singletonList(decorateTarget(target)));
 
-
             final DittoHeaders dittoHeaders = DittoHeaders.newBuilder().putHeader("device_id", "ditto:thing").build();
             final ExternalMessage externalMessage =
                     ExternalMessageFactory.newExternalMessageBuilder(dittoHeaders).withText("payload").build();
             final OutboundSignal.WithExternalMessage mappedOutboundSignal =
                     OutboundSignalFactory.newMappedOutboundSignal(outboundSignal, externalMessage);
 
-            final Props props = getPublisherActorProps();
+            final Props props = AmqpPublisherActor.props("theConnection",
+                    Collections.singletonList(TestConstants.Targets.TWIN_TARGET.withAddress(getOutboundAddress())),
+                    session,
+                    loadConnectionConfig());
             final ActorRef publisherActor = actorSystem.actorOf(props);
 
             publisherActor.tell(mappedOutboundSignal, getRef());
             publisherActor.tell(mappedOutboundSignal, getRef());
             // producer is cache so created only once
             verify(session, timeout(1_000)).createProducer(ArgumentMatchers.any(Destination.class));
-            
+
             publisherActor.tell(ProducerClosedStatusReport.get(messageProducer), getRef());
-            
-            publisherActor.tell(mappedOutboundSignal, getRef());
+
             // second producer created as first one was removed from cache
-            verify(session, timeout(1_000).times(2)).createProducer(ArgumentMatchers.any(Destination.class));            
+            verify(session, timeout(1_000)).createProducer(ArgumentMatchers.any(Destination.class));
         }};
 
     }
 
     @Override
     protected Props getPublisherActorProps() {
-        return AmqpPublisherActor.props("theConnection", Collections.emptyList(), session);
+        return AmqpPublisherActor.props("theConnection", Collections.emptyList(), session, loadConnectionConfig());
     }
 
     @Override
@@ -144,5 +152,9 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
 
     protected String getOutboundAddress() {
         return "outbound";
+    }
+
+    private static ConnectionConfig loadConnectionConfig() {
+        return DittoConnectivityConfig.of(DefaultScopedConfig.dittoScoped(CONFIG)).getConnectionConfig();
     }
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfigTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfigTest.java
@@ -76,6 +76,12 @@ public final class DefaultClientConfigTest {
         softly.assertThat(underTest.getTestingTimeout())
                 .as(ClientConfig.ClientConfigValue.TESTING_TIMEOUT.getConfigPath())
                 .isEqualTo(ClientConfig.ClientConfigValue.TESTING_TIMEOUT.getDefaultValue());
+        softly.assertThat(underTest.getMinBackoff())
+                .as(ClientConfig.ClientConfigValue.MIN_BACKOFF.getConfigPath())
+                .isEqualTo(ClientConfig.ClientConfigValue.MIN_BACKOFF.getDefaultValue());
+        softly.assertThat(underTest.getMaxBackoff())
+                .as(ClientConfig.ClientConfigValue.MAX_BACKOFF.getConfigPath())
+                .isEqualTo(ClientConfig.ClientConfigValue.MAX_BACKOFF.getDefaultValue());
     }
 
     @Test
@@ -97,6 +103,12 @@ public final class DefaultClientConfigTest {
         softly.assertThat(underTest.getTestingTimeout())
                 .as(ClientConfig.ClientConfigValue.TESTING_TIMEOUT.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(5L));
+        softly.assertThat(underTest.getMinBackoff())
+                .as(ClientConfig.ClientConfigValue.MIN_BACKOFF.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(6L));
+        softly.assertThat(underTest.getMaxBackoff())
+                .as(ClientConfig.ClientConfigValue.MAX_BACKOFF.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(7L));
     }
 
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
@@ -216,7 +216,7 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
             expectMsg(CONNECTED_SUCCESS);
 
             rabbitClientActor.tell(OpenConnection.of(CONNECTION_ID, DittoHeaders.empty()), getRef());
-            expectMsgClass(ConnectionSignalIllegalException.class);
+            expectMsg(CONNECTED_SUCCESS);
 
             // a publisher and a consumer channel should be created
             verify(mockConnection, Mockito.times(2)).createChannel();

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
@@ -176,14 +176,8 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
             final Props props = createClientActor(getRef());
             final ActorRef rabbitClientActor = actorSystem.actorOf(props);
 
-            rabbitClientActor.tell(OpenConnection.of(CONNECTION_ID, DittoHeaders.empty()), getRef());
-            expectMsg(CONNECTED_SUCCESS);
-
-            rabbitClientActor.tell(CloseConnection.of(CONNECTION_ID, DittoHeaders.empty()), getRef());
-            expectMsg(DISCONNECTED_SUCCESS);
-
-            // reconnect many times
-            for (int i = 0; i < 10; ++i) {
+            // reconnect a few times
+            for (int i = 0; i < 3; ++i) {
                 rabbitClientActor.tell(OpenConnection.of(CONNECTION_ID, DittoHeaders.empty()), getRef());
                 expectMsg(CONNECTED_SUCCESS);
 

--- a/services/connectivity/messaging/src/test/resources/client-test.conf
+++ b/services/connectivity/messaging/src/test/resources/client-test.conf
@@ -5,4 +5,6 @@ client {
   connecting-max-timeout = 120s
   connecting-max-tries = 10
   testing-timeout = 5s
+  min-backoff = 6s
+  max-backoff = 7s
 }

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -1,3 +1,6 @@
+// dead lettters log disabled because actors are being killed all the time
+akka.log-dead-letters = 0
+
 ditto {
   mapping-strategy.implementation = "org.eclipse.ditto.services.models.connectivity.ConnectivityMappingStrategies"
   cluster-downing.role = "connectivity"
@@ -43,6 +46,17 @@ ditto {
         kafka-clients {
         }
       }
+
+      amqp10 {
+        consumer {
+          throttling {
+            interval = 100ms
+            limit = 1
+          }
+        }
+
+        reply-to-cache-size = 10
+      }
     }
 
     mapping {
@@ -83,13 +97,6 @@ ditto {
       testing-timeout = 5s
       min-backoff = 0s
       max-backoff = 0s
-    }
-
-    amqp-consumer {
-      throttling {
-        interval = 100ms
-        limit = 1
-      }
     }
 
     monitoring {

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -55,7 +55,7 @@ ditto {
           }
         }
 
-        reply-to-cache-size = 10
+        producer-cache-size = 10
       }
     }
 

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -95,8 +95,8 @@ ditto {
       connecting-max-timeout = 5s
       connecting-max-tries = 10
       testing-timeout = 5s
-      min-backoff = 0s
-      max-backoff = 0s
+      min-backoff = 100ms
+      max-backoff = 100ms
     }
 
     monitoring {

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -81,6 +81,8 @@ ditto {
       connecting-max-timeout = 5s
       connecting-max-tries = 10
       testing-timeout = 5s
+      min-backoff = 0s
+      max-backoff = 0s
     }
 
     amqp-consumer {

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -47,6 +47,11 @@ ditto {
             limit = ${?AMQP10_CONSUMER_THROTTLING_LIMIT}
           }
         }
+
+        // How many reply-to addresses to cache per client actor.
+        // If 0 or negative, no message can be sent to any reply-to address that does not match any target address.
+        reply-to-cache-size = 10
+        reply-to-cache-size = ${?AMQP10_REPLY_TO_CACHE_SIZE}
       }
 
       mqtt {

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -48,10 +48,11 @@ ditto {
           }
         }
 
-        // How many reply-to addresses to cache per client actor.
-        // If 0 or negative, no message can be sent to any reply-to address that does not match any target address.
-        reply-to-cache-size = 10
-        reply-to-cache-size = ${?AMQP10_REPLY_TO_CACHE_SIZE}
+        // How many producers to cache per client actor (in addition to static addresses).
+        // If 0 or negative, no message can be sent to any reply-to address or addresses containing placeholders that
+        // do not match any target address.
+        producer-cache-size = 10
+        producer-cache-size = ${?AMQP10_PRODUCER_CACHE_SIZE}
       }
 
       mqtt {

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -136,16 +136,23 @@ ditto {
       # this time until it will try to reconnect. The max timeout is defined in connecting-max-timeout.
       connecting-min-timeout = 60s
       connecting-min-timeout = ${?CONNECTIVITY_CLIENT_CONNECTING_MIN_TIMEOUT}
-      # Max timeout (until reconnecting) when connecting to a remote system. Should be greater than connecting-min-timeout.
+      # Max timeout (until reconnecting) when connecting to a remote system.
+      # Should be greater than connecting-min-timeout.
       connecting-max-timeout = 60m
       connecting-max-timeout = ${?CONNECTIVITY_CLIENT_CONNECTING_MAX_TIMEOUT}
       # How many times we will try to reconnect when connecting to a remote system.
-      # max time ~= connecting-max-tries * connecting-max-timeout = 50 x 30m = 25h
+      # max time ~= connecting-max-tries * connecting-max-timeout = 50 * 60m = 50h
       connecting-max-tries = 50
       connecting-max-tries = ${?CONNECTIVITY_CLIENT_CONNECTING_MAX_TRIES}
       # how long the service will wait for a successful connection when testing a new connection. If no response is
       # received after this duration, the test will be assumed a failure.
       testing-timeout = 10s
+      # Min backoff after connection failure.
+      min-backoff = 5s
+      min-backoff = ${?CONNECTIVITY_CLIENT_MIN_BACKOFF}
+      # Max backoff after connection failure.
+      max-backoff = 60m
+      max-backoff = ${?CONNECTIVITY_CLIENT_MAX_BACKOFF}
     }
 
     monitoring {


### PR DESCRIPTION
- Fixed a bug where we relied on Akka FSM state timeout for connection handling. Actual duration of FSM state timeout is not deterministic.

- All client actors now react to `ConnectionFailure` in connected state by restarting the connection after exponential backoff.

- AMQP 1.0 consumers and publishers configured as sources and targets are recreated eagerly as the broker close them.

- There is a configurable limit on the number of open AMQP publishers created for `reply-to` addresses.

- Upgrade to Caffeine 2.7.0 due to [issue 301](https://github.com/ben-manes/caffeine/issues/301).

- When connected, client actors answer `OpenConnection` by `Status.Success` instead of ignoring it.