### PR TITLE
Reduced TTL for ThingUpdater to 15m and switched to passivation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install: true
 script:
   - if [ ! -n "$TRAVIS_TAG" ]; then
-    travis_wait 60 mvn install javadoc:jar source:jar --batch-mode --errors --quiet -Pbuild-documentation -DcreateJavadoc=true -Dakka.test.single-expect-default=10s;
+    travis_wait 60 mvn install javadoc:jar source:jar --batch-mode --errors --quiet -DcreateJavadoc=true -Dakka.test.single-expect-default=10s;
     fi;
   - if [ -n "$TRAVIS_TAG" ]; then
     export IMAGE_TAG=$TRAVIS_TAG;

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -71,7 +71,7 @@ ditto {
     }
 
     updater {
-      max-idle-time = 25h
+      max-idle-time = 15m
       max-idle-time = ${?ACTIVITY_CHECK_INTERVAL}
 
       event-processing-active = true

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
@@ -36,6 +36,7 @@ import akka.actor.ActorRef;
 import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.ReceiveTimeout;
+import akka.cluster.sharding.ShardRegion;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.event.Logging;
 
@@ -97,7 +98,7 @@ final class ThingUpdater extends AbstractActor {
 
     private void stopThisActor(final ReceiveTimeout receiveTimeout) {
         log.debug("stopping ThingUpdater <{}> due to <{}>", thingId, receiveTimeout);
-        getSelf().tell(PoisonPill.getInstance(), ActorRef.noSender());
+        getContext().getParent().tell(new ShardRegion.Passivate(PoisonPill.getInstance()), getSelf());
     }
 
     /**


### PR DESCRIPTION
ThingUpdater being a non-persistent actor with a cheap constructor, we can trade more restarts for less memory consumption. Instead of sending poison pill to self,it now passivates to avoid message loss.

Signed-off-by: Cai Yufei (INST/ECS1) <yufei.cai@bosch-si.com>