### PR TITLE
Use default time-out for devops commands

### DIFF
--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -41,7 +41,8 @@ ditto {
       # how long for connection actor to wait for response from client actors
       # by default this value is very high because connection establishment can take very long and if we timeout too
       # early the connection is not subscribed for events properly
-      client-actor-ask-timeout = 60s
+      # this timeout needs to be smaller then ditto.gateway.http.request-timeout in gateway.conf
+      client-actor-ask-timeout = 55s
       client-actor-ask-timeout = ${?CONNECTIVITY_CLIENT_ACTOR_ASK_TIMEOUT}
 
       amqp10 {
@@ -52,7 +53,7 @@ ditto {
             interval = ${?AMQP10_CONSUMER_THROTTLING_INTERVAL}
 
             # The maximum number of messages the consumer is allowed to receive within the configured
-            # throttling interval e.g. 100msgs/s. Disable throttling with a value of zero.
+            # throttling interval e.g. 100 msgs/s. Disable throttling with a value of zero.
             limit = 100
             limit = ${?AMQP10_CONSUMER_THROTTLING_LIMIT}
           }

--- a/services/utils/devops/src/main/java/org/eclipse/ditto/services/utils/devops/DevOpsCommandsActor.java
+++ b/services/utils/devops/src/main/java/org/eclipse/ditto/services/utils/devops/DevOpsCommandsActor.java
@@ -455,9 +455,12 @@ public final class DevOpsCommandsActor extends AbstractActor implements Retrieve
 
         private static Duration getReceiveTimeout(final DittoHeaders dittoHeaders) {
             Duration result = DEFAULT_RECEIVE_TIMEOUT;
+            final long defaultTimeout = DEFAULT_RECEIVE_TIMEOUT.toMillis();
             @Nullable final String timeoutHeaderValue = dittoHeaders.get(TIMEOUT_HEADER);
             if (null != timeoutHeaderValue) {
-                result = Duration.ofMillis(Integer.parseInt(timeoutHeaderValue));
+                final long parsedTimeout = Long.parseLong(timeoutHeaderValue);
+                final long timeout = Math.max(parsedTimeout, defaultTimeout);
+                result = Duration.ofMillis(timeout);
             }
             return result;
         }


### PR DESCRIPTION
When the specified time-out for a devops command is lower then 5 sec then the default time-out will be used.