### PR TITLE
fixed that UnmappedOutboundSignal did not serialize/deserialize headers

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectivityStatus.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectivityStatus.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 /**
  * An enumeration of status of connectivity resource.
+ * TODO make Jsonifiable as it is sent in cluster
  */
 public enum ConnectivityStatus implements CharSequence {
 

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignal.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignal.java
@@ -90,6 +90,13 @@ public interface OutboundSignal extends Jsonifiable.WithFieldSelectorAndPredicat
                 JsonFactory.newJsonArrayFieldDefinition("targets", FieldType.REGULAR, JsonSchemaVersion.V_1,
                         JsonSchemaVersion.V_2);
 
+        /**
+         * JSON field containing the {@code DittoHeaders} of the {@code source} {@link Signal}.
+         */
+        static final JsonFieldDefinition<JsonObject> JSON_DITTO_HEADERS =
+                JsonFactory.newJsonObjectFieldDefinition("dittoHeaders", FieldType.REGULAR, JsonSchemaVersion.V_1,
+                        JsonSchemaVersion.V_2);
+
         private JsonFields() {
             throw new AssertionError();
         }


### PR DESCRIPTION
The DittoHeaders were not added to the serialized JSON which causes that when using > 1 client for a connection, the DittoHeaders were missing when they were sent to another connectivity instance.
