### PR TITLE
use new adopter mechanism provided by Eclipse IoT to show "who's usining Ditto"

### DIFF
--- a/documentation/src/main/resources/_layouts/start.html
+++ b/documentation/src/main/resources/_layouts/start.html
@@ -7,6 +7,15 @@
             $('[data-toggle="tooltip"]').tooltip()
         })
     </script>
+    <script src="//iot.eclipse.org/assets/js/eclipsefdn.adopters.js"></script>
+    <script>
+        eclipseFdnAdopters.getList({
+           project_id: "iot.ditto",
+           selector: ".who .user-logos-container",
+           ul_classes: "user-logos",
+           logo_white: true
+        });
+    </script>
 </head>
 {% if site.google_analytics %}
 {% include google_analytics.html %}

--- a/documentation/src/main/resources/css/customstyles.css
+++ b/documentation/src/main/resources/css/customstyles.css
@@ -1374,20 +1374,15 @@ h4.panel-title {
     content: none;
 }
 
-.highlight.who .user-logos {
-    display: table;
-    padding-left: 0;
-    padding-right: 0;
-    width: 100%;
-    table-layout: fixed;
-    margin-left: auto;
-    margin-right: auto;
+.highlight.who ul.user-logos {
+    display: flex ;
+    flex-flow: row wrap;
+    padding: 0;
 }
 
-.highlight.who .user-logo {
-    display: table-cell;
-    float: none!important;
-    vertical-align: middle;
-    width: 100%;
+.highlight.who ul.user-logos > li {
+    flex: 1 1 33%; /* 3 logos per line */
+    padding-bottom: 2em;
+    list-style: none;
 }
 

--- a/documentation/src/main/resources/index.html
+++ b/documentation/src/main/resources/index.html
@@ -71,21 +71,7 @@ sidebar: false
 <div class="row highlight who">
   <div class="container">
     <h2>Who's using Eclipse Ditto?</h2>
-    <div class="row user-logos">
-      <div class="col-sm-3 user-logo">
-      </div>
-      <div class="col-sm-3 user-logo">
-        <a href="http://www.aloxy.io/">
-          <img src="{{ "images/user-logos/aloxy-word-white.svg" }}" alt="User of Eclipse Ditto: Aloxy"/>
-        </a>
-      </div>
-      <div class="col-sm-3 user-logo">
-        <a href="https://www.bosch-iot-suite.com/service/things/">
-          <img src="{{ "images/user-logos/bosch-en-white.svg" }}" alt="User of Eclipse Ditto: Robert Bosch GmbH logo"/>
-        </a>
-      </div>
-      <div class="col-sm-3 user-logo">
-      </div>
+    <div class="row user-logos-container">
     </div>
   </div>
 </div>


### PR DESCRIPTION
on the startpage as documented here: https://github.com/eclipsefdn/iot.eclipse.org#javascript-plugin

We change this as this is now the formal "process" of Eclipse IoT how to provide "user Logos" for the project websites.

Adopters of Ditto like e.g. Aloxy (ping to @BobClaerhout ) would have to upload their company logos by doing a PR to the iot.eclipse.org repo.
Documentation how to do that is provided here:
https://github.com/eclipsefdn/iot.eclipse.org#project-adopters
