### PR TITLE
prevent the state timeout canceling when switching to UNKNOWN state

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -413,11 +413,10 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
             clientConnectingGauge.reset();
         }
         // cancel our own state timeout if target state is stable
-        switch (to) {
-            case UNKNOWN:
-            case CONNECTED:
-            case DISCONNECTED:
-                cancelStateTimeout();
+        if (to == CONNECTED || to == DISCONNECTED) {
+            cancelStateTimeout();
+        } else if (to == UNKNOWN) {
+            log.debug("State transition to UNKNOWN which happens after actor initialization.");
         }
     }
 
@@ -504,7 +503,7 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
         if (getPublisherActor() != null) {
             getPublisherActor().forward(message.getOutboundSignal(), getContext());
         } else {
-            log.warning("No publisher actor available, dropping message.");
+            log.error("No publisher actor available, dropping message: {}", message);
         }
         return stay();
     }
@@ -1372,6 +1371,13 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
 
         OutboundSignal.WithExternalMessage getOutboundSignal() {
             return outboundSignal;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + " [" +
+                    "outboundSignal=" + outboundSignal +
+                    "]";
         }
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientState.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientState.java
@@ -21,5 +21,6 @@ public enum BaseClientState {
     DISCONNECTING,
     DISCONNECTED,
     UNKNOWN,
-    TESTING
+    TESTING,
+    INITIATING
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
@@ -16,7 +16,6 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.UPDATE_SUBSCRIPTIONS;
 import static org.eclipse.ditto.services.models.connectivity.ConnectivityMessagingConstants.CLUSTER_ROLE;
 
-import java.text.MessageFormat;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -416,8 +415,8 @@ public final class ConnectionPersistenceActor
             case UPDATE_SUBSCRIPTIONS:
                 prepareForSignalForwarding(command.next());
                 break;
-            case TELL_CLIENT_ACTORS_IF_STARTED:
-                tellClientActorsIfStarted(command.getCommand(), getSelf());
+            case BROADCAST_TO_CLIENT_ACTORS_IF_STARTED:
+                broadcastToClientActorsIfStarted(command.getCommand(), getSelf());
                 interpretStagedCommand(command.next());
                 break;
             case RETRIEVE_CONNECTION_LOGS:
@@ -458,7 +457,7 @@ public final class ConnectionPersistenceActor
 
     private void checkLoggingEnabled() {
         final CheckConnectionLogsActive checkLoggingActive = CheckConnectionLogsActive.of(entityId, Instant.now());
-        tellClientActorsIfStarted(checkLoggingActive, getSelf());
+        broadcastToClientActorsIfStarted(checkLoggingActive, getSelf());
     }
 
     private void forwardSignalToClientActors(final Signal signal) {
@@ -520,7 +519,8 @@ public final class ConnectionPersistenceActor
             // prevent strange behavior.
             origin.tell(TestConnectionResponse.alreadyCreated(entityId, command.getDittoHeaders()), self);
         } else {
-            askClientActor(command.getCommand())
+            // no need to start more than 1 client for tests
+            startAndAskClientActors(command.getCommand(), 1)
                     .thenAccept(response -> self.tell(
                             command.withResponse(TestConnectionResponse.success(command.getConnectionEntityId(),
                                     response.toString(), command.getDittoHeaders())),
@@ -538,7 +538,7 @@ public final class ConnectionPersistenceActor
     private void openConnection(final StagedCommand command, final boolean ignoreErrors) {
         final OpenConnection openConnection = OpenConnection.of(entityId, command.getDittoHeaders());
         final Consumer<Object> successConsumer = response -> getSelf().tell(command, ActorRef.noSender());
-        askClientActor(openConnection)
+        startAndAskClientActors(openConnection, getClientCount())
                 .thenAccept(successConsumer)
                 .exceptionally(error -> {
                     if (ignoreErrors) {
@@ -554,9 +554,13 @@ public final class ConnectionPersistenceActor
 
     private void closeConnection(final StagedCommand command) {
         final CloseConnection closeConnection = CloseConnection.of(entityId, command.getDittoHeaders());
-        askClientActorIfStarted(closeConnection)
+        broadcastToClientActorsIfStarted(closeConnection)
                 .thenAccept(response -> getSelf().tell(command, ActorRef.noSender()))
-                .exceptionally(error -> handleException("disconnect", command.getSender(), error));
+                .exceptionally(error -> {
+                    // stop client actors anyway---the closed status is already persisted.
+                    stopClientActors();
+                    return handleException("disconnect", command.getSender(), error);
+                });
     }
 
     private void enhanceLogUtil(final WithDittoHeaders<?> createConnection) {
@@ -589,7 +593,8 @@ public final class ConnectionPersistenceActor
     private void updateLoggingIfEnabled() {
         if (isLoggingEnabled()) {
             loggingEnabledUntil = Instant.now().plus(loggingEnabledDuration);
-            tellClientActorsIfStarted(EnableConnectionLogs.of(entityId, DittoHeaders.empty()), ActorRef.noSender());
+            broadcastToClientActorsIfStarted(EnableConnectionLogs.of(entityId, DittoHeaders.empty()),
+                    ActorRef.noSender());
         }
     }
 
@@ -619,43 +624,12 @@ public final class ConnectionPersistenceActor
         origin.tell(logsResponse, getSelf());
     }
 
-    /*
-     * NOT thread-safe.
-     */
-    private CompletionStage<Object> askClientActor(final Command<?> cmd) {
-
-        startClientActorIfRequired();
-        // timeout before sending the (partial) response
-        final long responseTimeout = Optional.ofNullable(cmd.getDittoHeaders().get("timeout"))
-                .map(Long::parseLong)
-                .orElse(clientActorAskTimeout.toMillis());
-        // wrap in Broadcast message because these management messages must be delivered to each client actor
-        if (clientActorRouter != null && entity != null) {
-            final ActorRef aggregationActor = getContext().actorOf(
-                    AggregateActor.props(clientActorRouter, entity.getClientCount(), responseTimeout,
-                            entityId));
-            return Patterns.ask(aggregationActor, cmd, clientActorAskTimeout)
-                    .thenCompose(response -> {
-                        if (response instanceof Status.Failure) {
-                            return failedFuture(((Status.Failure) response).cause());
-                        } else if (response instanceof DittoRuntimeException) {
-                            return failedFuture((DittoRuntimeException) response);
-                        } else {
-                            return CompletableFuture.completedFuture(response);
-                        }
-                    });
-        } else {
-            final String message =
-                    MessageFormat.format(
-                            "NOT asking client actor <{0}> for connection <{1}> because one of them is null.",
-                            clientActorRouter, entity);
-            final NullPointerException nullPointerException = new NullPointerException(message);
-            log.error(message);
-            return failedFuture(nullPointerException);
-        }
+    private CompletionStage<Object> startAndAskClientActors(final Command<?> cmd, final int clientCount) {
+        startClientActorsIfRequired(clientCount);
+        return processClientAskResult(Patterns.ask(clientActorRouter, cmd, clientActorAskTimeout));
     }
 
-    private void tellClientActorsIfStarted(final Command<?> cmd, final ActorRef sender) {
+    private void broadcastToClientActorsIfStarted(final Command<?> cmd, final ActorRef sender) {
         if (clientActorRouter != null && entity != null) {
             clientActorRouter.tell(new Broadcast(cmd), sender);
         }
@@ -664,9 +638,11 @@ public final class ConnectionPersistenceActor
     /*
      * NOT thread-safe.
      */
-    private CompletionStage<Object> askClientActorIfStarted(final Command<?> cmd) {
+    private CompletionStage<Object> broadcastToClientActorsIfStarted(final Command<?> cmd) {
         if (clientActorRouter != null && entity != null) {
-            return askClientActor(cmd);
+            // wrap in Broadcast message because these management messages must be delivered to each client actor
+            final Broadcast broadcast = new Broadcast(cmd);
+            return processClientAskResult(Patterns.ask(clientActorRouter, broadcast, clientActorAskTimeout));
         } else {
             return CompletableFuture.completedFuture(null);
         }
@@ -805,9 +781,8 @@ public final class ConnectionPersistenceActor
         }
     }
 
-    private void startClientActorIfRequired() {
-        if (entity != null && clientActorRouter == null) {
-            final int clientCount = entity.getClientCount();
+    private void startClientActorsIfRequired(final int clientCount) {
+        if (entity != null && clientActorRouter == null && clientCount > 0) {
             log.info("Starting ClientActor for connection <{}> with <{}> clients.", entityId, clientCount);
             final Props props = propsFactory.getActorPropsForType(entity, conciergeForwarder);
             final ClusterRouterPoolSettings clusterRouterPoolSettings =
@@ -824,6 +799,10 @@ public final class ConnectionPersistenceActor
         } else {
             log.error(new IllegalStateException(), "Trying to start client actor without a connection");
         }
+    }
+
+    private int getClientCount() {
+        return entity == null ? 0 : entity.getClientCount();
     }
 
     private void stopClientActors() {
@@ -893,6 +872,18 @@ public final class ConnectionPersistenceActor
                     .dittoHeaders(headers)
                     .build();
         }
+    }
+
+    private static CompletionStage<Object> processClientAskResult(final CompletionStage<Object> askResultFuture) {
+        return askResultFuture.thenCompose(response -> {
+            if (response instanceof Status.Failure) {
+                return failedFuture(((Status.Failure) response).cause());
+            } else if (response instanceof DittoRuntimeException) {
+                return failedFuture((DittoRuntimeException) response);
+            } else {
+                return CompletableFuture.completedFuture(response);
+            }
+        });
     }
 
     /**

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/stages/ConnectionAction.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/stages/ConnectionAction.java
@@ -80,7 +80,7 @@ public enum ConnectionAction {
     /**
      * Forward command to client actors without waiting for reply.
      */
-    TELL_CLIENT_ACTORS_IF_STARTED,
+    BROADCAST_TO_CLIENT_ACTORS_IF_STARTED,
 
     /**
      * Retrieve connection logs.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/EnableConnectionLogsStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/EnableConnectionLogsStrategy.java
@@ -14,7 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging.persistence.strategies
 
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.ENABLE_LOGGING;
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.SEND_RESPONSE;
-import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.TELL_CLIENT_ACTORS_IF_STARTED;
+import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.BROADCAST_TO_CLIENT_ACTORS_IF_STARTED;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +42,6 @@ final class EnableConnectionLogsStrategy extends AbstractEphemeralStrategy<Enabl
 
     @Override
     List<ConnectionAction> getActions() {
-        return Arrays.asList(TELL_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE, ENABLE_LOGGING);
+        return Arrays.asList(BROADCAST_TO_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE, ENABLE_LOGGING);
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ResetConnectionLogsStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ResetConnectionLogsStrategy.java
@@ -13,7 +13,7 @@
 package org.eclipse.ditto.services.connectivity.messaging.persistence.strategies.commands;
 
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.SEND_RESPONSE;
-import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.TELL_CLIENT_ACTORS_IF_STARTED;
+import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.BROADCAST_TO_CLIENT_ACTORS_IF_STARTED;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +42,6 @@ final class ResetConnectionLogsStrategy extends AbstractEphemeralStrategy<ResetC
 
     @Override
     List<ConnectionAction> getActions() {
-        return Arrays.asList(TELL_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE);
+        return Arrays.asList(BROADCAST_TO_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE);
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ResetConnectionMetricsStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ResetConnectionMetricsStrategy.java
@@ -13,7 +13,7 @@
 package org.eclipse.ditto.services.connectivity.messaging.persistence.strategies.commands;
 
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.SEND_RESPONSE;
-import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.TELL_CLIENT_ACTORS_IF_STARTED;
+import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.BROADCAST_TO_CLIENT_ACTORS_IF_STARTED;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,6 +42,6 @@ final class ResetConnectionMetricsStrategy extends AbstractEphemeralStrategy<Res
 
     @Override
     List<ConnectionAction> getActions() {
-        return Arrays.asList(TELL_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE);
+        return Arrays.asList(BROADCAST_TO_CLIENT_ACTORS_IF_STARTED, SEND_RESPONSE);
     }
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/AbstractMqttClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/AbstractMqttClientActorTest.java
@@ -151,11 +151,10 @@ public abstract class AbstractMqttClientActorTest<M> extends AbstractBaseClientA
 
             mqttClientActor.tell(TestConnection.of(connection, DittoHeaders.empty()), getRef());
             expectMsg(new Status.Success("successfully connected + initialized mapper"));
+            expectDisconnectCalled();
 
             // client actor should be stopped after testing
             expectTerminated(mqttClientActor);
-
-            expectDisconnectCalled();
         }};
     }
 

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -1,5 +1,7 @@
 // dead lettters log disabled because actors are being killed all the time
 akka.log-dead-letters = 0
+akka.cluster.jmx.multi-mbeans-in-same-jvm = on
+akka.cluster.roles = ["thing-event-aware", "live-signal-aware"]
 
 ditto {
   mapping-strategy.implementation = "org.eclipse.ditto.services.models.connectivity.ConnectivityMappingStrategies"
@@ -98,7 +100,7 @@ ditto {
     }
 
     client {
-      init-timeout = 1s
+      init-timeout = 3s
       connecting-min-timeout = 5s
       connecting-max-timeout = 5s
       connecting-max-tries = 10

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -154,7 +154,7 @@ ditto {
     client {
       # Init timeout for client actors (if no connect msg is received the parent actor is asked whether to connect)
       # Running into init-timeout is the only way for client actors on remote nodes to start a connection.
-      # Set to be as short as possible without timing out the lcoal client actor, which is used for acknowledgement.
+      # Set to be as short as possible without timing out the local client actor, which is used for acknowledgement.
       init-timeout = 3s
       init-timeout = ${?CONNECTIVITY_CLIENT_INIT_TIMEOUT}
       # Initial timeout when connecting to a remote system. If the connection could not be established after this time, the

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -152,8 +152,10 @@ ditto {
     }
 
     client {
-      # init timeout for client actors (if no connect msg is received the parent actor is asked whether to connect)
-      init-timeout = 5s
+      # Init timeout for client actors (if no connect msg is received the parent actor is asked whether to connect)
+      # Running into init-timeout is the only way for client actors on remote nodes to start a connection.
+      # Set to be as short as possible without timing out the lcoal client actor, which is used for acknowledgement.
+      init-timeout = 3s
       init-timeout = ${?CONNECTIVITY_CLIENT_INIT_TIMEOUT}
       # Initial timeout when connecting to a remote system. If the connection could not be established after this time, the
       # service will try to reconnect. If a failure happened during connecting, then the service will wait for at least

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
@@ -168,14 +168,10 @@ public final class SubUpdater<T> extends AbstractActorWithTimers {
 
     private void tick(final Clock tick) {
         final boolean forceUpdate = forceUpdate();
-        if (state == State.UPDATING) {
-            log.debug("ignoring tick in state <{}> with changed=<{}>", state, localSubscriptionsChanged);
-        } else if (!localSubscriptionsChanged && !forceUpdate) {
-            log.debug("tick in state <{}> with changed=<{}>: flushing acks", state, localSubscriptionsChanged);
+        if (!localSubscriptionsChanged && !forceUpdate) {
             moveAwaitUpdateToAwaitAcknowledge();
             flushAcknowledgements();
         } else {
-            log.debug("updating");
             final SubscriptionsReader snapshot;
             final CompletionStage<Void> ddataOp;
             if (subscriptions.isEmpty()) {
@@ -203,7 +199,6 @@ public final class SubUpdater<T> extends AbstractActorWithTimers {
     }
 
     private void updateSuccess(final SubscriptionsReader snapshot) {
-        log.debug("updateSuccess");
         flushAcknowledgements();
         state = State.WAITING;
         // race condition possible -- some published messages may arrive before the acknowledgement

--- a/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
+++ b/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
@@ -214,7 +214,7 @@ public final class PubSubFactoryTest {
     }
 
     @Test
-    public void startSeveralTimes() {
+    public void startSeveralTimes() throws Exception {
         // This test simulates the situation where the root actor of a Ditto service restarts several times.
         new TestKit(system2) {{
             // GIVEN: many pub- and sub-factories start under different actors.
@@ -234,6 +234,8 @@ public final class PubSubFactoryTest {
                     sub.subscribeWithAck(singleton("hello"), subscriber.ref()).toCompletableFuture().join();
             assertThat(subAck.getRequest()).isInstanceOf(SubUpdater.Subscribe.class);
             assertThat(subAck.getRequest().getTopics()).containsExactlyInAnyOrder("hello");
+
+            Thread.sleep(500L); // give local subscriber a chance to receive most updated subscriptions
             pub.publish("hello", publisher.ref());
             subscriber.expectMsg("hello");
         }};


### PR DESCRIPTION
* this caused that a client which should be connected did not connect at all after service restart
* reduced logging of SubUpdater which did a lot of noise on debug level