### PR TITLE
Enhance docs of docker deployment (fixes #443)

### DIFF
--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -21,6 +21,30 @@ password in front like this:
 ditto:A6BgmB8IEtPTs
 ```
 
+## Configuration of the services
+
+You may configure each service via passing variables to the java VM in the entrypoint section for each
+service.
+
+```yml
+    ...
+    entrypoint:
+      - java
+      # Alternative approach for configuration of the service
+      - -Dditto.gateway.authentication.devops.password=foobar
+      - -jar
+      - starter.jar
+```
+
+To get a list of available configuration options you may retrieve them from a running instance via:
+
+```bash
+# Substitute gateway with the service you are interested in
+curl http://devops:foobar@localhost:8080/devops/config/gateway/?path=ditto
+```
+
+Or by going through the configuration files in this repository e.g. [/services/gateway/starter/src/main/resources/gateway.conf](https://github.com/eclipse/ditto/blob/master/services/gateway/starter/src/main/resources/gateway.conf).
+
 ## Start Eclipse Ditto
 
 ```bash

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -26,6 +26,12 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
       - REMOTING_IDLE_CPU_LEVEL=1
+    entrypoint:
+      - java
+      # Set additional configuration options here
+      # -Dditto.policies...
+      - -jar
+      - starter.jar
 
   things:
     init: true
@@ -43,6 +49,12 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
       - REMOTING_IDLE_CPU_LEVEL=1
+    entrypoint:
+      - java
+      # Set additional configuration options here
+      # -Dditto.things...
+      - -jar
+      - starter.jar
 
   things-search:
     init: true
@@ -60,6 +72,12 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
       - REMOTING_IDLE_CPU_LEVEL=1
+    entrypoint:
+      - java
+      # Set additional configuration options here
+      # -Dditto.things-search...
+      - -jar
+      - starter.jar
 
   concierge:
     init: true
@@ -77,6 +95,12 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
       - REMOTING_IDLE_CPU_LEVEL=1
+    entrypoint:
+      - java
+      # Set additional configuration options here
+      # -Dditto.concierge...
+      - -jar
+      - starter.jar
 
   connectivity:
     init: true
@@ -95,6 +119,12 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
       - REMOTING_IDLE_CPU_LEVEL=1
+    entrypoint:
+      - java
+      # Set additional configuration options here
+      # -Dditto.connectivity...
+      - -jar
+      - starter.jar
 
   gateway:
     init: true
@@ -116,6 +146,14 @@ services:
       - REMOTING_IDLE_CPU_LEVEL=1
       - ENABLE_DUMMY_AUTH=true
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError
+      # You may use the environment for setting the devops password
+      #- DEVOPS_PASSWORD=foobar
+    entrypoint:
+      - java
+      # Setting the devops password via java VM environment
+      - -Dditto.gateway.authentication.devops.password=foobar
+      - -jar
+      - starter.jar
 
   swagger-ui:
     image: docker.io/swaggerapi/swagger-ui:v3.20.5

--- a/deployment/docker/sandbox/nginx-devops.htpasswd
+++ b/deployment/docker/sandbox/nginx-devops.htpasswd
@@ -1,1 +1,0 @@
-devops:9ht07jdPD3.8U

--- a/deployment/docker/sandbox/nginx.conf
+++ b/deployment/docker/sandbox/nginx.conf
@@ -190,9 +190,6 @@ http {
     location /devops {
       include nginx-cors.conf;
 
-      auth_basic                    "DevOps Authentication required";
-      auth_basic_user_file          nginx-devops.htpasswd;
-
       proxy_pass                    http://gateway:8080/devops;
       proxy_http_version            1.1;
       proxy_set_header              Host                $http_host;

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -11,6 +11,29 @@ Once you have successfully started Ditto, proceed with setting it up for continu
 
 This page shows the basics for operating Ditto.
 
+## Configuration
+
+Each service may be configured via it's java VM variables on service startup.
+
+The following example configures the devops password of the gateway-service started via docker-compose. In order
+to supply additional configuration one has to add the variable in the corresponding `entrypoint` section of the
+`docker-compose.yml` file.
+
+```yml
+    ...
+    entrypoint:
+      - java
+      # Alternative approach for configuration of the service
+      - -Dditto.gateway.authentication.devops.password=foobar
+      - -jar
+      - starter.jar
+```
+
+The executable for the microservice is called `starter.jar`. The configuration variables have to be set before
+the `-jar` option.
+
+For a list of available configuration options go to the respective configuration files under the services 
+directory. E.g. for the gateway service visit [/services/gateway/starter/src/main/resources/gateway.conf](https://github.com/eclipse/ditto/blob/master/services/gateway/starter/src/main/resources/gateway.conf).
 
 ## Logging
 


### PR DESCRIPTION
Add entrypoint section to compose file

To make it more obvious for the operator how a service may be
configured the entrypoint section used for the services is now
explicitly part of the compose file.

This way someone new to ditto and java has a better chance of
understanding how the services may be configured.

Add short summary on config to docker readme

To make it more clear this commit adds a section on configuration
to the docker deployment readme. This section handles two topics.

First the mechanics of a java application configuration are laid out.
The configuration is depicted via the entrypoint section of the
compose-file.
This approach is chosen, because it enables a fairly easy configuration
of the java service via the java VM parameters.
The chosen example is the devops command from the gateway service
due to it's practicability and importance when setting up an instance
for oneself.

Second follows a description on how to retrieve possible configuration
options either via HTTP REST API or via the given configuration files in
the repository. This should enable more people to faster learn how
to work with and configure each service.

Add a config section to operational docs

To enhance the understanding for configuration of the ditto
micro-services this commit adds a configuration section to the public docs
for operators. It contains a docker-specific example and hints on where
to find available configuration options.

This is necessary to give operators new to ditto and java applications
a better start on hosting and using their own instances of ditto.

Remove misleading configuration from sandbox

This will remove confusing and unecessary configuration from the sandbox
in the docker deployment.

Setting a devops user and password basic auth before the devops route is
not just uneccessary, because this is configured in the gateway service
already, it's also misleading to new operators of ditto.

This is an enhancement with regard to #443