### PR TITLE
Fixes #508: Add docs about the openid connect feature

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -28,11 +28,11 @@ A Subject ID must conform to one of the following rules:
 
 * The ID of a User defined in the nginx reverse proxy prefixed with `nginx`.
 * Different JWT providers with their JWT “iss” fields - the currently supported are listed in the table below.
+* OpenID Connect compliant providers - supported providers are listed at [OpenID Connect - Certified OpenID Provider Servers and Services](https://openid.net/developers/certified/) The `sub` claim and configured provider name are used in the form `<provider>:<sub-claim>`.
 
 | Prefix    | Type  | Description   |
 |-----------|-------|---------------|
 | google | jwt | A <a href="#" data-toggle="tooltip" data-original-title="{{site.data.glossary.jwt}}">JWT</a> issued by Google |
-
 
 ## Which Resources can be controlled?
 

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -11,6 +11,53 @@ Once you have successfully started Ditto, proceed with setting it up for continu
 
 This page shows the basics for operating Ditto.
 
+## Configuration
+
+### OpenID Connect
+
+The authentication provider must be added to the ditto-gateway configuration.
+
+```java
+ditto.gateway.authentication {
+    oauth {
+      openid-connect-issuers = {
+        myprovider = "https://localhost:9000/"
+      }
+    }
+}
+```
+
+The configured subject-issuer will be used to prefix the value of the “sub” claim, e.g.
+
+```json
+{
+  "subjects": {
+    "<provider>:<sub-claim>": {
+    "type": "generated"
+    }
+  }
+}
+```
+
+As of the OAuth2.0 and OpenID Connect standards Ditto expects the headers `Authorization: Bearer <JWT>` and 
+`Content-Type: application/json`, containing the issued token of the provider. 
+
+**The token has to be issued beforehand. The required logic is not provided by ditto.** When using 
+the OIDC provider [keycloak](https://www.keycloak.org/), a project like [keycloak-gatekeeper](https://github.com/keycloak/keycloak-gatekeeper) 
+may be put infront of ditto to handle the token-logic.
+
+**If the chosen OIDC provider uses a self-signed certificate**, the certificate has to be retrieved and configured for the 
+akka-http ssl configuration.
+
+```java
+ssl-config {
+  trustManager = {
+    stores = [
+      { type = "PEM", path = "/path/to/cert/globalsign.crt" }
+    ]
+  }
+}
+```
 
 ## Logging
 


### PR DESCRIPTION
The overall documentation is for once extracted from the blog post
about OIDC and verfified with an keycloak and keycloak-gatekeeper setup.

https://www.eclipse.org/ditto/2019-08-28-openid-connect.html

For the user / operator of ditto to know how the subject is addressed
and that OIDC is a valid option in the context of authorization, an
additional bullet-point is added to the list on basic-policy. A list of
certified providers shall aid at this point.

To avoid confusion about the extend of the OIDC implementation, this
adds a notice that tokens have to be issued beforehand and
keycloak-gatekeeper is used as an example application. This is because
keycloak is a common and certified provider and gatekeeper is
maintained by the same team.

Fixes #508 

Signed-off-by: Alexander Wellbrock <a.wellbrock@mailbox.org>