### PR TITLE
Fix state timeout in BaseClientActors

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -155,7 +155,7 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
                 ProtocolAdapterProvider.load(connectivityConfig.getProtocolConfig(), getContext().getSystem());
 
         final BaseClientData startingData = new BaseClientData(connectionId, connection,
-                ConnectivityStatus.UNKNOWN, ConnectivityStatus.OPEN, "initialized", Instant.now(), null, null);
+                ConnectivityStatus.UNKNOWN, ConnectivityStatus.OPEN, "initialized", Instant.now());
 
         clientGauge = DittoMetrics.gauge("connection_client")
                 .tag("id", connectionId.toString())

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -179,7 +179,12 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
 
         // start with UNKNOWN state but send self OpenConnection because client actors are never created closed
         startWith(UNKNOWN, startingData);
-        getSelf().tell(OpenConnection.of(connectionId, DittoHeaders.empty()), getSelf());
+
+        // Always open connection right away when desired---this actor may be deployed onto other instances and
+        // will not be directly controlled by the connection persistence actor.
+        if (connection.getConnectionStatus() == ConnectivityStatus.OPEN) {
+            getSelf().tell(OpenConnection.of(connectionId, DittoHeaders.empty()), getSelf());
+        }
 
         onTransition(this::onTransition);
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientState.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientState.java
@@ -21,6 +21,5 @@ public enum BaseClientState {
     DISCONNECTING,
     DISCONNECTED,
     UNKNOWN,
-    TESTING,
-    INITIATING
+    TESTING
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -99,11 +99,10 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
      */
     @SuppressWarnings("unused")
     private AmqpClientActor(final Connection connection,
-            final ConnectivityStatus connectionStatus,
             final JmsConnectionFactory jmsConnectionFactory,
             final ActorRef conciergeForwarder) {
 
-        super(connection, connectionStatus, conciergeForwarder);
+        super(connection, conciergeForwarder);
         this.jmsConnectionFactory = jmsConnectionFactory;
         connectionListener = new StatusReportingListener(getSelf(), connection.getId(), log, connectionLogger);
         consumerByNamePrefix = new HashMap<>();
@@ -115,12 +114,9 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
      * This constructor is called via reflection by the static method props(Connection, ActorRef).
      */
     @SuppressWarnings("unused")
-    private AmqpClientActor(final Connection connection,
-            final ConnectivityStatus connectionStatus,
-            final ActorRef conciergeForwarder) {
+    private AmqpClientActor(final Connection connection, final ActorRef conciergeForwarder) {
 
-        this(connection, connectionStatus, ConnectionBasedJmsConnectionFactory.getInstance(),
-                conciergeForwarder);
+        this(connection, ConnectionBasedJmsConnectionFactory.getInstance(), conciergeForwarder);
     }
 
     /**
@@ -132,25 +128,22 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
      */
     public static Props props(final Connection connection, final ActorRef conciergeForwarder) {
 
-        return Props.create(AmqpClientActor.class, validateConnection(connection), connection.getConnectionStatus(),
-                conciergeForwarder);
+        return Props.create(AmqpClientActor.class, validateConnection(connection), conciergeForwarder);
     }
 
     /**
      * Creates Akka configuration object for this actor.
      *
      * @param connection connection parameters.
-     * @param connectionStatus the desired status of the connection.
      * @param conciergeForwarder the actor used to send signals to the concierge service.
      * @param jmsConnectionFactory the JMS connection factory.
      * @return the Akka configuration Props object.
      */
     static Props propsForTests(final Connection connection,
-            final ConnectivityStatus connectionStatus,
             final ActorRef conciergeForwarder,
             final JmsConnectionFactory jmsConnectionFactory) {
 
-        return Props.create(AmqpClientActor.class, validateConnection(connection), connectionStatus,
+        return Props.create(AmqpClientActor.class, validateConnection(connection),
                 jmsConnectionFactory, conciergeForwarder);
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ClientConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/ClientConfig.java
@@ -22,14 +22,6 @@ import org.eclipse.ditto.services.utils.config.KnownConfigValue;
 public interface ClientConfig {
 
     /**
-     * Returns the duration after the init process is triggered (in case no connect command was received by the
-     * client actor).
-     *
-     * @return the init timeout.
-     */
-    Duration getInitTimeout();
-
-    /**
      * Initial timeout when connecting to a remote system. If the connection could not be established after this time, the
      * service will try to reconnect. If a failure happened during connecting, then the service will wait for at least this
      * time until it will try to reconnect. The max timeout is defined in {@link ClientConfig#getConnectingMaxTimeout()}.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfig.java
@@ -61,11 +61,6 @@ public final class DefaultClientConfig implements ClientConfig {
     }
 
     @Override
-    public Duration getInitTimeout() {
-        return initTimeout;
-    }
-
-    @Override
     public Duration getConnectingMinTimeout() {
         return connectingMinTimeout;
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActor.java
@@ -31,7 +31,6 @@ import javax.net.ssl.SSLSocketFactory;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.Connection;
-import org.eclipse.ditto.model.connectivity.ConnectivityStatus;
 import org.eclipse.ditto.services.base.config.http.HttpProxyConfig;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientActor;
 import org.eclipse.ditto.services.connectivity.messaging.config.DittoConnectivityConfig;
@@ -61,8 +60,8 @@ public final class HttpPushClientActor extends BaseClientActor {
     private final HttpPushConfig httpPushConfig;
 
     @SuppressWarnings("unused")
-    private HttpPushClientActor(final Connection connection, final ConnectivityStatus desiredConnectionStatus) {
-        super(connection, desiredConnectionStatus, ActorRef.noSender());
+    private HttpPushClientActor(final Connection connection) {
+        super(connection, ActorRef.noSender());
 
         httpPushConfig = DittoConnectivityConfig.of(
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
@@ -79,7 +78,7 @@ public final class HttpPushClientActor extends BaseClientActor {
      * @return the {@code Props} object.
      */
     public static Props props(final Connection connection) {
-        return Props.create(HttpPushClientActor.class, connection, connection.getConnectionStatus());
+        return Props.create(HttpPushClientActor.class, connection);
     }
 
     @Override
@@ -151,7 +150,8 @@ public final class HttpPushClientActor extends BaseClientActor {
                     hostWithoutLookup, port);
         } else {
             // check without HTTP proxy
-            final SSLContextCreator sslContextCreator = SSLContextCreator.fromConnection(connection, DittoHeaders.empty());
+            final SSLContextCreator sslContextCreator =
+                    SSLContextCreator.fromConnection(connection, DittoHeaders.empty());
             final SSLSocketFactory socketFactory = sslContextCreator.withoutClientCertificate().getSocketFactory();
             try (final SSLSocket socket = (SSLSocket) socketFactory.createSocket(hostWithoutLookup, port)) {
                 socket.startHandshake();

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaClientActor.java
@@ -51,11 +51,10 @@ public final class KafkaClientActor extends BaseClientActor {
 
     @SuppressWarnings("unused") // used by `props` via reflection
     private KafkaClientActor(final Connection connection,
-            final ConnectivityStatus desiredConnectionStatus,
             final ActorRef conciergeForwarder,
             final KafkaPublisherActorFactory factory) {
 
-        super(connection, desiredConnectionStatus, conciergeForwarder);
+        super(connection, conciergeForwarder);
         final ConnectionConfig connectionConfig = connectivityConfig.getConnectionConfig();
         final KafkaConfig kafkaConfig = connectionConfig.getKafkaConfig();
         connectionFactory = DefaultKafkaConnectionFactory.getInstance(connection, kafkaConfig);
@@ -75,8 +74,7 @@ public final class KafkaClientActor extends BaseClientActor {
             final ActorRef conciergeForwarder,
             final KafkaPublisherActorFactory factory) {
 
-        return Props.create(KafkaClientActor.class, validateConnection(connection), connection.getConnectionStatus(),
-                conciergeForwarder, factory);
+        return Props.create(KafkaClientActor.class, validateConnection(connection), conciergeForwarder, factory);
     }
 
     private static Connection validateConnection(final Connection connection) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/alpakka/MqttClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/alpakka/MqttClientActor.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.Connection;
-import org.eclipse.ditto.model.connectivity.ConnectivityStatus;
 import org.eclipse.ditto.model.connectivity.Source;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientActor;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientData;
@@ -83,12 +82,10 @@ public final class MqttClientActor extends BaseClientActor {
     private ActorRef mqttPublisherActor;
 
     @SuppressWarnings("unused")
-    MqttClientActor(final Connection connection,
-            final ConnectivityStatus desiredConnectionStatus,
-            final ActorRef conciergeForwarder,
+    MqttClientActor(final Connection connection, final ActorRef conciergeForwarder,
             final BiFunction<Connection, DittoHeaders, MqttConnectionFactory> connectionFactoryCreator) {
 
-        super(connection, desiredConnectionStatus, conciergeForwarder);
+        super(connection, conciergeForwarder);
         this.connectionFactoryCreator = connectionFactoryCreator;
         consumerByActorNameWithIndex = new HashMap<>();
         pendingStatusReportsFromStreams = new HashSet<>();
@@ -99,11 +96,9 @@ public final class MqttClientActor extends BaseClientActor {
     }
 
     @SuppressWarnings("unused") // used by `props` via reflection
-    private MqttClientActor(final Connection connection,
-            final ConnectivityStatus desiredConnectionStatus,
-            final ActorRef conciergeForwarder) {
+    private MqttClientActor(final Connection connection, final ActorRef conciergeForwarder) {
 
-        this(connection, desiredConnectionStatus, conciergeForwarder, MqttConnectionFactory::of);
+        this(connection, conciergeForwarder, MqttConnectionFactory::of);
     }
 
     /**
@@ -115,8 +110,7 @@ public final class MqttClientActor extends BaseClientActor {
      */
     public static Props props(final Connection connection, final ActorRef conciergeForwarder) {
 
-        return Props.create(MqttClientActor.class, validateConnection(connection), connection.getConnectionStatus(),
-                conciergeForwarder);
+        return Props.create(MqttClientActor.class, validateConnection(connection), conciergeForwarder);
     }
 
     private static Connection validateConnection(final Connection connection) {
@@ -206,7 +200,7 @@ public final class MqttClientActor extends BaseClientActor {
      * @param connection connection of the publisher and subscribers.
      */
     private void connectClient(final Connection connection) {
-        factory = connectionFactoryCreator.apply(connection, stateData().getSessionHeaders());
+        factory = connectionFactoryCreator.apply(connection, stateData().getLastSessionHeaders());
         getSelf().tell((ClientConnected) () -> null, ActorRef.noSender());
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/HiveMqtt3ClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/HiveMqtt3ClientActor.java
@@ -62,7 +62,7 @@ public final class HiveMqtt3ClientActor extends BaseClientActor {
     private HiveMqtt3ClientActor(final Connection connection,
             final ActorRef conciergeForwarder,
             final HiveMqtt3ClientFactory clientFactory) {
-        super(connection, connection.getConnectionStatus(), conciergeForwarder);
+        super(connection, conciergeForwarder);
         this.clientFactory = clientFactory;
 
         final MqttSpecificConfig mqttSpecificConfig = MqttSpecificConfig.fromConnection(connection);

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
@@ -524,6 +524,8 @@ public final class ConnectionPersistenceActor
             origin.tell(TestConnectionResponse.alreadyCreated(entityId, command.getDittoHeaders()), self);
         } else {
             // no need to start more than 1 client for tests
+            // set connection status to CLOSED so that client actors will not try to connect on startup
+            setConnectionStatusClosedForTestConnection();
             startAndAskClientActors(command.getCommand(), 1)
                     .thenAccept(response -> self.tell(
                             command.withResponse(TestConnectionResponse.success(command.getConnectionEntityId(),
@@ -536,6 +538,12 @@ public final class ConnectionPersistenceActor
                                 ActorRef.noSender());
                         return null;
                     });
+        }
+    }
+
+    private void setConnectionStatusClosedForTestConnection() {
+        if (entity != null) {
+            entity = entity.toBuilder().connectionStatus(ConnectivityStatus.CLOSED).build();
         }
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActor.java
@@ -90,11 +90,10 @@ public final class RabbitMQClientActor extends BaseClientActor {
      */
     @SuppressWarnings("unused")
     private RabbitMQClientActor(final Connection connection,
-            final ConnectivityStatus connectionStatus,
             final RabbitConnectionFactoryFactory rabbitConnectionFactoryFactory,
             final ActorRef conciergeForwarder) {
 
-        super(connection, connectionStatus, conciergeForwarder);
+        super(connection, conciergeForwarder);
 
         this.rabbitConnectionFactoryFactory = rabbitConnectionFactoryFactory;
         consumedTagsToAddresses = new HashMap<>();
@@ -107,12 +106,9 @@ public final class RabbitMQClientActor extends BaseClientActor {
      * This constructor is called via reflection by the static method props(Connection, ActorRef).
      */
     @SuppressWarnings("unused")
-    private RabbitMQClientActor(final Connection connection,
-            final ConnectivityStatus connectionStatus,
-            final ActorRef conciergeForwarder) {
+    private RabbitMQClientActor(final Connection connection, final ActorRef conciergeForwarder) {
 
-        this(connection, connectionStatus,
-                ConnectionBasedRabbitConnectionFactoryFactory.getInstance(), conciergeForwarder);
+        this(connection, ConnectionBasedRabbitConnectionFactoryFactory.getInstance(), conciergeForwarder);
     }
 
     /**
@@ -124,26 +120,23 @@ public final class RabbitMQClientActor extends BaseClientActor {
      */
     public static Props props(final Connection connection, final ActorRef conciergeForwarder) {
 
-        return Props.create(RabbitMQClientActor.class, validateConnection(connection), connection.getConnectionStatus(),
-                conciergeForwarder);
+        return Props.create(RabbitMQClientActor.class, validateConnection(connection), conciergeForwarder);
     }
 
     /**
      * Creates Akka configuration object for this actor.
      *
      * @param connection the connection.
-     * @param connectionStatus the desired status of the.
      * @param conciergeForwarder the actor used to send signals to the concierge service.
      * @param rabbitConnectionFactoryFactory the ConnectionFactory Factory to use.
      * @return the Akka configuration Props object.
      */
     static Props propsForTests(final Connection connection,
-            final ConnectivityStatus connectionStatus,
             final ActorRef conciergeForwarder,
             final RabbitConnectionFactoryFactory rabbitConnectionFactoryFactory) {
 
-        return Props.create(RabbitMQClientActor.class, validateConnection(connection), connectionStatus,
-                rabbitConnectionFactoryFactory, conciergeForwarder);
+        return Props.create(RabbitMQClientActor.class, validateConnection(connection), rabbitConnectionFactoryFactory,
+                conciergeForwarder);
     }
 
     private static Connection validateConnection(final Connection connection) {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -161,7 +161,10 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     @BeforeClass
     public static void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem", TestConstants.CONFIG);
-        connection = TestConstants.createConnection(CONNECTION_ID);
+        connection = TestConstants.createConnection(CONNECTION_ID)
+                .toBuilder()
+                .connectionStatus(ConnectivityStatus.CLOSED)
+                .build();
     }
 
     @AfterClass

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -217,10 +217,9 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                 .build();
 
         final ThrowableAssert.ThrowingCallable props1 =
-                () -> AmqpClientActor.propsForTests(connection, connectionStatus, null, null);
+                () -> AmqpClientActor.propsForTests(connection, null, null);
         final ThrowableAssert.ThrowingCallable props2 =
-                () -> AmqpClientActor.propsForTests(connection, connectionStatus, null,
-                        jmsConnectionFactory);
+                () -> AmqpClientActor.propsForTests(connection, null, jmsConnectionFactory);
 
         Stream.of(props1, props2).forEach(throwingCallable ->
                 assertThatExceptionOfType(ConnectionConfigurationInvalidException.class)
@@ -232,7 +231,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void testExceptionDuringJMSConnectionCreation() {
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (theConnection, exceptionListener) -> {
                                 throw JMS_EXCEPTION;
                             });
@@ -250,7 +249,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             final TestProbe aggregator = new TestProbe(actorSystem);
 
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (connection1, exceptionListener) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
             watch(amqpClientActor);
@@ -273,7 +272,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void testReconnect() {
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (connection1, exceptionListener) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
             watch(amqpClientActor);
@@ -301,7 +300,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             final TestProbe aggregator = new TestProbe(actorSystem);
 
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (connection1, exceptionListener) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
             watch(amqpClientActor);
@@ -342,7 +341,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
         new TestKit(actorSystem) {{
             final CountDownLatch latch = new CountDownLatch(1);
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> waitForLatchAndReturn(latch, mockConnection));
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
             watch(amqpClientActor);
@@ -359,7 +358,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void sendConnectCommandWhenAlreadyConnected() throws JMSException {
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -378,7 +377,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void sendDisconnectWhenAlreadyDisconnected() {
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -393,7 +392,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
         new TestKit(actorSystem) {{
             doThrow(JMS_EXCEPTION).when(mockConnection).start();
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -407,7 +406,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
         new TestKit(actorSystem) {{
             doThrow(JMS_EXCEPTION).when(mockConnection).createSession(Session.CLIENT_ACKNOWLEDGE);
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -422,7 +421,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
             when(mockConnection.createSession(Session.CLIENT_ACKNOWLEDGE)).thenReturn(mockSession);
             doThrow(JMS_EXCEPTION).when(mockSession).createConsumer(any());
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -436,7 +435,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
         new TestKit(actorSystem) {{
             doThrow(JMS_EXCEPTION).when(mockConnection).close();
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus,
+                    AmqpClientActor.propsForTests(connection,
                             getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -463,7 +462,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(), (ac, el) -> mockConnection);
+                    AmqpClientActor.propsForTests(connection, getRef(), (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
             // connect
@@ -552,7 +551,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -618,7 +617,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -661,7 +660,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -692,7 +691,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void testReceiveThingEventAndExpectForwardToJMSProducer() throws JMSException {
         final Target target = TestConstants.Targets.TWIN_TARGET;
         new TestKit(actorSystem) {{
-            final Props props = AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+            final Props props = AmqpClientActor.propsForTests(connection, getRef(),
                     (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -706,7 +705,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     @Test
     public void testConsumerClosedWhenConnected() throws JMSException {
         new TestKit(actorSystem) {{
-            final Props props = AmqpClientActor.propsForTests(singleConsumerConnection(), connectionStatus, getRef(),
+            final Props props = AmqpClientActor.propsForTests(singleConsumerConnection(), getRef(),
                     (ac, el) -> mockConnection);
             final TestActorRef<AmqpClientActor> amqpClientActorRef = TestActorRef.apply(props, actorSystem);
             final AmqpClientActor amqpClientActor = amqpClientActorRef.underlyingActor();
@@ -740,7 +739,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
         try {
             new TestKit(actorSystem) {{
                 final Props props =
-                        AmqpClientActor.propsForTests(singleConsumerConnection(), connectionStatus, getRef(),
+                        AmqpClientActor.propsForTests(singleConsumerConnection(), getRef(),
                                 (ac, el) -> mockConnection);
                 final TestActorRef<AmqpClientActor> amqpClientActorRef = TestActorRef.apply(props, actorSystem);
                 final AmqpClientActor amqpClientActor = amqpClientActorRef.underlyingActor();
@@ -860,7 +859,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void testTestConnection() {
         new TestKit(actorSystem) {{
             final Props props =
-                    AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                    AmqpClientActor.propsForTests(connection, getRef(),
                             (ac, el) -> mockConnection);
             final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -877,7 +876,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                 when(mockConnection.createSession(Session.CLIENT_ACKNOWLEDGE))
                         .thenAnswer(invocationOnMock -> waitForLatchAndReturn(latch, mockSession));
                 final Props props =
-                        AmqpClientActor.propsForTests(connection, connectionStatus, getRef(),
+                        AmqpClientActor.propsForTests(connection, getRef(),
                                 (ac, el) -> mockConnection);
                 final ActorRef amqpClientActor = actorSystem.actorOf(props);
 
@@ -918,8 +917,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
 
     @Override
     protected Props createClientActor(final ActorRef conciergeForwarder) {
-        return AmqpClientActor.propsForTests(connection, connectionStatus, conciergeForwarder,
-                (ac, el) -> mockConnection);
+        return AmqpClientActor.propsForTests(connection, conciergeForwarder, (ac, el) -> mockConnection);
     }
 
     @Override

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfigTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultClientConfigTest.java
@@ -61,9 +61,6 @@ public final class DefaultClientConfigTest {
     public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
         final DefaultClientConfig underTest = DefaultClientConfig.of(ConfigFactory.empty());
 
-        softly.assertThat(underTest.getInitTimeout())
-                .as(ClientConfig.ClientConfigValue.INIT_TIMEOUT.getConfigPath())
-                .isEqualTo(ClientConfig.ClientConfigValue.INIT_TIMEOUT.getDefaultValue());
         softly.assertThat(underTest.getConnectingMinTimeout())
                 .as(ClientConfig.ClientConfigValue.CONNECTING_MIN_TIMEOUT.getConfigPath())
                 .isEqualTo(ClientConfig.ClientConfigValue.CONNECTING_MIN_TIMEOUT.getDefaultValue());
@@ -88,9 +85,6 @@ public final class DefaultClientConfigTest {
     public void underTestReturnsValuesOfConfigFile() {
         final DefaultClientConfig underTest = DefaultClientConfig.of(clientTestConf);
 
-        softly.assertThat(underTest.getInitTimeout())
-                .as(ClientConfig.ClientConfigValue.INIT_TIMEOUT.getConfigPath())
-                .isEqualTo(Duration.ofSeconds(1L));
         softly.assertThat(underTest.getConnectingMinTimeout())
                 .as(ClientConfig.ClientConfigValue.CONNECTING_MIN_TIMEOUT.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(30L));

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
@@ -278,7 +278,7 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
     private Connection getConnectionToLocalBinding(final boolean isSecure) {
         return ConnectivityModelFactory.newConnectionBuilder(TestConstants.createRandomConnectionId(),
                 ConnectionType.HTTP_PUSH,
-                ConnectivityStatus.OPEN,
+                ConnectivityStatus.CLOSED,
                 (isSecure ? "https" : "http") + "://127.0.0.1:" + binding.localAddress().getPort())
                 .targets(singletonList(TARGET))
                 .validateCertificate(isSecure)

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaClientActorTest.java
@@ -126,7 +126,7 @@ public final class KafkaClientActorTest extends AbstractBaseClientActorTest {
         final String serverHost = "tcp://" + hostAndPort;
         final Map<String, String> specificConfig = specificConfigWithBootstrapServers(hostAndPort);
         connection = ConnectivityModelFactory.newConnectionBuilder(connectionId, ConnectionType.KAFKA,
-                ConnectivityStatus.OPEN, serverHost)
+                ConnectivityStatus.CLOSED, serverHost)
                 .targets(singletonList(TARGET))
                 .failoverEnabled(true)
                 .specificConfig(specificConfig)

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/AbstractMqttClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/AbstractMqttClientActorTest.java
@@ -113,7 +113,7 @@ public abstract class AbstractMqttClientActorTest<M> extends AbstractBaseClientA
         connectionId = TestConstants.createRandomConnectionId();
         serverHost = "tcp://localhost:" + freePort.getPort();
         connection = ConnectivityModelFactory.newConnectionBuilder(connectionId, ConnectionType.MQTT,
-                ConnectivityStatus.OPEN, serverHost)
+                ConnectivityStatus.CLOSED, serverHost)
                 .sources(singletonList(MQTT_SOURCE))
                 .targets(singletonList(TARGET))
                 .failoverEnabled(true)

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/alpakka/MqttClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/alpakka/MqttClientActorTest.java
@@ -72,8 +72,7 @@ public final class MqttClientActorTest extends AbstractMqttClientActorTest<MqttM
     private static Props mqttClientActor(final Connection connection, final ActorRef conciergeForwarder,
             final BiFunction<Connection, DittoHeaders, MqttConnectionFactory> factoryCreator) {
 
-        return Props.create(MqttClientActor.class, connection, connection.getConnectionStatus(), conciergeForwarder,
-                factoryCreator);
+        return Props.create(MqttClientActor.class, connection, conciergeForwarder, factoryCreator);
     }
 
     @Override

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
@@ -107,10 +107,10 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
                 .build();
 
         final ThrowableAssert.ThrowingCallable props1 =
-                () -> RabbitMQClientActor.propsForTests(connection, CONNECTION_STATUS,
+                () -> RabbitMQClientActor.propsForTests(connection,
                         null, null);
         final ThrowableAssert.ThrowingCallable props2 =
-                () -> RabbitMQClientActor.propsForTests(connection, CONNECTION_STATUS,
+                () -> RabbitMQClientActor.propsForTests(connection,
                         null, rabbitConnectionFactoryFactory);
         Stream.of(props1, props2)
                 .forEach(throwingCallable ->
@@ -125,7 +125,7 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
     public void testExceptionDuringConnectionFactoryCreation() {
         new TestKit(actorSystem) {{
             final Props props =
-                    RabbitMQClientActor.propsForTests(connection, CONNECTION_STATUS,
+                    RabbitMQClientActor.propsForTests(connection,
                             getRef(), (con, exHandler) -> { throw CUSTOM_EXCEPTION; })
                             .withDispatcher(CallingThreadDispatcher.Id());
             final ActorRef connectionActor = actorSystem.actorOf(props);
@@ -158,7 +158,7 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
             final Connection connectionWithoutTargets =
                     TestConstants.createConnection(randomConnectionId, new Target[0]);
             final Props props =
-                    RabbitMQClientActor.propsForTests(connectionWithoutTargets, CONNECTION_STATUS, getRef(),
+                    RabbitMQClientActor.propsForTests(connectionWithoutTargets, getRef(),
                             (con, exHandler) -> mockConnectionFactory).withDispatcher(CallingThreadDispatcher.Id());
             final ActorRef rabbitClientActor = actorSystem.actorOf(props);
             watch(rabbitClientActor);
@@ -251,7 +251,7 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
 
     @Override
     protected Props createClientActor(final ActorRef conciergeForwarder) {
-        return RabbitMQClientActor.propsForTests(getConnection(), CONNECTION_STATUS, conciergeForwarder,
+        return RabbitMQClientActor.propsForTests(getConnection(), conciergeForwarder,
                 (con, exHandler) -> mockConnectionFactory).withDispatcher(CallingThreadDispatcher.Id());
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQClientActorTest.java
@@ -83,7 +83,10 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
     @BeforeClass
     public static void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem", TestConstants.CONFIG);
-        connection = TestConstants.createConnection(CONNECTION_ID);
+        connection = TestConstants.createConnection(CONNECTION_ID)
+                .toBuilder()
+                .connectionStatus(ConnectivityStatus.CLOSED)
+                .build();
     }
 
     @AfterClass
@@ -101,10 +104,10 @@ public final class RabbitMQClientActorTest extends AbstractBaseClientActorTest {
     public void invalidTargetFormatThrowsConnectionConfigurationInvalidException() {
         final Connection connection =
                 ConnectivityModelFactory.newConnectionBuilder(CONNECTION_ID, ConnectionType.AMQP_091,
-                ConnectivityStatus.OPEN, TestConstants.getUriOfNewMockServer())
-                .targets(Collections.singletonList(ConnectivityModelFactory.newTarget("exchangeOnly",
-                        TestConstants.Authorization.AUTHORIZATION_CONTEXT, null, null, Topic.TWIN_EVENTS)))
-                .build();
+                        ConnectivityStatus.OPEN, TestConstants.getUriOfNewMockServer())
+                        .targets(Collections.singletonList(ConnectivityModelFactory.newTarget("exchangeOnly",
+                                TestConstants.Authorization.AUTHORIZATION_CONTEXT, null, null, Topic.TWIN_EVENTS)))
+                        .build();
 
         final ThrowableAssert.ThrowingCallable props1 =
                 () -> RabbitMQClientActor.propsForTests(connection,

--- a/services/connectivity/messaging/src/test/resources/client-test.conf
+++ b/services/connectivity/messaging/src/test/resources/client-test.conf
@@ -1,6 +1,5 @@
 # init timeout for client actors (if no connect msg is received the parent actor is asked whether to connect)
 client {
-  init-timeout = 1s
   connecting-min-timeout = 30s
   connecting-max-timeout = 120s
   connecting-max-tries = 10

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -125,7 +125,6 @@ ditto {
     }
 
     client {
-      init-timeout = 3s
       connecting-min-timeout = 5s
       connecting-max-timeout = 5s
       connecting-max-tries = 10

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -173,11 +173,6 @@ ditto {
     }
 
     client {
-      # Init timeout for client actors (if no connect msg is received the parent actor is asked whether to connect)
-      # Running into init-timeout is the only way for client actors on remote nodes to start a connection.
-      # Set to be as short as possible without timing out the local client actor, which is used for acknowledgement.
-      init-timeout = 3s
-      init-timeout = ${?CONNECTIVITY_CLIENT_INIT_TIMEOUT}
       # Initial timeout when connecting to a remote system. If the connection could not be established after this time, the
       # service will try to reconnect. If a failure happened during connecting, then the service will wait for at least
       # this time until it will try to reconnect. The max timeout is defined in connecting-max-timeout.


### PR DESCRIPTION
BaseClientActors sometimes did not receive the state timeout message reliably.
That was causing trouble for scaled connections (clientCount > 1) as the scaled connections did not connect to their backends like they should have.
This fixes that bug by simplifying the connection logic (by default always connect).