### PR TITLE
Make field "message" optional in serialization of DittoRuntimeException.

### DIFF
--- a/signals/base/src/main/java/org/eclipse/ditto/signals/base/GlobalErrorRegistry.java
+++ b/signals/base/src/main/java/org/eclipse/ditto/signals/base/GlobalErrorRegistry.java
@@ -99,10 +99,9 @@ public final class GlobalErrorRegistry
                             dittoHeaders));
         }
 
+        @Nullable
         private static String getMessage(final JsonObject jsonObject) {
-            return jsonObject.getValue(DittoJsonException.JsonFields.MESSAGE)
-                    .orElseThrow(() -> JsonMissingFieldException.newBuilder()
-                            .fieldName(DittoRuntimeException.JsonFields.MESSAGE.getPointer().toString()).build());
+            return jsonObject.getValue(DittoJsonException.JsonFields.MESSAGE).orElse(null);
         }
 
         @Nullable


### PR DESCRIPTION
Reason: Field "message" is nullable in DittoRuntimeException. If it is null, then the corresponding JSON field will not be there during serialization, causing an error at deserialization time and masking the actual DittoRuntimeException.