### PR TITLE
Document id regexes

### DIFF
--- a/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
+++ b/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
@@ -107,6 +107,9 @@ entries:
         - title: Policy
           url: /basic-policy.html
           output: web
+        - title: Namespaces and Names
+          url: /basic-namespaces-and-names.html
+          output: web
 
     - title: Authentication and Authorization
       url: /basic-auth.html

--- a/documentation/src/main/resources/jsonschema/thing_v1.json
+++ b/documentation/src/main/resources/jsonschema/thing_v1.json
@@ -6,7 +6,7 @@
   "properties": {
     "thingId": {
       "type": "string",
-      "description": "Unique identifier representing the Thing - has to:\n * contain the mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character\n * conform to [RFC-3986 (URI)](https://www.ietf.org/rfc/rfc3986.txt).\n\nExamples for a valid Thing ID:\n * `org.eclipse.ditto:xdk_53`\n * `foo:xdk_53`\n * `org.eclipse.vorto_42:xdk_thing`"
+      "description": "Unique identifier representing the Thing, has to conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).\n\nExamples for a valid Thing ID:\n * `org.eclipse.ditto:xdk_53`\n * `foo:xdk_53`\n * `org.eclipse.vorto_42:xdk_thing`"
     },
     "acl": {
       "title": "ACL",

--- a/documentation/src/main/resources/jsonschema/thing_v2.json
+++ b/documentation/src/main/resources/jsonschema/thing_v2.json
@@ -6,11 +6,11 @@
   "properties": {
     "thingId": {
       "type": "string",
-      "description": "Unique identifier representing the Thing - has to:\n * contain the mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character\n * conform to [RFC-3986 (URI)](https://www.ietf.org/rfc/rfc3986.txt).\n\nExamples for a valid Thing ID:\n * `org.eclipse.ditto:xdk_53`\n * `foo:xdk_53`\n * `org.eclipse.vorto_42:xdk_thing`"
+      "description": "Unique identifier representing the Thing, has to conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).\n\nExamples for a valid Thing ID:\n * `org.eclipse.ditto:xdk_53`\n * `foo:xdk_53`\n * `org.eclipse.vorto_42:xdk_thing`"
     },
     "policyId": {
       "type": "string",
-      "description": "Links to the ID of an existing Policy which contains the authorization information applied for this Thing."
+      "description": "Links to the ID of an existing Policy which contains the authorization information applied for this Thing. The policy ID has to conform to the namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))."
     },
     "attributes": {
       "title": "Attributes",

--- a/documentation/src/main/resources/openapi/ditto-api-1.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-1.yml
@@ -868,7 +868,7 @@ paths:
           $ref: '#/components/responses/preconditionFailed'
   '/things/{thingId}/attributes/{attributePath}':
     get:
-      ummary: Retrieve a specific Attribute of a specific Thing
+      summary: Retrieve a specific Attribute of a specific Thing
       description: |-
         Returns a specific Attribute of the Thing identified by the `thingId` path parameter. The Attribute (JSON) can be referenced hierarchically by applying JSON Pointer notation (RFC-6901), e.g.:
         `/things/{thingId}/attributes/address/city` in order to retrieve the `city` field of an `address` object.
@@ -2434,7 +2434,7 @@ components:
         - message
     Attributes:
       type: object
-      description: An arbitrary JSON object.
+      description: "Attributes of a Thing: an arbitrary JSON object."
     FeatureDefinition:
       type: array
       items:
@@ -2445,16 +2445,14 @@ components:
       pattern: ([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)
     FeatureProperties:
       type: object
-      description: An arbitrary JSON object.
+      description: "Properties of a Feature: an arbitrary JSON object."
     Feature:
       type: object
       properties:
         definition:
           $ref: '#/components/schemas/FeatureDefinition'
-          description: The Definition of this Feature
         properties:
           $ref: '#/components/schemas/FeatureProperties'
-          description: The Properties of this Feature
     SearchResultThings:
       properties:
         items:
@@ -2470,13 +2468,10 @@ components:
       properties:
         acl:
           $ref: '#/components/schemas/Acl'
-          description: The Access Control List of this Thing containing one AclEntry for each
         attributes:
           $ref: '#/components/schemas/Attributes'
-          description: The attributes of this Thing
         features:
           $ref: '#/components/schemas/Features'
-          description: The Features of this Thing
     Thing:
       type: object
       required:
@@ -2492,17 +2487,13 @@ components:
             (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
         acl:
           $ref: '#/components/schemas/Acl'
-          description: The Access Control List of this Thing containing one AclEntry for each arbitrary `authorizationSubject` key
         attributes:
           $ref: '#/components/schemas/Attributes'
-          description: The attributes of this Thing
         features:
           $ref: '#/components/schemas/Features'
-          description: The Features of this Thing
     Acl:
       type: object
       description: Access Control List containing one AclEntry for each arbitrary `authorizationSubject` key
-      properties:
       additionalProperties:
         $ref: '#/components/schemas/AclEntry'
     AclEntry:
@@ -2525,7 +2516,6 @@ components:
     Features:
       type: object
       description: List of Features where the key represents the `featureId` of each Feature. The `featureId` key must be unique in the list.
-      properties:
       additionalProperties:
         $ref: '#/components/schemas/Feature'
   responses:

--- a/documentation/src/main/resources/openapi/ditto-api-1.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-1.yml
@@ -167,12 +167,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -194,10 +191,8 @@ paths:
     put:
       summary: Create or update a Thing with a specified ID
       description: |-
-        Create or update the Thing specified by the `thingId` path parameter and the optional JSON body. The `thingId` has to:
-
-          * contain a mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
-          * conform to RFC-3986 (URI)
+        Create or update the Thing specified by the `thingId` path parameter and the optional JSON body. The `thingId` has to
+        conform to the [namespaced entity ID notation](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id).
 
         #### Valid examples
 
@@ -312,12 +307,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON of the Thing to be created/modified was either invalid or did contain a `thingId` which did not match the ID in the URL.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON of the Thing to be created/modified was either invalid or did contain a `thingId` which did not match the ID in the URL.
           content:
             application/json:
               schema:
@@ -369,10 +361,8 @@ paths:
           description: The Thing was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -440,10 +430,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -487,12 +475,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid ACL JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid ACL JSON object.
           content:
             application/json:
               schema:
@@ -571,10 +556,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -637,12 +620,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid ACL JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid ACL JSON object.
           content:
             application/json:
               schema:
@@ -692,10 +672,8 @@ paths:
           description: The ACL entry was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -752,10 +730,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -814,12 +790,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid or was not a JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid or was not a JSON object.
           content:
             application/json:
               schema:
@@ -865,10 +838,8 @@ paths:
           description: The Attributes were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -922,10 +893,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -982,10 +951,8 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1032,10 +999,8 @@ paths:
           description: The Attribute was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1102,12 +1067,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1167,12 +1129,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid or was not a JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid or was not a JSON object.
           content:
             application/json:
               schema:
@@ -1225,10 +1184,8 @@ paths:
           description: The Features were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1285,12 +1242,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1349,12 +1303,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON of the Feature to be created was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON of the Feature to be created was invalid.
           content:
             application/json:
               schema:
@@ -1408,10 +1359,8 @@ paths:
           description: The Feature was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1469,12 +1418,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1538,12 +1484,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1602,10 +1545,8 @@ paths:
           description: The Definition was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1666,12 +1607,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1727,12 +1665,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1786,10 +1721,8 @@ paths:
           description: The Properties were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1844,10 +1777,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1901,12 +1832,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1955,10 +1883,8 @@ paths:
           description: The Property was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2007,12 +1933,9 @@ paths:
           description: The Claim message was processed successfully and no custom response body was set. The response code defaults to `204` but may be chosen by the recipient.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2061,12 +1984,9 @@ paths:
           description: The message was sent but not necessarly received by the Thing (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2115,12 +2035,9 @@ paths:
           description: The message was sent (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2170,12 +2087,9 @@ paths:
           description: The message was sent but not necessarly received by the Feature (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2225,12 +2139,9 @@ paths:
           description: The message was sent (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2577,10 +2488,8 @@ components:
         thingId:
           type: string
           description: |-
-            Unique identifier representing the Thing - has to:
-
-              * contain the mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
-              * conform to RFC-3986 (URI)
+            Unique identifier representing the Thing, has to conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
         acl:
           $ref: '#/components/schemas/Acl'
           description: The Access Control List of this Thing containing one AclEntry for each arbitrary `authorizationSubject` key
@@ -2700,10 +2609,8 @@ components:
       name: thingId
       in: path
       description: |-
-        The ID of the Thing - has to:
-
-          * contain the mandatory namespace prefix (java package notation + `:` colon)
-          * conform to RFC-3986 (URI)
+        The ID of the Thing has to conform to the namespaced entity ID notation
+        (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
       required: true
       schema:
         type: string

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -201,12 +201,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -232,10 +229,8 @@ paths:
       summary: Create or update a Thing with a specified ID
       description: |-
         Create or update the Thing specified by the `thingId` path parameter and
-        the optional JSON body. The `thingId` has to:
-
-          * contain a mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
-          * conform to RFC-3986 (URI)
+        the optional JSON body. The `thingId` does not conform to the namespaced entity ID notation
+        (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
 
         #### Valid examples
 
@@ -349,12 +344,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON of the Thing to be created/modified was either invalid
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON of the Thing to be created/modified was either invalid
             or did contain a `thingId` which did not match the ID in the URL.
           content:
             application/json:
@@ -416,10 +408,8 @@ paths:
           description: The Thing was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+          (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -476,10 +466,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -537,10 +525,8 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -573,10 +559,8 @@ paths:
               example: '<namespace>:<policyName>'
         description: |-
           The Policy ID used for controlling access to this Thing. Managed by
-          resource `/policies/{policyId}`.
-
-            * contain the mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
-            * conform to RFC-3986 (URI)
+          resource `/policies/{policyId}`. The `policyId` has to conform to the namespaced entity ID notation
+          (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
         required: true
   '/things/{thingId}/attributes':
     get:
@@ -608,10 +592,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -673,12 +655,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid or was not a JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid or was not a JSON object.
           content:
             application/json:
               schema:
@@ -727,10 +706,8 @@ paths:
           description: The Attributes were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -788,10 +765,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -854,10 +829,8 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -910,10 +883,8 @@ paths:
           description: The Attribute was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -988,12 +959,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1058,12 +1026,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid or was not a JSON object.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid or was not a JSON object.
           content:
             application/json:
               schema:
@@ -1120,10 +1085,8 @@ paths:
           description: The Features were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1183,12 +1146,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1251,12 +1211,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON of the Feature to be created was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON of the Feature to be created was invalid.
           content:
             application/json:
               schema:
@@ -1314,10 +1271,8 @@ paths:
           description: The Feature was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1376,12 +1331,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1445,12 +1397,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1510,10 +1459,8 @@ paths:
           description: The Definition was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1574,12 +1521,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined query parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined query parameters was invalid.
           content:
             application/json:
               schema:
@@ -1640,12 +1584,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1705,10 +1646,8 @@ paths:
           description: The Properties were successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1768,10 +1707,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1833,12 +1770,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid.
           content:
             application/json:
               schema:
@@ -1892,10 +1826,8 @@ paths:
           description: The Property was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -1958,12 +1890,9 @@ paths:
             by the recipient.
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2016,12 +1945,9 @@ paths:
             The message was sent but not necessarily received by the Thing (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2070,12 +1996,9 @@ paths:
           description: The message was sent (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2127,12 +2050,9 @@ paths:
             (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2182,12 +2102,9 @@ paths:
           description: The message was sent (fire and forget).
         '400':
           description: |-
-            The request could not be completed. The `thingId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or at least one of the defined path parameters was invalid.
+            The request could not be completed. Either the `thingId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or at least one of the defined path parameters was invalid.
           content:
             application/json:
               schema:
@@ -2245,10 +2162,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2273,10 +2188,8 @@ paths:
     put:
       summary: Create or update a Policy with a specified ID
       description: |-
-        Modify the complete Policy identified by the `policyId` path parameter. The `policyId` has to:
-
-          * contain a mandatory namespace prefix (java package notation + `:` colon) - periods (`.`) may be used in namespace but not as first or last character
-          * conform to RFC-3986 (URI)
+        Modify the complete Policy identified by the `policyId` path parameter. The `policyId` has to conform to the
+        namespaced entity ID notation (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
 
         #### Valid examples
 
@@ -2327,12 +2240,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Policy JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Policy JSON object.
           content:
             application/json:
               schema:
@@ -2394,12 +2304,9 @@ paths:
           description: The Policy was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Policy JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Policy JSON object.
           content:
             application/json:
               schema:
@@ -2459,10 +2366,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2507,12 +2412,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Policy entry JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Policy entry JSON object.
           content:
             application/json:
               schema:
@@ -2589,10 +2491,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2657,12 +2557,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Policy entry JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Policy entry JSON object.
           content:
             application/json:
               schema:
@@ -2723,10 +2620,8 @@ paths:
           description: The Policy entry was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2786,10 +2681,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2837,12 +2730,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Subjects JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Subjects JSON object.
           content:
             application/json:
               schema:
@@ -2921,10 +2811,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -2990,12 +2878,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Subject JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Subject JSON object.
           content:
             application/json:
               schema:
@@ -3054,10 +2939,8 @@ paths:
           description: The Subject was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -3118,10 +3001,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -3169,12 +3050,9 @@ paths:
                 type: string
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Resources JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Resources JSON object.
           content:
             application/json:
               schema:
@@ -3249,10 +3127,8 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -3320,12 +3196,9 @@ paths:
           $ref: '#/components/responses/notModified'
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
-
-            Or the JSON was invalid, or no valid Resource JSON object.
+            The request could not be completed. Either the `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id))
+            or the JSON was invalid, or no valid Resource JSON object.
           content:
             application/json:
               schema:
@@ -3384,10 +3257,8 @@ paths:
           description: The Resource was successfully deleted.
         '400':
           description: |-
-            The request could not be completed. The `policyId` either
-
-              * does not contain the mandatory namespace prefix (java package notation + `:` colon)
-              * does not conform to RFC-3986 (URI)
+            The request could not be completed. The `policyId` does not conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -3887,10 +3758,8 @@ components:
       name: thingId
       in: path
       description: |-
-        The ID of the Thing - has to:
-
-          * contain the mandatory namespace prefix (java package notation + `:` colon)
-          * conform to RFC-3986 (URI)
+        The ID of the Thing has to conform to the namespaced entity ID notation
+        (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
       required: true
       schema:
         type: string
@@ -3898,10 +3767,8 @@ components:
       name: policyId
       in: path
       description: |-
-        The ID of the Policy - has to:
-
-          * contain the mandatory namespace prefix (java package notation + `:` colon)
-          * conform to RFC-3986 (URI)
+        The ID of the Policy has to conform to the namespaced entity ID notation
+        (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
       required: true
       schema:
         type: string

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -409,7 +409,7 @@ paths:
         '400':
           description: |-
             The request could not be completed. The `thingId` does not conform to the namespaced entity ID notation
-          (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
           content:
             application/json:
               schema:
@@ -3485,7 +3485,7 @@ components:
         - message
     Attributes:
       type: object
-      description: An arbitrary JSON object.
+      description: "Attributes of a Thing: an arbitrary JSON object."
     FeatureDefinition:
       type: array
       items:
@@ -3494,16 +3494,14 @@ components:
         pattern: ([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)
     FeatureProperties:
       type: object
-      description: An arbitrary JSON object.
+      description: "Properties of a Feature: an arbitrary JSON object."
     Feature:
       type: object
       properties:
         definition:
           $ref: '#/components/schemas/FeatureDefinition'
-          description: The Definition of this Feature
         properties:
           $ref: '#/components/schemas/FeatureProperties'
-          description: The Properties of this Feature
     SearchResultThings:
       properties:
         items:
@@ -3518,12 +3516,7 @@ components:
       type: object
       properties:
         _policy:
-          $ref: '#/components/schemas/Policy'
-          description: |-
-            The initial Policy to create for this Thing. This will create a separate Policy entity managed by resource `/policies/{thingId}`.
-
-
-            Use the placeholder `{{ request:subjectId }}` in order to let the backend insert the authenticated subjectId of the HTTP request.
+          $ref: '#/components/schemas/InitialPolicy'
         _copyPolicyFrom:
           type: string
           description: |-
@@ -3543,10 +3536,8 @@ components:
             resource `/policies/{policyId}`.
         attributes:
           $ref: '#/components/schemas/Attributes'
-          description: The attributes of this Thing
         features:
           $ref: '#/components/schemas/Features'
-          description: The Features of this Thing
     Thing:
       type: object
       required:
@@ -3563,13 +3554,19 @@ components:
           description: The policy ID used for controlling access to this thing, managed by resource `/policies/{policyId}`
         attributes:
           $ref: '#/components/schemas/Attributes'
-          description: The attributes of this thing
         features:
           $ref: '#/components/schemas/Features'
-          description: The features of this thing
     Policy:
       type: object
       description: Policy consisting of PolicyEntries
+      properties:
+        entries:
+          $ref: '#/components/schemas/PolicyEntries'
+    InitialPolicy:
+      type: object
+      description: |-
+        The initial Policy when creating a Thing. This will create a separate Policy entity managed by resource `/policies/{thingId}`.
+        Use the placeholder `{{ request:subjectId }}` in order to let the backend insert the authenticated subjectId of the HTTP request.
       properties:
         entries:
           $ref: '#/components/schemas/PolicyEntries'

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -3548,10 +3548,13 @@ components:
       properties:
         thingId:
           type: string
-          description: Unique identifier representing the thing
+          description: Unique identifier representing the Thing, has to conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
         policyId:
           type: string
-          description: The policy ID used for controlling access to this thing, managed by resource `/policies/{policyId}`
+          description: The policy ID used for controlling access to this thing, managed by resource `/policies/{policyId}`,
+            has to conform to the namespaced entity ID notation
+            (see [Ditto documentation on namespaced entity IDs](https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id)).
         attributes:
           $ref: '#/components/schemas/Attributes'
         features:

--- a/documentation/src/main/resources/pages/ditto/basic-namespaces-and-names.md
+++ b/documentation/src/main/resources/pages/ditto/basic-namespaces-and-names.md
@@ -1,0 +1,63 @@
+---
+title: Namespaces and Names
+keywords: namespace, name, id, entity, model, regex
+tags: [model]
+permalink: basic-namespaces-and-names.html
+---
+
+Ditto uses namespaces and names for the IDs of important entity types like Things or Policies. Due to the fact that those
+IDs often need to be set in the path of HTTP requests, we have restricted the set of allowed characters.
+
+## Namespace
+
+The namespace must conform to the following notation:
+* must start with a lower- or uppercase character from a-z
+* may use dots (`.`) to separate characters
+* a dot must be followed by a lower- or uppercase character from a-z
+* numbers may be used
+* underscore may be used
+	
+When writing a Java application, you can use the following regex to validate your namespaces: <br/>
+    `(?<ns>|(?:(?:[a-zA-Z]\w*+)(?:\.[a-zA-Z]\w*+)*+))` 
+    (see [RegexPatterns#NAMESPACE_REGEX](https://github.com/eclipse/ditto/blob/master/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/RegexPatterns.java#L42)).
+	
+Examples for valid namespaces:
+* `org.eclipse.ditto`,
+* `com.google`,
+* `foo.bar_42`
+
+## Name
+
+The name must conform to the following notation:
+* may not be empty
+* may contain lower- and uppercase characters from a-z
+* numbers may be used
+* may contain hex encoded characters, e.g. `%3A`, `%4B`
+* may also contain the characters: `-` (hyphen), `:` (colon), `@` (at sign), `&` (ampersand), `=` (equals sign),
+`+` (plus sign), `,` (comma), `.` (period), `!` (exclamation mark), `~` (tilde), `*` (asterisk), `'` (apostrophe),
+`_` (underscore), `;` (semicolon), `<` (less-than sign), `>` (greater-than sign), `$` (dollar sign)
+* may not start with `$` (dollar sign)
+
+When writing a Java application, you can use the following regex to validate your namespaces: <br/>
+    `(?<name>(?:[-\w:@&=+,.!~*'_;<>]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'_;<>$]|%\p{XDigit}{2})*+)` 
+    (see [RegexPatterns#ENTITY_NAME_REGEX](https://github.com/eclipse/ditto/blob/master/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/RegexPatterns.java#L85)).
+
+Examples for valid names:
+    * `ditto`,
+    * `smart-coffee-1`,
+    * `foo%2Fbar`
+
+## Namespaced ID
+
+A namespaced ID must conform to the following notation:
+* namespace and name separated by a `:` (colon)
+
+When writing a Java application, you can use the following regex to validate your namespaced IDs: <br/>
+	`(?<ns>|(?:(?:[a-zA-Z]\w*+)(?:\.[a-zA-Z]\w*+)*+)):(?<name>(?:[-\w:@&=+,.!~*'_;<>]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'_;<>$]|%\p{XDigit}{2})*+)` 
+	(see [RegexPatterns#ID_REGEX](https://github.com/eclipse/ditto/blob/master/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/RegexPatterns.java#L92)).
+
+Examples for valid IDs:
+* `org.eclipse.ditto:smart-coffee-1`,
+* `foo:bar`,
+* `org.eclipse.ditto_42:smart-coffeee`
+* `org.eclipse:admin-policy`

--- a/documentation/src/main/resources/pages/ditto/basic-thing.md
+++ b/documentation/src/main/resources/pages/ditto/basic-thing.md
@@ -24,32 +24,8 @@ Examples:
 
 ### Thing ID
 
-Unique identifier of a Thing. For choosing custom Thing IDs when creating a Thing, following rules apply:
-
-#### Allowed Characters
-
-Due to the fact that a Thing ID often needs to be set in the path of a HTTP request, we have restricted the set of
-allowed characters to those for [Uniform Resource Identifiers (URI)](http://www.ietf.org/rfc/rfc3986.txt).
-
-In order to separate Things from different Solution spaces from each other, they are required to be created in a
-specific *Namespace*.
-This Namespace needs to be provided additionally to every REST request as a **prefix** of the Thing ID:
-
-* The Namespace must conform to Java package naming:
-    * must start with a lower- or uppercase character from a-z,
-    * can use dots (`.`) to separate characters,
-    * a dot (`.`) must be followed by a lower- or uppercase character from a-z,
-    * numbers can be used,
-    * underscore can be used,
-* The Namespace is separated by a mandatory colon (`:`) from the thingId.
-
-#### Examples
-
-Following some examples of valid Thing IDs are given:
-* `org.eclipse.ditto:fancycar-1`,
-* `foo:fancycar-1`,
-* `org.eclipse.ditto_42:fancycar-1`.
-
+Unique identifier of a Thing. For choosing custom Thing IDs when creating a Thing, the rules for 
+[namespaced IDs](basic-namespaces-and-names.html#namespaced-id) apply.
 
 ### Access control
 

--- a/documentation/src/main/resources/pages/ditto/protocol/policies/exceptions/policies_id_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/policies/exceptions/policies_id_invalid.md
@@ -9,7 +9,8 @@
     "status": 400,
     "error": "policies:id.invalid",
     "message": "Policy ID 'invalid id' is not valid!",
-    "description": "It must contain a namespace prefix (java package notation + a colon ':') + ID and must be a valid URI path segment according to RFC-3986"
+    "description": "It must conform to the namespaced entity ID notation (see Ditto documentation)",
+    "url": "https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id"
   },
   "status": 400
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/things/exceptions/things_id_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/things/exceptions/things_id_invalid.md
@@ -9,7 +9,8 @@
     "status": 400,
     "error": "things:id.invalid",
     "message": "Thing ID 'invalid id' is not valid!",
-    "description": "It must contain a namespace prefix (java package notation + a colon ':') + ID and must be a valid URI path segment according to RFC-3986"
+    "description": "It must conform to the namespaced entity ID notation (see Ditto documentation)",
+    "url": "https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id"
   },
   "status": 400
 }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/NamespacedEntityIdInvalidException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/NamespacedEntityIdInvalidException.java
@@ -49,10 +49,9 @@ public final class NamespacedEntityIdInvalidException extends DittoRuntimeExcept
     private static final String MESSAGE_TEMPLATE = "Namespaced entity ID ''{0}'' is not valid!";
 
     private static final String NAMESPACED_ENTITY_ID_DESCRIPTION =
-            "It must contain a namespace prefix (java package notation + a colon ':') + ID and must be a valid URI " +
-                    "path segment according to RFC-2396";
+            "It must conform to the namespaced entity ID notation (see Ditto documentation)";
 
-    private static final long serialVersionUID = -2426810319409279256L;
+    private static final URI DEFAULT_HREF = URI.create("https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id");
 
     private final CharSequence entityId;
 
@@ -92,7 +91,7 @@ public final class NamespacedEntityIdInvalidException extends DittoRuntimeExcept
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(""))
-                .href(readHRef(jsonObject).orElse(null))
+                .href(readHRef(jsonObject).orElse(DEFAULT_HREF))
                 .build();
     }
 
@@ -116,6 +115,7 @@ public final class NamespacedEntityIdInvalidException extends DittoRuntimeExcept
         private Builder(@Nullable final CharSequence entityId) {
             this.entityId = entityId;
             message(MessageFormat.format(MESSAGE_TEMPLATE, entityId));
+            href(DEFAULT_HREF);
         }
 
         private Builder(@Nullable final CharSequence entityId, final String description) {

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/RegexPatterns.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/RegexPatterns.java
@@ -80,8 +80,7 @@ public final class RegexPatterns {
     public static final String URI_PATH_SEGMENT_INCLUDING_DOLLAR =
             "(?:[" + ALLOWED_CHARACTERS_IN_NAME_INCLUDING_DOLLAR + "]|" + URL_ESCAPES + ")";
     /**
-     * The regex pattern for an Entity Name. Has to be conform to
-     * <a href="http://www.ietf.org/rfc/rfc2396.txt">RFC-2396</a>.
+     * The regex pattern for an Entity Name.
      */
     public static final String ENTITY_NAME_REGEX = "(?<" + ENTITY_NAME_GROUP_NAME +
             ">" + URI_PATH_SEGMENT + URI_PATH_SEGMENT_INCLUDING_DOLLAR + "*+)";

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/entity/id/RegexPatternsTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/entity/id/RegexPatternsTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.model.base.entity.id;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link RegexPatterns}.
+ */
+public final class RegexPatternsTest {
+
+    private static final List<String> GOOD_NAMESPACES = Arrays.asList(
+            "",
+            "ditto.eclipse.org",
+            "com.google",
+            "Foo.bar_122_"
+    );
+    private static final List<String> BAD_NAMESPACES = Arrays.asList(
+            "org.eclipse.",
+            ".org.eclipse",
+            "_org.eclipse",
+            "org._eclipse",
+            "1org.eclipse",
+            "org.1eclipse",
+            "org.ec lipse",
+            "org.",
+            ".org"
+    );
+
+    private static final List<String> GOOD_NAMES = Arrays.asList(
+            "ditto",
+            "thing42",
+            "-:@&=+,.!~*'_;<>$",
+            "foo%2Fbar"
+    );
+    private static final List<String> BAD_NAMES = Arrays.asList(
+            "",
+            "$ditto",
+            "foo/bar",
+            "foo bar"
+    );
+
+    private static final List<String> BAD_IDS = Arrays.asList(
+            "org.eclipse.ditto",
+            "foo;bar",
+            "foo%3A"
+    );
+
+    @Test
+    public void entityNameRegex() {
+        GOOD_NAMES.forEach(this::assertNameMatches);
+        BAD_NAMES.forEach(this::assertNameNotMatches);
+    }
+
+    private void assertNameMatches(final String name) {
+        assertMatches(RegexPatterns.ENTITY_NAME_PATTERN, name);
+    }
+
+    private void assertNameNotMatches(final String name) {
+        assertNotMatches(RegexPatterns.ENTITY_NAME_PATTERN, name);
+    }
+
+    @Test
+    public void namespaceRegex() {
+        GOOD_NAMESPACES.forEach(this::assertNamespaceMatches);
+        BAD_NAMESPACES.forEach(this::assertNamespaceNotMatches);
+    }
+
+    private void assertNamespaceMatches(final String namespace) {
+        assertMatches(RegexPatterns.NAMESPACE_PATTERN, namespace);
+    }
+
+    private void assertNamespaceNotMatches(final String namespace) {
+        assertNotMatches(RegexPatterns.NAMESPACE_PATTERN, namespace);
+    }
+
+    @Test
+    public void idRegex() {
+        GOOD_NAMESPACES.forEach(namespace -> GOOD_NAMES.forEach(name -> {
+            assertIdMatches(namespace + ":" + name);
+        }));
+        BAD_NAMESPACES.forEach(namespace -> BAD_NAMES.forEach(name -> {
+            assertIdNotMatches(namespace + ":" + name);
+        }));
+        BAD_IDS.forEach(this::assertIdNotMatches);
+    }
+
+    private void assertIdMatches(final String id) {
+        assertMatches(RegexPatterns.ID_PATTERN, id);
+    }
+
+    private void assertIdNotMatches(final String id) {
+        assertNotMatches(RegexPatterns.ID_PATTERN, id);
+    }
+
+    private void assertMatches(final Pattern pattern, final String toMatch) {
+        assertThat(matches(pattern, toMatch)).isTrue();
+    }
+
+    private void assertNotMatches(final Pattern pattern, final String toMatch) {
+        assertThat(matches(pattern, toMatch)).isFalse();
+    }
+
+    private boolean matches(final Pattern pattern, final String toMatch) {
+        return pattern.matcher(toMatch).matches();
+    }
+}

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/ThingIdInvalidException.java
@@ -41,8 +41,9 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
     private static final String MESSAGE_TEMPLATE = "Thing ID ''{0}'' is not valid!";
 
     private static final String DEFAULT_DESCRIPTION =
-            "It must contain a namespace prefix (java package notation + a colon ':') + ID and must be a valid URI " +
-                    "path segment according to RFC-3986";
+            "It must conform to the namespaced entity ID notation (see Ditto documentation)";
+
+    private static final URI DEFAULT_HREF = URI.create("https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id");
 
     private static final long serialVersionUID = -2426810319409279256L;
 
@@ -52,7 +53,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
      * @param thingId the invalid Thing ID.
      */
     public ThingIdInvalidException(final String thingId) {
-        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, thingId), DEFAULT_DESCRIPTION, null, null);
+        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, thingId), DEFAULT_DESCRIPTION, null, DEFAULT_HREF);
     }
 
     private ThingIdInvalidException(final DittoHeaders dittoHeaders,
@@ -103,7 +104,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
-                .href(readHRef(jsonObject).orElse(null))
+                .href(readHRef(jsonObject).orElse(DEFAULT_HREF))
                 .build();
     }
 
@@ -115,6 +116,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
 
         private Builder() {
             description(DEFAULT_DESCRIPTION);
+            href(DEFAULT_HREF);
         }
 
         private Builder(@Nullable final CharSequence thingId) {

--- a/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
+++ b/model/policies/src/main/java/org/eclipse/ditto/model/policies/PolicyIdInvalidException.java
@@ -42,8 +42,9 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
     private static final String MESSAGE_TEMPLATE = "Policy ID ''{0}'' is not valid!";
 
     private static final String DEFAULT_DESCRIPTION =
-            "It must contain a namespace prefix (java package notation + a colon ':') + a name and must be a valid " +
-                    "URI path segment according to RFC-3986";
+            "It must conform to the namespaced entity ID notation (see Ditto documentation)";
+
+    private static final URI DEFAULT_HREF = URI.create("https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id");
 
     private static final long serialVersionUID = 8154256308793903738L;
 
@@ -53,7 +54,7 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
      * @param policyId the invalid Policy ID.
      */
     public PolicyIdInvalidException(@Nullable final String policyId) {
-        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, policyId), DEFAULT_DESCRIPTION, null, null);
+        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, policyId), DEFAULT_DESCRIPTION, null, DEFAULT_HREF);
     }
 
     private PolicyIdInvalidException(final DittoHeaders dittoHeaders,
@@ -105,7 +106,7 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
-                .href(readHRef(jsonObject).orElse(null))
+                .href(readHRef(jsonObject).orElse(DEFAULT_HREF))
                 .build();
     }
 
@@ -123,6 +124,7 @@ public final class PolicyIdInvalidException extends DittoRuntimeException implem
 
         private Builder() {
             description(DEFAULT_DESCRIPTION);
+            href(DEFAULT_HREF);
         }
 
         private Builder(@Nullable final CharSequence policyId) {

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingIdInvalidException.java
@@ -41,8 +41,9 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
     private static final String MESSAGE_TEMPLATE = "Thing ID ''{0}'' is not valid!";
 
     private static final String DEFAULT_DESCRIPTION =
-            "It must contain a namespace prefix (java package notation + a colon ':') + a name and must be a valid " +
-                    "URI path segment according to RFC-3986";
+            "It must conform to the namespaced entity ID notation (see Ditto documentation)";
+
+    private static final URI DEFAULT_HREF = URI.create("https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id");
 
     private static final long serialVersionUID = -2026814719409279158L;
 
@@ -52,7 +53,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
      * @param thingId the invalid Thing ID.
      */
     public ThingIdInvalidException(final String thingId) {
-        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, thingId), DEFAULT_DESCRIPTION, null, null);
+        this(DittoHeaders.empty(), MessageFormat.format(MESSAGE_TEMPLATE, thingId), DEFAULT_DESCRIPTION, null, DEFAULT_HREF);
     }
 
     private ThingIdInvalidException(final DittoHeaders dittoHeaders,
@@ -101,7 +102,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
                 .dittoHeaders(dittoHeaders)
                 .message(readMessage(jsonObject))
                 .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
-                .href(readHRef(jsonObject).orElse(null))
+                .href(readHRef(jsonObject).orElse(DEFAULT_HREF))
                 .build();
     }
 
@@ -113,6 +114,7 @@ public final class ThingIdInvalidException extends DittoRuntimeException impleme
 
         private Builder() {
             description(DEFAULT_DESCRIPTION);
+            href(DEFAULT_HREF);
         }
 
         private Builder(@Nullable final CharSequence thingId) {


### PR DESCRIPTION
Document what regexes the namespaced entity IDs use and add links to the corresponding documentation in exceptions, OpenAPI and JSON Schema docs