### PR TITLE
Fix ImmutableJsonObject#contains

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
@@ -212,8 +212,9 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         } else {
             result = pointer.getRoot()
                     .flatMap(this::getValueForKey)
-                    .map(jsonValue -> !jsonValue.isObject() ||
-                            jsonValue.asObject().contains(pointer.nextLevel())) // Recursion
+                    .filter(JsonValue::isObject)
+                    .map(JsonValue::asObject)
+                    .map(jsonObject -> jsonObject.contains(pointer.nextLevel()))
                     .orElse(false);
         }
 

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonObjectTest.java
@@ -985,6 +985,16 @@ public final class ImmutableJsonObjectTest {
         assertThat(underTest.contains(jsonPointer)).isTrue();
     }
 
+    @Test
+    public void containsShouldReturnFalseOnPointerDeeperThanObject() {
+        // When JsonObject
+        final ImmutableJsonObject underTest = ImmutableJsonObject.of(toMap(KNOWN_KEY_FOO, KNOWN_VALUE_BAR));
+        // pointer that goes deeper
+        final JsonPointer deeperThanObject = KNOWN_KEY_FOO.asPointer().append(JsonPointer.of("/foo/not/known/path"));
+
+        assertThat(underTest.contains(deeperThanObject)).isFalse();
+    }
+
     @Test(expected = NullPointerException.class)
     public void tryToGetJsonObjectWithNullJsonPointer() {
         final JsonObject underTest = ImmutableJsonObject.empty();


### PR DESCRIPTION
The method did not respect the whole length of the checked pointer if a nested primitive JSON value still matched the pointer.
That's why asking `{ 'nested': { 'foo' : 'bar' } }.contains('/nested/foo/not/known/path')` returned `true`. The method will now return `false` if the JSON value is a primitive but the pointer still has levels.