### PR TITLE
Remove method from JwtSubjectIssuersConfig

### DIFF
--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtSubjectIssuersConfig.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtSubjectIssuersConfig.java
@@ -68,19 +68,6 @@ public final class JwtSubjectIssuersConfig {
     }
 
     /**
-     * Gets the configuration item for the given subject issuer.
-     *
-     * @param subjectIssuer the subject issuer
-     * @return the configuration for the given subject issuer, or an empty {@link Optional} if no configuration is
-     * provided for this subject issuer
-     */
-    public Optional<JwtSubjectIssuerConfig> getConfigItem(final SubjectIssuer subjectIssuer) {
-        return subjectIssuerConfigMap.values().stream()
-                .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getSubjectIssuer().equals(subjectIssuer))
-                .findFirst();
-    }
-
-    /**
      * Gets a collection of all configuration items.
      *
      * @return the configuration items
@@ -100,7 +87,7 @@ public final class JwtSubjectIssuersConfig {
         checkNotNull(subjectIssuer);
 
         return subjectIssuerConfigMap.values().stream()
-                .filter(jwtSubjectIssuerConfig -> subjectIssuer.equals(jwtSubjectIssuerConfig.getSubjectIssuer()))
+                .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getSubjectIssuer().equals(subjectIssuer))
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
Should have been removed with #533 already as it makes no sense to get a single value when at least two are configured (with and without "https://").