### PR TITLE
Fixes three issues with connections

### DIFF
--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ConnectionStatusMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ConnectionStatusMessageMapper.java
@@ -72,7 +72,7 @@ public class ConnectionStatusMessageMapper extends AbstractMessageMapper {
     static final String FEATURE_PROPERTY_READY_UNTIL = "readyUntil";
 
     // (unix time) 253402300799 = (ISO-8601) 9999-12-31T23:59:59
-    static final Instant DISTANT_FUTURE_INSTANT = Instant.ofEpochMilli(253402300799L);
+    private static final Instant DISTANT_FUTURE_INSTANT = Instant.ofEpochSecond(253402300799L);
 
     private static final List<Adaptable> EMPTY_RESULT = Collections.emptyList();
     private static final DittoProtocolAdapter DITTO_PROTOCOL_ADAPTER = DittoProtocolAdapter.newInstance();

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMessageMapperFactory.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMessageMapperFactory.java
@@ -118,9 +118,20 @@ public final class DefaultMessageMapperFactory implements MessageMapperFactory {
     @Override
     public Optional<MessageMapper> mapperOf(final String mapperId, final MappingContext mappingContext) {
         final Optional<MessageMapper> mapper = createMessageMapperInstance(mappingContext.getMappingEngine());
+        final Map<String, String> defaultOptions =
+                mapper.map(MessageMapper::getDefaultOptions).orElse(Collections.emptyMap());
+        final Map<String, String> configuredAndDefaultOptions =
+                mergeMappingOptions(defaultOptions, mappingContext.getOptions());
         final MessageMapperConfiguration options =
-                DefaultMessageMapperConfiguration.of(mapperId, mappingContext.getOptions());
+                DefaultMessageMapperConfiguration.of(mapperId, configuredAndDefaultOptions);
         return mapper.flatMap(m -> configureInstance(m, options));
+    }
+
+    private Map<String, String> mergeMappingOptions(final Map<String, String> defaultOptions,
+            final Map<String, String> configuredOptions) {
+        final HashMap<String, String> mergedOptions = new HashMap<>(defaultOptions);
+        mergedOptions.putAll(configuredOptions);
+        return mergedOptions;
     }
 
     @Override

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
@@ -97,6 +97,11 @@ public final class DittoMessageMapper extends AbstractMessageMapper {
                         .build());
     }
 
+    @Override
+    public Map<String, String> getDefaultOptions() {
+        return DEFAULT_OPTIONS;
+    }
+
     private static String extractPayloadAsString(final ExternalMessage message) {
         final Optional<String> payload;
         if (message.isTextMessage()) {

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.services.connectivity.mapping;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +80,13 @@ public interface MessageMapper {
      * @throws org.eclipse.ditto.model.connectivity.MessageMappingFailedException if the given adaptable can not be mapped
      */
     List<ExternalMessage> map(Adaptable adaptable);
+
+    /**
+     * @return a map of default options for this mapper
+     */
+    default Map<String, String> getDefaultOptions() {
+        return Collections.emptyMap();
+    }
 
     /**
      * Finds the content-type header from the passed ExternalMessage.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -938,9 +938,7 @@ public abstract class BaseClientActor extends AbstractFSM<BaseClientState, BaseC
 
         ConnectionLogUtil.enhanceLogWithCorrelationIdAndConnectionId(log, command, command.getConnectionEntityId());
         log.debug("Received ResetConnectionMetrics message, resetting metrics.");
-        //  TODO: think about just clearing the counters instead of completely rebuilding them
         connectionCounterRegistry.resetForConnection(data.getConnection());
-        connectionCounterRegistry.initForConnection(data.getConnection());
 
         return stay();
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/ConnectionMetricsCounter.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/ConnectionMetricsCounter.java
@@ -34,4 +34,9 @@ public interface ConnectionMetricsCounter {
      * @return the metricType of this collector.
      */
     MetricType getMetricType();
+
+    /**
+     * Resets the counter.
+     */
+    void reset();
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/ConnectivityCounterRegistry.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/ConnectivityCounterRegistry.java
@@ -105,9 +105,9 @@ public final class ConnectivityCounterRegistry implements ConnectionMonitorRegis
     public void resetForConnection(final Connection connection) {
 
         final ConnectionId connectionId = connection.getId();
-        counters.keySet().stream()
-                .filter(key -> key.connectionId.equals(connectionId))
-                .forEach(counters::remove);
+        counters.entrySet().stream()
+                .filter(entry -> entry.getKey().connectionId.equals(connectionId))
+                .forEach(entry -> entry.getValue().reset());
     }
 
     private static void initCounter(final ConnectionId connectionId, final MetricDirection metricDirection,

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/DefaultConnectionMetricsCounter.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/DefaultConnectionMetricsCounter.java
@@ -49,14 +49,24 @@ public final class DefaultConnectionMetricsCounter implements ConnectionMetricsC
 
     @Override
     public void recordSuccess() {
-        LOGGER.trace("Increment success counter ({},{},{})", metricDirection, address, metricType);
+        logAction("Increment success counter");
         counter.increment();
     }
 
     @Override
     public void recordFailure() {
-        LOGGER.trace("Increment failure counter ({},{},{})", metricDirection, address, metricType);
+        logAction("Increment failure counter");
         counter.increment(false);
+    }
+
+    @Override
+    public void reset() {
+        logAction("Reset counter");
+        counter.reset();
+    }
+
+    private void logAction(final String action) {
+        LOGGER.trace("{} ({},{},{})", action, metricDirection, address, metricType);
     }
 
     @Override

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
@@ -69,6 +69,7 @@ public class MessageMappingProcessorTest {
     private MessageMappingProcessor underTest;
 
     private static final String DITTO_MAPPER = "ditto";
+    private static final String DITTO_MAPPER_BY_ALIAS = "ditto-by-alias";
     private static final String DITTO_MAPPER_CUSTOM_HEADER_BLACKLIST = "ditto-cust-header";
     private static final String DROPPING_MAPPER = "dropping";
     private static final String FAILING_MAPPER = "faulty";
@@ -96,6 +97,8 @@ public class MessageMappingProcessorTest {
     public void init() {
         final Map<String, MappingContext> mappings = new HashMap<>();
         mappings.put(DITTO_MAPPER, DittoMessageMapper.CONTEXT);
+        mappings.put(DITTO_MAPPER_BY_ALIAS,
+                ConnectivityModelFactory.newMappingContext("Ditto", Collections.emptyMap()));
 
         final Map<String, String> dittoCustomMapperHeaders = new HashMap<>();
         dittoCustomMapperHeaders.put(
@@ -193,6 +196,16 @@ public class MessageMappingProcessorTest {
         headers.put(ExternalMessage.CONTENT_TYPE_HEADER, "application/vnd.eclipse-hono-empty-notification");
         final ExternalMessage message = ExternalMessageFactory.newExternalMessageBuilder(headers)
                 .withPayloadMapping(ConnectivityModelFactory.newPayloadMapping(DITTO_MAPPER))
+                .build();
+        testInbound(message, 0, 1, 0);
+    }
+
+    @Test
+    public void testInboundMessageDroppedForHonoEmptyNotificationMessagesWithDittoByAliasMapper() {
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(ExternalMessage.CONTENT_TYPE_HEADER, "application/vnd.eclipse-hono-empty-notification");
+        final ExternalMessage message = ExternalMessageFactory.newExternalMessageBuilder(headers)
+                .withPayloadMapping(ConnectivityModelFactory.newPayloadMapping(DITTO_MAPPER_BY_ALIAS))
                 .build();
         testInbound(message, 0, 1, 0);
     }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/DefaultConnectionMetricsCounterTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/metrics/DefaultConnectionMetricsCounterTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.messaging.monitoring.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.stream.IntStream;
+
+import org.eclipse.ditto.model.connectivity.MetricDirection;
+import org.eclipse.ditto.model.connectivity.MetricType;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests {@link DefaultConnectionMetricsCounter}.
+ */
+public class DefaultConnectionMetricsCounterTest {
+
+    private DefaultConnectionMetricsCounter underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new DefaultConnectionMetricsCounter(MetricDirection.INBOUND, "source", MetricType.CONSUMED,
+                new SlidingWindowCounter(Clock.systemUTC(), MeasurementWindow.ONE_MINUTE));
+    }
+
+    @Test
+    public void testResetCounter() {
+        // initially counter is expected to be empty
+        assertCounterValues(0L, 0L);
+
+        // record some values
+        recordCounterValues(10, 5);
+
+        // expect the correct counter values
+        assertCounterValues(10L, 5L);
+
+        // reset counter
+        underTest.reset();
+
+        // counter is expected to be empty after reset
+        assertCounterValues(0L, 0L);
+
+        // record some values again
+        recordCounterValues(20, 10);
+        // expect the correct counter values
+        assertCounterValues(20L, 10L);
+    }
+
+    private void recordCounterValues(final int successes, final int failures) {
+        IntStream.range(0, successes).forEach(i -> underTest.recordSuccess());
+        IntStream.range(0, failures).forEach(i -> underTest.recordFailure());
+    }
+
+    private void assertCounterValues(final long successes, final long failures) {
+        assertThat(underTest.toMeasurement(true).getCounts()).containsEntry(Duration.ofMinutes(1), successes);
+        assertThat(underTest.toMeasurement(false).getCounts()).containsEntry(Duration.ofMinutes(1), failures);
+    }
+}


### PR DESCRIPTION
- readyUntil date was parsed in wrong unit (milliseconds instead of seconds) 
- after a connection metrics reset e.g. `consumed` messages were not counted
- default options were not loaded when ditto mapper was referenced by its alias  (`Ditto`)

Signed-off-by: Dominik Guggemos <dominik.guggemos@bosch-si.com>