### PR TITLE
use "/sbin/tini" as start command wrapping invocation of "java"

### DIFF
--- a/deployment/helm/eclipse-ditto/Chart.yaml
+++ b/deployment/helm/eclipse-ditto/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0.0-M3"
 description: A Helm chart for Eclipse Ditto
 name: eclipse-ditto
 version: 0.6.1
-home: www.eclipse.org/ditto
+home: https://www.eclipse.org/ditto
 sources:
 - https://github.com/eclipse/ditto
 - https://github.com/kiwigrid/helm-charts/tree/master/charts/eclipse-ditto
@@ -11,3 +11,5 @@ icon: https://www.eclipse.org/ditto/images/ditto.svg
 maintainers:
 - name: axdotl
   email: axel.koehler@kiwigrid.com
+- name: thjaeckle
+  email: thomas.jaeckle@bosch-si.com

--- a/deployment/helm/eclipse-ditto/Chart.yaml
+++ b/deployment/helm/eclipse-ditto/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0.0-M3"
 description: A Helm chart for Eclipse Ditto
 name: eclipse-ditto
-version: 0.6.1
+version: 0.7.0
 home: https://www.eclipse.org/ditto
 sources:
 - https://github.com/eclipse/ditto

--- a/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: {{ .Chart.Name }}-concierge
           image: "{{ .Values.concierge.image.repository }}:{{ .Values.concierge.image.tag }}"
           imagePullPolicy: {{ .Values.concierge.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.concierge.systemProps }}
             {{- toYaml .Values.concierge.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
@@ -47,9 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-concierge
           image: "{{ .Values.concierge.image.repository }}:{{ .Values.concierge.image.tag }}"
           imagePullPolicy: {{ .Values.concierge.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.concierge.systemProps }}
             {{- toYaml .Values.concierge.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/concierge-deployment.yaml
@@ -47,8 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-concierge
           image: "{{ .Values.concierge.image.repository }}:{{ .Values.concierge.image.tag }}"
           imagePullPolicy: {{ .Values.concierge.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.concierge.systemProps }}
             {{- toYaml .Values.concierge.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
@@ -47,9 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-connectivity
           image: "{{ .Values.connectivity.image.repository }}:{{ .Values.connectivity.image.tag }}"
           imagePullPolicy: {{ .Values.connectivity.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.connectivity.systemProps }}
             {{- toYaml .Values.connectivity.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: {{ .Chart.Name }}-connectivity
           image: "{{ .Values.connectivity.image.repository }}:{{ .Values.connectivity.image.tag }}"
           imagePullPolicy: {{ .Values.connectivity.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.connectivity.systemProps }}
             {{- toYaml .Values.connectivity.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/connectivity-deployment.yaml
@@ -47,8 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-connectivity
           image: "{{ .Values.connectivity.image.repository }}:{{ .Values.connectivity.image.tag }}"
           imagePullPolicy: {{ .Values.connectivity.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.connectivity.systemProps }}
             {{- toYaml .Values.connectivity.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
@@ -48,8 +48,9 @@ spec:
         - name: {{ .Chart.Name }}-gateway
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.gateway.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.gateway.systemProps }}
             {{- toYaml .Values.gateway.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
@@ -48,9 +48,8 @@ spec:
         - name: {{ .Chart.Name }}-gateway
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.gateway.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.gateway.systemProps }}
             {{- toYaml .Values.gateway.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/gateway-deployment.yaml
@@ -48,8 +48,8 @@ spec:
         - name: {{ .Chart.Name }}-gateway
           image: "{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}"
           imagePullPolicy: {{ .Values.gateway.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.gateway.systemProps }}
             {{- toYaml .Values.gateway.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
@@ -47,8 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-policies
           image: "{{ .Values.policies.image.repository }}:{{ .Values.policies.image.tag }}"
           imagePullPolicy: {{ .Values.policies.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.policies.systemProps }}
             {{- toYaml .Values.policies.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
@@ -47,9 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-policies
           image: "{{ .Values.policies.image.repository }}:{{ .Values.policies.image.tag }}"
           imagePullPolicy: {{ .Values.policies.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.policies.systemProps }}
             {{- toYaml .Values.policies.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/policies-deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: {{ .Chart.Name }}-policies
           image: "{{ .Values.policies.image.repository }}:{{ .Values.policies.image.tag }}"
           imagePullPolicy: {{ .Values.policies.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.policies.systemProps }}
             {{- toYaml .Values.policies.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
@@ -47,9 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-things
           image: "{{ .Values.things.image.repository }}:{{ .Values.things.image.tag }}"
           imagePullPolicy: {{ .Values.things.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.things.systemProps }}
             {{- toYaml .Values.things.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
@@ -47,8 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-things
           image: "{{ .Values.things.image.repository }}:{{ .Values.things.image.tag }}"
           imagePullPolicy: {{ .Values.things.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.things.systemProps }}
             {{- toYaml .Values.things.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/things-deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: {{ .Chart.Name }}-things
           image: "{{ .Values.things.image.repository }}:{{ .Values.things.image.tag }}"
           imagePullPolicy: {{ .Values.things.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.things.systemProps }}
             {{- toYaml .Values.things.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
@@ -47,8 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-thingssearch
           image: "{{ .Values.thingsSearch.image.repository }}:{{ .Values.thingsSearch.image.tag }}"
           imagePullPolicy: {{ .Values.thingsSearch.image.imagePullPolicy }}
-          command: ["java"]
           args:
+            - "java"
           {{- if .Values.thingsSearch.systemProps }}
             {{- toYaml .Values.thingsSearch.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
@@ -47,9 +47,8 @@ spec:
         - name: {{ .Chart.Name }}-thingssearch
           image: "{{ .Values.thingsSearch.image.repository }}:{{ .Values.thingsSearch.image.tag }}"
           imagePullPolicy: {{ .Values.thingsSearch.image.imagePullPolicy }}
-          command: ["/sbin/tini"]
+          command: ["java"]
           args:
-            - "java"
           {{- if .Values.thingsSearch.systemProps }}
             {{- toYaml .Values.thingsSearch.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/eclipse-ditto/templates/thingssearch-deployment.yaml
@@ -47,8 +47,9 @@ spec:
         - name: {{ .Chart.Name }}-thingssearch
           image: "{{ .Values.thingsSearch.image.repository }}:{{ .Values.thingsSearch.image.tag }}"
           imagePullPolicy: {{ .Values.thingsSearch.image.imagePullPolicy }}
-          command: ["java"]
+          command: ["/sbin/tini"]
           args:
+            - "java"
           {{- if .Values.thingsSearch.systemProps }}
             {{- toYaml .Values.thingsSearch.systemProps | nindent 12 }}
           {{- end }}

--- a/deployment/kubernetes/ditto/ditto-cluster.yaml
+++ b/deployment/kubernetes/ditto/ditto-cluster.yaml
@@ -17,9 +17,8 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
+        command: ["java"]
         args:
-          - "java"
           - "-jar"
           - "/opt/ditto/starter.jar"
         ports:
@@ -79,11 +78,8 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -141,11 +137,8 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -202,11 +195,8 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -263,11 +253,8 @@ spec:
       - name: policies
         image: docker.io/eclipse/ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -324,11 +311,8 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551

--- a/deployment/kubernetes/ditto/ditto-cluster.yaml
+++ b/deployment/kubernetes/ditto/ditto-cluster.yaml
@@ -17,8 +17,8 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
         args:
+          - "java"
           - "-jar"
           - "/opt/ditto/starter.jar"
         ports:
@@ -78,8 +78,10 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -137,8 +139,10 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -195,8 +199,10 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -253,8 +259,10 @@ spec:
       - name: policies
         image: docker.io/eclipse/ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -311,8 +319,10 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551

--- a/deployment/kubernetes/ditto/ditto-cluster.yaml
+++ b/deployment/kubernetes/ditto/ditto-cluster.yaml
@@ -17,8 +17,11 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -76,8 +79,11 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -135,8 +141,11 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -193,8 +202,11 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -251,8 +263,11 @@ spec:
       - name: policies
         image: docker.io/eclipse/ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -309,8 +324,11 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551

--- a/deployment/openshift/ditto/ditto-cluster.yaml
+++ b/deployment/openshift/ditto/ditto-cluster.yaml
@@ -24,8 +24,8 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:lastest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
         args:
+          - "java"
           - "-jar"
           - "/opt/ditto/starter.jar"
         ports:
@@ -101,8 +101,10 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -176,8 +178,10 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -250,8 +254,10 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -323,8 +329,10 @@ spec:
       - name: policies
         image: docker.io/eclipse//eclipse-ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -398,8 +406,10 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551

--- a/deployment/openshift/ditto/ditto-cluster.yaml
+++ b/deployment/openshift/ditto/ditto-cluster.yaml
@@ -24,8 +24,11 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:lastest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -99,8 +102,11 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -174,8 +180,11 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -248,8 +257,11 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -321,8 +333,11 @@ spec:
       - name: policies
         image: docker.io/eclipse//eclipse-ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551
@@ -396,8 +411,11 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["java"]
-        args: ["-jar", "/opt/ditto/starter.jar"]
+        command: ["/sbin/tini"]
+        args:
+          - "java"
+          - "-jar"
+          - "/opt/ditto/starter.jar"
         ports:
         - name: remoting
           containerPort: 2551

--- a/deployment/openshift/ditto/ditto-cluster.yaml
+++ b/deployment/openshift/ditto/ditto-cluster.yaml
@@ -24,9 +24,8 @@ spec:
       - name: concierge
         image: docker.io/eclipse/ditto-concierge:lastest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
+        command: ["java"]
         args:
-          - "java"
           - "-jar"
           - "/opt/ditto/starter.jar"
         ports:
@@ -102,11 +101,8 @@ spec:
       - name: connectivity
         image: docker.io/eclipse/ditto-connectivity:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -180,11 +176,8 @@ spec:
       - name: things
         image: docker.io/eclipse/ditto-things:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -257,11 +250,8 @@ spec:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -333,11 +323,8 @@ spec:
       - name: policies
         image: docker.io/eclipse//eclipse-ditto-policies:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551
@@ -411,11 +398,8 @@ spec:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
         imagePullPolicy: IfNotPresent
-        command: ["/sbin/tini"]
-        args:
-          - "java"
-          - "-jar"
-          - "/opt/ditto/starter.jar"
+        command: ["java"]
+        args: ["-jar", "/opt/ditto/starter.jar"]
         ports:
         - name: remoting
           containerPort: 2551

--- a/services/src/Dockerfile
+++ b/services/src/Dockerfile
@@ -22,4 +22,5 @@ RUN set -x \
     && apk add --no-cache tini
 
 WORKDIR $DITTO_HOME
-ENTRYPOINT ["java","-jar","starter.jar"]
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["java", "-jar", "/opt/ditto/starter.jar"]


### PR DESCRIPTION
The reason is that otherwise "java" will be started with PID 1 which causes that PID 1 is not terminated when the docker daemon stops the container (e.g. during a rolling update or rebalancing, etc.).

"tini" forwards the SIGTERM command to the "java" process which then has the chance to shutdown itself gracefully.