### PR TITLE
Fix materializer creation of SearchActor.

### DIFF
--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchActor.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchActor.java
@@ -105,7 +105,7 @@ public final class SearchActor extends AbstractActor {
 
         this.queryParser = queryParser;
         this.searchPersistence = searchPersistence;
-        materializer = ActorMaterializer.create(getContext().system());
+        materializer = ActorMaterializer.create(getContext());
 
         dispatcher = getContext().system().dispatchers().lookup(SEARCH_DISPATCHER_ID);
     }


### PR DESCRIPTION
SearchActor should not run its streams under the system guardian; errors in stream won't be handled and there is the danger of resource leak.