### PR TITLE
Issue #567: Limit length of namespaced entity IDs to 256 characters

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-namespaces-and-names.md
+++ b/documentation/src/main/resources/pages/ditto/basic-namespaces-and-names.md
@@ -49,8 +49,9 @@ Examples for valid names:
 
 ## Namespaced ID
 
-A namespaced ID must conform to the following notation:
+A namespaced ID must conform to the following expectations:
 * namespace and name separated by a `:` (colon)
+* have a maximum length of 256 characters
 
 When writing a Java application, you can use the following regex to validate your namespaced IDs: <br/>
 	`(?<ns>|(?:(?:[a-zA-Z]\w*+)(?:\.[a-zA-Z]\w*+)*+)):(?<name>(?:[-\w:@&=+,.!~*'_;<>]|%\p{XDigit}{2})(?:[-\w:@&=+,.!~*'_;<>$]|%\p{XDigit}{2})*+)` 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
@@ -33,6 +33,7 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
 
     private static final NamespacedEntityId DUMMY_ID = DefaultNamespacedEntityId.of(":_");
     private static final String DEFAULT_NAMESPACE = "";
+    private static int MAXIMUM_ID_LENGTH = 256;
 
     private final String namespace;
     private final String name;
@@ -55,7 +56,7 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
             throw NamespacedEntityIdInvalidException.newBuilder(entityId).build();
         }
 
-        if (entityId.length() > 256) {
+        if (entityId.length() > MAXIMUM_ID_LENGTH) {
             throw NamespacedEntityIdInvalidException.newBuilder(entityId).build();
         }
 
@@ -149,7 +150,7 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
             throw NamespacedEntityIdInvalidException.newBuilder(stringRepresentation).build();
         }
 
-        if (stringRepresentation.length() > 256) {
+        if (stringRepresentation.length() > MAXIMUM_ID_LENGTH) {
             throw NamespacedEntityIdInvalidException.newBuilder(stringRepresentation).build();
         }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
@@ -33,7 +33,7 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
 
     private static final NamespacedEntityId DUMMY_ID = DefaultNamespacedEntityId.of(":_");
     private static final String DEFAULT_NAMESPACE = "";
-    private static int MAXIMUM_ID_LENGTH = 256;
+    private static final int MAXIMUM_ID_LENGTH = 256;
 
     private final String namespace;
     private final String name;

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityId.java
@@ -55,6 +55,10 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
             throw NamespacedEntityIdInvalidException.newBuilder(entityId).build();
         }
 
+        if (entityId.length() > 256) {
+            throw NamespacedEntityIdInvalidException.newBuilder(entityId).build();
+        }
+
         final Matcher nsMatcher = ID_PATTERN.matcher(entityId);
 
         if (nsMatcher.matches()) {
@@ -142,6 +146,10 @@ public final class DefaultNamespacedEntityId implements NamespacedEntityId {
         }
 
         if (namespace == null) {
+            throw NamespacedEntityIdInvalidException.newBuilder(stringRepresentation).build();
+        }
+
+        if (stringRepresentation.length() > 256) {
             throw NamespacedEntityIdInvalidException.newBuilder(stringRepresentation).build();
         }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/NamespacedEntityIdInvalidException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/entity/id/NamespacedEntityIdInvalidException.java
@@ -49,7 +49,8 @@ public final class NamespacedEntityIdInvalidException extends DittoRuntimeExcept
     private static final String MESSAGE_TEMPLATE = "Namespaced entity ID ''{0}'' is not valid!";
 
     private static final String NAMESPACED_ENTITY_ID_DESCRIPTION =
-            "It must conform to the namespaced entity ID notation (see Ditto documentation)";
+            "It must conform to the namespaced entity ID notation (see Ditto documentation) with a maximum length of " +
+                    "256 characters.";
 
     private static final URI DEFAULT_HREF = URI.create("https://www.eclipse.org/ditto/basic-namespaces-and-names.html#namespaced-id");
 

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityIdTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/entity/id/DefaultNamespacedEntityIdTest.java
@@ -19,7 +19,6 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import javax.annotation.Nullable;
 
@@ -93,6 +92,26 @@ public class DefaultNamespacedEntityIdTest {
 
         assertThat(namespacedEntityId.getNamespace()).isEqualTo(invalidNamespace);
         assertThat(namespacedEntityId.getName()).isEqualTo(invalidName);
+    }
+
+    @Test
+    public void canHaveMaximumLengthOf256Characters() {
+        final int maximumAllowedCharactersForName = 255 - VALID_NAMESPACE.length();
+        final StringBuilder nameWithMaximumLength = new StringBuilder();
+        for (int i = 0; i < maximumAllowedCharactersForName; i++) {
+            nameWithMaximumLength.append("a");
+        }
+        assertValidId(VALID_NAMESPACE, nameWithMaximumLength.toString());
+    }
+
+    @Test
+    public void cannotHaveMoreThan256Characters() {
+        final int maximumAllowedCharactersForName = 255 - VALID_NAMESPACE.length();
+        final StringBuilder nameWithMaximumLength = new StringBuilder();
+        for (int i = 0; i < maximumAllowedCharactersForName; i++) {
+            nameWithMaximumLength.append("a");
+        }
+        assertInValidId(VALID_NAMESPACE, nameWithMaximumLength.append("a").toString());
     }
 
     @Test
@@ -201,19 +220,6 @@ public class DefaultNamespacedEntityIdTest {
     @Test
     public void notSpecialCharactersInNamespacesAreAllowed() {
         assertInvalidNamespace("my$namespace");
-    }
-
-    @Test
-    public void validateLongIdSucceeds() {
-        final int numberOfUUIDs = 1000;
-        final StringBuilder idBuilder = new StringBuilder("namespace");
-        for (int i = 0; i < numberOfUUIDs; ++i) {
-            idBuilder.append(':').append(UUID.randomUUID());
-        }
-
-        final NamespacedEntityId namespacedEntityId = DefaultNamespacedEntityId.of(idBuilder.toString());
-
-        assertThat(namespacedEntityId.getNamespace()).isEqualTo("namespace");
     }
 
     private static void assertInvalidNamespace(@Nullable final String namespace) {

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
@@ -218,14 +218,14 @@ public final class ThingsRoute extends AbstractRoute {
     private Route thingsEntry(final RequestContext ctx, final DittoHeaders dittoHeaders, final ThingId thingId) {
         return pathEndOrSingleSlash(() ->
                 concat(
-                        get(() -> // GET /things/things/<thingId>?fields=<fieldsString>
+                        get(() -> // GET /things/<thingId>?fields=<fieldsString>
                                 parameterOptional(ThingsParameter.FIELDS.toString(), fieldsString ->
                                         handlePerRequest(ctx, RetrieveThing.getBuilder(thingId, dittoHeaders)
                                                 .withSelectedFields(calculateSelectedFields(fieldsString).orElse(null))
                                                 .build())
                                 )
                         ),
-                        put(() -> // PUT /things/things/<thingId>
+                        put(() -> // PUT /things/<thingId>
                                 extractDataBytes(payloadSource ->
                                         handlePerRequest(ctx, dittoHeaders, payloadSource,
                                                 thingJson -> ModifyThing.of(thingId, ThingsModelFactory.newThing(
@@ -235,7 +235,7 @@ public final class ThingsRoute extends AbstractRoute {
                                                         dittoHeaders))
                                 )
                         ),
-                        delete(() -> // DELETE /things/things/<thingId>
+                        delete(() -> // DELETE /things/<thingId>
                                 handlePerRequest(ctx, DeleteThing.of(thingId, dittoHeaders))
                         )
                 )

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.services.gateway.endpoints.routes.things;
 
-import java.util.UUID;
-
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestBase;
 import org.eclipse.ditto.services.utils.protocol.ProtocolAdapterProvider;
@@ -56,17 +54,6 @@ public final class ThingsRouteTest extends EndpointTestBase {
     public void postFeaturesReturnsMethodNotAllowed() {
         final TestRouteResult result = underTest.run(HttpRequest.POST("/things/org.eclipse.ditto%3Adummy/features"));
         result.assertStatusCode(StatusCodes.METHOD_NOT_ALLOWED);
-    }
-
-    @Test
-    public void getThingWithVeryLongId() {
-        final int numberOfUUIDs = 100;
-        final StringBuilder pathBuilder = new StringBuilder("/things/").append("namespace");
-        for (int i = 0; i < numberOfUUIDs; ++i) {
-            pathBuilder.append(':').append(UUID.randomUUID());
-        }
-        final TestRouteResult result = underTest.run(HttpRequest.GET(pathBuilder.toString()));
-        result.assertStatusCode(StatusCodes.OK);
     }
 
     @Test


### PR DESCRIPTION
This PR limits the length of namespaced entity IDs to 256 characters as mentioned in Issue #567 