### PR TITLE
Fix: Add migration note for OpenID Connect conf

### DIFF
--- a/documentation/src/main/resources/pages/ditto/release_notes_100.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_100.md
@@ -68,6 +68,10 @@ When closing a WebSocket session, a `NullPointerException` occurred which is fix
 
 ### Migration notes
 
+OpenID Connect URLs are now prefixes with `https://` per default. Any configured URLs containing `https://` will break the configuration.
+Instead of `https://auth.eclipse.de/auth/realms/ditto` it has to be `auth.eclipse.de/auth/realms/ditto` instead.
+The Configuration option is `ditto.gateway.authentication.oauth.openid-connect-issuers.myprovider`.
+
 Because we removed support for suffixed collections with this release, an offline migration with the provided script 
 is needed.
 

--- a/documentation/src/main/resources/pages/ditto/release_notes_100.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_100.md
@@ -68,7 +68,7 @@ When closing a WebSocket session, a `NullPointerException` occurred which is fix
 
 ### Migration notes
 
-OpenID Connect URLs are now prefixes with `https://` per default. Any configured URLs containing `https://` will break the configuration.
+OpenID Connect URLs are now prefixed with `https://` per default. Any configured URLs containing `https://` will break the configuration.
 Instead of `https://auth.eclipse.de/auth/realms/ditto` it has to be `auth.eclipse.de/auth/realms/ditto` instead.
 The Configuration option is `ditto.gateway.authentication.oauth.openid-connect-issuers.myprovider`.
 


### PR DESCRIPTION
URLs in the OpenID Connect configuration are now prefixed with https://
per default. Administrators have to be aware of this when upgrading.

Signed-off-by: Alexander Wellbrock <a.wellbrock@mailbox.org>

Fixes #580 