### PR TITLE
Fix payload mapping for multiple targets

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
@@ -32,6 +32,7 @@ import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
 import org.eclipse.ditto.model.connectivity.PayloadMapping;
 import org.eclipse.ditto.model.connectivity.PayloadMappingDefinition;
+import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.HeaderTranslator;
 import org.eclipse.ditto.protocoladapter.ProtocolAdapter;
@@ -150,10 +151,43 @@ public final class MessageMappingProcessor {
         final MappingTimer timer = MappingTimer.outbound(connectionId);
         final Adaptable adaptable = timer.protocol(() -> protocolAdapter.toAdaptable(outboundSignal.getSource()));
         enhanceLogFromAdaptable(adaptable);
-        final List<MessageMapper> mappers = getMappers(outboundSignal);
-        log.debug("Resolved mappers for message {} to targets {}: {}",
-                outboundSignal.getSource().getDittoHeaders().getCorrelationId(), outboundSignal.getTargets(), mappers);
-        mappers.forEach(mapper -> convertOutboundMessage(outboundSignal, adaptable, mapper, timer, resultHandler));
+
+        if (outboundSignal.getTargets().isEmpty()) {
+            // responses/errors do not have a target assigned, read mapper from internal header
+            final PayloadMapping payloadMapping = outboundSignal.getSource()
+                    .getDittoHeaders()
+                    .getInboundPayloadMapper()
+                    .map(ConnectivityModelFactory::newPayloadMapping)
+                    .orElseGet(ConnectivityModelFactory::emptyPayloadMapping);
+            final OutboundSignal.Mappable mappableSignal =
+                    OutboundSignalFactory.newMappableOutboundSignal(outboundSignal.getSource(),
+                            outboundSignal.getTargets(), payloadMapping);
+            final List<MessageMapper> mappers = getMappers(mappableSignal.getPayloadMapping());
+            log.debug("Resolved mappers for response {} to targets {}: {}",
+                    outboundSignal.getSource().getDittoHeaders().getCorrelationId(), outboundSignal.getTargets(),
+                    mappers);
+            mappers.forEach(
+                    mapper -> convertOutboundMessage(mappableSignal, adaptable, mapper, timer, resultHandler));
+        } else {
+            // group targets with exact same list of mappers together
+            final List<OutboundSignal.Mappable> outboundSignals = outboundSignal.getTargets()
+                    .stream()
+                    .collect(Collectors.groupingBy(Target::getPayloadMapping, Collectors.toList()))
+                    .entrySet()
+                    .stream()
+                    .map(e -> OutboundSignalFactory.newMappableOutboundSignal(outboundSignal.getSource(), e.getValue(),
+                            e.getKey()))
+                    .collect(Collectors.toList());
+
+            for (final OutboundSignal.Mappable mappableSignal : outboundSignals) {
+                final List<MessageMapper> mappers = getMappers(mappableSignal.getPayloadMapping());
+                log.debug("Resolved mappers for message {} to targets {}: {}",
+                        outboundSignal.getSource().getDittoHeaders().getCorrelationId(), outboundSignal.getTargets(),
+                        mappers);
+                mappers.forEach(
+                        mapper -> convertOutboundMessage(mappableSignal, adaptable, mapper, timer, resultHandler));
+            }
+        }
     }
 
     /**
@@ -213,7 +247,7 @@ public final class MessageMappingProcessor {
     }
 
     private void convertOutboundMessage(
-            final OutboundSignal outboundSignal,
+            final OutboundSignal.Mappable outboundSignal,
             final Adaptable adaptable, final MessageMapper mapper,
             final MappingTimer timer, final MappingResultHandler<OutboundSignal.Mapped> resultHandler) {
         try {
@@ -274,24 +308,10 @@ public final class MessageMappingProcessor {
         }
     }
 
-    private List<MessageMapper> getMappers(final OutboundSignal outboundSignal) {
-        final PayloadMapping payloadMapping;
-        if (outboundSignal.getTargets().isEmpty()) {
-            // responses/errors do not have a target assigned, read mapper from internal header
-            payloadMapping = outboundSignal.getSource()
-                    .getDittoHeaders()
-                    .getInboundPayloadMapper()
-                    .map(ConnectivityModelFactory::newPayloadMapping)
-                    .orElseGet(ConnectivityModelFactory::emptyPayloadMapping);
-        } else {
-            // note: targets have been grouped by mapping -> all targets have the same mapping here
-            payloadMapping = outboundSignal.getTargets().get(0).getPayloadMapping();
-        }
-
+    private List<MessageMapper> getMappers(final PayloadMapping payloadMapping) {
         final List<MessageMapper> mappers = registry.getMappers(payloadMapping);
         if (mappers.isEmpty()) {
-            log.debug("Falling back to Default MessageMapper for mapping as no MessageMapper was present: {}",
-                    outboundSignal);
+            log.debug("Falling back to Default MessageMapper for mapping as no MessageMapper was present.");
             return Collections.singletonList(registry.getDefaultMapper());
         } else {
             return mappers;

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
@@ -145,7 +145,7 @@ public class MessageMappingProcessorTest {
     @Test
     public void testGroupingOfTargets() {
         /*
-          expect 6 mapped messages:
+          expect 6 mappings:
            - 3 targets with 1 mapper  (can be grouped together, mapping is done once)  -> 1 message (with 3 targets)
            - 2 targets with 2 mappers (can be grouped together, mapping is done twice) -> 2 messages (with 2 targets)
            - 1 target  with 3 mappers (no grouping, mapping is done three times)       -> 3 messages (with 1 target)

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorTest.java
@@ -22,7 +22,11 @@ import static org.mockito.Mockito.verify;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.connectivity.ConnectionId;
@@ -130,7 +134,30 @@ public class MessageMappingProcessorTest {
 
     @Test
     public void testOutboundMessageMapped() {
+        testOutbound(1, 0, 0, targetWithMapping(DITTO_MAPPER));
+    }
+
+    @Test
+    public void testOutboundResponseMapped() {
         testOutbound(1, 0, 0);
+    }
+
+    @Test
+    public void testGroupingOfTargets() {
+        /*
+          expect 6 mapped messages:
+           - 3 targets with 1 mapper  (can be grouped together, mapping is done once)  -> 1 message (with 3 targets)
+           - 2 targets with 2 mappers (can be grouped together, mapping is done twice) -> 2 messages (with 2 targets)
+           - 1 target  with 3 mappers (no grouping, mapping is done three times)       -> 3 messages (with 1 target)
+         */
+        testOutbound(6, 0, 0,
+                targetWithMapping(DITTO_MAPPER),
+                targetWithMapping(DITTO_MAPPER),
+                targetWithMapping(DITTO_MAPPER),
+                targetWithMapping(DITTO_MAPPER, DITTO_MAPPER),
+                targetWithMapping(DITTO_MAPPER, DITTO_MAPPER),
+                targetWithMapping(DITTO_MAPPER, DITTO_MAPPER, DITTO_MAPPER)
+        );
     }
 
     @Test
@@ -140,7 +167,7 @@ public class MessageMappingProcessorTest {
 
     @Test
     public void testOutboundMessageDuplicated() {
-        testOutbound(2, 0, 0, targetWithMapping(DUPLICATING_MAPPER));
+        testOutbound(2, 0, 0, false, targetWithMapping(DUPLICATING_MAPPER));
     }
 
     @Test
@@ -150,7 +177,7 @@ public class MessageMappingProcessorTest {
 
     @Test
     public void testOutboundMessageDroppedFailedMappedDuplicated() {
-        testOutbound(2 /* duplicated */ + 1 /* mapped */, 1, 1,
+        testOutbound(2 /* duplicated */ + 1 /* mapped */, 1, 1, false,
                 targetWithMapping(DROPPING_MAPPER, FAILING_MAPPER, DITTO_MAPPER, DUPLICATING_MAPPER));
     }
 
@@ -233,15 +260,28 @@ public class MessageMappingProcessorTest {
 
     private static Target targetWithMapping(final String... mappings) {
         return ConnectivityModelFactory.newTargetBuilder(TestConstants.Targets.TWIN_TARGET)
+                .address(UUID.randomUUID().toString())
                 .payloadMapping(ConnectivityModelFactory.newPayloadMapping(mappings))
                 .build();
     }
 
     private void testOutbound(final int mapped, final int dropped, final int failed, final Target... targets) {
+        testOutbound(mapped, dropped, failed, true, targets);
+    }
+
+    private void testOutbound(final int mapped, final int dropped, final int failed,
+            final boolean assertTargets, final Target... targets) {
         new TestKit(actorSystem) {{
-            final ThingModifiedEvent signal = TestConstants.thingModified(Collections.emptyList());
+
+            // expect one message per mapper per target
+            final List<Target> expectedTargets = Arrays.stream(targets)
+                    .flatMap(t -> Stream.generate(() -> t).limit(t.getPayloadMapping().getMappings().size()))
+                    .collect(Collectors.toList());
+
+            final ThingModifiedEvent<?> signal = TestConstants.thingModified(Collections.emptyList());
             final OutboundSignal outboundSignal =
                     OutboundSignalFactory.newOutboundSignal(signal, Arrays.asList(targets));
+            //noinspection unchecked
             final MappingResultHandler<OutboundSignal.Mapped> mock = Mockito.mock(MappingResultHandler.class);
             underTest.process(outboundSignal, mock);
             final ArgumentCaptor<OutboundSignal.Mapped> captor = ArgumentCaptor.forClass(OutboundSignal.Mapped.class);
@@ -252,6 +292,14 @@ public class MessageMappingProcessorTest {
             assertThat(captor.getAllValues()).allSatisfy(em ->
                     assertThat(em.getExternalMessage().getTextPayload())
                             .contains(TestConstants.signalToDittoProtocolJsonString(signal)));
+
+            if (assertTargets && mapped > 0) {
+                assertThat(captor.getAllValues()
+                        .stream()
+                        .flatMap(mapped -> mapped.getTargets().stream())
+                        .collect(Collectors.toList()))
+                        .containsExactlyInAnyOrderElementsOf(expectedTargets);
+            }
         }};
     }
 

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignal.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+Copyright (c) 2019 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignal.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignal.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.ditto.services.models.connectivity;
 
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkArgument;
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
+
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -19,35 +22,31 @@ import java.util.function.Predicate;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.connectivity.PayloadMapping;
 import org.eclipse.ditto.model.connectivity.Target;
-import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.signals.base.Signal;
 
 /**
- * Represent an outbound signal that was mapped to an external message. It wraps the original signal, the mapped
- * external message and the targets that are allowed to receive this external message.
+ * Represent an outbound signal that is ready to be mapped with the given {@link org.eclipse.ditto.model.connectivity.PayloadMapping}.
+ * This class is used to group targets that have the same payload mapping defined.
  */
-final class MappedOutboundSignal implements OutboundSignal.Mapped {
+final class MappableOutboundSignal implements OutboundSignal.Mappable {
 
     private final OutboundSignal delegate;
-    private final Adaptable adaptable;
-    private final ExternalMessage externalMessage;
+    private final PayloadMapping payloadMapping;
 
-    MappedOutboundSignal(final OutboundSignal delegate, final Adaptable adaptable,
-            final ExternalMessage externalMessage) {
-        this.delegate = delegate;
-        this.adaptable = adaptable;
-        this.externalMessage = externalMessage;
+    MappableOutboundSignal(final Signal<?> signal, final List<Target> targets, final PayloadMapping payloadMapping) {
+        checkNotNull(signal, "signal");
+        this.payloadMapping = checkNotNull(payloadMapping, "payloadMapping");
+
+        checkNotNull(targets, "targets");
+        checkArgument(targets, verifyPayloadMappings(payloadMapping), () -> "Payload mappings must all be equal.");
+        this.delegate = OutboundSignalFactory.newOutboundSignal(signal, targets);
     }
 
     @Override
-    public ExternalMessage getExternalMessage() {
-        return externalMessage;
-    }
-
-    @Override
-    public Adaptable getAdaptable() {
-        return adaptable;
+    public PayloadMapping getPayloadMapping() {
+        return payloadMapping;
     }
 
     @Override
@@ -66,27 +65,29 @@ final class MappedOutboundSignal implements OutboundSignal.Mapped {
         return delegate.toJson(schemaVersion, thePredicate);
     }
 
+    private Predicate<List<Target>> verifyPayloadMappings(final PayloadMapping payloadMapping) {
+        return targets1 -> targets1.stream().allMatch(t -> payloadMapping.equals(t.getPayloadMapping()));
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        final MappedOutboundSignal that = (MappedOutboundSignal) o;
+        final MappableOutboundSignal that = (MappableOutboundSignal) o;
         return Objects.equals(delegate, that.delegate) &&
-                Objects.equals(adaptable, that.adaptable) &&
-                Objects.equals(externalMessage, that.externalMessage);
+                Objects.equals(payloadMapping, that.payloadMapping);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(delegate, adaptable, externalMessage);
+        return Objects.hash(delegate, payloadMapping);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "delegate=" + delegate +
-                ", adaptable=" + adaptable +
-                ", externalMessage=" + externalMessage +
+                ", payloadMapping=" + payloadMapping +
                 "]";
     }
 }

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignal.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignal.java
@@ -25,6 +25,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
+import org.eclipse.ditto.model.connectivity.PayloadMapping;
 import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.signals.base.Signal;
@@ -58,6 +59,18 @@ public interface OutboundSignal extends Jsonifiable.WithFieldSelectorAndPredicat
     @Override
     default JsonObject toJson(final JsonSchemaVersion schemaVersion, final JsonFieldSelector fieldSelector) {
         return toJson(schemaVersion, FieldType.notHidden()).get(fieldSelector);
+    }
+
+    /**
+     * Extends the {@link OutboundSignal} by adding the payload mapping used to map the signal.
+     */
+    interface Mappable extends OutboundSignal {
+
+        /**
+         * @return the {@link PayloadMapping} common to all {@link Target}s.
+         */
+        PayloadMapping getPayloadMapping();
+
     }
 
     /**

--- a/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignalFactory.java
+++ b/services/models/connectivity/src/main/java/org/eclipse/ditto/services/models/connectivity/OutboundSignalFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.services.models.connectivity;
 import java.util.List;
 
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.connectivity.PayloadMapping;
 import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.services.utils.cluster.MappingStrategies;
@@ -53,6 +54,19 @@ public final class OutboundSignalFactory {
             final Adaptable adaptable, final ExternalMessage externalMessage) {
 
         return new MappedOutboundSignal(outboundSignal, adaptable, externalMessage);
+    }
+
+    /**
+     * Creates a OutboundSignal wrapping an existing {@code outboundSignal} that has the same {@link PayloadMapping}
+     * for all targets.
+     *
+     * @param signal the original signal
+     * @param payloadMapping the payload mapping common to all targets
+     * @return the created OutboundSignal with the {@link PayloadMapping} that will be used to map the signal
+     */
+    public static OutboundSignal.Mappable newMappableOutboundSignal(final Signal<?> signal, final List<Target> targets,
+            final PayloadMapping payloadMapping) {
+        return new MappableOutboundSignal(signal, targets, payloadMapping);
     }
 
     /**

--- a/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignalTest.java
+++ b/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/MappableOutboundSignalTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.models.connectivity;
+
+import org.eclipse.ditto.model.connectivity.PayloadMapping;
+import org.junit.Test;
+import org.mutabilitydetector.unittesting.AllowedReason;
+import org.mutabilitydetector.unittesting.MutabilityAssert;
+import org.mutabilitydetector.unittesting.MutabilityMatchers;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class MappableOutboundSignalTest {
+
+    @Test
+    public void assertImmutability() {
+        MutabilityAssert.assertInstancesOf(MappableOutboundSignal.class, MutabilityMatchers.areImmutable(),
+                AllowedReason.provided(OutboundSignal.class, PayloadMapping.class).areAlsoImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(MappableOutboundSignal.class)
+                .usingGetClass()
+                .verify();
+    }
+
+}

--- a/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/MappedOutboundSignalTest.java
+++ b/services/models/connectivity/src/test/java/org/eclipse/ditto/services/models/connectivity/MappedOutboundSignalTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.models.connectivity;
+
+import org.eclipse.ditto.protocoladapter.Adaptable;
+import org.junit.Test;
+import org.mutabilitydetector.unittesting.AllowedReason;
+import org.mutabilitydetector.unittesting.MutabilityAssert;
+import org.mutabilitydetector.unittesting.MutabilityMatchers;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+public class MappedOutboundSignalTest {
+
+    @Test
+    public void assertImmutability() {
+        MutabilityAssert.assertInstancesOf(MappedOutboundSignal.class, MutabilityMatchers.areImmutable(),
+                AllowedReason.provided(Adaptable.class, ExternalMessage.class, OutboundSignal.class)
+                        .areAlsoImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(MappedOutboundSignal.class)
+                .usingGetClass()
+                .verify();
+    }
+
+}


### PR DESCRIPTION
If multiple targets of a connection defined different payload mappings, only the first mapping was applied.