### PR TITLE
Add a protocol header for the subject who caused an event.

### DIFF
--- a/documentation/src/main/resources/pages/ditto/protocol-specification.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification.md
@@ -72,6 +72,7 @@ There are some pre-defined headers which have a special meaning for Ditto:
 | `response-required` | Configures for a sent **command** whether a **response** should be sent back. | `Boolean` - default: `true` |
 | `If-Match` | Has the same semantics as defined for the [HTTP API](httpapi-concepts.html#conditional-requests). | `String` |
 | `If-None-Match` | Has the same semantics as defined for the [HTTP API](httpapi-concepts.html#conditional-requests). | `String` |
+| `ditto-originator` | Contains the first authorization subject of the command that caused the sending of this message. Set by Ditto. | `String` |
 
 Custom headers of messages through the [live channel](protocol-twinlive.html) are delivered verbatim. When naming 
 custom headers, it is best to attach a prefix specific to your application that does not conflict with Ditto or
@@ -81,6 +82,7 @@ HTTP protocol, for example the prefix `ditto-*`.
   and will not be delivered.
   ```
   channel
+  ditto-*
   raw-request-url
   read-subjects
   subject

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
@@ -140,7 +140,16 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
      * Key: {@code "ditto-inbound-payload-mapper"}, Java type: {@link String}.
      * </p>
      */
-    INBOUND_PAYLOAD_MAPPER("ditto-inbound-payload-mapper", String.class, false, false);
+    INBOUND_PAYLOAD_MAPPER("ditto-inbound-payload-mapper", String.class, false, false),
+
+    /**
+     * Header definition for the authorization subject that caused an event.
+     * External header of the same name is always discarded.
+     * <p>
+     * Key: {@code "ditto-originator"}, Java type: {@link String}.
+     * </p>
+     */
+    ORIGINATOR("ditto-originator", String.class, false, true);
 
     /**
      * Map to speed up lookup of header definition by key.

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinitionTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinitionTest.java
@@ -26,7 +26,7 @@ public final class DittoHeaderDefinitionTest {
         for (DittoHeaderDefinition definition : DittoHeaderDefinition.values()) {
             if (!definition.shouldReadFromExternalHeaders() && !definition.shouldWriteToExternalHeaders()) {
                 assertThat(definition.getKey()).startsWith("ditto-");
-            } else {
+            } else if (definition.shouldReadFromExternalHeaders()) {
                 assertThat(definition.getKey()).doesNotStartWith("ditto-");
             }
         }

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
@@ -65,6 +65,7 @@ public final class ImmutableDittoHeadersTest {
     private static final String KNOWN_ORIGIN = "knownOrigin";
     private static final String KNOWN_REPLY_TARGET = "5";
     private static final String KNOWN_MAPPER = "knownMapper";
+    private static final String KNOWN_ORIGINATOR = "known:originator";
 
     @Test
     public void assertImmutability() {
@@ -97,6 +98,7 @@ public final class ImmutableDittoHeadersTest {
                 .contentType(KNOWN_CONTENT_TYPE)
                 .replyTarget(Integer.valueOf(KNOWN_REPLY_TARGET))
                 .inboundPayloadMapper(KNOWN_MAPPER)
+                .putHeader(DittoHeaderDefinition.ORIGINATOR.getKey(), KNOWN_ORIGINATOR)
                 .build();
 
         assertThat(underTest).isEqualTo(expectedHeaderMap);
@@ -216,6 +218,7 @@ public final class ImmutableDittoHeadersTest {
                 .set(DittoHeaderDefinition.CONTENT_TYPE.getKey(), KNOWN_CONTENT_TYPE)
                 .set(DittoHeaderDefinition.REPLY_TARGET.getKey(), Integer.parseInt(KNOWN_REPLY_TARGET))
                 .set(DittoHeaderDefinition.INBOUND_PAYLOAD_MAPPER.getKey(), KNOWN_MAPPER)
+                .set(DittoHeaderDefinition.ORIGINATOR.getKey(), KNOWN_ORIGINATOR)
                 .build();
         final Map<String, String> allKnownHeaders = createMapContainingAllKnownHeaders();
 
@@ -375,6 +378,7 @@ public final class ImmutableDittoHeadersTest {
         result.put(DittoHeaderDefinition.ORIGIN.getKey(), KNOWN_ORIGIN);
         result.put(DittoHeaderDefinition.REPLY_TARGET.getKey(), KNOWN_REPLY_TARGET);
         result.put(DittoHeaderDefinition.INBOUND_PAYLOAD_MAPPER.getKey(), KNOWN_MAPPER);
+        result.put(DittoHeaderDefinition.ORIGINATOR.getKey(), KNOWN_ORIGINATOR);
 
         return result;
     }

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/DefaultEnforcerActorFactory.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/proxy/DefaultEnforcerActorFactory.java
@@ -17,11 +17,13 @@ import static org.eclipse.ditto.services.models.concierge.ConciergeMessagingCons
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.enforcers.Enforcer;
 import org.eclipse.ditto.model.things.Thing;
@@ -155,6 +157,25 @@ public final class DefaultEnforcerActorFactory implements EnforcerActorFactory<C
         return context.actorOf(enforcerProps, EnforcerActor.ACTOR_NAME);
     }
 
+    /**
+     * Set the "ditto-originator" header to the primary authorization subject of a signal.
+     *
+     * @param originalSignal A signal with authorization context.
+     * @return A copy of the signal with the header "ditto-originator" set.
+     */
+    public static WithDittoHeaders setOriginatorHeader(final WithDittoHeaders originalSignal) {
+        final List<String> authSubjects = originalSignal.getDittoHeaders().getAuthorizationSubjects();
+        if (authSubjects.isEmpty()) {
+            return originalSignal;
+        } else {
+            final String originatorSubjectId = authSubjects.get(0);
+            return originalSignal.setDittoHeaders(originalSignal.getDittoHeaders()
+                    .toBuilder()
+                    .putHeader(DittoHeaderDefinition.ORIGINATOR.getKey(), originatorSubjectId)
+                    .build());
+        }
+    }
+
     private static Function<WithDittoHeaders, CompletionStage<WithDittoHeaders>> newPreEnforcer(
             final BlockedNamespaces blockedNamespaces, final PlaceholderSubstitution placeholderSubstitution) {
 
@@ -163,6 +184,7 @@ public final class DefaultEnforcerActorFactory implements EnforcerActorFactory<C
                         .block(withDittoHeaders)
                         .thenApply(CommandWithOptionalEntityValidator.getInstance())
                         .thenApply(DefaultEnforcerActorFactory::prependDefaultNamespaceToCreateThing)
+                        .thenApply(DefaultEnforcerActorFactory::setOriginatorHeader)
                         .thenCompose(placeholderSubstitution);
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/internal/ssl/AbstractSSLContextTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/internal/ssl/AbstractSSLContextTest.java
@@ -19,17 +19,16 @@ import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.Ce
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.net.SocketException;
 import java.util.concurrent.CompletableFuture;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLServerSocket;
 
 import org.eclipse.ditto.model.connectivity.ClientCertificateCredentials;
 import org.eclipse.ditto.model.connectivity.Credentials;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -197,18 +196,13 @@ public abstract class AbstractSSLContextTest {
     }
 
     @Test
-    public void distrustSelfSignedClient() {
+    public void distrustSelfSignedClient() throws Exception {
         try (final ServerSocket serverSocket = startServer(true);
                 final Socket underTest = createSSLContext(Certificates.CA_CRT, null, SELF_SIGNED_CLIENT_CREDENTIALS)
                         .getSocketFactory()
                         .createSocket(serverSocket.getInetAddress(), serverSocket.getLocalPort())) {
 
-            underTest.getOutputStream().write(234);
-        } catch (SSLHandshakeException | SocketException expected) {
-            // one of these is expected. should only be SSLHandshakeException, but JDK has a bug
-        } catch (final Exception e) {
-            e.printStackTrace();
-            Assert.fail("Got different exception than expected");
+            assertThatExceptionOfType(SSLException.class).isThrownBy(() -> underTest.getOutputStream().write(234));
         }
     }
 


### PR DESCRIPTION
Add the protocol header `ditto-originator` that is set for all outgoing messages to the subject who caused the sending of the message.

Motivation: The cause of any message is available for connections via the header mapping placeholder `{{ request:subjectId }}`. This information is not available over Websocket, where header (or payload) mapping is not possible.