### PR TITLE
Bugfix websocket response + Update license headers + Minor improvement in connectivity service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -566,6 +566,7 @@
                     <validHeaders>
                         <header>${project.basedir}/src/license-header-2017.txt</header>
                         <header>${project.basedir}/src/license-header-2018.txt</header>
+                        <header>${project.basedir}/src/license-header-2019.txt</header>
                     </validHeaders>
                     <aggregate>true</aggregate>
                     <quiet>false</quiet>

--- a/services/base/src/main/java/org/eclipse/ditto/services/base/DittoService.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/DittoService.java
@@ -368,9 +368,9 @@ public abstract class DittoService<C extends ServiceSpecificConfig> {
         startActor(actorSystem, StatusSupplierActor.props(rootActorName), StatusSupplierActor.ACTOR_NAME);
     }
 
-    private void startActor(final ActorSystem actorSystem, final Props actorProps, final String actorName) {
+    private ActorRef startActor(final ActorSystem actorSystem, final Props actorProps, final String actorName) {
         logStartingActor(actorName);
-        actorSystem.actorOf(actorProps, actorName);
+        return actorSystem.actorOf(actorProps, actorName);
     }
 
     private void logStartingActor(final String actorName) {
@@ -465,8 +465,8 @@ public abstract class DittoService<C extends ServiceSpecificConfig> {
      * @param actorSystem Akka actor system for starting actors.
      * @param mainRootActorProps the Props of the main root actor.
      */
-    protected void startMainRootActor(final ActorSystem actorSystem, final Props mainRootActorProps) {
-        startActor(actorSystem, mainRootActorProps, rootActorName);
+    protected ActorRef startMainRootActor(final ActorSystem actorSystem, final Props mainRootActorProps) {
+        return startActor(actorSystem, mainRootActorProps, rootActorName);
     }
 
     /**

--- a/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.base.actors;
+
+import org.eclipse.ditto.services.utils.akka.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
+
+import akka.actor.AbstractActor;
+import akka.actor.Props;
+import akka.japi.pf.ReceiveBuilder;
+
+public abstract class DittoRootActor extends AbstractActor {
+
+    private final DittoDiagnosticLoggingAdapter log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
+
+    @Override
+    public Receive createReceive() {
+        return ReceiveBuilder.create()
+                .match(StartChildActor.class, this::startChildActor)
+                .build();
+    }
+
+    private void startChildActor(final StartChildActor startChildActor) {
+        log.info("Starting child actor <{}>.", startChildActor.actorName);
+        getContext().actorOf(startChildActor.props, startChildActor.actorName);
+    }
+
+    public static class StartChildActor {
+
+        private final Props props;
+        private final String actorName;
+
+        public StartChildActor(final Props props, final String actorName) {
+            this.props = props;
+            this.actorName = actorName;
+        }
+
+    }
+
+}

--- a/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.ConnectException;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.services.utils.akka.logging.DittoDiagnosticLoggingAdapter;
@@ -159,6 +160,32 @@ public abstract class DittoRootActor extends AbstractActor {
         public StartChildActor(final Props props, final String actorName) {
             this.props = props;
             this.actorName = actorName;
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final StartChildActor that = (StartChildActor) o;
+            return props.equals(that.props) &&
+                    actorName.equals(that.actorName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(props, actorName);
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + " [" +
+                    "props=" + props +
+                    ", actorName=" + actorName +
+                    "]";
         }
 
     }

--- a/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/actors/DittoRootActor.java
@@ -29,6 +29,7 @@ import akka.actor.ActorRef;
 import akka.actor.InvalidActorNameException;
 import akka.actor.OneForOneStrategy;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.actor.SupervisorStrategy;
 import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
@@ -97,6 +98,11 @@ public abstract class DittoRootActor extends AbstractActor {
     public Receive createReceive() {
         return ReceiveBuilder.create()
                 .match(StartChildActor.class, this::startChildActor)
+                .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure <{}>!", f))
+                .matchAny(m -> {
+                    log.warning("Unknown message <{}>.", m);
+                    unhandled(m);
+                })
                 .build();
     }
 

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
@@ -16,12 +16,10 @@ import static akka.http.javadsl.server.Directives.logRequest;
 import static akka.http.javadsl.server.Directives.logResult;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
-import java.net.ConnectException;
 import java.time.Duration;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionStage;
 
-import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.services.base.actors.DittoRootActor;
 import org.eclipse.ditto.services.base.config.http.HttpConfig;
 import org.eclipse.ditto.services.concierge.actors.ShardRegions;
 import org.eclipse.ditto.services.concierge.actors.cleanup.CleanupStatusReporter;
@@ -43,88 +41,31 @@ import org.eclipse.ditto.services.utils.health.routes.StatusRoute;
 import org.eclipse.ditto.services.utils.persistence.mongo.MongoHealthChecker;
 
 import akka.Done;
-import akka.actor.AbstractActor;
-import akka.actor.ActorInitializationException;
-import akka.actor.ActorKilledException;
 import akka.actor.ActorRef;
-import akka.actor.ActorRefFactory;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
-import akka.actor.InvalidActorNameException;
-import akka.actor.OneForOneStrategy;
 import akka.actor.Props;
 import akka.actor.Status;
-import akka.actor.SupervisorStrategy;
 import akka.cluster.Cluster;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
-import akka.pattern.AskTimeoutException;
 import akka.stream.ActorMaterializer;
 
 /**
  * The root actor of the concierge service.
  */
-public final class ConciergeRootActor extends AbstractActor {
+public final class ConciergeRootActor extends DittoRootActor {
 
     /**
      * Name of this actor.
      */
     public static final String ACTOR_NAME = "conciergeRoot";
 
-    private static final String RESTARTING_CHILD_MSG = "Restarting child...";
-
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
-    private final SupervisorStrategy supervisorStrategy = new OneForOneStrategy(true, DeciderBuilder
-            .match(NullPointerException.class, e -> {
-                log.error(e, "NullPointer in child actor: {}", e.getMessage());
-                log.info(RESTARTING_CHILD_MSG);
-                return SupervisorStrategy.restart();
-            }).match(IllegalArgumentException.class, e -> {
-                log.warning("Illegal Argument in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IndexOutOfBoundsException.class, e -> {
-                log.warning("IndexOutOfBounds in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IllegalStateException.class, e -> {
-                log.warning("Illegal State in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(NoSuchElementException.class, e -> {
-                log.warning("NoSuchElement in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(AskTimeoutException.class, e -> {
-                log.warning("AskTimeoutException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(ConnectException.class, e -> {
-                log.warning("ConnectException in child actor: {}", e.getMessage());
-                log.info(RESTARTING_CHILD_MSG);
-                return SupervisorStrategy.restart();
-            }).match(InvalidActorNameException.class, e -> {
-                log.warning("InvalidActorNameException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(ActorInitializationException.class, e -> {
-                log.error(e, "ActorInitializationException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.stop();
-            }).match(ActorKilledException.class, e -> {
-                log.error(e, "ActorKilledException in child actor: {}", e.message());
-                log.info(RESTARTING_CHILD_MSG);
-                return SupervisorStrategy.restart();
-            }).match(DittoRuntimeException.class, e -> {
-                log.error(e,
-                        "DittoRuntimeException '{}' should not be escalated to RootActor. Simply resuming Actor.",
-                        e.getErrorCode());
-                return SupervisorStrategy.resume();
-            }).match(Throwable.class, e -> {
-                log.error(e, "Escalating above root actor!");
-                return SupervisorStrategy.escalate();
-            }).matchAny(e -> {
-                log.error("Unknown message:'{}'! Escalating above root actor!", e);
-                return SupervisorStrategy.escalate();
-            }).build());
 
     @SuppressWarnings("unused")
     private <C extends ConciergeConfig> ConciergeRootActor(final C conciergeConfig,
@@ -142,12 +83,12 @@ public final class ConciergeRootActor extends AbstractActor {
         final ActorRef conciergeForwarder = context.findChild(ConciergeForwarderActor.ACTOR_NAME).orElseThrow(() ->
                 new IllegalStateException("ConciergeForwarder could not be found"));
 
-        final ActorRef cleanupCoordinator = startClusterSingletonActor(context,
+        final ActorRef cleanupCoordinator = startClusterSingletonActor(
                 EventSnapshotCleanupCoordinator.ACTOR_NAME,
                 EventSnapshotCleanupCoordinator.props(conciergeConfig.getPersistenceCleanupConfig(), pubSubMediator,
                         shardRegions));
 
-        final ActorRef healthCheckingActor = startHealthCheckingActor(context, conciergeConfig, cleanupCoordinator);
+        final ActorRef healthCheckingActor = startHealthCheckingActor(conciergeConfig, cleanupCoordinator);
 
         bindHttpStatusRoute(healthCheckingActor, conciergeConfig.getHttpConfig(), materializer);
     }
@@ -177,14 +118,13 @@ public final class ConciergeRootActor extends AbstractActor {
     }
 
 
-    private static ActorRef startClusterSingletonActor(final ActorContext context, final String actorName,
-            final Props props) {
+    private ActorRef startClusterSingletonActor(final String actorName, final Props props) {
 
-        return ClusterUtil.startSingleton(context, ConciergeMessagingConstants.CLUSTER_ROLE, actorName, props);
+        return ClusterUtil.startSingleton(getContext(), ConciergeMessagingConstants.CLUSTER_ROLE, actorName, props);
     }
 
-    private static ActorRef startHealthCheckingActor(final ActorContext context,
-            final ConciergeConfig conciergeConfig, final ActorRef cleanupCoordinator) {
+    private ActorRef startHealthCheckingActor(final ConciergeConfig conciergeConfig,
+            final ActorRef cleanupCoordinator) {
 
         final HealthCheckConfig healthCheckConfig = conciergeConfig.getHealthCheckConfig();
 
@@ -197,18 +137,13 @@ public final class ConciergeRootActor extends AbstractActor {
         }
         final HealthCheckingActorOptions healthCheckingActorOptions = hcBuilder.build();
 
-        final ActorRef cleanupCoordinatorProxy = ClusterUtil.startSingletonProxy(context,
+        final ActorRef cleanupCoordinatorProxy = ClusterUtil.startSingletonProxy(getContext(),
                 ConciergeMessagingConstants.CLUSTER_ROLE, cleanupCoordinator);
 
-        return startChildActor(context, DefaultHealthCheckingActorFactory.ACTOR_NAME,
+        return startChildActor(DefaultHealthCheckingActorFactory.ACTOR_NAME,
                 DefaultHealthCheckingActorFactory.props(healthCheckingActorOptions,
                         MongoHealthChecker.props(),
                         CleanupStatusReporter.props(cleanupCoordinatorProxy)));
-    }
-
-    private static ActorRef startChildActor(final ActorRefFactory context, final String actorName, final Props props) {
-
-        return context.actorOf(props, actorName);
     }
 
     private static Route createRoute(final ActorSystem actorSystem, final ActorRef healthCheckingActor) {
@@ -220,18 +155,14 @@ public final class ConciergeRootActor extends AbstractActor {
     }
 
     @Override
-    public SupervisorStrategy supervisorStrategy() {
-        return supervisorStrategy;
-    }
-
-    @Override
     public Receive createReceive() {
-        return ReceiveBuilder.create()
-                .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure <{}>!", f))
-                .matchAny(m -> {
-                    log.warning("Unknown message <{}>.", m);
-                    unhandled(m);
-                }).build();
+        return super.createReceive()
+                .orElse(ReceiveBuilder.create()
+                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure <{}>!", f))
+                        .matchAny(m -> {
+                            log.warning("Unknown message <{}>.", m);
+                            unhandled(m);
+                        }).build());
     }
 
     private void bindHttpStatusRoute(final ActorRef healthCheckingActor, final HttpConfig httpConfig,

--- a/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
+++ b/services/concierge/starter/src/main/java/org/eclipse/ditto/services/concierge/starter/actors/ConciergeRootActor.java
@@ -45,14 +45,12 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.Props;
-import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.event.DiagnosticLoggingAdapter;
 import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.japi.pf.ReceiveBuilder;
 import akka.stream.ActorMaterializer;
 
 /**
@@ -152,17 +150,6 @@ public final class ConciergeRootActor extends DittoRootActor {
 
         return logRequest("http-request", () ->
                 logResult("http-response", statusRoute::buildStatusRoute));
-    }
-
-    @Override
-    public Receive createReceive() {
-        return super.createReceive()
-                .orElse(ReceiveBuilder.create()
-                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure <{}>!", f))
-                        .matchAny(m -> {
-                            log.warning("Unknown message <{}>.", m);
-                            unhandled(m);
-                        }).build());
     }
 
     private void bindHttpStatusRoute(final ActorRef healthCheckingActor, final HttpConfig httpConfig,

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapperExtension.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapperExtension.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.connectivity.mapping;
 
 import javax.annotation.Nullable;
 
+import org.atteo.classindex.IndexSubclasses;
 import org.eclipse.ditto.model.connectivity.ConnectionId;
 
 import akka.actor.ExtendedActorSystem;
@@ -22,6 +23,7 @@ import akka.actor.ExtendedActorSystem;
  * Interface for wrapping an existing message mapper after creation.
  */
 @FunctionalInterface
+@IndexSubclasses
 public interface MessageMapperExtension {
 
     /**

--- a/services/connectivity/starter/src/main/java/org/eclipse/ditto/services/connectivity/actors/ConnectivityRootActor.java
+++ b/services/connectivity/starter/src/main/java/org/eclipse/ditto/services/connectivity/actors/ConnectivityRootActor.java
@@ -61,7 +61,6 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.Props;
-import akka.actor.Status;
 import akka.actor.SupervisorStrategy;
 import akka.cluster.Cluster;
 import akka.cluster.sharding.ClusterSharding;
@@ -72,7 +71,6 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
 import akka.japi.pf.DeciderBuilder;
-import akka.japi.pf.ReceiveBuilder;
 import akka.stream.ActorMaterializer;
 import scala.PartialFunction;
 
@@ -176,17 +174,6 @@ public final class ConnectivityRootActor extends DittoRootActor {
 
         return Props.create(ConnectivityRootActor.class, connectivityConfig, pubSubMediator, materializer,
                 conciergeForwarderSignalTransformer, null);
-    }
-
-    @Override
-    public Receive createReceive() {
-        return super.createReceive()
-                .orElse(ReceiveBuilder.create()
-                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                        .matchAny(m -> {
-                            log.warning("Unknown message: {}", m);
-                            unhandled(m);
-                        }).build());
     }
 
     @Override

--- a/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
+++ b/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
@@ -12,15 +12,13 @@
  */
 package org.eclipse.ditto.services.gateway.starter;
 
-import java.net.ConnectException;
 import java.time.Duration;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
-import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeadersSizeChecker;
 import org.eclipse.ditto.protocoladapter.HeaderTranslator;
+import org.eclipse.ditto.services.base.actors.DittoRootActor;
 import org.eclipse.ditto.services.base.config.limits.LimitsConfig;
 import org.eclipse.ditto.services.gateway.endpoints.config.HttpConfig;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DittoGatewayAuthenticationDirectiveFactory;
@@ -29,10 +27,10 @@ import org.eclipse.ditto.services.gateway.endpoints.routes.RootRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.devops.DevOpsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.health.CachingHealthRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.policies.PoliciesRoute;
-import org.eclipse.ditto.services.gateway.endpoints.routes.things.ThingsSseRouteBuilder;
 import org.eclipse.ditto.services.gateway.endpoints.routes.stats.StatsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.status.OverallStatusRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.things.ThingsRoute;
+import org.eclipse.ditto.services.gateway.endpoints.routes.things.ThingsSseRouteBuilder;
 import org.eclipse.ditto.services.gateway.endpoints.routes.thingsearch.ThingSearchRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.websocket.WebSocketRoute;
 import org.eclipse.ditto.services.gateway.health.DittoStatusAndHealthProviderFactory;
@@ -65,16 +63,11 @@ import org.eclipse.ditto.services.utils.health.routes.StatusRoute;
 import org.eclipse.ditto.services.utils.protocol.ProtocolAdapterProvider;
 
 import akka.Done;
-import akka.actor.AbstractActor;
-import akka.actor.ActorKilledException;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
-import akka.actor.InvalidActorNameException;
-import akka.actor.OneForOneStrategy;
 import akka.actor.Props;
 import akka.actor.Status;
-import akka.actor.SupervisorStrategy;
 import akka.cluster.Cluster;
 import akka.dispatch.MessageDispatcher;
 import akka.event.DiagnosticLoggingAdapter;
@@ -84,15 +77,13 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Directives;
 import akka.http.javadsl.server.Route;
-import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
-import akka.pattern.AskTimeoutException;
 import akka.stream.ActorMaterializer;
 
 /**
  * The Root Actor of the API Gateway's Akka ActorSystem.
  */
-final class GatewayRootActor extends AbstractActor {
+final class GatewayRootActor extends DittoRootActor {
 
     /**
      * The name of this Actor in the ActorSystem.
@@ -101,53 +92,7 @@ final class GatewayRootActor extends AbstractActor {
 
     private static final String AUTHENTICATION_DISPATCHER_NAME = "authentication-dispatcher";
 
-    private static final String CHILD_RESTART_INFO_MSG = "Restarting child ...";
-
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
-
-    private final SupervisorStrategy strategy = new OneForOneStrategy(true, DeciderBuilder
-            .match(NullPointerException.class, e -> {
-                log.error(e, "NullPointer in child actor: {}", e.getMessage());
-                log.info(CHILD_RESTART_INFO_MSG);
-                return SupervisorStrategy.restart();
-            }).match(IllegalArgumentException.class, e -> {
-                log.warning("Illegal Argument in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IndexOutOfBoundsException.class, e -> {
-                log.warning("IndexOutOfBounds in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IllegalStateException.class, e -> {
-                log.warning("Illegal State in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(NoSuchElementException.class, e -> {
-                log.warning("NoSuchElement in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(AskTimeoutException.class, e -> {
-                log.warning("AskTimeoutException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(ConnectException.class, e -> {
-                log.warning("ConnectException in child actor: {}", e.getMessage());
-                log.info(CHILD_RESTART_INFO_MSG);
-                return SupervisorStrategy.restart();
-            }).match(InvalidActorNameException.class, e -> {
-                log.warning("InvalidActorNameException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(DittoRuntimeException.class, e -> {
-                log.error(e,
-                        "DittoRuntimeException <{}> should not be escalated to GatewayRootActor. Simply resuming Actor.",
-                        e.getErrorCode());
-                return SupervisorStrategy.resume();
-            }).match(ActorKilledException.class, e -> {
-                log.error(e, "ActorKilledException in child actor: {}", e.message());
-                log.info(CHILD_RESTART_INFO_MSG);
-                return SupervisorStrategy.restart();
-            }).match(Throwable.class, e -> {
-                log.error(e, "Escalating above root actor!");
-                return SupervisorStrategy.escalate();
-            }).matchAny(e -> {
-                log.error("Unknown message: '{}'! Escalating above root actor!", e);
-                return SupervisorStrategy.escalate();
-            }).build());
 
     private final CompletionStage<ServerBinding> httpBinding;
 
@@ -241,28 +186,19 @@ final class GatewayRootActor extends AbstractActor {
     }
 
     @Override
-    public SupervisorStrategy supervisorStrategy() {
-        return strategy;
-    }
-
-    @Override
     public Receive createReceive() {
-        return ReceiveBuilder.create()
-                .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                .matchEquals(GatewayHttpReadinessCheck.READINESS_ASK_MESSAGE, msg -> {
-                    final ActorRef sender = getSender();
-                    httpBinding.thenAccept(binding -> sender.tell(
-                            GatewayHttpReadinessCheck.READINESS_ASK_MESSAGE_RESPONSE, ActorRef.noSender()));
-                })
-                .matchAny(m -> {
-                    log.warning("Unknown message: {}", m);
-                    unhandled(m);
-                }).build();
-    }
-
-    private ActorRef startChildActor(final String actorName, final Props props) {
-        log.info("Starting child actor <{}>.", actorName);
-        return getContext().actorOf(props, actorName);
+        return super.createReceive()
+                .orElse(ReceiveBuilder.create()
+                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
+                        .matchEquals(GatewayHttpReadinessCheck.READINESS_ASK_MESSAGE, msg -> {
+                            final ActorRef sender = getSender();
+                            httpBinding.thenAccept(binding -> sender.tell(
+                                    GatewayHttpReadinessCheck.READINESS_ASK_MESSAGE_RESPONSE, ActorRef.noSender()));
+                        })
+                        .matchAny(m -> {
+                            log.warning("Unknown message: {}", m);
+                            unhandled(m);
+                        }).build());
     }
 
     private static Route createRoute(final ActorSystem actorSystem,

--- a/services/policies/starter/src/main/java/org/eclipse/ditto/services/policies/starter/PoliciesRootActor.java
+++ b/services/policies/starter/src/main/java/org/eclipse/ditto/services/policies/starter/PoliciesRootActor.java
@@ -51,7 +51,6 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.Props;
-import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.cluster.sharding.ClusterSharding;
 import akka.cluster.sharding.ClusterShardingSettings;
@@ -175,14 +174,9 @@ public final class PoliciesRootActor extends DittoRootActor {
 
     @Override
     public Receive createReceive() {
-        return super.createReceive()
-                .orElse(ReceiveBuilder.create()
-                        .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
-                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                        .matchAny(m -> {
-                            log.warning("Unknown message: {}", m);
-                            unhandled(m);
-                        }).build());
+        return ReceiveBuilder.create()
+                .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
+                .build().orElse(super.createReceive());
     }
 
     private void handleRetrieveStatisticsDetails(final RetrieveStatisticsDetails command) {

--- a/services/things/starter/src/main/java/org/eclipse/ditto/services/things/starter/ThingsRootActor.java
+++ b/services/things/starter/src/main/java/org/eclipse/ditto/services/things/starter/ThingsRootActor.java
@@ -16,12 +16,10 @@ import static akka.http.javadsl.server.Directives.logRequest;
 import static akka.http.javadsl.server.Directives.logResult;
 import static org.eclipse.ditto.services.models.things.ThingsMessagingConstants.CLUSTER_ROLE;
 
-import java.net.ConnectException;
 import java.time.Duration;
-import java.util.NoSuchElementException;
 import java.util.concurrent.CompletionStage;
 
-import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.services.base.actors.DittoRootActor;
 import org.eclipse.ditto.services.base.config.http.HttpConfig;
 import org.eclipse.ditto.services.models.things.ThingEventPubSubFactory;
 import org.eclipse.ditto.services.models.things.ThingsMessagingConstants;
@@ -50,16 +48,11 @@ import org.eclipse.ditto.signals.commands.devops.RetrieveStatisticsDetails;
 import org.eclipse.ditto.signals.events.things.ThingEvent;
 
 import akka.Done;
-import akka.actor.AbstractActor;
-import akka.actor.ActorKilledException;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
-import akka.actor.InvalidActorNameException;
-import akka.actor.OneForOneStrategy;
 import akka.actor.Props;
 import akka.actor.Status;
-import akka.actor.SupervisorStrategy;
 import akka.cluster.Cluster;
 import akka.cluster.sharding.ClusterSharding;
 import akka.cluster.sharding.ClusterShardingSettings;
@@ -68,80 +61,21 @@ import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.japi.pf.DeciderBuilder;
 import akka.japi.pf.ReceiveBuilder;
-import akka.pattern.AskTimeoutException;
 import akka.pattern.Patterns;
 import akka.stream.ActorMaterializer;
 
 /**
  * Our "Parent" Actor which takes care of supervision of all other Actors in our system.
  */
-public final class ThingsRootActor extends AbstractActor {
+public final class ThingsRootActor extends DittoRootActor {
 
     /**
      * The name of this Actor in the ActorSystem.
      */
     public static final String ACTOR_NAME = "thingsRoot";
 
-    private static final String RESTARTING_CHILD_MESSAGE = "Restarting child ...";
-
     private final DiagnosticLoggingAdapter log = LogUtil.obtain(this);
-    private final SupervisorStrategy strategy = new OneForOneStrategy(true, DeciderBuilder
-            .match(NullPointerException.class, e ->
-            {
-                log.error(e, "NullPointer in child actor: {}", e.getMessage());
-                log.info(RESTARTING_CHILD_MESSAGE);
-                return SupervisorStrategy.restart();
-            }).match(IllegalArgumentException.class, e ->
-            {
-                log.warning("Illegal Argument in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IndexOutOfBoundsException.class, e -> {
-
-                log.warning("IndexOutOfBounds in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(IllegalStateException.class, e ->
-            {
-                log.warning("Illegal State in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(NoSuchElementException.class, e ->
-            {
-                log.warning("NoSuchElement in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(AskTimeoutException.class, e ->
-            {
-                log.warning("AskTimeoutException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(ConnectException.class, e ->
-            {
-                log.warning("ConnectException in child actor: {}", e.getMessage());
-                log.info(RESTARTING_CHILD_MESSAGE);
-                return SupervisorStrategy.restart();
-            }).match(InvalidActorNameException.class, e ->
-            {
-                log.warning("InvalidActorNameException in child actor: {}", e.getMessage());
-                return SupervisorStrategy.resume();
-            }).match(ActorKilledException.class, e ->
-            {
-                log.error(e, "ActorKilledException in child actor: {}", e.message());
-                log.info(RESTARTING_CHILD_MESSAGE);
-                return SupervisorStrategy.restart();
-            }).match(DittoRuntimeException.class, e ->
-            {
-                log.error(e,
-                        "DittoRuntimeException <{}> should not be escalated to ThingsRootActor. Simply resuming Actor.",
-                        e.getErrorCode());
-                return SupervisorStrategy.resume();
-            }).match(Throwable.class, e ->
-            {
-                log.error(e, "Escalating above root actor!");
-                return SupervisorStrategy.escalate();
-            }).matchAny(e ->
-            {
-                log.error("Unknown message:'{}'! Escalating above root actor!", e);
-                return SupervisorStrategy.escalate();
-            }).build());
 
     private final RetrieveStatisticsDetailsResponseSupplier retrieveStatisticsDetailsResponseSupplier;
 
@@ -252,30 +186,21 @@ public final class ThingsRootActor extends AbstractActor {
     }
 
     @Override
-    public SupervisorStrategy supervisorStrategy() {
-        return strategy;
-    }
-
-    @Override
     public Receive createReceive() {
-        return ReceiveBuilder.create()
-                .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
-                .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                .matchAny(m -> {
-                    log.warning("Unknown message: {}", m);
-                    unhandled(m);
-                }).build();
+        return super.createReceive()
+                .orElse(ReceiveBuilder.create()
+                        .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
+                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
+                        .matchAny(m -> {
+                            log.warning("Unknown message: {}", m);
+                            unhandled(m);
+                        }).build());
     }
 
     private void handleRetrieveStatisticsDetails(final RetrieveStatisticsDetails command) {
         log.info("Sending the namespace stats of the things shard as requested ...");
         Patterns.pipe(retrieveStatisticsDetailsResponseSupplier
                 .apply(command.getDittoHeaders()), getContext().dispatcher()).to(getSender());
-    }
-
-    private ActorRef startChildActor(final String actorName, final Props props) {
-        log.info("Starting child actor <{}>.", actorName);
-        return getContext().actorOf(props, actorName);
     }
 
     private void logServerBinding(final ServerBinding serverBinding) {

--- a/services/things/starter/src/main/java/org/eclipse/ditto/services/things/starter/ThingsRootActor.java
+++ b/services/things/starter/src/main/java/org/eclipse/ditto/services/things/starter/ThingsRootActor.java
@@ -52,7 +52,6 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.Props;
-import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.cluster.sharding.ClusterSharding;
 import akka.cluster.sharding.ClusterShardingSettings;
@@ -187,14 +186,9 @@ public final class ThingsRootActor extends DittoRootActor {
 
     @Override
     public Receive createReceive() {
-        return super.createReceive()
-                .orElse(ReceiveBuilder.create()
-                        .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
-                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                        .matchAny(m -> {
-                            log.warning("Unknown message: {}", m);
-                            unhandled(m);
-                        }).build());
+        return ReceiveBuilder.create()
+                .match(RetrieveStatisticsDetails.class, this::handleRetrieveStatisticsDetails)
+                .build().orElse(super.createReceive());
     }
 
     private void handleRetrieveStatisticsDetails(final RetrieveStatisticsDetails command) {

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchRootActor.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchRootActor.java
@@ -64,7 +64,6 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.CoordinatedShutdown;
 import akka.actor.Props;
-import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.event.Logging;
 import akka.event.LoggingAdapter;
@@ -72,7 +71,6 @@ import akka.http.javadsl.ConnectHttp;
 import akka.http.javadsl.Http;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.server.Route;
-import akka.japi.pf.ReceiveBuilder;
 import akka.stream.ActorMaterializer;
 
 /**
@@ -224,18 +222,6 @@ public final class SearchRootActor extends DittoRootActor {
             final ActorMaterializer materializer) {
 
         return Props.create(SearchRootActor.class, searchConfig, pubSubMediator, materializer);
-    }
-
-    @Override
-    public Receive createReceive() {
-        return super.createReceive()
-                .orElse(ReceiveBuilder.create()
-                        .match(Status.Failure.class, f -> log.error(f.cause(), "Got failure: {}", f))
-                        .matchAny(m -> {
-                            log.warning("Unknown message: {}", m);
-                            unhandled(m);
-                        })
-                        .build());
     }
 
     private static Route createRoute(final ActorSystem actorSystem, final ActorRef healthCheckingActor) {

--- a/src/license-header-2019.txt
+++ b/src/license-header-2019.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Contributors to the Eclipse Foundation
+Copyright (c) 2019 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.


### PR DESCRIPTION
This PR fixes an issue where ditto sends a response to a command sent over websocket even if the "response-required" header was false.

In addition this PR updates the license headers to match 2020 and allows to start child actors in connectivity root actor.