### PR TITLE
discard entity bytes of response in http forwarding

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -225,7 +225,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                             log.info("Got <{}> when reading body of publish response to <{}>", bodyReadError,
                                     message);
                             return null;
-                        });
+                        }).thenRun(() -> response.discardEntityBytes(materializer));
             }
         }
     }


### PR DESCRIPTION
I noticed the following warn log, logged by HttpPublisherActor:

`java.util.concurrent.TimeoutException:` Response entity was not subscribed after 1 second. Make sure to read the response entity body or call `discardBytes()` on it. POST /xyz/messages Strict(675 bytes) -> 201 Created Chunked`

This PR follows the suggestion of the log message and discards the entity bytes.