### PR TITLE
Fixed double slashes in attributes and feature properties path

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRoute.java
@@ -265,8 +265,10 @@ final class FeaturesRoute extends AbstractRoute {
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), featureId ->
                 rawPathPrefix(PathMatchers.slash()
                                 .concat(PATH_PROPERTIES)
+                                .concat(PathMatchers.slash())
                                 .concat(PathMatchers.remaining())
-                                .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986)),
+                                .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986))
+                                .map(path -> "/" + path), // Prepend slash to path to fail request with double slashes
                         jsonPointerString ->
                                 concat(
                                         get(() -> // GET /features/{featureId}/properties/<propertyJsonPointerStr>

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRoute.java
@@ -265,15 +265,13 @@ final class FeaturesRoute extends AbstractRoute {
         return rawPathPrefix(PathMatchers.slash().concat(PathMatchers.segment()), featureId ->
                 rawPathPrefix(PathMatchers.slash()
                                 .concat(PATH_PROPERTIES)
-                                .concat(PathMatchers.slash())
                                 .concat(PathMatchers.remaining())
-                                .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986))
-                                .map(JsonFactory::newPointer),
-                        jsonPointer ->
+                                .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986)),
+                        jsonPointerString ->
                                 concat(
                                         get(() -> // GET /features/{featureId}/properties/<propertyJsonPointerStr>
                                                 handlePerRequest(ctx, RetrieveFeatureProperty.of(thingId, featureId,
-                                                        JsonFactory.newPointer(jsonPointer), dittoHeaders))
+                                                        JsonFactory.newPointer(jsonPointerString), dittoHeaders))
                                         ),
                                         put(() ->
                                                 extractDataBytes(payloadSource ->
@@ -283,7 +281,8 @@ final class FeaturesRoute extends AbstractRoute {
                                                                         ModifyFeatureProperty.of(
                                                                                 thingId,
                                                                                 featureId,
-                                                                                JsonFactory.newPointer(jsonPointer),
+                                                                                JsonFactory.newPointer(
+                                                                                        jsonPointerString),
                                                                                 DittoJsonException.wrapJsonRuntimeException(
                                                                                         () -> JsonFactory.readFrom(
                                                                                                 propertyJson)),
@@ -293,7 +292,7 @@ final class FeaturesRoute extends AbstractRoute {
                                         delete(() ->
                                                 // DELETE /features/{featureId}/properties/<propertyJsonPointerStr>
                                                 handlePerRequest(ctx, DeleteFeatureProperty.of(thingId, featureId,
-                                                        JsonFactory.newPointer(jsonPointer), dittoHeaders))
+                                                        JsonFactory.newPointer(jsonPointerString), dittoHeaders))
                                         )
                                 )
                 )

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
@@ -416,8 +416,10 @@ public final class ThingsRoute extends AbstractRoute {
 
         return rawPathPrefix(PathMatchers.slash()
                         .concat(PATH_ATTRIBUTES)
+                        .concat(PathMatchers.slash())
                         .concat(PathMatchers.remaining())
-                        .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986)),
+                        .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986))
+                        .map(path -> "/" + path), // Prepend slash to path to fail request with double slashes
                 jsonPointerString -> concat(
                         get(() -> // GET /things/<thingId>/attributes/<attributePointerStr>
                                 handlePerRequest(ctx,

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRoute.java
@@ -416,25 +416,27 @@ public final class ThingsRoute extends AbstractRoute {
 
         return rawPathPrefix(PathMatchers.slash()
                         .concat(PATH_ATTRIBUTES)
-                        .concat(PathMatchers.slash())
                         .concat(PathMatchers.remaining())
-                        .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986))
-                        .map(JsonFactory::newPointer),
-                jsonPointer -> concat(
+                        .map(path -> UriEncoding.decode(path, UriEncoding.EncodingType.RFC3986)),
+                jsonPointerString -> concat(
                         get(() -> // GET /things/<thingId>/attributes/<attributePointerStr>
-                                handlePerRequest(ctx, RetrieveAttribute.of(thingId, jsonPointer, dittoHeaders))
+                                handlePerRequest(ctx,
+                                        RetrieveAttribute.of(thingId, JsonFactory.newPointer(jsonPointerString),
+                                                dittoHeaders))
                         ),
                         put(() -> // PUT /things/<thingId>/attributes/<attributePointerStr>
                                 extractDataBytes(payloadSource ->
                                         handlePerRequest(ctx, dittoHeaders, payloadSource, attributeValueJson ->
-                                                ModifyAttribute.of(thingId, jsonPointer,
+                                                ModifyAttribute.of(thingId, JsonFactory.newPointer(jsonPointerString),
                                                         DittoJsonException.wrapJsonRuntimeException(() ->
                                                                 JsonFactory.readFrom(attributeValueJson)),
                                                         dittoHeaders))
                                 )
                         ),
                         delete(() -> // DELETE /things/<thingId>/attributes/<attributePointerStr>
-                                handlePerRequest(ctx, DeleteAttribute.of(thingId, jsonPointer, dittoHeaders))
+                                handlePerRequest(ctx,
+                                        DeleteAttribute.of(thingId, JsonFactory.newPointer(jsonPointerString),
+                                                dittoHeaders))
                         )
                 )
         );

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRouteTest.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.services.gateway.endpoints.routes.things;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants.KNOWN_SUBJECT;
 import static org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants.KNOWN_THING_ID;
 import static org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants.UNKNOWN_PATH;
@@ -27,6 +28,7 @@ import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestBase;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestConstants;
 import org.eclipse.ditto.services.utils.protocol.ProtocolAdapterProvider;
+import org.eclipse.ditto.signals.commands.things.query.RetrieveFeatureProperties;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -266,11 +268,30 @@ public final class FeaturesRouteTest extends EndpointTestBase {
     }
 
     @Test
-    public void putAttributeWithJsonPointerException() {
+    public void putPropertyWithJsonPointerException() {
         final String featureJson = "{\"/wrongProperty\":\"value\"}";
         final TestRouteResult result =
                 underTest.run(HttpRequest.PUT(FEATURE_ENTRY_PROPERTIES_PATH)
                         .withEntity(HttpEntities.create(ContentTypes.APPLICATION_JSON, featureJson)));
+        result.assertStatusCode(StatusCodes.BAD_REQUEST);
+    }
+
+    @Test
+    public void getPropertiesWithTrailingSlash() {
+        final HttpRequest request = HttpRequest.GET(FEATURE_ENTRY_PROPERTIES_PATH + "/");
+        final TestRouteResult result =
+                underTest.run(request);
+        result.assertStatusCode(StatusCodes.OK);
+        final String entityString = result.entityString();
+        assertThat(entityString).contains(RetrieveFeatureProperties.TYPE);
+    }
+
+    @Test
+    public void putPropertyWithEmptyPointer() {
+        final HttpRequest request = HttpRequest.PUT(FEATURE_ENTRY_PROPERTIES_PATH + "//bar")
+                .withEntity("bumlux");
+        final TestRouteResult result =
+                underTest.run(request);
         result.assertStatusCode(StatusCodes.BAD_REQUEST);
     }
 

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/FeaturesRouteTest.java
@@ -287,9 +287,17 @@ public final class FeaturesRouteTest extends EndpointTestBase {
     }
 
     @Test
+    public void getPropertiesWithoutSlashButOtherText() {
+        final HttpRequest request = HttpRequest.GET(FEATURE_ENTRY_PROPERTIES_PATH + "sfsdgsdg");
+        final TestRouteResult result =
+                underTest.run(request);
+        result.assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
     public void putPropertyWithEmptyPointer() {
         final HttpRequest request = HttpRequest.PUT(FEATURE_ENTRY_PROPERTIES_PATH + "//bar")
-                .withEntity("bumlux");
+                .withEntity("\"bumlux\"");
         final TestRouteResult result =
                 underTest.run(request);
         result.assertStatusCode(StatusCodes.BAD_REQUEST);

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
@@ -137,6 +137,14 @@ public final class ThingsRouteTest extends EndpointTestBase {
     }
 
     @Test
+    public void getAttributesWithoutSlashButRandomText() {
+        final HttpRequest request = HttpRequest.GET("/things/org.eclipse.ditto%3Adummy/attributesasfsafa");
+        final TestRouteResult result =
+                underTest.run(request);
+        result.assertStatusCode(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
     public void putAttributeWithEmptyPointer() {
         final String body = "\"bumlux\"";
         final HttpRequest request = HttpRequest.PUT("/things/org.eclipse.ditto%3Adummy/attributes//bar")

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/ThingsRouteTest.java
@@ -22,6 +22,7 @@ import org.eclipse.ditto.services.utils.protocol.ProtocolAdapterProvider;
 import org.eclipse.ditto.signals.commands.things.exceptions.MissingThingIdsException;
 import org.eclipse.ditto.signals.commands.things.modify.ModifyPolicyId;
 import org.eclipse.ditto.signals.commands.things.modify.ModifyThingDefinition;
+import org.eclipse.ditto.signals.commands.things.query.RetrieveAttributes;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -126,9 +127,19 @@ public final class ThingsRouteTest extends EndpointTestBase {
     }
 
     @Test
+    public void getAttributesWithTrailingSlash() {
+        final HttpRequest request = HttpRequest.GET("/things/org.eclipse.ditto%3Adummy/attributes/");
+        final TestRouteResult result =
+                underTest.run(request);
+        result.assertStatusCode(StatusCodes.OK);
+        final String entityString = result.entityString();
+        assertThat(entityString).contains(RetrieveAttributes.TYPE);
+    }
+
+    @Test
     public void putAttributeWithEmptyPointer() {
         final String body = "\"bumlux\"";
-        final HttpRequest request = HttpRequest.PUT("/things/org.eclipse.ditto%3Adummy/attributes//")
+        final HttpRequest request = HttpRequest.PUT("/things/org.eclipse.ditto%3Adummy/attributes//bar")
                 .withEntity(HttpEntities.create(ContentTypes.APPLICATION_JSON, body));
         final TestRouteResult result =
                 underTest.run(request);


### PR DESCRIPTION
These are not allowed anymore and should return a 400 bad request.