### PR TITLE
Improves Exception handling and Logging of DittoPublicKeyProvider

### DIFF
--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/PublicKeyProviderUnavailableException.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/PublicKeyProviderUnavailableException.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableException;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayException;
+
+@Immutable
+@JsonParsableException(errorCode = PublicKeyProviderUnavailableException.ERROR_CODE)
+public final class PublicKeyProviderUnavailableException extends DittoRuntimeException implements GatewayException {
+
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "publickey.provider.unavailable";
+
+    private static final String DEFAULT_MESSAGE = "The public key provider is not available.";
+
+    private static final String DEFAULT_DESCRIPTION =
+            "If after retry it is still unavailable, please contact the service team.";
+
+    private static final long serialVersionUID = 1875913424069407158L;
+
+    private PublicKeyProviderUnavailableException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatusCode.SERVICE_UNAVAILABLE, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for a {@code PublicKeyProviderUnavailableException}.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a new {@code PublicKeyProviderUnavailableException} object with the exception message extracted from the given
+     * JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new PublicKeyProviderUnavailableException.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static PublicKeyProviderUnavailableException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+
+        return new PublicKeyProviderUnavailableException.Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link PublicKeyProviderUnavailableException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends
+            DittoRuntimeExceptionBuilder<PublicKeyProviderUnavailableException> {
+
+        private Builder() {
+            message(DEFAULT_MESSAGE);
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        @Override
+        protected PublicKeyProviderUnavailableException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new PublicKeyProviderUnavailableException(dittoHeaders, message, description, cause,
+                    href);
+        }
+    }
+
+}

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DittoPublicKeyProviderTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DittoPublicKeyProviderTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.jwt.JsonWebKey;
+import org.eclipse.ditto.model.policies.SubjectIssuer;
+import org.eclipse.ditto.services.gateway.security.utils.HttpClientFacade;
+import org.eclipse.ditto.services.utils.cache.config.CacheConfig;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationProviderUnavailableException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import akka.actor.ActorSystem;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.model.StatusCodes;
+import akka.stream.ActorMaterializer;
+
+@RunWith(MockitoJUnitRunner.class)
+public final class DittoPublicKeyProviderTest {
+
+    private static final Long LATCH_TIMEOUT = 20L;
+
+    private static final HttpRequest DISCOVERY_ENDPOINT_REQUEST =
+            HttpRequest.GET("https://google.com/.well-known/openid-configuration");
+    private static final String JWKS_URI = "https://the.uri.com";
+    private static final HttpRequest PUBLIC_KEYS_REQUEST = HttpRequest.GET(JWKS_URI);
+    private static final String KEY_ID = "cc34c0a0-bd5a-4a3c-a50d-a2a7db7643df";
+
+    private ActorSystem actorSystem;
+    private PublicKeyProvider underTest;
+
+    @Mock
+    public HttpClientFacade httpClientMock;
+
+    @Mock
+    public CacheConfig cacheConfigMock;
+
+    @Before
+    public void setup() {
+        actorSystem = ActorSystem.create(getClass().getSimpleName());
+        when(httpClientMock.getActorMaterializer()).thenReturn(ActorMaterializer.create(actorSystem));
+        final JwtSubjectIssuersConfig subjectIssuersConfig = new JwtSubjectIssuersConfig(
+                Collections.singleton(new JwtSubjectIssuerConfig("google.com", SubjectIssuer.GOOGLE)));
+        when(cacheConfigMock.getMaximumSize()).thenReturn(100L);
+        when(cacheConfigMock.getExpireAfterWrite()).thenReturn(Duration.ofMinutes(3));
+        underTest = DittoPublicKeyProvider.of(subjectIssuersConfig, httpClientMock, cacheConfigMock,
+                getClass().getSimpleName());
+    }
+
+    @After
+    public void tearDown() {
+        if (actorSystem != null) {
+            actorSystem.terminate();
+            actorSystem = null;
+        }
+    }
+
+    @Test
+    public void verifyThatKeyIsCached() throws InterruptedException, TimeoutException, ExecutionException {
+
+        mockSuccessfulDiscoveryEndpointRequest();
+        mockSuccessfulPublicKeysRequest();
+
+        underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
+        verify(httpClientMock).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
+
+        Mockito.clearInvocations(httpClientMock);
+
+        underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        verifyNoMoreInteractions(httpClientMock);
+    }
+
+    @Test
+    public void verifyThatKeyIsNotCachedOnErrorResponseFromDiscoveryEndpoint()
+            throws TimeoutException, InterruptedException {
+
+        mockErrorDiscoveryEndpointRequest();
+
+        try {
+            underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        } catch (final CompletionException | ExecutionException e) {
+            verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
+            verify(httpClientMock, never()).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
+            assertThat(e.getCause()).isInstanceOf(GatewayAuthenticationProviderUnavailableException.class);
+        }
+
+        Mockito.clearInvocations(httpClientMock);
+
+        try {
+            underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        } catch (final CompletionException | ExecutionException e) {
+            verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
+            verify(httpClientMock, never()).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
+            assertThat(e.getCause()).isInstanceOf(GatewayAuthenticationProviderUnavailableException.class);
+        }
+    }
+
+    @Test
+    public void verifyThatKeyIsNotCachedIfResponseDoesNotContainKeyId()
+            throws TimeoutException, InterruptedException {
+
+        mockSuccessfulDiscoveryEndpointRequest();
+        mockSuccessfulPublicKeysRequestWithoutMatchingKeyId();
+
+        try {
+            underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        } catch (final CompletionException | ExecutionException e) {
+            verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
+            verify(httpClientMock, never()).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
+            assertThat(e.getCause()).isInstanceOf(GatewayAuthenticationProviderUnavailableException.class);
+        }
+
+        Mockito.clearInvocations(httpClientMock);
+
+        try {
+            underTest.getPublicKey("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+        } catch (final CompletionException | ExecutionException e) {
+            verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
+            verify(httpClientMock, never()).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
+            assertThat(e.getCause()).isInstanceOf(GatewayAuthenticationProviderUnavailableException.class);
+        }
+    }
+
+    private void mockSuccessfulDiscoveryEndpointRequest() {
+        final JsonObject jwksUriResponse = JsonObject.newBuilder().set("jwks_uri", JWKS_URI).build();
+        final HttpResponse discoveryEndpointResponse = HttpResponse.create().withStatus(StatusCodes.OK)
+                .withEntity(jwksUriResponse.toString());
+        when(httpClientMock.createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST))
+                .thenReturn(CompletableFuture.completedFuture(discoveryEndpointResponse));
+    }
+
+    private void mockErrorDiscoveryEndpointRequest() {
+        final JsonObject errorBody = JsonObject.newBuilder().set("message", "Something went wrong.").build();
+        final HttpResponse discoveryEndpointResponse =
+                HttpResponse.create().withStatus(StatusCodes.SERVICE_UNAVAILABLE).withEntity(errorBody.toString());
+        when(httpClientMock.createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST))
+                .thenReturn(CompletableFuture.completedFuture(discoveryEndpointResponse));
+    }
+
+    private void mockSuccessfulPublicKeysRequest() {
+
+        final JsonObject jsonWebKey = JsonObject.newBuilder()
+                .set(JsonWebKey.JsonFields.KEY_TYPE, "RSA")
+                .set(JsonWebKey.JsonFields.KEY_ALGORITHM, "HS256")
+                .set(JsonWebKey.JsonFields.KEY_USAGE, "sig")
+                .set(JsonWebKey.JsonFields.KEY_ID, KEY_ID)
+                .set(JsonWebKey.JsonFields.KEY_MODULUS,
+                        "pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w")
+                .set(JsonWebKey.JsonFields.KEY_EXPONENT, "AQAB")
+                .build();
+        final JsonArray keysArray = JsonArray.newBuilder().add(jsonWebKey).build();
+        final JsonObject keysJson = JsonObject.newBuilder().set("keys", keysArray).build();
+        final HttpResponse publicKeysResponse = HttpResponse.create()
+                .withStatus(StatusCodes.OK)
+                .withEntity(keysJson.toString());
+        final HttpRequest publicKeysRequest = HttpRequest.GET(JWKS_URI);
+        when(httpClientMock.createSingleHttpRequest(publicKeysRequest))
+                .thenReturn(CompletableFuture.completedFuture(publicKeysResponse));
+    }
+
+    private void mockSuccessfulPublicKeysRequestWithoutMatchingKeyId() {
+
+        final JsonObject jsonWebKey = JsonObject.newBuilder()
+                .set(JsonWebKey.JsonFields.KEY_TYPE, "RSA")
+                .set(JsonWebKey.JsonFields.KEY_ALGORITHM, "HS256")
+                .set(JsonWebKey.JsonFields.KEY_USAGE, "sig")
+                .set(JsonWebKey.JsonFields.KEY_ID, "anotherId")
+                .set(JsonWebKey.JsonFields.KEY_MODULUS,
+                        "pjdss8ZaDfEH6K6U7GeW2nxDqR4IP049fk1fK0lndimbMMVBdPv_hSpm8T8EtBDxrUdi1OHZfMhUixGaut-3nQ4GG9nM249oxhCtxqqNvEXrmQRGqczyLxuh-fKn9Fg--hS9UpazHpfVAFnB5aCfXoNhPuI8oByyFKMKaOVgHNqP5NBEqabiLftZD3W_lsFCPGuzr4Vp0YS7zS2hDYScC2oOMu4rGU1LcMZf39p3153Cq7bS2Xh6Y-vw5pwzFYZdjQxDn8x8BG3fJ6j8TGLXQsbKH1218_HcUJRvMwdpbUQG5nvA2GXVqLqdwp054Lzk9_B_f1lVrmOKuHjTNHq48w")
+                .set(JsonWebKey.JsonFields.KEY_EXPONENT, "AQAB")
+                .build();
+        final JsonArray keysArray = JsonArray.newBuilder().add(jsonWebKey).build();
+        final JsonObject keysJson = JsonObject.newBuilder().set("keys", keysArray).build();
+        final HttpResponse publicKeysResponse = HttpResponse.create()
+                .withStatus(StatusCodes.OK)
+                .withEntity(keysJson.toString());
+        final HttpRequest publicKeysRequest = HttpRequest.GET(JWKS_URI);
+        when(httpClientMock.createSingleHttpRequest(publicKeysRequest))
+                .thenReturn(CompletableFuture.completedFuture(publicKeysResponse));
+    }
+
+}

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/PublicKeyProviderUnavailableExceptionTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/PublicKeyProviderUnavailableExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.junit.Test;
+
+public final class PublicKeyProviderUnavailableExceptionTest {
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(PublicKeyProviderUnavailableException.class, areImmutable());
+    }
+
+    @Test
+    public void toJsonFromJsonResultsInEqualObject() {
+        final PublicKeyProviderUnavailableException originalException =
+                PublicKeyProviderUnavailableException.newBuilder()
+                        .message("Test!")
+                        .description("Test2!")
+                        .cause(new IllegalStateException("Hello!"))
+                        .build();
+
+        final JsonObject jsonException = originalException.toJson();
+        final PublicKeyProviderUnavailableException deserializedException =
+                PublicKeyProviderUnavailableException.fromJson(jsonException, DittoHeaders.empty());
+
+        assertThat(deserializedException).isEqualTo(originalException);
+    }
+
+}

--- a/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
+++ b/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
@@ -12,11 +12,10 @@
  */
 package org.eclipse.ditto.services.gateway.starter;
 
-import java.util.Arrays;
-
 import org.eclipse.ditto.model.base.entity.id.NamespacedEntityIdInvalidException;
 import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
 import org.eclipse.ditto.model.connectivity.ConnectionConfigurationInvalidException;
+import org.eclipse.ditto.model.jwt.JwtAudienceInvalidException;
 import org.eclipse.ditto.model.messages.AuthorizationSubjectBlockedException;
 import org.eclipse.ditto.model.namespaces.NamespaceBlockedException;
 import org.eclipse.ditto.model.placeholders.PlaceholderFunctionSignatureInvalidException;
@@ -25,7 +24,7 @@ import org.eclipse.ditto.model.policies.PolicyIdInvalidException;
 import org.eclipse.ditto.model.things.AclEntryInvalidException;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.protocoladapter.UnknownCommandException;
-import org.eclipse.ditto.model.jwt.JwtAudienceInvalidException;
+import org.eclipse.ditto.services.gateway.security.authentication.jwt.PublicKeyProviderUnavailableException;
 import org.eclipse.ditto.services.utils.test.GlobalErrorRegistryTestCases;
 import org.eclipse.ditto.signals.base.JsonTypeNotParsableException;
 import org.eclipse.ditto.signals.commands.base.CommandNotSupportedException;
@@ -56,7 +55,8 @@ public final class GatewayServiceGlobalErrorRegistryTest extends GlobalErrorRegi
                 JwtAudienceInvalidException.class,
                 NamespacedEntityIdInvalidException.class,
                 ThingIdInvalidException.class,
-                PolicyIdInvalidException.class
+                PolicyIdInvalidException.class,
+                PublicKeyProviderUnavailableException.class
         );
     }
 


### PR DESCRIPTION
* Adds a warn log for each IllegalStateException
* Throws GatewayAuthenticationProviderUnavailable exception on non-success
  response from issuer.
* Adds tests to verify caching works as expected