### PR TITLE
Specify parameter type of options for /search/things as string

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-1.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-1.yml
@@ -2222,9 +2222,7 @@ paths:
             The deprecated paging option `limit` may not combine with the other paging options `size` and `cursor`.
           required: false
           schema:
-            type: array
-            items:
-              type: string
+            type: string
 
       tags:
         - Things-Search

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -3534,9 +3534,8 @@ paths:
             The deprecated paging option `limit` may not combine with the other paging options `size` and `cursor`.
           required: false
           schema:
-            type: array
-            items:
-              type: string
+            type: string
+
       tags:
         - Things-Search
       responses:


### PR DESCRIPTION
This is done because in ditto we don't support multiple headers with the same name