### PR TITLE
Add limit for log size to not violate maximum-frame-size of ditto cluster

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultMonitoringLoggerConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultMonitoringLoggerConfig.java
@@ -33,12 +33,14 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
 
     private final int successCapacity;
     private final int failureCapacity;
+    private final long maxLogSizeInBytes;
     private final Duration logDuration;
     private final Duration loggingActiveCheckInterval;
 
     private DefaultMonitoringLoggerConfig(final ConfigWithFallback config) {
         successCapacity = config.getInt(MonitoringLoggerConfigValue.SUCCESS_CAPACITY.getConfigPath());
         failureCapacity = config.getInt(MonitoringLoggerConfigValue.FAILURE_CAPACITY.getConfigPath());
+        maxLogSizeInBytes = config.getLong(MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES.getConfigPath());
         logDuration = config.getDuration(MonitoringLoggerConfigValue.LOG_DURATION.getConfigPath());
         loggingActiveCheckInterval =
                 config.getDuration(MonitoringLoggerConfigValue.LOGGING_ACTIVE_CHECK_INTERVAL.getConfigPath());
@@ -67,6 +69,11 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
     }
 
     @Override
+    public long maxLogSizeInBytes() {
+        return maxLogSizeInBytes;
+    }
+
+    @Override
     public Duration logDuration() {
         return logDuration;
     }
@@ -87,13 +94,15 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
         final DefaultMonitoringLoggerConfig that = (DefaultMonitoringLoggerConfig) o;
         return successCapacity == that.successCapacity &&
                 failureCapacity == that.failureCapacity &&
+                maxLogSizeInBytes == that.maxLogSizeInBytes &&
                 Objects.equals(logDuration, that.logDuration) &&
                 Objects.equals(loggingActiveCheckInterval, that.loggingActiveCheckInterval);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(successCapacity, failureCapacity, logDuration, loggingActiveCheckInterval);
+        return Objects.hash(successCapacity, failureCapacity, maxLogSizeInBytes, logDuration,
+                loggingActiveCheckInterval);
     }
 
     @Override
@@ -101,6 +110,7 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
         return getClass().getSimpleName() + " [" +
                 ", successCapacity=" + successCapacity +
                 ", failureCapacity=" + failureCapacity +
+                ", maxLogSizeInBytes=" + maxLogSizeInBytes +
                 ", logDuration=" + logDuration +
                 ", loggingActiveCheckInterval=" + loggingActiveCheckInterval +
                 "]";

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/MonitoringLoggerConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/config/MonitoringLoggerConfig.java
@@ -42,6 +42,13 @@ public interface MonitoringLoggerConfig {
     int failureCapacity();
 
     /**
+     * Returns the maximum length of all log entries JSON representation.
+     *
+     * @return maximum length of all log entries JSON representation.
+     */
+    long maxLogSizeInBytes();
+
+    /**
      * Returns how long logs will stay enabled after enabling them.
      *
      * @return the logging duration.
@@ -72,6 +79,11 @@ public interface MonitoringLoggerConfig {
          * {@link org.eclipse.ditto.model.connectivity.LogType}.
          */
         FAILURE_CAPACITY("failureCapacity", 10),
+
+        /**
+         * The maximum length of aggregated log entries in JSON representation. This is related to maximum-frame-size.
+         */
+        MAX_LOG_SIZE_BYTES("maxLogSizeBytes", 250_000),
 
         /**
          * How long logs will stay enabled after enabling them.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/logs/ConnectionLoggerRegistry.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/monitoring/logs/ConnectionLoggerRegistry.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -64,11 +65,13 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
     private final int successCapacity;
     private final int failureCapacity;
     private final TemporalAmount loggingDuration;
+    private final long maximumLogSizeInByte;
 
     private ConnectionLoggerRegistry(final int successCapacity, final int failureCapacity,
-            final Duration loggingDuration) {
+            final long maximumLogSizeInByte, final Duration loggingDuration) {
         this.successCapacity = successCapacity;
         this.failureCapacity = failureCapacity;
+        this.maximumLogSizeInByte = maximumLogSizeInByte;
         this.loggingDuration = checkNotNull(loggingDuration);
     }
 
@@ -78,10 +81,10 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
      * @param config the configuration to use.
      * @return a new instance of {@code ConnectionLoggerRegistry}.
      */
-    public static ConnectionLoggerRegistry fromConfig(
-            final MonitoringLoggerConfig config) {
+    public static ConnectionLoggerRegistry fromConfig(final MonitoringLoggerConfig config) {
         checkNotNull(config);
-        return new ConnectionLoggerRegistry(config.successCapacity(), config.failureCapacity(), config.logDuration());
+        return new ConnectionLoggerRegistry(config.successCapacity(), config.failureCapacity(),
+                config.maxLogSizeInBytes(), config.logDuration());
     }
 
     /**
@@ -96,22 +99,35 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
         LOGGER.info("Aggregating logs for connection <{}>.", connectionId);
 
         final LogMetadata timing;
-        final Collection<LogEntry> logs;
+        final List<LogEntry> logs = new ArrayList<>();
 
         if (isActiveForConnection(connectionId)) {
             LOGGER.trace("Logging is enabled, will aggregate logs for connection <{}>", connectionId);
-
             timing = refreshMetadata(connectionId);
-            logs = streamLoggers(connectionId)
+            final List<LogEntry> allLogs = streamLoggers(connectionId)
                     .map(ConnectionLogger::getLogs)
                     .flatMap(Collection::stream)
-                    .sorted(Comparator.comparing(LogEntry::getTimestamp))
+                    .sorted(Comparator.comparing(LogEntry::getTimestamp).reversed())
                     .collect(Collectors.toList());
+
+            long currentSize = 0;
+            for (final LogEntry logEntry : allLogs) {
+                final long sizeOfLogEntry = logEntry.toJson().toString().length();
+                final long newSize = currentSize + sizeOfLogEntry;
+                if (newSize > maximumLogSizeInByte) {
+                    LOGGER.info("Dropping log entries for connection with ID <{}>, because of size limit.",
+                            connectionId);
+                    break;
+                }
+                logs.add(logEntry);
+                currentSize = newSize;
+            }
+            Collections.reverse(logs);
+
         } else {
             LOGGER.debug("Logging is disabled, will return empty logs for connection <{}>", connectionId);
 
             timing = getMetadata(connectionId);
-            logs = Collections.emptyList();
         }
 
         LOGGER.debug("Aggregated logs for connection <{}>: {}", connectionId, logs);
@@ -360,20 +376,22 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
         final ConnectionLoggerRegistry that = (ConnectionLoggerRegistry) o;
         return successCapacity == that.successCapacity &&
                 failureCapacity == that.failureCapacity &&
+                maximumLogSizeInByte == that.maximumLogSizeInByte &&
                 Objects.equals(loggingDuration, that.loggingDuration);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(successCapacity, failureCapacity, loggingDuration);
+        return Objects.hash(successCapacity, failureCapacity, loggingDuration, maximumLogSizeInByte);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", successCapacity=" + successCapacity +
+                "successCapacity=" + successCapacity +
                 ", failureCapacity=" + failureCapacity +
                 ", loggingDuration=" + loggingDuration +
+                ", maximumLogSizeInByte=" + maximumLogSizeInByte +
                 "]";
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultMonitoringConfigTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/config/DefaultMonitoringConfigTest.java
@@ -72,6 +72,9 @@ public final class DefaultMonitoringConfigTest {
                     softly.assertThat(loggerConfig.failureCapacity())
                             .as(MonitoringLoggerConfig.MonitoringLoggerConfigValue.FAILURE_CAPACITY.getConfigPath())
                             .isEqualTo(11);
+                    softly.assertThat(loggerConfig.maxLogSizeInBytes())
+                            .as(MonitoringLoggerConfig.MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES.getConfigPath())
+                            .isEqualTo(1000);
                     softly.assertThat(loggerConfig.logDuration())
                             .as(MonitoringLoggerConfig.MonitoringLoggerConfigValue.LOG_DURATION.getConfigPath())
                             .isEqualTo(Duration.ofMinutes(12));

--- a/services/connectivity/messaging/src/test/resources/monitoring-test.conf
+++ b/services/connectivity/messaging/src/test/resources/monitoring-test.conf
@@ -5,6 +5,8 @@ monitoring {
     successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
     failureCapacity = 11
     failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
+    maxLogSizeBytes = 1000
+    maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}
     logDuration = 12m
     logDuration = ${?CONNECTIVITY_LOGGER_LOG_DURATION}
     loggingActiveCheckInterval = 13m

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -142,9 +142,9 @@ ditto {
     monitoring {
 
       logger {
-        successCapacity = 1
+        successCapacity = 3
         successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
-        failureCapacity = 3
+        failureCapacity = 10
         failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
         maxLogSizeBytes = 1000
         maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}

--- a/services/connectivity/messaging/src/test/resources/test.conf
+++ b/services/connectivity/messaging/src/test/resources/test.conf
@@ -146,6 +146,8 @@ ditto {
         successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
         failureCapacity = 3
         failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
+        maxLogSizeBytes = 1000
+        maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}
         logDuration = 10m
         logDuration = ${?CONNECTIVITY_LOGGER_LOG_DURATION}
         loggingActiveCheckInterval = 1m

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -226,6 +226,8 @@ ditto {
         successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
         failureCapacity = 10
         failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
+        maxLogSizeBytes = 250000
+        maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}
         logDuration = 1h
         logDuration = ${?CONNECTIVITY_LOGGER_LOG_DURATION}
         loggingActiveCheckInterval = 5m

--- a/services/connectivity/starter/src/test/resources/test.conf
+++ b/services/connectivity/starter/src/test/resources/test.conf
@@ -13,6 +13,8 @@ ditto {
         successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
         failureCapacity = 3
         failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
+        maxLogSizeBytes = 1000
+        maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}
         logDuration = 1d
         logDuration = ${?CONNECTIVITY_LOGGER_LOG_DURATION}
         loggingActiveCheckInterval = 10m

--- a/services/connectivity/util/src/test/resources/test.conf
+++ b/services/connectivity/util/src/test/resources/test.conf
@@ -8,6 +8,8 @@ ditto {
         successCapacity = ${?CONNECTIVITY_LOGGER_SUCCESS_CAPACITY}
         failureCapacity = 3
         failureCapacity = ${?CONNECTIVITY_LOGGER_FAILURE_CAPACITY}
+        maxLogSizeBytes = 1000
+        maxLogSizeBytes = ${?CONNECTIVITY_LOGGER_MAX_LOG_SIZE_BYTES}
         logDuration = 1d
         logDuration = ${?CONNECTIVITY_LOGGER_LOG_DURATION}
       }


### PR DESCRIPTION
This PR changes the way logs are aggregated.
It aggregates from new to old only as much log entries as the maximum size is not violated.

This means, older log entries will be dropped in case there are too many or too big log entries.