### PR TITLE
Improve validation of message headers.

### DIFF
--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
@@ -113,11 +113,33 @@ public final class MessageHeadersBuilder extends AbstractDittoHeadersBuilder<Mes
     }
 
     private static void validateMandatoryHeaders(final Map<String, String> headers) {
+        // check all mandatory headers are non-null
         for (final MessageHeaderDefinition mandatoryHeader : MANDATORY_HEADERS) {
-            if (!headers.containsKey(mandatoryHeader.getKey())) {
+            final String mandatoryHeaderValue = headers.get(mandatoryHeader.getKey());
+            if (mandatoryHeaderValue == null) {
                 final String msgTemplate = "The headers did not contain a value for mandatory header with key <{0}>!";
                 throw new IllegalArgumentException(MessageFormat.format(msgTemplate, mandatoryHeader.getKey()));
             }
+        }
+        // check non-emptiness of subject
+        final String subjectHeaderKey = MessageHeaderDefinition.SUBJECT.getKey();
+        if (headers.get(subjectHeaderKey).isEmpty()) {
+            final String msgTemplate = "Message subject may not be empty!";
+            throw new IllegalArgumentException(MessageFormat.format(msgTemplate, subjectHeaderKey));
+        }
+        // validate thing ID header against its model
+        ThingId.of(headers.get(MessageHeaderDefinition.THING_ID.getKey()));
+
+        // validate direction header against its enum
+        final String directionHeaderValue = headers.get(MessageHeaderDefinition.DIRECTION.getKey());
+        if (!MessageDirection.FROM.name().equals(directionHeaderValue) &&
+                !MessageDirection.TO.name().equals(directionHeaderValue)) {
+            final String msgTemplate = "Message direction must be one of: <{1}>, <{2}>!";
+            throw new IllegalArgumentException(MessageFormat.format(msgTemplate,
+                    MessageHeaderDefinition.DIRECTION.getKey(),
+                    MessageDirection.FROM,
+                    MessageDirection.TO
+            ));
         }
     }
 

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageBuilderTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageBuilderTest.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.model.messages;
 
 import static org.eclipse.ditto.json.assertions.DittoJsonAssertions.assertThat;
 
-import java.io.UnsupportedEncodingException;
 import java.time.Duration;
 
 import org.eclipse.ditto.json.JsonObject;
@@ -50,7 +49,7 @@ public final class ImmutableMessageBuilderTest {
     }
 
     @Test
-    public void buildFromFeatureMessageWithStringPayload() throws UnsupportedEncodingException {
+    public void buildFromFeatureMessageWithStringPayload() {
         final MessageHeaders messageHeaders =
                 MessageHeaders.newBuilder(MessageDirection.FROM, KNOWN_THING_ID, KNOWN_SUBJECT)
                         .featureId(KNOWN_FEATURE_ID)

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
@@ -20,11 +20,14 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.enforcers.AclEnforcer;
 import org.eclipse.ditto.model.enforcers.EffectedSubjects;
 import org.eclipse.ditto.model.enforcers.Enforcer;
+import org.eclipse.ditto.model.messages.MessageFormatInvalidException;
 import org.eclipse.ditto.model.messages.MessageSendNotAllowedException;
 import org.eclipse.ditto.model.policies.PoliciesResourceType;
 import org.eclipse.ditto.model.policies.ResourceKey;
@@ -335,11 +338,24 @@ public final class LiveSignalEnforcement extends AbstractEnforcement<Signal> {
         return withMessageToReceiver(signal, pub.getPublisher(), obj -> pub.wrapForPublication((T) obj));
     }
 
-    private static boolean isAuthorized(final MessageCommand command, final Enforcer enforcer) {
+    private boolean isAuthorized(final MessageCommand command, final Enforcer enforcer) {
         return enforcer.hasUnrestrictedPermissions(
-                PoliciesResourceType.messageResource(command.getResourcePath()),
+                extractMessageResourceKey(command),
                 command.getDittoHeaders().getAuthorizationContext(),
                 WRITE);
+    }
+
+    private ResourceKey extractMessageResourceKey(final MessageCommand command) {
+        try {
+            final JsonPointer resourcePath = command.getResourcePath();
+            return PoliciesResourceType.messageResource(resourcePath);
+        } catch (final IllegalArgumentException e) {
+            throw MessageFormatInvalidException.newBuilder(JsonFactory.nullArray())
+                    .message("Unable to determine message resource path.")
+                    .description("Please verify that the thing ID, message subject and direction are set correctly.")
+                    .dittoHeaders(command.getDittoHeaders())
+                    .build();
+        }
     }
 
     /**

--- a/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcementTest.java
+++ b/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcementTest.java
@@ -165,7 +165,8 @@ public final class LiveSignalEnforcementTest {
             final ThingCommand read = readCommand();
             mockEntitiesActorInstance.setReply(read);
             underTest.tell(read, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.LIVE_COMMANDS.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(ThingCommand.class);
             assertThat((CharSequence) ((ThingCommand) publish.msg()).getEntityId()).isEqualTo(read.getEntityId());
@@ -208,7 +209,8 @@ public final class LiveSignalEnforcementTest {
             final ThingCommand write = writeCommand();
             mockEntitiesActorInstance.setReply(write);
             underTest.tell(write, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.LIVE_COMMANDS.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(ThingCommand.class);
             assertThat((CharSequence) ((ThingCommand) publish.msg()).getEntityId()).isEqualTo(write.getEntityId());
@@ -284,7 +286,8 @@ public final class LiveSignalEnforcementTest {
             final MessageCommand msgCommand = thingMessageCommand();
             mockEntitiesActorInstance.setReply(msgCommand);
             underTest.tell(msgCommand, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.MESSAGES.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(MessageCommand.class);
             assertThat((CharSequence) ((MessageCommand) publish.msg()).getEntityId()).isEqualTo(
@@ -319,7 +322,8 @@ public final class LiveSignalEnforcementTest {
             final MessageCommand msgCommand = thingMessageCommand();
             mockEntitiesActorInstance.setReply(msgCommand);
             underTest.tell(msgCommand, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.MESSAGES.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(MessageCommand.class);
             assertThat((CharSequence) ((MessageCommand) publish.msg()).getEntityId())
@@ -345,10 +349,12 @@ public final class LiveSignalEnforcementTest {
             final MessageCommand msgCommand = thingMessageCommand();
             mockEntitiesActorInstance.setReply(msgCommand);
             underTest.tell(msgCommand, responseProbe.ref());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.MESSAGES.getDistributedPubSubTopic());
 
-            final MessageCommandResponse messageCommandResponse = thingMessageCommandResponse((MessageCommand) publish.msg());
+            final MessageCommandResponse messageCommandResponse =
+                    thingMessageCommandResponse((MessageCommand) publish.msg());
 
             underTest.tell(messageCommandResponse, responseProbe.ref());
             responseProbe.expectMsg(messageCommandResponse);
@@ -382,7 +388,8 @@ public final class LiveSignalEnforcementTest {
             final MessageCommand msgCommand = featureMessageCommand();
             mockEntitiesActorInstance.setReply(msgCommand);
             underTest.tell(msgCommand, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.MESSAGES.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(MessageCommand.class);
             assertThat((CharSequence) ((MessageCommand) publish.msg()).getEntityId())
@@ -448,7 +455,8 @@ public final class LiveSignalEnforcementTest {
             final ThingEvent liveEvent = liveEvent();
             mockEntitiesActorInstance.setReply(liveEvent);
             underTest.tell(liveEvent, getRef());
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.LIVE_EVENTS.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(Event.class);
             assertThat((CharSequence) ((Event) publish.msg()).getEntityId()).isEqualTo(liveEvent.getEntityId());
@@ -483,7 +491,8 @@ public final class LiveSignalEnforcementTest {
             mockEntitiesActorInstance.setReply(liveEvent);
             underTest.tell(liveEvent, getRef());
 
-            final DistributedPubSubMediator.Publish publish = fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
+            final DistributedPubSubMediator.Publish publish =
+                    fishForMsgClass(this, DistributedPubSubMediator.Publish.class);
             assertThat(publish.topic()).isEqualTo(StreamingType.LIVE_EVENTS.getDistributedPubSubTopic());
             assertThat(publish.msg()).isInstanceOf(Event.class);
             assertThat((CharSequence) ((Event) publish.msg()).getEntityId()).isEqualTo(liveEvent.getEntityId());

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -210,6 +210,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                 responsePublishedMonitor.success(message,
                         "HTTP call to <{0}> successfully responded with status <{1}>.",
                         stripUserInfo(requestUri), response.status());
+                response.discardEntityBytes(materializer);
             } else {
                 getResponseBody(response, materializer)
                         .thenAccept(body -> responsePublishedMonitor.failure(message,
@@ -225,7 +226,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                             log.info("Got <{}> when reading body of publish response to <{}>", bodyReadError,
                                     message);
                             return null;
-                        }).thenRun(() -> response.discardEntityBytes(materializer));
+                        });
             }
         }
     }


### PR DESCRIPTION
- MessageHeadersBuilder now validates mandatory headers when
  deserializing from JSON.

- LiveSignalEnforcement handles IllegalArgumentException
  when computing the resource path of a message command.

- HttpPublisherActor: move response.discardEntityBytes() to correct position.