### PR TITLE
Fix message response adaption in ditto-protocol-adapter

### DIFF
--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapter.java
@@ -17,7 +17,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.messages.KnownMessageSubjects;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandResponse;
 import org.eclipse.ditto.signals.commands.messages.SendClaimMessageResponse;

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/MessageCommandResponseAdapter.java
@@ -78,8 +78,6 @@ final class MessageCommandResponseAdapter extends AbstractAdapter<MessageCommand
     protected String getType(final Adaptable adaptable) {
         if (adaptable.getTopicPath().getSubject().filter(KnownMessageSubjects.CLAIM_SUBJECT::equals).isPresent()) {
             return SendClaimMessageResponse.TYPE;
-        } else if (!adaptable.getHeaders().map(DittoHeaders::isResponseRequired).orElse(true)) {
-            return SendMessageAcceptedResponse.TYPE;
         } else if (adaptable.getPayload().getPath().getFeatureId().isPresent()) {
             return SendFeatureMessageResponse.TYPE;
         } else {


### PR DESCRIPTION
There was a bug in ditto-protocol-adapter which led to false adaption of message responses. Responses  with a defined payload and statuscode were converted into an accepted response without any payload.