### PR TITLE
Fix Zombie connections in case of TestConnection for AMQP

### DIFF
--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActorTest.java
@@ -64,6 +64,7 @@ public final class BaseClientActorTest {
 
     private static final Status.Success CONNECTED_STATUS = new Status.Success(BaseClientState.CONNECTED);
     private static final Status.Success DISCONNECTED_STATUS = new Status.Success(BaseClientState.DISCONNECTED);
+    private static final Duration DEFAULT_MESSAGE_TIMEOUT = Duration.ofSeconds(3);
     private static ActorSystem actorSystem;
     private static DittoConnectivityConfig connectivityConfig;
 
@@ -330,11 +331,12 @@ public final class BaseClientActorTest {
     }
 
     private void thenExpectConnectClientCalled() {
-        thenExpectConnectClientCalledAfterTimeout(Duration.ZERO);
+        thenExpectConnectClientCalledAfterTimeout(DEFAULT_MESSAGE_TIMEOUT);
     }
 
     private void thenExpectDisconnectClientCalled() {
-        verify(delegate, timeout(200)).doDisconnectClient(any(Connection.class), nullable(ActorRef.class));
+        verify(delegate, timeout(DEFAULT_MESSAGE_TIMEOUT.toMillis())).doDisconnectClient(any(Connection.class),
+                nullable(ActorRef.class));
     }
 
     private void thenExpectConnectClientCalledAfterTimeout(final Duration connectingTimeout) {


### PR DESCRIPTION
When testing an AMQP connection, sometimes an open link remained after the testing has been failed.

It's very likely that the cause is the thrown `ConnectionFailedException` by `createConsumers(session)`.

To be safe I catched all `RuntimeException`s here and terminate the connection in this case because otherwise it'll not be closed by TestConnection handling.