### PR TITLE
Remove duplicated "auth-subjects" in headers

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -17,19 +17,23 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.text.MessageFormat;
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
@@ -47,7 +51,7 @@ import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 @Immutable
 @SuppressWarnings("squid:S2160")
 public abstract class AbstractDittoHeaders extends AbstractMap<String, String> implements DittoHeaders {
-
+    private static final String ISSUER_DIVIDER = ":";
     private final Map<String, String> headers;
 
     /**
@@ -58,7 +62,28 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
      */
     protected AbstractDittoHeaders(final Map<String, String> headers) {
         checkNotNull(headers, "headers map");
-        this.headers = Collections.unmodifiableMap(new HashMap<>(headers));
+        final Map<String, String> headersWithOnlyPrefixedSubjects = keepSubjectsWithIssuer(headers);
+        this.headers = Collections.unmodifiableMap(new HashMap<>(headersWithOnlyPrefixedSubjects));
+    }
+
+    private static Map<String, String> keepSubjectsWithIssuer(final Map<String, String> headers) {
+        if (headers.containsKey(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey())) {
+            final Map<String, String> newHeaders = new HashMap<>(headers);
+            final Stream<String> authSubjects = getJsonArrayForDefinition(headers, DittoHeaderDefinition.AUTHORIZATION_SUBJECTS)
+                    .stream()
+                    .map(JsonValue::asString);
+            final String authSubjectsWithoutDups = keepSubjectsWithIssuer(authSubjects)
+                    .map(JsonValue::of)
+                    .collect(JsonCollectors.valuesToArray())
+                    .toString();
+            newHeaders.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), authSubjectsWithoutDups);
+            return newHeaders;
+        }
+        return headers;
+    }
+
+    protected static Stream<String> keepSubjectsWithIssuer(final Stream<String> subjects) {
+        return subjects.filter(authorizationSubject -> authorizationSubject.split(ISSUER_DIVIDER, 2).length == 2);
     }
 
     @Override
@@ -67,7 +92,7 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
     }
 
     protected Optional<String> getStringForDefinition(final HeaderDefinition definition) {
-        return Optional.ofNullable(headers.get(definition.getKey()));
+        return getStringForDefinition(headers, definition);
     }
 
     @Override
@@ -85,15 +110,34 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
     @Override
     public List<String> getAuthorizationSubjects() {
         final JsonArray jsonValueArray = getJsonArrayForDefinition(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS);
-        return jsonValueArray.stream()
+        final List<String> subjectsWithIssuerPrefix = jsonValueArray.stream()
                 .map(JsonValue::asString)
                 .collect(Collectors.toList());
+        return duplicateSubjectsByStrippingIssuerPrefix(subjectsWithIssuerPrefix);
+    }
+
+    private static List<String> duplicateSubjectsByStrippingIssuerPrefix(
+            final List<String> subjectsWithPrefix) {
+
+        final Set<String> mergedSet = new LinkedHashSet<>(subjectsWithPrefix);
+        subjectsWithPrefix.stream()
+                .map(AbstractDittoHeaders::getSubjectWithoutIssuer)
+                .forEach(mergedSet::add);
+
+        return new ArrayList<>(mergedSet);
+    }
+
+    private static String getSubjectWithoutIssuer(final String subjectId) {
+        final String[] splittedInIssuerAndSubject = subjectId.split(ISSUER_DIVIDER, 2);
+        if (splittedInIssuerAndSubject.length == 2) {
+            return splittedInIssuerAndSubject[1];
+        } else {
+            return subjectId;
+        }
     }
 
     protected JsonArray getJsonArrayForDefinition(final HeaderDefinition definition) {
-        return getStringForDefinition(definition)
-                .map(JsonFactory::newArray)
-                .orElseGet(JsonFactory::newArray);
+        return getJsonArrayForDefinition(headers, definition);
     }
 
     @Override
@@ -303,6 +347,16 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
     @Override
     public String toString() {
         return headers.toString();
+    }
+
+    private static JsonArray getJsonArrayForDefinition(final Map<String, String> headers, final HeaderDefinition definition) {
+        return getStringForDefinition(headers, definition)
+                .map(JsonFactory::newArray)
+                .orElseGet(JsonFactory::newArray);
+    }
+
+    private static Optional<String> getStringForDefinition(final Map<String, String> headers, final HeaderDefinition definition) {
+        return Optional.ofNullable(headers.get(definition.getKey()));
     }
 
 }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
@@ -21,8 +21,10 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -171,8 +173,15 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
 
     @Override
     public S authorizationSubjects(final Collection<String> authorizationSubjectIds) {
-        putStringCollection(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS, authorizationSubjectIds);
+        final List<String> onlyWithIssuerPrefix = keepSubjectsWithIssuerPrefix(authorizationSubjectIds);
+        putStringCollection(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS, onlyWithIssuerPrefix);
         return myself;
+    }
+
+    private static List<String> keepSubjectsWithIssuerPrefix(
+            final Collection<String> subjectsWithAndWithoutPrefix) {
+        return AbstractDittoHeaders.keepSubjectsWithIssuer(subjectsWithAndWithoutPrefix.stream())
+                .collect(Collectors.toList());
     }
 
     @Override

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
@@ -28,6 +28,7 @@ import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.assertions.DittoBaseAssertions;
 import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTagMatchers;
@@ -273,4 +274,15 @@ public final class DefaultDittoHeadersBuilderTest {
         assertThat(dittoHeaders).hasSize(0);
     }
 
+    @Test
+    public void removesDuplicatedAuthSubjects() {
+        final Collection<String> authSubjectsWithDuplicates = Arrays.asList("test:sub", "sub");
+        final String authSubjectsWithoutDuplicates = JsonArray.of(JsonValue.of("test:sub")).toString();
+        final DittoHeaders dittoHeaders = underTest
+                .authorizationSubjects(authSubjectsWithDuplicates)
+                .build();
+
+        assertThat(dittoHeaders.getAuthorizationSubjects()).isEqualTo(authSubjectsWithDuplicates);
+        assertThat(dittoHeaders.get(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey())).isEqualTo(authSubjectsWithoutDuplicates);
+    }
 }

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
@@ -50,7 +50,9 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class ImmutableDittoHeadersTest {
 
-    private static final Collection<String> AUTH_SUBJECTS = Arrays.asList("JohnOldman", "FrankGrimes");
+    private static final Collection<String>
+            AUTH_SUBJECTS_WITHOUT_DUPLICATES = Arrays.asList("test:JohnOldman", "test:FrankGrimes");
+    private static final Collection<String> AUTH_SUBJECTS = Arrays.asList("test:JohnOldman", "test:FrankGrimes", "JohnOldman", "FrankGrimes");
     private static final String KNOWN_CORRELATION_ID = "knownCorrelationId";
     private static final JsonSchemaVersion KNOWN_SCHEMA_VERSION = JsonSchemaVersion.V_2;
     private static final String KNOWN_READ_SUBJECT_WITHOUT_ISSUER = "knownReadSubject";
@@ -231,7 +233,7 @@ public final class ImmutableDittoHeadersTest {
     @Test
     public void toJsonReturnsExpected() {
         final JsonObject expectedHeadersJsonObject = JsonFactory.newObjectBuilder()
-                .set(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), stringCollectionToJsonArray(AUTH_SUBJECTS))
+                .set(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), stringCollectionToJsonArray(AUTH_SUBJECTS_WITHOUT_DUPLICATES))
                 .set(DittoHeaderDefinition.CORRELATION_ID.getKey(), KNOWN_CORRELATION_ID)
                 .set(DittoHeaderDefinition.SCHEMA_VERSION.getKey(), KNOWN_SCHEMA_VERSION.toInt())
                 .set(DittoHeaderDefinition.CHANNEL.getKey(), KNOWN_CHANNEL)
@@ -255,6 +257,36 @@ public final class ImmutableDittoHeadersTest {
         final JsonObject actualHeadersJsonObject = underTest.toJson();
 
         assertThat(actualHeadersJsonObject).isEqualTo(expectedHeadersJsonObject);
+    }
+
+    @Test
+    public void removesDuplicatedAuthSubjectsFromHeaderMap() {
+        final String expectedWithoutDups = stringCollectionToJsonArray(AUTH_SUBJECTS_WITHOUT_DUPLICATES).toString();
+        final String withDups = stringCollectionToJsonArray(AUTH_SUBJECTS).toString();
+
+        final Map<String, String> headersWithDuplicatedAuthSubjects = new HashMap<>();
+        headersWithDuplicatedAuthSubjects.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), withDups);
+
+        final ImmutableDittoHeaders dittoHeaders = ImmutableDittoHeaders.of(headersWithDuplicatedAuthSubjects);
+
+        assertThat(dittoHeaders.get(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey())).isEqualTo(expectedWithoutDups);
+
+    }
+
+    @Test
+    public void removesDuplicatedAuthSubjectsFromJsonRepresentation() {
+        final String withDups = stringCollectionToJsonArray(AUTH_SUBJECTS).toString();
+        final JsonObject expected = JsonFactory.newObjectBuilder()
+                .set(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), stringCollectionToJsonArray(AUTH_SUBJECTS_WITHOUT_DUPLICATES))
+                .build();
+
+        final Map<String, String> headersWithDuplicatedAuthSubjects = new HashMap<>();
+        headersWithDuplicatedAuthSubjects.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), withDups);
+
+        final ImmutableDittoHeaders dittoHeaders = ImmutableDittoHeaders.of(headersWithDuplicatedAuthSubjects);
+
+        assertThat(dittoHeaders.toJson()).isEqualTo(expected);
+
     }
 
     @Test
@@ -394,7 +426,7 @@ public final class ImmutableDittoHeadersTest {
     private static Map<String, String> createMapContainingAllKnownHeaders() {
         final Map<String, String> result = new HashMap<>();
         result.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(),
-                stringCollectionToJsonArray(AUTH_SUBJECTS).toString());
+                stringCollectionToJsonArray(AUTH_SUBJECTS_WITHOUT_DUPLICATES).toString());
         result.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), KNOWN_CORRELATION_ID);
         result.put(DittoHeaderDefinition.SCHEMA_VERSION.getKey(), KNOWN_SCHEMA_VERSION.toString());
         result.put(DittoHeaderDefinition.CHANNEL.getKey(), KNOWN_CHANNEL);

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
@@ -20,6 +20,7 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,7 +49,10 @@ public final class ImmutableMessageHeadersTest {
     private static final MessageDirection DIRECTION = MessageDirection.TO;
     private static final ThingId THING_ID = ThingId.of("test.ns", "theThingId");
     private static final String SUBJECT = KnownMessageSubjects.CLAIM_SUBJECT;
-    private static final Collection<String> AUTH_SUBJECT_IDS = Lists.list("JohnOldman", "FrankGrimes");
+
+    private static final Collection<String>
+            AUTH_SUBJECTS_WITHOUT_DUPLICATES = Arrays.asList("test:JohnOldman", "test:FrankGrimes");
+    private static final Collection<String> AUTH_SUBJECTS = Arrays.asList("test:JohnOldman", "test:FrankGrimes", "JohnOldman", "FrankGrimes");
     private static final String KNOWN_CORRELATION_ID = "knownCorrelationId";
     private static final JsonSchemaVersion KNOWN_SCHEMA_VERSION = JsonSchemaVersion.V_2;
     private static final AuthorizationSubject KNOWN_READ_SUBJECT = AuthorizationSubject.newInstance("knownReadSubject");
@@ -78,7 +82,7 @@ public final class ImmutableMessageHeadersTest {
         final Map<String, String> expectedHeaderMap = createMapContainingAllKnownHeaders();
 
         final MessageHeaders messageHeaders = MessageHeadersBuilder.newInstance(DIRECTION, THING_ID, SUBJECT)
-                .authorizationSubjects(AUTH_SUBJECT_IDS)
+                .authorizationSubjects(AUTH_SUBJECTS)
                 .correlationId(KNOWN_CORRELATION_ID)
                 .schemaVersion(KNOWN_SCHEMA_VERSION)
                 .channel(KNOWN_CHANNEL)
@@ -256,7 +260,7 @@ public final class ImmutableMessageHeadersTest {
 
     private static Map<String, String> createMapContainingAllKnownHeaders() {
         final Map<String, String> result = new HashMap<>();
-        result.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), String.valueOf(AUTH_SUBJECT_IDS.stream()
+        result.put(DittoHeaderDefinition.AUTHORIZATION_SUBJECTS.getKey(), String.valueOf(AUTH_SUBJECTS_WITHOUT_DUPLICATES.stream()
                 .map(JsonValue::of)
                 .collect(JsonCollectors.valuesToArray())));
         result.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), "knownCorrelationId");

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.Au
 import static org.eclipse.ditto.services.connectivity.messaging.TestConstants.disableLogging;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -65,7 +66,6 @@ import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
 import org.eclipse.ditto.protocoladapter.ProtocolFactory;
 import org.eclipse.ditto.services.connectivity.mapping.ConnectivityCachingSignalEnrichmentProvider;
 import org.eclipse.ditto.services.connectivity.messaging.BaseClientActor.PublishMappedMessage;
-import org.eclipse.ditto.services.connectivity.messaging.config.HttpPushConfig;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
 import org.eclipse.ditto.services.models.connectivity.ExternalMessageFactory;
 import org.eclipse.ditto.services.models.connectivity.OutboundSignal;
@@ -107,6 +107,7 @@ public final class MessageMappingProcessorActorTest {
     private static final String FAULTY_MAPPER = FaultyMessageMapper.ALIAS;
     private static final String ADD_HEADER_MAPPER = AddHeaderMessageMapper.ALIAS;
     private static final String DUPLICATING_MAPPER = DuplicatingMessageMapper.ALIAS;
+    private static final AuthorizationContext AUTHORIZATION_CONTEXT_WITH_DUPLICATES = withUnprefixedSubjects(AUTHORIZATION_CONTEXT);
 
     private static final HeaderMapping CORRELATION_ID_AND_SOURCE_HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
@@ -198,6 +199,7 @@ public final class MessageMappingProcessorActorTest {
             // WHEN: a signal is received with 2 targets, one with enrichment and one without
             final JsonFieldSelector extraFields = JsonFieldSelector.newInstance("attributes/x", "attributes/y");
             final AuthorizationSubject targetAuthSubject = AuthorizationSubject.newInstance("target:auth-subject");
+            final AuthorizationSubject targetAuthSubjectWithoutIssuer = AuthorizationSubject.newInstance("auth-subject");
             final Target targetWithEnrichment = ConnectivityModelFactory.newTargetBuilder()
                     .address("target/address")
                     .authorizationContext(AuthorizationContext.newInstance(targetAuthSubject))
@@ -219,7 +221,7 @@ public final class MessageMappingProcessorActorTest {
             // THEN: Receive a RetrieveThing command from the facade.
             final RetrieveThing retrieveThing = conciergeForwarderProbe.expectMsgClass(RetrieveThing.class);
             assertThat(retrieveThing.getSelectedFields()).contains(extraFields);
-            assertThat(retrieveThing.getDittoHeaders().getAuthorizationContext()).containsExactly(targetAuthSubject);
+            assertThat(retrieveThing.getDittoHeaders().getAuthorizationContext()).containsExactly(targetAuthSubject, targetAuthSubjectWithoutIssuer);
 
             final JsonObject extra = JsonObject.newBuilder().set("/attributes/x", 5).build();
             conciergeForwarderProbe.reply(
@@ -267,6 +269,7 @@ public final class MessageMappingProcessorActorTest {
             final JsonFieldSelector extraFields = JsonFactory.newFieldSelector("attributes/x,attributes/y",
                     JsonParseOptions.newBuilder().withoutUrlDecoding().build());
             final AuthorizationSubject targetAuthSubject = AuthorizationSubject.newInstance("target:auth-subject");
+            final AuthorizationSubject targetAuthSubjectWithoutIssuer = AuthorizationSubject.newInstance("auth-subject");
             final Target targetWithEnrichment = ConnectivityModelFactory.newTargetBuilder()
                     .address("target/address")
                     .authorizationContext(AuthorizationContext.newInstance(targetAuthSubject))
@@ -354,7 +357,7 @@ public final class MessageMappingProcessorActorTest {
                     .addFieldDefinition(Thing.JsonFields.REVISION) // additionally always select the revision
                     .build();
             assertThat(retrieveThing.getSelectedFields()).contains(extraFieldsWithAdditionalCachingSelectedOnes);
-            assertThat(retrieveThing.getDittoHeaders().getAuthorizationContext()).containsExactly(targetAuthSubject);
+            assertThat(retrieveThing.getDittoHeaders().getAuthorizationContext()).containsExactly(targetAuthSubject, targetAuthSubjectWithoutIssuer);
             final JsonObject extra = JsonObject.newBuilder()
                     .set("/attributes/x", 5)
                     .build();
@@ -451,7 +454,7 @@ public final class MessageMappingProcessorActorTest {
                 assertThat(modifyAttribute.getDittoHeaders().getCorrelationId()).contains(
                         modifyCommand.getDittoHeaders().getCorrelationId().orElse(null));
                 assertThat(modifyAttribute.getDittoHeaders().getAuthorizationContext())
-                        .isEqualTo(AUTHORIZATION_CONTEXT);
+                        .isEqualTo(AUTHORIZATION_CONTEXT_WITH_DUPLICATES);
                 // thing ID is included in the header for error reporting
                 assertThat(modifyAttribute.getDittoHeaders())
                         .extracting(headers -> headers.get(MessageHeaderDefinition.THING_ID.getKey()))
@@ -496,14 +499,15 @@ public final class MessageMappingProcessorActorTest {
                 AuthorizationModelFactory.newAuthSubject(
                         "integration:{{header:content-type}}:hub-{{ header:correlation-id }}"));
 
-        final AuthorizationContext expectedAuthContext = AuthorizationModelFactory.newAuthContext(
+        final AuthorizationContext expectedAuthContext = withUnprefixedSubjects(AuthorizationModelFactory.newAuthContext(
                 AuthorizationModelFactory.newAuthSubject("integration:" + correlationId + ":hub-application/json"),
-                AuthorizationModelFactory.newAuthSubject("integration:application/json:hub-" + correlationId));
+                AuthorizationModelFactory.newAuthSubject("integration:application/json:hub-" + correlationId)));
 
         testMessageMapping(correlationId, contextWithPlaceholders, ModifyAttribute.class, modifyAttribute -> {
             assertThat(modifyAttribute.getType()).isEqualTo(ModifyAttribute.TYPE);
             assertThat(modifyAttribute.getDittoHeaders().getCorrelationId()).contains(correlationId);
-            assertThat(modifyAttribute.getDittoHeaders().getAuthorizationContext()).isEqualTo(expectedAuthContext);
+            assertThat(modifyAttribute.getDittoHeaders().getAuthorizationContext().getAuthorizationSubjects())
+                    .isEqualTo(expectedAuthContext.getAuthorizationSubjects());
 
             // mapped by source <- {{ request:subjectId }}
             assertThat(modifyAttribute.getDittoHeaders().get("source"))
@@ -551,13 +555,15 @@ public final class MessageMappingProcessorActorTest {
     @Test
     public void testMessageWithoutCorrelationId(){
 
-        final AuthorizationContext expectedAuthContext = AuthorizationModelFactory.newAuthContext(
-                AuthorizationModelFactory.newAuthSubject("hub-application/json"),
-                AuthorizationModelFactory.newAuthSubject("integration:application/json:hub"));
+        final AuthorizationContext connectionAuthContext = AuthorizationModelFactory.newAuthContext(
+                AuthorizationModelFactory.newAuthSubject("integration:application/json:hub"),
+                AuthorizationModelFactory.newAuthSubject("integration:hub-application/json"));
 
-        testMessageMappingWithoutCorrelationId(expectedAuthContext, ModifyAttribute.class, modifyAttribute -> {
+        final AuthorizationContext expectedMessageAuthContext = withUnprefixedSubjects(connectionAuthContext);
+
+        testMessageMappingWithoutCorrelationId(connectionAuthContext, ModifyAttribute.class, modifyAttribute -> {
             assertThat(modifyAttribute.getType()).isEqualTo(ModifyAttribute.TYPE);
-            assertThat(modifyAttribute.getDittoHeaders().getAuthorizationContext()).isEqualTo(expectedAuthContext);
+            assertThat(modifyAttribute.getDittoHeaders().getAuthorizationContext()).isEqualTo(expectedMessageAuthContext);
 
         });
     }
@@ -809,5 +815,16 @@ public final class MessageMappingProcessorActorTest {
         }
 
     }
+
+    private static AuthorizationContext withUnprefixedSubjects(final AuthorizationContext authorizationContext) {
+        final List<AuthorizationSubject> mergedSubjects = new ArrayList<>(authorizationContext.getAuthorizationSubjects());
+        authorizationContext.getAuthorizationSubjectIds().stream()
+                .map(subject -> subject.split(":", 2)[1])
+                .map(AuthorizationSubject::newInstance)
+                .forEach(mergedSubjects::add);
+
+        return AuthorizationModelFactory.newAuthContext(mergedSubjects);
+    }
+
 
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
@@ -107,7 +107,8 @@ public final class MessageMappingProcessorActorTest {
     private static final String FAULTY_MAPPER = FaultyMessageMapper.ALIAS;
     private static final String ADD_HEADER_MAPPER = AddHeaderMessageMapper.ALIAS;
     private static final String DUPLICATING_MAPPER = DuplicatingMessageMapper.ALIAS;
-    private static final AuthorizationContext AUTHORIZATION_CONTEXT_WITH_DUPLICATES = withUnprefixedSubjects(AUTHORIZATION_CONTEXT);
+    private static final AuthorizationContext AUTHORIZATION_CONTEXT_WITH_DUPLICATES =
+            TestConstants.Authorization.withUnprefixedSubjects(AUTHORIZATION_CONTEXT);
 
     private static final HeaderMapping CORRELATION_ID_AND_SOURCE_HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
@@ -499,7 +500,7 @@ public final class MessageMappingProcessorActorTest {
                 AuthorizationModelFactory.newAuthSubject(
                         "integration:{{header:content-type}}:hub-{{ header:correlation-id }}"));
 
-        final AuthorizationContext expectedAuthContext = withUnprefixedSubjects(AuthorizationModelFactory.newAuthContext(
+        final AuthorizationContext expectedAuthContext = TestConstants.Authorization.withUnprefixedSubjects(AuthorizationModelFactory.newAuthContext(
                 AuthorizationModelFactory.newAuthSubject("integration:" + correlationId + ":hub-application/json"),
                 AuthorizationModelFactory.newAuthSubject("integration:application/json:hub-" + correlationId)));
 
@@ -559,7 +560,7 @@ public final class MessageMappingProcessorActorTest {
                 AuthorizationModelFactory.newAuthSubject("integration:application/json:hub"),
                 AuthorizationModelFactory.newAuthSubject("integration:hub-application/json"));
 
-        final AuthorizationContext expectedMessageAuthContext = withUnprefixedSubjects(connectionAuthContext);
+        final AuthorizationContext expectedMessageAuthContext = TestConstants.Authorization.withUnprefixedSubjects(connectionAuthContext);
 
         testMessageMappingWithoutCorrelationId(connectionAuthContext, ModifyAttribute.class, modifyAttribute -> {
             assertThat(modifyAttribute.getType()).isEqualTo(ModifyAttribute.TYPE);
@@ -815,16 +816,5 @@ public final class MessageMappingProcessorActorTest {
         }
 
     }
-
-    private static AuthorizationContext withUnprefixedSubjects(final AuthorizationContext authorizationContext) {
-        final List<AuthorizationSubject> mergedSubjects = new ArrayList<>(authorizationContext.getAuthorizationSubjects());
-        authorizationContext.getAuthorizationSubjectIds().stream()
-                .map(subject -> subject.split(":", 2)[1])
-                .map(AuthorizationSubject::newInstance)
-                .forEach(mergedSubjects::add);
-
-        return AuthorizationModelFactory.newAuthContext(mergedSubjects);
-    }
-
 
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
@@ -55,6 +55,7 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.base.auth.AuthorizationModelFactory;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
@@ -269,6 +270,17 @@ public final class TestConstants {
                 SOURCE_SUBJECT);
         private static final AuthorizationContext UNAUTHORIZED_AUTHORIZATION_CONTEXT = AuthorizationContext.newInstance(
                 UNAUTHORIZED_SUBJECT);
+
+
+        public static AuthorizationContext withUnprefixedSubjects(final AuthorizationContext authorizationContext) {
+            final List<AuthorizationSubject> mergedSubjects = new ArrayList<>(authorizationContext.getAuthorizationSubjects());
+            authorizationContext.getAuthorizationSubjectIds().stream()
+                    .map(subject -> subject.split(":", 2)[1])
+                    .map(AuthorizationSubject::newInstance)
+                    .forEach(mergedSubjects::add);
+
+            return AuthorizationModelFactory.newAuthContext(mergedSubjects);
+        }
 
     }
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActorTest.java
@@ -505,7 +505,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
     public void testConsumeMessageAndExpectForwardToConciergeForwarder() throws JMSException {
         testConsumeMessageAndExpectForwardToConciergeForwarder(connection, 1,
                 c -> assertThat(c.getDittoHeaders().getAuthorizationContext()).isEqualTo(
-                        Authorization.SOURCE_SPECIFIC_CONTEXT));
+                        TestConstants.Authorization.withUnprefixedSubjects(Authorization.SOURCE_SPECIFIC_CONTEXT)));
     }
 
     @Test
@@ -521,12 +521,12 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                 c -> {
                     if (c.getDittoHeaders()
                             .getAuthorizationContext()
-                            .equals(Authorization.SOURCE_SPECIFIC_CONTEXT)) {
+                            .equals(TestConstants.Authorization.withUnprefixedSubjects(Authorization.SOURCE_SPECIFIC_CONTEXT))) {
                         messageReceivedForSourceContext.set(true);
                     }
                     if (c.getDittoHeaders()
                             .getAuthorizationContext()
-                            .equals(Authorization.SOURCE_SPECIFIC_CONTEXT)) {
+                            .equals(TestConstants.Authorization.withUnprefixedSubjects(Authorization.SOURCE_SPECIFIC_CONTEXT))) {
                         messageReceivedForGlobalContext.set(true);
                     }
                 });
@@ -541,7 +541,7 @@ public final class AmqpClientActorTest extends AbstractBaseClientActorTest {
                         TestConstants.Sources.SOURCES_WITH_AUTH_CONTEXT);
         testConsumeMessageAndExpectForwardToConciergeForwarder(connection, 1,
                 c -> assertThat(c.getDittoHeaders().getAuthorizationContext())
-                        .isEqualTo(Authorization.SOURCE_SPECIFIC_CONTEXT));
+                        .isEqualTo(TestConstants.Authorization.withUnprefixedSubjects(Authorization.SOURCE_SPECIFIC_CONTEXT)));
     }
 
     private void testConsumeMessageAndExpectForwardToConciergeForwarder(final Connection connection,

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -154,7 +154,7 @@ public final class RootRouteTest extends EndpointTestBase {
                 .headerTranslator(headerTranslator)
                 .httpAuthenticationDirective(authenticationDirectiveFactory.buildHttpAuthentication())
                 .wsAuthenticationDirective(authenticationDirectiveFactory.buildWsAuthentication())
-                .dittoHeadersSizeChecker(DittoHeadersSizeChecker.of(4096, 10))
+                .dittoHeadersSizeChecker(DittoHeadersSizeChecker.of(4096, 20))
                 .build();
 
         rootTestRoute = testRoute(rootRoute);
@@ -345,7 +345,7 @@ public final class RootRouteTest extends EndpointTestBase {
 
     @Test
     public void getExceptionDueToTooManyAuthSubjects() {
-        final String hugeSubjects = IntStream.range(0, 11)
+        final String hugeSubjects = IntStream.range(0, 22)
                 .mapToObj(i -> "i:foo" + i)
                 .collect(Collectors.joining(","));
         final HttpRequest request =

--- a/services/models/policies/src/main/java/org/eclipse/ditto/services/models/policies/PoliciesAclMigrations.java
+++ b/services/models/policies/src/main/java/org/eclipse/ditto/services/models/policies/PoliciesAclMigrations.java
@@ -22,6 +22,7 @@ import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.model.policies.PolicyId;
 import org.eclipse.ditto.model.policies.SubjectIssuer;
 import org.eclipse.ditto.model.things.AccessControlList;
+import org.eclipse.ditto.model.things.AclEntry;
 import org.eclipse.ditto.model.things.Thing;
 
 /**
@@ -53,7 +54,7 @@ public final class PoliciesAclMigrations {
             final PolicyId policyId, final List<SubjectIssuer> subjectIssuers) {
         final PolicyBuilder policyBuilder = PoliciesModelFactory.newPolicyBuilder(policyId);
         accessControlList.getEntriesSet().forEach(aclEntry -> {
-            final String sid = aclEntry.getAuthorizationSubject().getId();
+            final String sid = getSubjectWithoutIssuer(aclEntry);
             final PolicyBuilder.LabelScoped labelScoped = policyBuilder.forLabel(ACL_LABEL_PREFIX + sid);
 
             subjectIssuers.forEach(
@@ -92,4 +93,11 @@ public final class PoliciesAclMigrations {
         return policyBuilder.build();
     }
 
+    private static String getSubjectWithoutIssuer(final AclEntry aclEntry) {
+        final String sid = aclEntry.getAuthorizationSubject().getId();
+        if (sid.contains(":")) {
+            return sid.split(":", 2)[1];
+        }
+        return sid;
+    }
 }

--- a/services/models/policies/src/test/java/org/eclipse/ditto/services/models/policies/PoliciesAclMigrationsTest.java
+++ b/services/models/policies/src/test/java/org/eclipse/ditto/services/models/policies/PoliciesAclMigrationsTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.services.models.policies;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
+import org.eclipse.ditto.model.policies.EffectedPermissions;
+import org.eclipse.ditto.model.policies.PoliciesResourceType;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resource;
+import org.eclipse.ditto.model.policies.Resources;
+import org.eclipse.ditto.model.policies.Subject;
+import org.eclipse.ditto.model.policies.SubjectId;
+import org.eclipse.ditto.model.policies.SubjectIssuer;
+import org.eclipse.ditto.model.things.AccessControlList;
+import org.eclipse.ditto.model.things.AclEntry;
+import org.eclipse.ditto.model.things.Permission;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link PoliciesAclMigrations}.
+ */
+public final class PoliciesAclMigrationsTest {
+
+    private static final EffectedPermissions READ_PERMISSIONS =
+            EffectedPermissions.newInstance(Collections.singleton(Permission.READ.name()),
+                    Collections.emptyList());
+    private static final EffectedPermissions REVOKED_WRITE_PERMISSIONS =
+            EffectedPermissions.newInstance(Collections.emptyList(), Collections.singleton(Permission.WRITE.name()));
+
+    @Test
+    public void verifyMigratedSubjects() {
+        final SubjectId subjectId = SubjectId.newInstance(SubjectIssuer.GOOGLE, "user");
+        final AccessControlList aclToMigrate = AccessControlList.newBuilder()
+                .set(AclEntry.newInstance(AuthorizationSubject.newInstance(subjectId), Permission.READ))
+                .build();
+        final PolicyId policyId = PolicyId.dummy();
+        final List<SubjectIssuer> issuers = Arrays.asList(SubjectIssuer.GOOGLE, SubjectIssuer.newInstance("any-other"));
+
+        final String expectedLabel = "acl_" + subjectId.getSubject();
+        final PolicyEntry expectedEntry = createExpectedPolicyEntry(expectedLabel, subjectId, issuers);
+
+        final Policy migratedPolicy =
+                PoliciesAclMigrations.accessControlListToPolicyEntries(aclToMigrate, policyId, issuers);
+
+        assertThat(migratedPolicy.getEntryFor(expectedLabel)).contains(expectedEntry);
+    }
+
+    private static PolicyEntry createExpectedPolicyEntry(final String label, final SubjectId subjectId, final List<SubjectIssuer> issuers) {
+        final List<Subject> expectedSubjects = issuers.stream()
+                .map(issuer -> Subject.newInstance(issuer, subjectId.getSubject()))
+                .collect(Collectors.toList());
+        final Resources expectedResources = Resources.newInstance(
+                Resource.newInstance(PoliciesResourceType.thingResource("/"), READ_PERMISSIONS),
+                Resource.newInstance(PoliciesResourceType.thingResource("/acl"), REVOKED_WRITE_PERMISSIONS),
+                Resource.newInstance(PoliciesResourceType.policyResource("/"), READ_PERMISSIONS),
+                Resource.newInstance(PoliciesResourceType.messageResource("/"), READ_PERMISSIONS)
+        );
+        return PolicyEntry.newInstance(label,
+                expectedSubjects,
+                expectedResources);
+    }
+}

--- a/services/models/signalenrichment/src/test/java/org/eclipse/ditto/services/models/signalenrichment/CachingSignalEnrichmentFacadeTest.java
+++ b/services/models/signalenrichment/src/test/java/org/eclipse/ditto/services/models/signalenrichment/CachingSignalEnrichmentFacadeTest.java
@@ -48,6 +48,7 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
             "  maximum-size = 10\n" +
             "  expire-after-create = 2m\n" +
             "}";
+    private static final String ISSUER_PREFIX = "test:";
 
     @Override
     protected SignalEnrichmentFacade createSignalEnrichmentFacadeUnderTest(final TestKit kit,
@@ -95,7 +96,7 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
             final SignalEnrichmentFacade underTest =
                     createSignalEnrichmentFacadeUnderTest(kit, Duration.ofSeconds(10L));
             final ThingId thingId = ThingId.dummy();
-            final String userId = "user";
+            final String userId = ISSUER_PREFIX + "user";
             final DittoHeaders headers = DittoHeaders.newBuilder()
                     .authorizationSubjects(userId)
                     .correlationId(UUID.randomUUID().toString()).build();
@@ -104,7 +105,8 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
 
             // WHEN: Command handler receives expected RetrieveThing and responds with RetrieveThingResponse
             final RetrieveThing retrieveThing = kit.expectMsgClass(RetrieveThing.class);
-            assertThat(retrieveThing.getDittoHeaders().getAuthorizationSubjects()).contains(userId);
+            assertThat(retrieveThing.getDittoHeaders().getAuthorizationSubjects())
+                    .contains(userId);
             assertThat(retrieveThing.getSelectedFields()).contains(actualSelectedFields(SELECTOR));
             // WHEN: response is handled so that it is also added to the cache
             kit.reply(RetrieveThingResponse.of(thingId, getThingResponseThingJson(), headers));
@@ -169,8 +171,8 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
             final SignalEnrichmentFacade underTest =
                     createSignalEnrichmentFacadeUnderTest(kit, Duration.ofSeconds(10L));
             final ThingId thingId = ThingId.dummy();
-            final String userId1 = "user1";
-            final String userId2 = "user2";
+            final String userId1 = ISSUER_PREFIX + "user1";
+            final String userId2 = ISSUER_PREFIX + "user2";
             final DittoHeaders headers = DittoHeaders.newBuilder()
                     .authorizationSubjects(userId1)
                     .correlationId(UUID.randomUUID().toString()).build();
@@ -188,7 +190,7 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
 
             // WHEN: same thing is asked again with same selector for an event with one revision ahead but other auth subjects
             final DittoHeaders headers2 = headers.toBuilder()
-                    .authorizationSubjects("user2")
+                    .authorizationSubjects(ISSUER_PREFIX + "user2")
                     .build();
             underTest.retrievePartialThing(thingId, SELECTOR, headers2,
                     THING_EVENT.setRevision(THING_EVENT.getRevision() + 1));
@@ -207,7 +209,7 @@ public final class CachingSignalEnrichmentFacadeTest extends AbstractSignalEnric
             final SignalEnrichmentFacade underTest =
                     createSignalEnrichmentFacadeUnderTest(kit, Duration.ofSeconds(10L));
             final ThingId thingId = ThingId.dummy();
-            final String userId = "user1";
+            final String userId = ISSUER_PREFIX + "user1";
             final DittoHeaders headers = DittoHeaders.newBuilder()
                     .authorizationSubjects(userId)
                     .correlationId(UUID.randomUUID().toString()).build();

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/PersistenceActorTestBase.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/PersistenceActorTestBase.java
@@ -156,8 +156,8 @@ public abstract class PersistenceActorTestBase {
         pubSubTestProbe = TestProbe.apply("mock-pubSub-mediator", actorSystem);
         pubSubMediator = pubSubTestProbe.ref();
 
-        dittoHeadersV1 = createDittoHeadersMock(JsonSchemaVersion.V_1, AUTH_SUBJECT);
-        dittoHeadersV2 = createDittoHeadersMock(JsonSchemaVersion.V_2, AUTH_SUBJECT);
+        dittoHeadersV1 = createDittoHeadersMock(JsonSchemaVersion.V_1, "test:" + AUTH_SUBJECT);
+        dittoHeadersV2 = createDittoHeadersMock(JsonSchemaVersion.V_2, "test:" + AUTH_SUBJECT);
     }
 
     @After


### PR DESCRIPTION
For providing backwards compatibility for ACLs (API version 1), the DittoHeaders always contain auth-subjects without issuer-prefix.
To use less space when sending the auth-subjects through the cluster, this PR will remove the duplicates from the serialized version of DittoHeaders.