### PR TITLE
Add readPreference config key to MongoDbConfig

### DIFF
--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -11,6 +11,8 @@ ditto {
     options {
       ssl = false
       ssl = ${?MONGO_DB_SSL_ENABLED}
+      readPreference = primaryPreferred
+      readPreference = ${?MONGO_DB_READ_PREFERENCE}
       w = 1
     }
   }

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -3,6 +3,8 @@ ditto {
     options {
       ssl = false
       ssl = ${?MONGO_DB_SSL_ENABLED}
+      readPreference = primaryPreferred
+      readPreference = ${?MONGO_DB_READ_PREFERENCE}
       w = 1
     }
   }

--- a/services/policies/starter/src/main/resources/policies.conf
+++ b/services/policies/starter/src/main/resources/policies.conf
@@ -6,6 +6,8 @@ ditto {
     options {
       ssl = false
       ssl = ${?MONGO_DB_SSL_ENABLED}
+      readPreference = primaryPreferred
+      readPreference = ${?MONGO_DB_READ_PREFERENCE}
       w = 1
     }
   }

--- a/services/things/starter/src/main/resources/things.conf
+++ b/services/things/starter/src/main/resources/things.conf
@@ -9,6 +9,8 @@ ditto {
     options {
       ssl = false
       ssl = ${?MONGO_DB_SSL_ENABLED}
+      readPreference = primaryPreferred
+      readPreference = ${?MONGO_DB_READ_PREFERENCE}
       w = 1
     }
   }

--- a/services/thingsearch/starter/src/main/resources/things-search.conf
+++ b/services/thingsearch/starter/src/main/resources/things-search.conf
@@ -38,6 +38,8 @@ ditto {
     options {
       ssl = false
       ssl = ${?MONGO_DB_SSL_ENABLED}
+      readPreference = primaryPreferred
+      readPreference = ${?MONGO_DB_READ_PREFERENCE}
       w = 1
     }
   }

--- a/services/thingsearch/starter/src/test/java/org/eclipse/ditto/services/thingsearch/starter/config/DittoSearchConfigTest.java
+++ b/services/thingsearch/starter/src/test/java/org/eclipse/ditto/services/thingsearch/starter/config/DittoSearchConfigTest.java
@@ -20,6 +20,7 @@ import org.eclipse.ditto.services.base.config.DittoServiceConfig;
 import org.eclipse.ditto.services.thingsearch.common.config.DefaultUpdaterConfig;
 import org.eclipse.ditto.services.thingsearch.common.config.DittoSearchConfig;
 import org.eclipse.ditto.services.utils.health.config.DefaultHealthCheckConfig;
+import org.eclipse.ditto.services.utils.persistence.mongo.config.DefaultMongoDbConfig;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -33,7 +34,8 @@ public final class DittoSearchConfigTest {
     public void assertImmutability() {
         assertInstancesOf(DittoSearchConfig.class,
                 areImmutable(),
-                provided(DefaultHealthCheckConfig.class, DittoServiceConfig.class, DefaultUpdaterConfig.class)
+                provided(DefaultHealthCheckConfig.class, DittoServiceConfig.class, DefaultUpdaterConfig.class,
+                        DefaultMongoDbConfig.class)
                         .areAlsoImmutable());
     }
 

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/DittoMongoClientBuilder.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/DittoMongoClientBuilder.java
@@ -17,6 +17,7 @@ import java.time.Duration;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import com.mongodb.ReadPreference;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
 
@@ -151,6 +152,14 @@ public interface DittoMongoClientBuilder {
          * @return this builder instance to allow method chaining.
          */
         GeneralPropertiesStep addConnectionPoolListener(@Nullable ConnectionPoolListener connectionPoolListener);
+
+        /**
+         * Sets the read preference that should be used for the mongo client.
+         *
+         * @param readPreference the read preference.
+         * @return this builder instance with the updated read preference.
+         */
+        GeneralPropertiesStep setReadPreference(ReadPreference readPreference);
 
         /**
          * Creates a new instance of {@code DittoMongoClient} with the properties of this builder.

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
@@ -246,7 +246,7 @@ public final class MongoClientWrapper implements DittoMongoClient {
 
         private MongoClientWrapperBuilder() {
             mongoClientSettingsBuilder = MongoClientSettings.builder();
-            mongoClientSettingsBuilder.readPreference(ReadPreference.secondaryPreferred());
+            mongoClientSettingsBuilder.readPreference(ReadPreference.primaryPreferred());
             dittoMongoClientSettingsBuilder = DittoMongoClientSettings.getBuilder();
             connectionString = null;
             defaultDatabaseName = null;
@@ -285,6 +285,23 @@ public final class MongoClientWrapper implements DittoMongoClient {
 
             final MongoDbConfig.OptionsConfig optionsConfig = mongoDbConfig.getOptionsConfig();
             builder.enableSsl(optionsConfig.isSslEnabled());
+            switch (optionsConfig.readPreference()) {
+                case PRIMARY:
+                    builder.setReadPreference(ReadPreference.primary());
+                    break;
+                case PRIMARY_PREFERRED:
+                    builder.setReadPreference(ReadPreference.primaryPreferred());
+                    break;
+                case SECONDARY:
+                    builder.setReadPreference(ReadPreference.secondary());
+                    break;
+                case SECONDARY_PREFERRED:
+                    builder.setReadPreference(ReadPreference.secondaryPreferred());
+                    break;
+                case NEAREST:
+                    builder.setReadPreference(ReadPreference.nearest());
+                    break;
+            }
 
             return builder;
         }
@@ -382,6 +399,12 @@ public final class MongoClientWrapper implements DittoMongoClient {
                 mongoClientSettingsBuilder.applyToConnectionPoolSettings(
                         builder -> builder.addConnectionPoolListener(connectionPoolListener));
             }
+            return this;
+        }
+
+        @Override
+        public GeneralPropertiesStep setReadPreference(final ReadPreference readPreference) {
+            mongoClientSettingsBuilder.readPreference(readPreference);
             return this;
         }
 

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
@@ -221,7 +221,6 @@ public final class MongoClientWrapper implements DittoMongoClient {
         return mongoClient.startSession(options);
     }
 
-
     @Override
     public void close() {
         if (null != eventLoopGroup) {
@@ -285,23 +284,7 @@ public final class MongoClientWrapper implements DittoMongoClient {
 
             final MongoDbConfig.OptionsConfig optionsConfig = mongoDbConfig.getOptionsConfig();
             builder.enableSsl(optionsConfig.isSslEnabled());
-            switch (optionsConfig.readPreference()) {
-                case PRIMARY:
-                    builder.setReadPreference(ReadPreference.primary());
-                    break;
-                case PRIMARY_PREFERRED:
-                    builder.setReadPreference(ReadPreference.primaryPreferred());
-                    break;
-                case SECONDARY:
-                    builder.setReadPreference(ReadPreference.secondary());
-                    break;
-                case SECONDARY_PREFERRED:
-                    builder.setReadPreference(ReadPreference.secondaryPreferred());
-                    break;
-                case NEAREST:
-                    builder.setReadPreference(ReadPreference.nearest());
-                    break;
-            }
+            builder.setReadPreference(optionsConfig.readPreference().getMongoReadPreference());
 
             return builder;
         }

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -12,11 +12,13 @@
  */
 package org.eclipse.ditto.services.utils.persistence.mongo.config;
 
+import java.text.MessageFormat;
 import java.util.Objects;
 
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.services.utils.config.DittoConfigError;
 import org.eclipse.ditto.services.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
@@ -25,7 +27,7 @@ import com.typesafe.config.Config;
  * This class is the default implementation of {@link MongoDbConfig.OptionsConfig}.
  */
 @Immutable
-public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig{
+public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
 
     /**
      * The supposed path of the OptionsConfig within the MongoDB config object.
@@ -33,9 +35,19 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig{
     static final String CONFIG_PATH = "options";
 
     private final boolean sslEnabled;
+    private final ReadPreference readPreference;
 
     private DefaultOptionsConfig(final ScopedConfig config) {
         sslEnabled = config.getBoolean(OptionsConfigValue.SSL_ENABLED.getConfigPath());
+        final String readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
+        readPreference = ReadPreference.ofReadPreference(readPreferenceString)
+                .orElseThrow(() -> {
+                    final String msg =
+                            MessageFormat.format("Could not parse a ReadPreference from configured string <{0}>",
+                                    readPreferenceString);
+                    return new DittoConfigError(msg);
+                });
+
     }
 
     /**
@@ -53,6 +65,11 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig{
     @Override
     public boolean isSslEnabled() {
         return sslEnabled;
+    }
+
+    @Override
+    public ReadPreference readPreference() {
+        return readPreference;
     }
 
     @Override

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
@@ -127,7 +127,7 @@ public interface MongoDbConfig {
             SSL_ENABLED("ssl", false),
 
             /**
-             * Determines whether SSL should be enabled for the configured MongoDB source.
+             * Determines the read preference used for MongoDB connections. See {@link ReadPreference} for available options.
              */
             READ_PREFERENCE("readPreference", "primaryPreferred");
 

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
@@ -110,6 +110,13 @@ public interface MongoDbConfig {
         boolean isSslEnabled();
 
         /**
+         * Gets the desired read preference that should be used for accessing MongoDB.
+         *
+         * @return the desired read preference.
+         */
+        ReadPreference readPreference();
+
+        /**
          * An enumeration of known value paths and associated default values of the OptionsConfig.
          */
         enum OptionsConfigValue implements KnownConfigValue {
@@ -117,7 +124,12 @@ public interface MongoDbConfig {
             /**
              * Determines whether SSL should be enabled for the configured MongoDB source.
              */
-            SSL_ENABLED("ssl", false);
+            SSL_ENABLED("ssl", false),
+
+            /**
+             * Determines whether SSL should be enabled for the configured MongoDB source.
+             */
+            READ_PREFERENCE("readPreference", "primaryPreferred");
 
             private final String path;
             private final Object defaultValue;

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/ReadPreference.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/ReadPreference.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.persistence.mongo.config;
+
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * Enumeration of read preferences for mongo client.
+ */
+public enum ReadPreference {
+
+    PRIMARY("primary"),
+    PRIMARY_PREFERRED("primaryPreferred"),
+    SECONDARY("secondary"),
+    SECONDARY_PREFERRED("secondaryPreferred"),
+    NEAREST("nearest");
+
+    private final String readPreference;
+
+    ReadPreference(final String readPreference) {
+        this.readPreference = readPreference;
+    }
+
+    /**
+     * Tries to create a ReadPreference from the given read preference string.
+     *
+     * @param readPreference the string value of read preference.
+     * @return An optional of the ReadPreference matching to the given read preference string. Empty if no matching
+     * ReadPreference exists.
+     */
+    static Optional<ReadPreference> ofReadPreference(final String readPreference) {
+        checkNotNull(readPreference, "readPreference");
+        return Arrays.stream(values())
+                .filter(c -> c.readPreference.contentEquals(readPreference))
+                .findFirst();
+    }
+
+}

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/ReadPreference.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/ReadPreference.java
@@ -22,16 +22,22 @@ import java.util.Optional;
  */
 public enum ReadPreference {
 
-    PRIMARY("primary"),
-    PRIMARY_PREFERRED("primaryPreferred"),
-    SECONDARY("secondary"),
-    SECONDARY_PREFERRED("secondaryPreferred"),
-    NEAREST("nearest");
+    PRIMARY("primary", com.mongodb.ReadPreference.primary()),
+    PRIMARY_PREFERRED("primaryPreferred", com.mongodb.ReadPreference.primaryPreferred()),
+    SECONDARY("secondary", com.mongodb.ReadPreference.secondary()),
+    SECONDARY_PREFERRED("secondaryPreferred", com.mongodb.ReadPreference.secondaryPreferred()),
+    NEAREST("nearest", com.mongodb.ReadPreference.nearest());
 
-    private final String readPreference;
+    private final String name;
+    private final com.mongodb.ReadPreference mongoReadPreference;
 
-    ReadPreference(final String readPreference) {
-        this.readPreference = readPreference;
+    ReadPreference(final String name, final com.mongodb.ReadPreference mongoReadPreference) {
+        this.name = name;
+        this.mongoReadPreference = mongoReadPreference;
+    }
+
+    public com.mongodb.ReadPreference getMongoReadPreference() {
+        return mongoReadPreference;
     }
 
     /**
@@ -44,7 +50,7 @@ public enum ReadPreference {
     static Optional<ReadPreference> ofReadPreference(final String readPreference) {
         checkNotNull(readPreference, "readPreference");
         return Arrays.stream(values())
-                .filter(c -> c.readPreference.contentEquals(readPreference))
+                .filter(c -> c.name.contentEquals(readPreference))
                 .findFirst();
     }
 

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
@@ -72,7 +72,7 @@ public final class DefaultMongoDbConfigTest {
 
         softly.assertThat(underTest.toString()).contains(underTest.getClass().getSimpleName())
                 .contains("maxQueryTime", "mongoDbUri", "optionsConfig", "connectionPoolConfig",
-                "circuitBreakerConfig", "monitoringConfig");
+                        "circuitBreakerConfig", "monitoringConfig");
     }
 
     @Test
@@ -80,7 +80,8 @@ public final class DefaultMongoDbConfigTest {
         final DefaultMongoDbConfig underTest = DefaultMongoDbConfig.of(rawMongoDbConfig);
 
         softly.assertThat(underTest.getMaxQueryTime()).isEqualTo(Duration.ofSeconds(10));
-        softly.assertThat(underTest.getMongoDbUri()).isEqualTo("mongodb://foo:bar@mongodb:27017/test?w=1&ssl=false");
+        softly.assertThat(underTest.getMongoDbUri())
+                .isEqualTo("mongodb://foo:bar@mongodb:27017/test?w=1&readPreference=secondaryPreferred&ssl=false");
         softly.assertThat(underTest.getOptionsConfig()).satisfies(optionsConfig -> {
             softly.assertThat(optionsConfig.isSslEnabled()).isFalse();
         });
@@ -116,11 +117,16 @@ public final class DefaultMongoDbConfigTest {
         softly.assertThat(underTest.getMongoDbUri()).as("mongoDbUri").isEqualTo("mongodb://foo:bar@mongodb:27017/test");
         softly.assertThat(underTest.getOptionsConfig()).satisfies(optionsConfig -> {
             softly.assertThat(optionsConfig.isSslEnabled()).as("ssl").isFalse();
+            softly.assertThat(optionsConfig.readPreference())
+                    .as("readPreference")
+                    .isEqualTo(ReadPreference.PRIMARY_PREFERRED);
         });
         softly.assertThat(underTest.getConnectionPoolConfig()).satisfies(connectionPoolConfig -> {
             softly.assertThat(connectionPoolConfig.getMaxSize()).as("maxSize").isEqualTo(100);
             softly.assertThat(connectionPoolConfig.getMaxWaitQueueSize()).as("maxWaitQueueSize").isEqualTo(100);
-            softly.assertThat(connectionPoolConfig.getMaxWaitTime()).as("maxWaitTime").isEqualTo(Duration.ofSeconds(30L));
+            softly.assertThat(connectionPoolConfig.getMaxWaitTime())
+                    .as("maxWaitTime")
+                    .isEqualTo(Duration.ofSeconds(30L));
             softly.assertThat(connectionPoolConfig.isJmxListenerEnabled()).as("jmxListenerEnabled").isFalse();
         });
         softly.assertThat(underTest.getCircuitBreakerConfig()).satisfies(circuitBreakerConfig -> {

--- a/services/utils/persistence/src/test/resources/mongodb_test.conf
+++ b/services/utils/persistence/src/test/resources/mongodb_test.conf
@@ -13,6 +13,7 @@ mongodb {
 
   options {
     ssl = false
+    readPreference = "secondaryPreferred"
     w = 1
   }
 


### PR DESCRIPTION
This PR allows to configure the read preference via environment variable.
In addition this PR assumes primaryPreferred as the default read preference.