### PR TITLE
Fix a bug in Concierge where pre-enforcement failure leads to error log spams.

### DIFF
--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/Contextual.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/Contextual.java
@@ -130,6 +130,15 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
                 startedTimer, receiver, receiverWrapperFunction, responseReceivers, askFuture, changesAuthorization);
     }
 
+    /**
+     * Retrieve the message but tolerate that it may be null.
+     *
+     * @return the optional message.
+     */
+    public Optional<T> getMessageOptional() {
+        return Optional.ofNullable(message);
+    }
+
     @Override
     public T getMessage() {
         if (message == null) {


### PR DESCRIPTION
Pre-enforcer failures create a contextual with 'null' as message. EnforcementScheduler should anticipate it instead of throwing an error and polluting the logs.