### PR TITLE
IndexLengthRestrictionEnforcer: Fix unicode handling.

### DIFF
--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/util/TestStringGenerator.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/util/TestStringGenerator.java
@@ -12,27 +12,36 @@
  */
 package org.eclipse.ditto.services.thingsearch.persistence.util;
 
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 /**
  * Generates test strings.
  */
 public final class TestStringGenerator {
 
-    private TestStringGenerator(){
+    private TestStringGenerator() {
         throw new AssertionError();
     }
 
     /**
-     * Creates a test string of the given {@code length}.
+     * Creates a test string of the given {@code bytes} in bytes.
      *
-     * @param length the length
+     * @param bytes the bytes
      * @return the test string
      */
-    public static String createString(final int length) {
-        return IntStream.range(0, length)
-                .mapToObj(i -> "$")
+    public static String createStringOfBytes(final int bytes) {
+        final String unicodeString = "ひらがな";
+        final int bytesOfUnicodeString = unicodeString.getBytes(StandardCharsets.UTF_8).length;
+        final int multiples = bytes / bytesOfUnicodeString;
+        final int remainder = bytes % bytesOfUnicodeString;
+        return Stream.concat(repeat(unicodeString, multiples), repeat("x", remainder))
                 .collect(Collectors.joining());
+    }
+
+    private static Stream<String> repeat(final String element, final int number) {
+        return IntStream.range(0, number).mapToObj(i -> element);
     }
 }

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/mapping/EnforcedThingFlattenerTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/mapping/EnforcedThingFlattenerTest.java
@@ -33,7 +33,6 @@ import org.eclipse.ditto.model.enforcers.PolicyEnforcers;
 import org.eclipse.ditto.model.policies.PoliciesModelFactory;
 import org.eclipse.ditto.model.policies.PolicyId;
 import org.eclipse.ditto.model.policies.SubjectType;
-import org.eclipse.ditto.model.things.ThingDefinition;
 import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.services.models.policies.Permission;
 import org.junit.Test;
@@ -42,8 +41,6 @@ import org.junit.Test;
  * Tests {@link EnforcedThingFlattener}
  */
 public final class EnforcedThingFlattenerTest {
-
-    final ThingDefinition DEFINITION = ThingsModelFactory.newDefinition("example:test:definition");
 
     @Test
     public void testWithAclEnforcer() {
@@ -146,7 +143,7 @@ public final class EnforcedThingFlattenerTest {
                 "}");
 
         final Enforcer enforcer = PolicyEnforcers.defaultEvaluator(
-                PoliciesModelFactory.newPolicyBuilder(PolicyId.of("policy","id"))
+                PoliciesModelFactory.newPolicyBuilder(PolicyId.of("policy", "id"))
                         .forLabel("grant-root")
                         .setSubject("grant:root", SubjectType.GENERATED)
                         .setGrantedPermissions(THING, "/", Permission.READ)
@@ -294,7 +291,7 @@ public final class EnforcedThingFlattenerTest {
                 "    \"example:test:definition\"}");
 
         final Enforcer emptyEnforcer = PolicyEnforcers.defaultEvaluator(
-                PoliciesModelFactory.newPolicyBuilder(PolicyId.of("policy","id"))
+                PoliciesModelFactory.newPolicyBuilder(PolicyId.of("policy", "id"))
                         .forLabel("grant-root")
                         .setSubject("grant:root", SubjectType.GENERATED)
                         .setGrantedPermissions(THING, "/", Permission.READ)


### PR DESCRIPTION
IndexLengthRestrictionEnforcer truncated unicode strings by character instead of by bytes, which was incorrect.