### PR TITLE
Replace insecure rubygems proxy. Fix #625

### DIFF
--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -197,6 +197,13 @@
                 </executions>
             </plugin>
         </plugins>
+        <extensions>
+            <extension>
+                <groupId>org.torquebox.mojo</groupId>
+                <artifactId>mavengem-wagon</artifactId>
+                <version>1.0.3</version>
+            </extension>
+        </extensions>
     </build>
 
     <!-- Jekyll Linux Build -->
@@ -205,17 +212,8 @@
             <id>build-documentation</id>
             <repositories>
                 <repository>
-                    <id>rubygems-proxy</id>
-                    <name>Rubygems Proxy</name>
-                    <url>http://rubygems-proxy.torquebox.org/releases</url>
-                    <layout>default</layout>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </snapshots>
+                    <id>mavengems</id>
+                    <url>mavengem:https://rubygems.org</url>
                 </repository>
             </repositories>
             <dependencies>
@@ -298,17 +296,8 @@
             <id>validate-documentation</id>
             <repositories>
                 <repository>
-                    <id>rubygems-proxy</id>
-                    <name>Rubygems Proxy</name>
-                    <url>http://rubygems-proxy.torquebox.org/releases</url>
-                    <layout>default</layout>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>false</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </snapshots>
+                    <id>mavengems</id>
+                    <url>mavengem:https://rubygems.org</url>
                 </repository>
             </repositories>
             <dependencyManagement>

--- a/legal/NOTICE.md
+++ b/legal/NOTICE.md
@@ -27,6 +27,7 @@ SPDX-License-Identifier: EPL-2.0
 * Copyright 2019-2020 othermo GmbH
 * Copyright 2019 Kiwigrid GmbH
 * Copyright 2020 Bosch.IO GmbH
+* Copyright 2020 DevBoost GmbH
 
 All content is the property of the respective authors or their employers.
 For more information regarding authorship of content, please consult the


### PR DESCRIPTION
I replaced the insecure rubygems proxy by using `mavengem-wagon` project. See https://github.com/jruby/mavengem for details.

Fixes: #625