### PR TITLE
Bugfix/header mapping

### DIFF
--- a/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/PipelineFunctionParameterResolverFactoryTest.java
+++ b/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/PipelineFunctionParameterResolverFactoryTest.java
@@ -15,9 +15,7 @@ package org.eclipse.ditto.model.placeholders;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 

--- a/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/PipelineFunctionParameterResolverFactoryTest.java
+++ b/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/PipelineFunctionParameterResolverFactoryTest.java
@@ -17,7 +17,8 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Predicate;
@@ -45,7 +46,7 @@ public class PipelineFunctionParameterResolverFactoryTest {
         final String params = "(\"" + KNOWN_VALUE + "\")";
         assertThat(parameterResolver.apply(params, expressionResolver, DUMMY)).contains(KNOWN_VALUE);
 
-        verifyZeroInteractions(expressionResolver);
+        verifyNoInteractions(expressionResolver);
     }
 
     @Test
@@ -56,7 +57,7 @@ public class PipelineFunctionParameterResolverFactoryTest {
         final String params = "(\'" + KNOWN_VALUE + "\')";
         assertThat(parameterResolver.apply(params, expressionResolver, DUMMY)).contains(KNOWN_VALUE);
 
-        verifyZeroInteractions(expressionResolver);
+        verifyNoInteractions(expressionResolver);
     }
 
     @Test
@@ -75,7 +76,7 @@ public class PipelineFunctionParameterResolverFactoryTest {
         assertThatExceptionOfType(PlaceholderFunctionSignatureInvalidException.class)
                 .isThrownBy(() -> parameterResolver.apply(paramsPlaceholders, expressionResolver, DUMMY));
 
-        verifyZeroInteractions(expressionResolver);
+        verifyNoInteractions(expressionResolver);
     }
 
     @Test
@@ -147,7 +148,7 @@ public class PipelineFunctionParameterResolverFactoryTest {
         assertThatExceptionOfType(PlaceholderFunctionSignatureInvalidException.class)
                 .isThrownBy(() -> stringResolver.apply(stringPlaceholder, expressionResolver, DUMMY));
 
-        verifyZeroInteractions(expressionResolver);
+        verifyNoInteractions(expressionResolver);
     }
 
     @Test
@@ -164,7 +165,7 @@ public class PipelineFunctionParameterResolverFactoryTest {
         assertThatExceptionOfType(PlaceholderFunctionSignatureInvalidException.class)
                 .isThrownBy(() -> stringResolver.apply(stringPlaceholder, expressionResolver, DUMMY));
 
-        verifyZeroInteractions(expressionResolver);
+        verifyNoInteractions(expressionResolver);
     }
 
     @Test

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
@@ -26,7 +26,6 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
 import org.eclipse.ditto.protocoladapter.adaptables.MappingStrategies;
-import org.eclipse.ditto.signals.commands.base.CommandResponse;
 
 /**
  * Abstract implementation of {@link Adapter} to provide common functionality.

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
@@ -152,27 +152,9 @@ public abstract class AbstractAdapter<T extends Jsonifiable.WithPredicate<JsonOb
     @Override
     public final Adaptable toAdaptable(final T signal, final TopicPath.Channel channel) {
         final Adaptable adaptable = mapSignalToAdaptable(signal, channel);
-        final Map<String, String> externalHeaders;
-        if (filterOutUnknownExternalHeaders(signal, channel)) {
-            externalHeaders = headerTranslator.toExternalAndRetainKnownHeaders(adaptable.getDittoHeaders());
-        } else {
-            externalHeaders = headerTranslator.toExternalHeaders(adaptable.getDittoHeaders());
-        }
+        final Map<String, String> externalHeaders = headerTranslator.toExternalHeaders(adaptable.getDittoHeaders());
 
         return adaptable.setDittoHeaders(DittoHeaders.of(externalHeaders));
-    }
-
-    /**
-     * Called in order to determine whether to filter out unknown headers (then return {@code true}) or to keep all
-     * unknown headers (then return {@code false}).
-     * By default for CommandResponses the unknown headers will be filtered.
-     *
-     * @param signal the signal which can be used to determine the decision on.
-     * @param channel the channel of the signal.
-     * @return {@code true} when unknown external headers should be filtered, {@code false} otherwise.
-     */
-    protected boolean filterOutUnknownExternalHeaders(final T signal, final TopicPath.Channel channel) {
-        return channel == TopicPath.Channel.TWIN && signal instanceof CommandResponse;
     }
 
     /**


### PR DESCRIPTION
Remove filtering of unknown headers for adaptables.

We need those headers for header mapping in connectivity.