### PR TITLE
Fix extraneous warning logs due to out-of-sync reporting

### DIFF
--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
@@ -212,8 +212,12 @@ final class QueryThingsPerRequestActor extends AbstractActor {
                 .filter(thingId -> !retrievedThingIds.contains(thingId))
                 .collect(Collectors.toList());
 
-        final ThingsOutOfSync thingsOutOfSync = ThingsOutOfSync.of(outOfSyncThingIds, queryThingsResponse.getDittoHeaders());
-        pubSubMediator.tell(DistPubSubAccess.publishViaGroup(ThingsOutOfSync.TYPE, thingsOutOfSync), ActorRef.noSender());
+        if (!outOfSyncThingIds.isEmpty()) {
+            final ThingsOutOfSync thingsOutOfSync =
+                    ThingsOutOfSync.of(outOfSyncThingIds, queryThingsResponse.getDittoHeaders());
+            pubSubMediator.tell(DistPubSubAccess.publishViaGroup(ThingsOutOfSync.TYPE, thingsOutOfSync),
+                    ActorRef.noSender());
+        }
     }
 
     private void stopMyself() {


### PR DESCRIPTION
QueryThingsPerRequestActor: Don't report out-of-sync things if none is found.