### PR TITLE
Handle unknown hosts in connections correctly

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
@@ -91,6 +91,7 @@ import org.eclipse.ditto.signals.acks.base.Acknowledgement;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommand;
+import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommandInterceptor;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionFailedException;
 import org.eclipse.ditto.signals.commands.connectivity.exceptions.ConnectionNotAccessibleException;
 import org.eclipse.ditto.signals.commands.connectivity.modify.CheckConnectionLogsActive;
@@ -156,7 +157,7 @@ public final class ConnectionPersistenceActor
     private final ActorRef conciergeForwarder;
     private final ClientActorPropsFactory propsFactory;
     private final int clientActorsPerNode;
-    private final Consumer<ConnectivityCommand<?>> commandValidator;
+    private final ConnectivityCommandInterceptor commandValidator;
     private final ConnectionLogger connectionLogger;
     private Instant connectionClosedAt = Instant.now();
 
@@ -179,7 +180,7 @@ public final class ConnectionPersistenceActor
             final DittoProtocolSub dittoProtocolSub,
             final ActorRef conciergeForwarder,
             final ClientActorPropsFactory propsFactory,
-            @Nullable final Consumer<ConnectivityCommand<?>> customCommandValidator,
+            @Nullable final ConnectivityCommandInterceptor customCommandValidator,
             final int clientActorsPerNode) {
 
         super(connectionId, new ConnectionMongoSnapshotAdapter());
@@ -245,7 +246,7 @@ public final class ConnectionPersistenceActor
             final DittoProtocolSub dittoProtocolSub,
             final ActorRef conciergeForwarder,
             final ClientActorPropsFactory propsFactory,
-            @Nullable final Consumer<ConnectivityCommand<?>> commandValidator
+            @Nullable final ConnectivityCommandInterceptor commandValidator
     ) {
         return Props.create(ConnectionPersistenceActor.class, connectionId, dittoProtocolSub, conciergeForwarder,
                 propsFactory, commandValidator, CLIENT_ACTORS_PER_NODE);

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/stages/ConnectionState.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/stages/ConnectionState.java
@@ -12,11 +12,9 @@
  */
 package org.eclipse.ditto.services.connectivity.messaging.persistence.stages;
 
-import java.util.function.Consumer;
-
 import org.eclipse.ditto.model.connectivity.ConnectionId;
 import org.eclipse.ditto.services.connectivity.messaging.monitoring.logs.ConnectionLogger;
-import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommand;
+import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommandInterceptor;
 
 /**
  * Everything needed by connection strategies from the state of a connection actor.
@@ -25,10 +23,10 @@ public final class ConnectionState {
 
     private final ConnectionId connectionId;
     private final ConnectionLogger connectionLogger;
-    private final Consumer<ConnectivityCommand<?>> validator;
+    private final ConnectivityCommandInterceptor validator;
 
     private ConnectionState(final ConnectionId connectionId,
-            final ConnectionLogger connectionLogger, final Consumer<ConnectivityCommand<?>> validator) {
+            final ConnectionLogger connectionLogger, final ConnectivityCommandInterceptor validator) {
         this.connectionId = connectionId;
         this.connectionLogger = connectionLogger;
         this.validator = validator;
@@ -45,7 +43,7 @@ public final class ConnectionState {
     public static ConnectionState of(
             final ConnectionId connectionId,
             final ConnectionLogger connectionLogger,
-            final Consumer<ConnectivityCommand<?>> validator) {
+            final ConnectivityCommandInterceptor validator) {
 
         return new ConnectionState(connectionId, connectionLogger, validator);
     }
@@ -67,7 +65,7 @@ public final class ConnectionState {
     /**
      * @return the command validator.
      */
-    public Consumer<ConnectivityCommand<?>> getValidator() {
+    public ConnectivityCommandInterceptor getValidator() {
         return validator;
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/OpenConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/OpenConnectionStrategy.java
@@ -16,13 +16,16 @@ import static org.eclipse.ditto.services.connectivity.messaging.persistence.stag
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.PERSIST_AND_APPLY_EVENT;
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.SEND_RESPONSE;
 import static org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction.UPDATE_SUBSCRIPTIONS;
+import static org.eclipse.ditto.services.utils.persistentactors.results.ResultFactory.newErrorResult;
 import static org.eclipse.ditto.services.utils.persistentactors.results.ResultFactory.newMutationResult;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.connectivity.Connection;
 import org.eclipse.ditto.services.connectivity.messaging.persistence.stages.ConnectionAction;
@@ -46,11 +49,16 @@ final class OpenConnectionStrategy extends AbstractConnectivityCommandStrategy<O
     @Override
     protected Result<ConnectivityEvent> doApply(final Context<ConnectionState> context,
             @Nullable final Connection connection, final long nextRevision, final OpenConnection command) {
-        final ConnectivityEvent event = ConnectionOpened.of(context.getState().id(), command.getDittoHeaders());
-        final WithDittoHeaders response =
-                OpenConnectionResponse.of(context.getState().id(), command.getDittoHeaders());
-        final List<ConnectionAction> actions =
-                Arrays.asList(PERSIST_AND_APPLY_EVENT, OPEN_CONNECTION, UPDATE_SUBSCRIPTIONS, SEND_RESPONSE);
-        return newMutationResult(StagedCommand.of(command, event, response, actions), event, response);
+        final Optional<DittoRuntimeException> validationError = validate(context, command, connection);
+        if (validationError.isPresent()) {
+            return newErrorResult(validationError.get());
+        } else {
+            final ConnectivityEvent event = ConnectionOpened.of(context.getState().id(), command.getDittoHeaders());
+            final WithDittoHeaders response =
+                    OpenConnectionResponse.of(context.getState().id(), command.getDittoHeaders());
+            final List<ConnectionAction> actions =
+                    Arrays.asList(PERSIST_AND_APPLY_EVENT, OPEN_CONNECTION, UPDATE_SUBSCRIPTIONS, SEND_RESPONSE);
+            return newMutationResult(StagedCommand.of(command, event, response, actions), event, response);
+        }
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/CompoundConnectivityCommandInterceptor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/CompoundConnectivityCommandInterceptor.java
@@ -14,8 +14,9 @@ package org.eclipse.ditto.services.connectivity.messaging.validation;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.function.Consumer;
+import java.util.function.Supplier;
 
+import org.eclipse.ditto.model.connectivity.Connection;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommand;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommandInterceptor;
 
@@ -24,15 +25,15 @@ import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommandInterc
  */
 public final class CompoundConnectivityCommandInterceptor implements ConnectivityCommandInterceptor {
 
-    private final Collection<Consumer<ConnectivityCommand<?>>> validators;
+    private final Collection<ConnectivityCommandInterceptor> validators;
 
     @SafeVarargs
-    public CompoundConnectivityCommandInterceptor(final Consumer<ConnectivityCommand<?>>... validators) {
+    public CompoundConnectivityCommandInterceptor(final ConnectivityCommandInterceptor... validators) {
         this.validators = Arrays.asList(validators);
     }
 
     @Override
-    public void accept(final ConnectivityCommand<?> command) {
-        validators.forEach(c -> c.accept(command));
+    public void accept(final ConnectivityCommand<?> command, final Supplier<Connection> connectionSupplier) {
+        validators.forEach(c -> c.accept(command, connectionSupplier));
     }
 }

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractBaseClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractBaseClientActorTest.java
@@ -16,6 +16,7 @@ package org.eclipse.ditto.services.connectivity.messaging;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import javax.net.ssl.SSLContext;
@@ -186,7 +187,7 @@ public abstract class AbstractBaseClientActorTest {
             underTest.tell(TestConnection.of(insecureConnection, DittoHeaders.empty()), getRef());
 
             // THEN: the test should succeed, or it should fail with a different reason than SSL validation
-            final Object response = expectMsgClass(Object.class);
+            final Object response = expectMsgClass(Duration.ofSeconds(5), Object.class);
             if (response instanceof Status.Failure) {
                 final DittoRuntimeException error =
                         (DittoRuntimeException) getEventualCause(((Status.Failure) response).cause());

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActorTest.java
@@ -22,12 +22,7 @@ import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.services.connectivity.messaging.AbstractPublisherActorTest;
 import org.eclipse.ditto.services.connectivity.messaging.TestConstants;
-import org.eclipse.ditto.services.models.connectivity.OutboundSignal;
-import org.junit.Test;
 
-import com.typesafe.config.ConfigValueFactory;
-
-import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.event.LoggingAdapter;
@@ -42,7 +37,6 @@ import akka.japi.Pair;
 import akka.stream.ActorMaterializer;
 import akka.stream.javadsl.Flow;
 import akka.testkit.TestProbe;
-import akka.testkit.javadsl.TestKit;
 import scala.util.Try;
 
 /**
@@ -51,7 +45,7 @@ import scala.util.Try;
 public final class HttpPublisherActorTest extends AbstractPublisherActorTest {
 
     private HttpPushFactory httpPushFactory;
-    private BlockingQueue<HttpRequest> received = new LinkedBlockingQueue<>();
+    private final BlockingQueue<HttpRequest> received = new LinkedBlockingQueue<>();
 
     @Override
     protected String getOutboundAddress() {
@@ -64,33 +58,6 @@ public final class HttpPublisherActorTest extends AbstractPublisherActorTest {
             received.offer(request);
             return HttpResponse.create().withStatus(StatusCodes.OK);
         });
-    }
-
-    @Test
-    public void testIpv6Blacklist() {
-        final ActorSystem systemWithBlacklist = ActorSystem.create("systemWithBlackList",
-                CONFIG.withValue("ditto.connectivity.connection.blacklisted-hostnames",
-                        ConfigValueFactory.fromAnyRef("8.8.8.8,2001:4860:4860:0000:0000:0000:0000:0001")));
-        try {
-            new TestKit(systemWithBlacklist) {{
-                // GIVEN: A connection has a blacklisted host configured
-                final TestProbe probe = new TestProbe(systemWithBlacklist);
-                httpPushFactory = new DummyHttpPushFactory("[2001:4860:4860::1]", request -> {
-                    probe.ref().tell(request, ActorRef.noSender());
-                    return HttpResponse.create().withStatus(StatusCodes.OK);
-                });
-
-                // WHEN: the publisher is requested to send a message
-                final OutboundSignal.Mapped outboundSignal = getMockOutboundSignal();
-                final ActorRef underTest = childActorOf(getPublisherActorProps());
-                underTest.tell(outboundSignal, getRef());
-
-                // THEN: the message is dropped
-                probe.expectNoMessage();
-            }};
-        } finally {
-            TestKit.shutdownActorSystem(systemWithBlacklist);
-        }
     }
 
     @Override

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidatorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidatorTest.java
@@ -23,6 +23,7 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -57,6 +58,7 @@ import org.junit.rules.ExpectedException;
 import com.typesafe.config.ConfigValueFactory;
 
 import akka.actor.ActorSystem;
+import akka.http.javadsl.model.Host;
 import akka.http.javadsl.model.Uri;
 import akka.testkit.javadsl.TestKit;
 
@@ -256,6 +258,13 @@ public class ConnectionValidatorTest {
         expectConnectionConfigurationInvalid(underTest, getConnectionWithHost("192.168.0.1"));
         // multicast
         expectConnectionConfigurationInvalid(underTest, getConnectionWithHost("224.0.1.1"));
+    }
+
+    @Test
+    public void expectExceptionForInvalidHost() {
+        assertThatExceptionOfType(ConnectionConfigurationInvalidException.class).isThrownBy(
+                () -> ConnectionValidator.isHostForbidden(Host.create("ditto"),
+                        singletonList(InetAddress.getLoopbackAddress())));
     }
 
     private static void expectConnectionConfigurationInvalid(final ConnectionValidator underTest,

--- a/services/connectivity/messaging/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/services/connectivity/messaging/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/services/connectivity/starter/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceOperationsActorIT.java
+++ b/services/connectivity/starter/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceOperationsActorIT.java
@@ -125,7 +125,7 @@ public final class ConnectionPersistenceOperationsActorIT extends MongoEventSour
             final ConnectionId id) {
         // essentially never restart
         final TestProbe conciergeForwarderProbe = new TestProbe(system, "conciergeForwarder");
-        final ConnectivityCommandInterceptor dummyInterceptor = command -> {};
+        final ConnectivityCommandInterceptor dummyInterceptor = (command, connectionSupplier) -> {};
         final ClientActorPropsFactory entityActorFactory = DefaultClientActorPropsFactory.getInstance();
         final Props props =
                 ConnectionSupervisorActor.props(nopSub(), conciergeForwarderProbe.ref(), entityActorFactory,

--- a/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/ConnectivityCommandInterceptor.java
+++ b/signals/commands/connectivity/src/main/java/org/eclipse/ditto/signals/commands/connectivity/ConnectivityCommandInterceptor.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.signals.commands.connectivity;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
@@ -25,7 +27,8 @@ import org.eclipse.ditto.signals.commands.connectivity.modify.TestConnection;
  * Intercepts a {@link ConnectivityCommand}s and may throw a {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException}
  * if the command is invalid.
  */
-public interface ConnectivityCommandInterceptor extends Consumer<ConnectivityCommand<?>> {
+public interface ConnectivityCommandInterceptor extends Consumer<ConnectivityCommand<?>>,
+        BiConsumer<ConnectivityCommand<?>, Supplier<Connection>> {
 
     @Nullable
     default Connection getConnectionFromCommand(final ConnectivityCommand<?> command) {
@@ -39,5 +42,15 @@ public interface ConnectivityCommandInterceptor extends Consumer<ConnectivityCom
             default:
                 return null;
         }
+    }
+
+    /**
+     * By default resolve connection from the given {@link ConnectivityCommand}.
+     *
+     * @param command the intercepted command
+     */
+    @Override
+    default void accept(final ConnectivityCommand<?> command) {
+        accept(command, () -> getConnectionFromCommand(command));
     }
 }


### PR DESCRIPTION
An unknown/invalid host in a connection configuration caused an exception with an error message that did not indicate the actual cause. This is now fixed.