### PR TITLE
Fix nullable EvenStrategy

### DIFF
--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
 import javax.annotation.Nullable;
@@ -21,10 +20,23 @@ import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
 import org.eclipse.ditto.signals.events.policies.PolicyEvent;
 
+/**
+ * This abstract implementation of {@code EventStrategy} checks if the Policy to be handled is {@code null}.
+ * If the Policy is {@code null} the {@code handle} method returns with {@code null}; otherwise a PolicyBuilder
+ * will be derived from the Policy with the revision and modified timestamp set.
+ * This builder is then passed to the
+ * {@link #applyEvent(T, org.eclipse.ditto.model.policies.PolicyBuilder)}
+ * method for further handling.
+ * However, sub-classes are free to implement the {@code handle} method directly and thus completely circumvent the
+ * {@code applyEvent} method.
+ *
+ * @param <T> the type of the handled PolicyEvent.
+ */
 @Immutable
 abstract class AbstractPolicyEventStrategy<T extends PolicyEvent<T>> implements EventStrategy<T, Policy> {
+
     /**
-     * Constructs a new {@code AbstractEventStrategy} object.
+     * Constructs a new {@code AbstractPolicyEventStrategy} object.
      */
     protected AbstractPolicyEventStrategy() {
         super();
@@ -37,7 +49,7 @@ abstract class AbstractPolicyEventStrategy<T extends PolicyEvent<T>> implements 
             PolicyBuilder policyBuilder = policy.toBuilder()
                     .setRevision(revision)
                     .setModified(event.getTimestamp().orElse(null));
-            policyBuilder = applyEvent(event, policyBuilder);
+            policyBuilder = applyEvent(event, policy, policyBuilder);
             return policyBuilder.build();
         }
         return null;
@@ -48,7 +60,22 @@ abstract class AbstractPolicyEventStrategy<T extends PolicyEvent<T>> implements 
      * set as well as the event's timestamp.
      *
      * @param event the ThingEvent to be applied.
-     * @param policyBuilder builder which is derived from the {@code event}'s Thing with the revision and event
+     * @param policy the {@link org.eclipse.ditto.model.policies.Policy} to apply the event to.
+     * @param policyBuilder builder which is derived from the {@code event}'s Policy with the revision and event
+     * timestamp already set.
+     * @return the updated {@code policyBuilder} after applying {@code event}.
+     */
+    protected PolicyBuilder applyEvent(final T event, final Policy policy, final PolicyBuilder policyBuilder) {
+        return applyEvent(event, policyBuilder);
+    }
+
+
+    /**
+     * Apply the specified event to the also specified PolicyBuilder. The builder has already the specified revision
+     * set as well as the event's timestamp.
+     *
+     * @param event the ThingEvent to be applied.
+     * @param policyBuilder builder which is derived from the {@code event}'s Policy with the revision and event
      * timestamp already set.
      * @return the updated {@code policyBuilder} after applying {@code event}.
      */

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
+import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.signals.events.policies.PolicyEvent;
+
+@Immutable
+abstract class AbstractPolicyEventStrategy<T extends PolicyEvent<T>> implements EventStrategy<T, Policy> {
+    /**
+     * Constructs a new {@code AbstractEventStrategy} object.
+     */
+    protected AbstractPolicyEventStrategy() {
+        super();
+    }
+
+    @Nullable
+    @Override
+    public Policy handle(final T event, @Nullable final Policy policy, final long revision) {
+        if (null != policy) {
+            PolicyBuilder policyBuilder = policy.toBuilder()
+                    .setRevision(revision)
+                    .setModified(event.getTimestamp().orElse(null));
+            policyBuilder = applyEvent(event, policyBuilder);
+            return policyBuilder.build();
+        }
+        return null;
+    }
+
+    /**
+     * Apply the specified event to the also specified PolicyBuilder. The builder has already the specified revision
+     * set as well as the event's timestamp.
+     *
+     * @param event the ThingEvent to be applied.
+     * @param policyBuilder builder which is derived from the {@code event}'s Thing with the revision and event
+     * timestamp already set.
+     * @return the updated {@code policyBuilder} after applying {@code event}.
+     */
+    protected PolicyBuilder applyEvent(final T event, final PolicyBuilder policyBuilder) {
+        return policyBuilder;
+    }
+}

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyDeletedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyDeletedStrategy.java
@@ -12,29 +12,18 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.model.policies.PolicyLifecycle;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
 import org.eclipse.ditto.signals.events.policies.PolicyDeleted;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyDeleted} events.
  */
-final class PolicyDeletedStrategy implements EventStrategy<PolicyDeleted, Policy> {
+final class PolicyDeletedStrategy extends AbstractPolicyEventStrategy<PolicyDeleted> {
 
-    @Nullable
     @Override
-    public Policy handle(final PolicyDeleted event, @Nullable final Policy policy, final long revision) {
-        if (policy != null) {
-            return policy.toBuilder()
-                    .setLifecycle(PolicyLifecycle.DELETED)
-                    .setRevision(revision)
-                    .setModified(event.getTimestamp().orElse(null))
-                    .build();
-        } else {
-            return null;
-        }
+    protected PolicyBuilder applyEvent(final PolicyDeleted pd, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setLifecycle(PolicyLifecycle.DELETED);
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategy.java
@@ -12,27 +12,19 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyEntriesModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyEntriesModified} events.
  */
-final class PolicyEntriesModifiedStrategy implements EventStrategy<PolicyEntriesModified, Policy> {
+final class PolicyEntriesModifiedStrategy extends AbstractPolicyEventStrategy<PolicyEntriesModified> {
 
     @Override
-    public Policy handle(final PolicyEntriesModified pem, @Nullable final Policy policy, final long revision) {
-        final Policy nonNullPolicy = checkNotNull(policy, "policy");
-        return nonNullPolicy.toBuilder()
-                .removeAll(nonNullPolicy.getEntriesSet())
-                .setAll(pem.getPolicyEntries())
-                .setRevision(revision)
-                .setModified(pem.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final PolicyEntriesModified pem, final PolicyBuilder policyBuilder) {
+        return policyBuilder
+                .removeAll(policyBuilder.build())
+                .setAll(pem.getPolicyEntries());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategy.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
+import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyEntriesModified;
 
@@ -21,10 +22,10 @@ import org.eclipse.ditto.signals.events.policies.PolicyEntriesModified;
 final class PolicyEntriesModifiedStrategy extends AbstractPolicyEventStrategy<PolicyEntriesModified> {
 
     @Override
-    protected PolicyBuilder applyEvent(final PolicyEntriesModified pem, final PolicyBuilder policyBuilder) {
+    protected PolicyBuilder applyEvent(final PolicyEntriesModified pem, final Policy policy,
+            final PolicyBuilder policyBuilder) {
         return policyBuilder
-                .removeAll(policyBuilder.build())
+                .removeAll(policy.getEntriesSet())
                 .setAll(pem.getPolicyEntries());
     }
-
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryCreatedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryCreatedStrategy.java
@@ -12,25 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyEntryCreated;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyEntryCreated} events.
  */
-final class PolicyEntryCreatedStrategy implements EventStrategy<PolicyEntryCreated, Policy> {
+final class PolicyEntryCreatedStrategy extends AbstractPolicyEventStrategy<PolicyEntryCreated> {
 
     @Override
-    public Policy handle(final PolicyEntryCreated pec, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").toBuilder()
-                .set(pec.getPolicyEntry())
-                .setRevision(revision)
-                .setModified(pec.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final PolicyEntryCreated pec, final PolicyBuilder policyBuilder) {
+        return policyBuilder.set(pec.getPolicyEntry());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryDeletedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryDeletedStrategy.java
@@ -12,25 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyEntryDeleted;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyEntryDeleted} events.
  */
-final class PolicyEntryDeletedStrategy implements EventStrategy<PolicyEntryDeleted, Policy> {
+final class PolicyEntryDeletedStrategy extends AbstractPolicyEventStrategy<PolicyEntryDeleted> {
 
     @Override
-    public Policy handle(final PolicyEntryDeleted ped, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").toBuilder()
-                .remove(ped.getLabel())
-                .setRevision(revision)
-                .setModified(ped.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final PolicyEntryDeleted ped, final PolicyBuilder policyBuilder) {
+        return policyBuilder.remove(ped.getLabel());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryModifiedStrategy.java
@@ -12,25 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyEntryModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyEntryModified} events.
  */
-final class PolicyEntryModifiedStrategy implements EventStrategy<PolicyEntryModified, Policy> {
+final class PolicyEntryModifiedStrategy extends AbstractPolicyEventStrategy<PolicyEntryModified> {
 
     @Override
-    public Policy handle(final PolicyEntryModified pem, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").toBuilder()
-                .set(pem.getPolicyEntry())
-                .setRevision(revision)
-                .setModified(pem.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final PolicyEntryModified pem, final PolicyBuilder policyBuilder) {
+        return policyBuilder.set(pem.getPolicyEntry());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEventStrategies.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEventStrategies.java
@@ -32,7 +32,7 @@ import org.eclipse.ditto.signals.events.policies.SubjectModified;
 import org.eclipse.ditto.signals.events.policies.SubjectsModified;
 
 /**
- * PersistentActor which "knows" the state of a single {@link org.eclipse.ditto.model.policies.Policy}.
+ * Holds all {@link org.eclipse.ditto.signals.events.policies.PolicyEvent} strategies.
  */
 public final class PolicyEventStrategies extends AbstractEventStrategies<PolicyEvent, Policy> {
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategy.java
@@ -12,29 +12,19 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.policies.PolicyBuilder;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
 import org.eclipse.ditto.signals.events.policies.PolicyModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.PolicyModified} events.
  */
-final class PolicyModifiedStrategy implements EventStrategy<PolicyModified, Policy> {
+final class PolicyModifiedStrategy extends AbstractPolicyEventStrategy<PolicyModified> {
 
     @Override
-    public Policy handle(final PolicyModified event, @Nullable final Policy policy, final long revision) {
-        // we need to use the current policy as base otherwise we would loose its state
-        final PolicyBuilder copyBuilder = checkNotNull(policy, "policy").toBuilder();
-
-        copyBuilder.removeAll(policy); // remove all old policyEntries!
-        copyBuilder.setAll(event.getPolicy().getEntriesSet()); // add the new ones
-        return copyBuilder.setRevision(revision)
-                .setModified(event.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final PolicyModified pm, final PolicyBuilder policyBuilder) {
+        return policyBuilder
+                .removeAll(policyBuilder.build())
+                .setAll(pm.getPolicy().getEntriesSet());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategy.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
+import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.PolicyModified;
 
@@ -21,10 +22,10 @@ import org.eclipse.ditto.signals.events.policies.PolicyModified;
 final class PolicyModifiedStrategy extends AbstractPolicyEventStrategy<PolicyModified> {
 
     @Override
-    protected PolicyBuilder applyEvent(final PolicyModified pm, final PolicyBuilder policyBuilder) {
+    protected PolicyBuilder applyEvent(final PolicyModified pm, final Policy policy,
+            final PolicyBuilder policyBuilder) {
         return policyBuilder
-                .removeAll(policyBuilder.build())
+                .removeAll(policy.getEntriesSet())
                 .setAll(pm.getPolicy().getEntriesSet());
     }
-
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceCreatedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceCreatedStrategy.java
@@ -12,31 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.ResourceCreated;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.ResourceCreated} events.
  */
-final class ResourceCreatedStrategy implements EventStrategy<ResourceCreated, Policy> {
+final class ResourceCreatedStrategy extends AbstractPolicyEventStrategy<ResourceCreated> {
 
     @Override
-    public Policy handle(final ResourceCreated rc, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(rc.getLabel())
-                .map(policyEntry -> PoliciesModelFactory.newPolicyEntry(rc.getLabel(),
-                        policyEntry.getSubjects(),
-                        policyEntry.getResources().setResource(rc.getResource())))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(rc.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final ResourceCreated rc, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setResourceFor(rc.getLabel(), rc.getResource());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceDeletedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceDeletedStrategy.java
@@ -12,26 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.ResourceDeleted;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.ResourceDeleted} events.
  */
-final class ResourceDeletedStrategy implements EventStrategy<ResourceDeleted, Policy> {
+final class ResourceDeletedStrategy extends AbstractPolicyEventStrategy<ResourceDeleted> {
 
     @Override
-    public Policy handle(final ResourceDeleted rd, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").toBuilder()
-                .forLabel(rd.getLabel())
-                .removeResource(rd.getResourceKey())
-                .setRevision(revision)
-                .setModified(rd.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final ResourceDeleted rd, final PolicyBuilder policyBuilder) {
+        return policyBuilder.removeResourceFor(rd.getLabel(), rd.getResourceKey());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategy.java
@@ -12,31 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.ResourceModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.ResourceModified} events.
  */
-final class ResourceModifiedStrategy implements EventStrategy<ResourceModified, Policy> {
+final class ResourceModifiedStrategy extends AbstractPolicyEventStrategy<ResourceModified> {
 
     @Override
-    public Policy handle(final ResourceModified rm, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(rm.getLabel())
-                .map(policyEntry -> PoliciesModelFactory.newPolicyEntry(rm.getLabel(),
-                        policyEntry.getSubjects(),
-                        policyEntry.getResources().setResource(rm.getResource())))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(rm.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final ResourceModified rm, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setResourceFor(rm.getLabel(), rm.getResource());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategy.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.ResourcesModified;
 
@@ -21,8 +23,12 @@ import org.eclipse.ditto.signals.events.policies.ResourcesModified;
 final class ResourcesModifiedStrategy extends AbstractPolicyEventStrategy<ResourcesModified> {
 
     @Override
-    protected PolicyBuilder applyEvent(final ResourcesModified rm, final PolicyBuilder policyBuilder) {
-        return policyBuilder.setResourcesFor(rm.getLabel(), rm.getResources());
+    protected PolicyBuilder applyEvent(final ResourcesModified rm, final Policy policy,
+            final PolicyBuilder policyBuilder) {
+        return policy.getEntryFor(rm.getLabel())
+                .map(policyEntry -> PoliciesModelFactory.newPolicyEntry(rm.getLabel(), policyEntry.getSubjects(),
+                        rm.getResources()))
+                .map(modifiedPolicyEntry -> policyBuilder.set(modifiedPolicyEntry))
+                .orElse(policyBuilder.setResourcesFor(rm.getLabel(), rm.getResources()));
     }
-
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategy.java
@@ -12,30 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.ResourcesModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.ResourcesModified} events.
  */
-final class ResourcesModifiedStrategy implements EventStrategy<ResourcesModified, Policy> {
+final class ResourcesModifiedStrategy extends AbstractPolicyEventStrategy<ResourcesModified> {
 
     @Override
-    public Policy handle(final ResourcesModified rm, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(rm.getLabel())
-                .map(policyEntry -> PoliciesModelFactory
-                        .newPolicyEntry(rm.getLabel(), policyEntry.getSubjects(), rm.getResources()))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(rm.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final ResourcesModified rm, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setResourcesFor(rm.getLabel(), rm.getResources());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectCreatedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectCreatedStrategy.java
@@ -12,31 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.SubjectCreated;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.SubjectCreated} events.
  */
-final class SubjectCreatedStrategy implements EventStrategy<SubjectCreated, Policy> {
+final class SubjectCreatedStrategy extends AbstractPolicyEventStrategy<SubjectCreated> {
 
     @Override
-    public Policy handle(final SubjectCreated sc, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(sc.getLabel())
-                .map(policyEntry -> PoliciesModelFactory
-                        .newPolicyEntry(sc.getLabel(), policyEntry.getSubjects().setSubject(sc.getSubject()),
-                                policyEntry.getResources()))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(sc.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final SubjectCreated sc, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setSubjectFor(sc.getLabel(), sc.getSubject());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectDeletedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectDeletedStrategy.java
@@ -12,26 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.SubjectDeleted;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.SubjectDeleted} events.
  */
-final class SubjectDeletedStrategy implements EventStrategy<SubjectDeleted, Policy> {
+final class SubjectDeletedStrategy extends AbstractPolicyEventStrategy<SubjectDeleted> {
 
     @Override
-    public Policy handle(final SubjectDeleted sd, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").toBuilder()
-                .forLabel(sd.getLabel())
-                .removeSubject(sd.getSubjectId())
-                .setRevision(revision)
-                .setModified(sd.getTimestamp().orElse(null))
-                .build();
+    protected PolicyBuilder applyEvent(final SubjectDeleted sd, final PolicyBuilder policyBuilder) {
+        return policyBuilder.removeSubjectFor(sd.getLabel(), sd.getSubjectId());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategy.java
@@ -24,5 +24,4 @@ final class SubjectModifiedStrategy extends AbstractPolicyEventStrategy<SubjectM
     protected PolicyBuilder applyEvent(final SubjectModified sm, final PolicyBuilder policyBuilder) {
         return policyBuilder.setSubjectFor(sm.getLabel(), sm.getSubject());
     }
-
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategy.java
@@ -12,31 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.SubjectModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.SubjectModified} events.
  */
-final class SubjectModifiedStrategy implements EventStrategy<SubjectModified, Policy> {
+final class SubjectModifiedStrategy extends AbstractPolicyEventStrategy<SubjectModified> {
 
     @Override
-    public Policy handle(final SubjectModified sm, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(sm.getLabel())
-                .map(policyEntry -> PoliciesModelFactory
-                        .newPolicyEntry(sm.getLabel(), policyEntry.getSubjects().setSubject(sm.getSubject()),
-                                policyEntry.getResources()))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(sm.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final SubjectModified sm, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setSubjectFor(sm.getLabel(), sm.getSubject());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategy.java
@@ -12,30 +12,17 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
-import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
-
-import javax.annotation.Nullable;
-
-import org.eclipse.ditto.model.policies.PoliciesModelFactory;
-import org.eclipse.ditto.model.policies.Policy;
-import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.SubjectsModified;
 
 /**
  * This strategy handles {@link org.eclipse.ditto.signals.events.policies.SubjectsModified} events.
  */
-final class SubjectsModifiedStrategy implements EventStrategy<SubjectsModified, Policy> {
+final class SubjectsModifiedStrategy extends AbstractPolicyEventStrategy<SubjectsModified> {
 
     @Override
-    public Policy handle(final SubjectsModified sm, @Nullable final Policy policy, final long revision) {
-        return checkNotNull(policy, "policy").getEntryFor(sm.getLabel())
-                .map(policyEntry -> PoliciesModelFactory
-                        .newPolicyEntry(sm.getLabel(), sm.getSubjects(), policyEntry.getResources()))
-                .map(modifiedPolicyEntry -> policy.toBuilder()
-                        .set(modifiedPolicyEntry)
-                        .setRevision(revision)
-                        .setModified(sm.getTimestamp().orElse(null))
-                        .build())
-                .orElse(policy);
+    protected PolicyBuilder applyEvent(final SubjectsModified sm, final PolicyBuilder policyBuilder) {
+        return policyBuilder.setSubjectsFor(sm.getLabel(), sm.getSubjects());
     }
+
 }

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategy.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
 
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.Policy;
 import org.eclipse.ditto.model.policies.PolicyBuilder;
 import org.eclipse.ditto.signals.events.policies.SubjectsModified;
 
@@ -21,8 +23,13 @@ import org.eclipse.ditto.signals.events.policies.SubjectsModified;
 final class SubjectsModifiedStrategy extends AbstractPolicyEventStrategy<SubjectsModified> {
 
     @Override
-    protected PolicyBuilder applyEvent(final SubjectsModified sm, final PolicyBuilder policyBuilder) {
-        return policyBuilder.setSubjectsFor(sm.getLabel(), sm.getSubjects());
+    protected PolicyBuilder applyEvent(final SubjectsModified sm, final Policy policy,
+            final PolicyBuilder policyBuilder) {
+        return policy.getEntryFor(sm.getLabel())
+                .map(policyEntry -> PoliciesModelFactory.newPolicyEntry(sm.getLabel(), sm.getSubjects(),
+                        policyEntry.getResources()))
+                .map(modifiedPolicyEntry -> policyBuilder.set(modifiedPolicyEntry))
+                .orElse(policyBuilder.setSubjectsFor(sm.getLabel(), sm.getSubjects()));
     }
 
 }

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/TestConstants.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/TestConstants.java
@@ -13,7 +13,18 @@
 package org.eclipse.ditto.services.policies.persistence;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
 
+import org.eclipse.ditto.model.policies.EffectedPermissions;
+import org.eclipse.ditto.model.policies.Label;
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resource;
+import org.eclipse.ditto.model.policies.ResourceKey;
+import org.eclipse.ditto.model.policies.Subject;
+import org.eclipse.ditto.model.policies.SubjectId;
+import org.eclipse.ditto.model.policies.SubjectIssuer;
 import org.eclipse.ditto.model.policies.SubjectType;
 
 /**
@@ -50,6 +61,50 @@ public final class TestConstants {
          * All known permissions.
          */
         public static final Iterable<String> PERMISSIONS_ALL = Arrays.asList(PERMISSION_READ, PERMISSION_WRITE);
+
+        public static final EffectedPermissions READ_GRANTED =
+                EffectedPermissions.newInstance(Collections.singleton(PERMISSION_READ), Collections.emptySet());
+        public static final EffectedPermissions READ_WRITE_REVOKED =
+                EffectedPermissions.newInstance( Collections.emptySet(), Arrays.asList(PERMISSION_READ, PERMISSION_WRITE));
+        public static final ResourceKey FEATURES_RESOURCE_KEY = ResourceKey.newInstance("thing", "/features");
+        public static final ResourceKey NEW_ATTRIBUTE_RESOURCE_KEY = ResourceKey.newInstance("thing",
+                "/attribute/new");
+        public static final Resource NEW_ATTRIBUTE_RESOURCE = Resource.newInstance(NEW_ATTRIBUTE_RESOURCE_KEY,
+                READ_GRANTED);
+        public static final Resource FEATURES_RESOURCE = Resource.newInstance(FEATURES_RESOURCE_KEY, READ_WRITE_REVOKED);
+        public static final Resource
+                MODIFIED_FEATURES_RESOURCE = Resource.newInstance(FEATURES_RESOURCE_KEY, READ_GRANTED);
+        public static final Label SUPPORT_LABEL = Label.of("Support");
+        public static final SubjectId
+                SUPPORT_SUBJECT_ID = SubjectId.newInstance(SubjectIssuer.GOOGLE, UUID.randomUUID().toString());
+        public static final Subject SUPPORT_SUBJECT = Subject.newInstance(SUPPORT_SUBJECT_ID);
+
+        public static final SubjectId ADDITIONAL_SUPPORT_SUBJECT_ID = SubjectId.newInstance(SubjectIssuer.GOOGLE,
+                UUID.randomUUID().toString());
+        public static final Subject ADDITIONAL_SUPPORT_SUBJECT = Subject.newInstance(ADDITIONAL_SUPPORT_SUBJECT_ID);
+
+        public static org.eclipse.ditto.model.policies.Policy policyWithRandomName() {
+            return PoliciesModelFactory.newPolicyBuilder(PolicyId.inNamespaceWithRandomName("test"))
+                    .forLabel("EndUser")
+                    .setSubject(SubjectIssuer.GOOGLE, UUID.randomUUID().toString(), SubjectType.newInstance("type"))
+                    .setGrantedPermissions("thing", "/", PERMISSION_READ, PERMISSION_WRITE)
+                    .setRevokedPermissions("thing", "/attributes", PERMISSION_WRITE)
+                    .forLabel(SUPPORT_LABEL)
+                    .setSubject(SUPPORT_SUBJECT)
+                    .setRevokedPermissions(FEATURES_RESOURCE_KEY, PERMISSION_READ, PERMISSION_WRITE)
+                    .build();
+        }
+
+        public static org.eclipse.ditto.model.policies.PolicyEntry policyEntryWithLabel(final String label) {
+            return PoliciesModelFactory.newPolicyEntry(label,
+                    PoliciesModelFactory.newSubjects(Subject.newInstance(SubjectIssuer.GOOGLE,
+                            UUID.randomUUID().toString())),
+                    PoliciesModelFactory.newResources(Resource.newInstance(ResourceKey.newInstance("thing",
+                            "/attributes/custom"),
+                            PoliciesModelFactory.newEffectedPermissions(Collections.singleton(PERMISSION_READ),
+                                    Collections.singleton(PERMISSION_WRITE))))
+            );
+        }
 
         private Policy() {
             throw new AssertionError();

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/AbstractPolicyEventStrategyTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyRevision;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.services.utils.persistentactors.events.EventStrategy;
+import org.eclipse.ditto.signals.events.policies.PolicyEvent;
+import org.junit.Before;
+import org.junit.Test;
+
+public abstract class AbstractPolicyEventStrategyTest<T extends PolicyEvent<T>> {
+
+    private Instant instant;
+    private Policy policy;
+    private T policyEvent;
+    private EventStrategy<T, Policy> strategy;
+
+    @Before
+    public void setUp() {
+        policy = TestConstants.Policy.policyWithRandomName();
+        instant = Instant.now();
+        policyEvent = getPolicyEvent(instant, policy);
+        strategy = getStrategyUnderTest();
+    }
+
+    @Test
+    public void testHandleReturnsNullForNullEntity() {
+        assertThat(getStrategyUnderTest().handle(getPolicyEvent(instant, policy), null, 0L)).isNull();
+    }
+
+    @Test
+    public void testHandlePolicyEvent() {
+        final Policy policyWithEventApplied = strategy.handle(policyEvent, policy, 10L);
+        assertThat(policyWithEventApplied.getModified()).contains(instant);
+        assertThat(policyWithEventApplied.getRevision()).contains(PolicyRevision.newInstance(10L));
+        additionalAssertions(policyWithEventApplied);
+    }
+
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // override in subclass
+    }
+
+    abstract EventStrategy<T, Policy> getStrategyUnderTest();
+
+    abstract T getPolicyEvent(final Instant instant, final Policy policy);
+
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyCreatedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyCreatedStrategyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyLifecycle;
+import org.eclipse.ditto.signals.events.policies.PolicyCreated;
+import org.junit.Test;
+
+/**
+ * Tests {@link PolicyCreatedStrategy}.
+ */
+public class PolicyCreatedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyCreated> {
+
+    @Override
+    PolicyCreatedStrategy getStrategyUnderTest() {
+        return new PolicyCreatedStrategy();
+    }
+
+    @Override
+    PolicyCreated getPolicyEvent(final Instant instant, final Policy policy) {
+        return PolicyCreated.of(policy, 0, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getLifecycle()).contains(PolicyLifecycle.ACTIVE);
+    }
+
+    @Test
+    public void testHandleReturnsNullForNullEntity() {
+        // makes no sense for PolicyCreatedStrategy
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyDeletedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyDeletedStrategyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyLifecycle;
+import org.eclipse.ditto.signals.events.policies.PolicyDeleted;
+
+/**
+ * Tests {@link PolicyDeletedStrategy}.
+ */
+public class PolicyDeletedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyDeleted> {
+
+    @Override
+    PolicyDeletedStrategy getStrategyUnderTest() {
+        return new PolicyDeletedStrategy();
+    }
+
+    @Override
+    PolicyDeleted getPolicyEvent(final Instant instant, final Policy policy) {
+        return PolicyDeleted.of(policy.getEntityId().orElseThrow(), 0, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getLifecycle()).contains(PolicyLifecycle.DELETED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategyTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+
+import java.time.Instant;
+import java.util.Arrays;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.PolicyEntriesModified;
+
+/**
+ * Tests {@link PolicyEntriesModifiedStrategy}.
+ */
+public class PolicyEntriesModifiedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyEntriesModified> {
+
+    private static final PolicyEntry MODIFIED_1 = TestConstants.Policy.policyEntryWithLabel("modified1");
+    private static final PolicyEntry MODIFIED_2 = TestConstants.Policy.policyEntryWithLabel("modified2");
+
+    @Override
+    PolicyEntriesModifiedStrategy getStrategyUnderTest() {
+        return new PolicyEntriesModifiedStrategy();
+    }
+
+    @Override
+    PolicyEntriesModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return PolicyEntriesModified.of(policyId, Arrays.asList(MODIFIED_1, MODIFIED_2), 10L, instant,
+                DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEntryFor(MODIFIED_1.getLabel())).contains(MODIFIED_1);
+        assertThat(policyWithEventApplied.getEntryFor(MODIFIED_2.getLabel())).contains(MODIFIED_2);
+        assertThat(policyWithEventApplied.getEntryFor(SUPPORT_LABEL)).isEmpty();
+        assertThat(policyWithEventApplied).containsExactly(MODIFIED_1, MODIFIED_2);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntriesModifiedStrategyTest.java
@@ -50,6 +50,6 @@ public class PolicyEntriesModifiedStrategyTest extends AbstractPolicyEventStrate
         assertThat(policyWithEventApplied.getEntryFor(MODIFIED_1.getLabel())).contains(MODIFIED_1);
         assertThat(policyWithEventApplied.getEntryFor(MODIFIED_2.getLabel())).contains(MODIFIED_2);
         assertThat(policyWithEventApplied.getEntryFor(SUPPORT_LABEL)).isEmpty();
-        assertThat(policyWithEventApplied).containsExactly(MODIFIED_1, MODIFIED_2);
+        assertThat(policyWithEventApplied).containsExactlyInAnyOrder(MODIFIED_1, MODIFIED_2);
     }
 }

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryCreatedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryCreatedStrategyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.PolicyEntryCreated;
+
+/**
+ * Tests {@link PolicyEntryCreatedStrategy}.
+ */
+public class PolicyEntryCreatedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyEntryCreated> {
+
+    private static final PolicyEntry CREATED = TestConstants.Policy.policyEntryWithLabel("created");
+
+    @Override
+    PolicyEntryCreatedStrategy getStrategyUnderTest() {
+        return new PolicyEntryCreatedStrategy();
+    }
+
+    @Override
+    PolicyEntryCreated getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return PolicyEntryCreated.of(policyId, CREATED, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEntryFor(CREATED.getLabel())).contains(CREATED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryDeletedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryDeletedStrategyTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.PolicyEntryDeleted;
+
+/**
+ * Tests {@link PolicyEntryDeletedStrategy}.
+ */
+public class PolicyEntryDeletedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyEntryDeleted> {
+
+    @Override
+    PolicyEntryDeletedStrategy getStrategyUnderTest() {
+        return new PolicyEntryDeletedStrategy();
+    }
+
+    @Override
+    PolicyEntryDeleted getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return PolicyEntryDeleted.of(policyId, TestConstants.Policy.SUPPORT_LABEL, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEntryFor(TestConstants.Policy.SUPPORT_LABEL)).isEmpty();
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryModifiedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyEntryModifiedStrategyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.PolicyEntryModified;
+
+/**
+ * Tests {@link PolicyEntryModifiedStrategy}.
+ */
+public class PolicyEntryModifiedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyEntryModified> {
+
+    private static final PolicyEntry MODIFIED = TestConstants.Policy.policyEntryWithLabel("Support");
+
+    @Override
+    PolicyEntryModifiedStrategy getStrategyUnderTest() {
+        return new PolicyEntryModifiedStrategy();
+    }
+
+    @Override
+    PolicyEntryModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return PolicyEntryModified.of(policyId, MODIFIED, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEntryFor(MODIFIED.getLabel())).contains(MODIFIED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/PolicyModifiedStrategyTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.PolicyModified;
+
+/**
+ * Tests {@link PolicyModifiedStrategy}.
+ */
+public class PolicyModifiedStrategyTest extends AbstractPolicyEventStrategyTest<PolicyModified> {
+
+    private static final PolicyEntry MODIFIED = TestConstants.Policy.policyEntryWithLabel("modified");
+
+    @Override
+    PolicyModifiedStrategy getStrategyUnderTest() {
+        return new PolicyModifiedStrategy();
+    }
+
+    @Override
+    PolicyModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final Policy modified = policy.toBuilder().set(MODIFIED).build();
+        return PolicyModified.of(modified, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEntryFor(MODIFIED.getLabel())).contains(MODIFIED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceCreatedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceCreatedStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_GRANTED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.services.policies.persistence.TestConstants;
+import org.eclipse.ditto.signals.events.policies.ResourceCreated;
+
+/**
+ * Tests {@link ResourceCreatedStrategy}.
+ */
+public class ResourceCreatedStrategyTest extends AbstractPolicyEventStrategyTest<ResourceCreated> {
+
+    @Override
+    ResourceCreatedStrategy getStrategyUnderTest() {
+        return new ResourceCreatedStrategy();
+    }
+
+    @Override
+    ResourceCreated getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return ResourceCreated.of(policyId, SUPPORT_LABEL, TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE,
+                10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                NEW_ATTRIBUTE_RESOURCE_KEY)).contains(READ_GRANTED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceDeletedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceDeletedStrategyTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.signals.events.policies.ResourceDeleted;
+
+/**
+ * Tests {@link ResourceDeletedStrategy}.
+ */
+public class ResourceDeletedStrategyTest extends AbstractPolicyEventStrategyTest<ResourceDeleted> {
+
+    @Override
+    ResourceDeletedStrategy getStrategyUnderTest() {
+        return new ResourceDeletedStrategy();
+    }
+
+    @Override
+    ResourceDeleted getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return ResourceDeleted.of(policyId, SUPPORT_LABEL, FEATURES_RESOURCE_KEY, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).isEmpty();
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategyCreateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategyCreateTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.MODIFIED_FEATURES_RESOURCE;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Label;
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resources;
+import org.eclipse.ditto.signals.events.policies.ResourceModified;
+
+/**
+ * Tests {@link ResourceModifiedStrategy} with modified Label.
+ */
+public class ResourceModifiedStrategyCreateTest extends AbstractPolicyEventStrategyTest<ResourceModified> {
+
+    private static final Label NEW_LABEL = Label.of("new");
+    private static final Resources RESOURCES = Resources.newInstance(MODIFIED_FEATURES_RESOURCE);
+
+    @Override
+    ResourceModifiedStrategy getStrategyUnderTest() {
+        return new ResourceModifiedStrategy();
+    }
+
+    @Override
+    ResourceModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return ResourceModified.of(policyId, NEW_LABEL, MODIFIED_FEATURES_RESOURCE,
+                10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+
+        // new resource created under new label
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getResources)).contains(RESOURCES);
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getSubjects))
+                .contains(PoliciesModelFactory.emptySubjects());
+
+        // existing label not changed
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategyModifyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourceModifiedStrategyModifyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.MODIFIED_FEATURES_RESOURCE;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_GRANTED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.signals.events.policies.ResourceModified;
+
+/**
+ * Tests {@link ResourceModifiedStrategy} with modified Label.
+ */
+public class ResourceModifiedStrategyModifyTest extends AbstractPolicyEventStrategyTest<ResourceModified> {
+
+    @Override
+    ResourceModifiedStrategy getStrategyUnderTest() {
+        return new ResourceModifiedStrategy();
+    }
+
+    @Override
+    ResourceModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return ResourceModified.of(policyId, SUPPORT_LABEL, MODIFIED_FEATURES_RESOURCE,
+                10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_GRANTED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategyCreateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategyCreateTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_GRANTED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resources;
+import org.eclipse.ditto.signals.events.policies.ResourcesModified;
+
+/**
+ * Tests {@link ResourcesModifiedStrategy} with newly created Label.
+ */
+public class ResourcesModifiedStrategyCreateTest extends AbstractPolicyEventStrategyTest<ResourcesModified> {
+
+    @Override
+    ResourcesModifiedStrategy getStrategyUnderTest() {
+        return new ResourcesModifiedStrategy();
+    }
+
+    @Override
+    ResourcesModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        final Resources resources = Resources.newInstance(NEW_ATTRIBUTE_RESOURCE);
+        return ResourcesModified.of(policyId, SUPPORT_LABEL, resources, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // new resource added
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                NEW_ATTRIBUTE_RESOURCE_KEY)).contains(READ_GRANTED);
+
+        // existing resources removed
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).isEmpty();
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategyUpdateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/ResourcesModifiedStrategyUpdateTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.NEW_ATTRIBUTE_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_GRANTED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resources;
+import org.eclipse.ditto.model.policies.Subject;
+import org.eclipse.ditto.model.policies.Subjects;
+import org.eclipse.ditto.signals.events.policies.ResourcesModified;
+
+/**
+ * Tests {@link ResourcesModifiedStrategy} with modified Label.
+ */
+public class ResourcesModifiedStrategyUpdateTest extends AbstractPolicyEventStrategyTest<ResourcesModified> {
+
+    @Override
+    ResourcesModifiedStrategy getStrategyUnderTest() {
+        return new ResourcesModifiedStrategy();
+    }
+
+    @Override
+    ResourcesModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        final Resources resources = Resources.newInstance(NEW_ATTRIBUTE_RESOURCE);
+        return ResourcesModified.of(policyId, SUPPORT_LABEL, resources, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // new resource added
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                NEW_ATTRIBUTE_RESOURCE_KEY)).contains(READ_GRANTED);
+
+        // existing resources removed
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).isEmpty();
+
+        // subjects were not changed
+        assertThat(policyWithEventApplied.getEntryFor(SUPPORT_LABEL)
+                .map(pe -> pe.getSubjects()))
+                .contains(Subjects.newInstance(Subject.newInstance(SUPPORT_SUBJECT_ID)));
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectCreatedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectCreatedStrategyTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT_ID;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.signals.events.policies.SubjectCreated;
+
+/**
+ * Tests {@link SubjectCreatedStrategy}.
+ */
+public class SubjectCreatedStrategyTest extends AbstractPolicyEventStrategyTest<SubjectCreated> {
+
+    @Override
+    SubjectCreatedStrategy getStrategyUnderTest() {
+        return new SubjectCreatedStrategy();
+    }
+
+    @Override
+    SubjectCreated getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectCreated.of(policyId, SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT, 10L, instant,
+                DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectDeletedStrategyTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectDeletedStrategyTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT_ID;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.signals.events.policies.SubjectDeleted;
+
+/**
+ * Tests {@link SubjectDeletedStrategy}.
+ */
+public class SubjectDeletedStrategyTest extends AbstractPolicyEventStrategyTest<SubjectDeleted> {
+
+    @Override
+    SubjectDeletedStrategy getStrategyUnderTest() {
+        return new SubjectDeletedStrategy();
+    }
+
+    @Override
+    SubjectDeleted getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectDeleted.of(policyId, SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT_ID, 10L, instant,
+                DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).isEmpty();
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategyCreateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategyCreateTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Label;
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Subjects;
+import org.eclipse.ditto.signals.events.policies.SubjectModified;
+
+/**
+ * Tests {@link SubjectModifiedStrategy} with newly created Label.
+ */
+public class SubjectModifiedStrategyCreateTest extends AbstractPolicyEventStrategyTest<SubjectModified> {
+
+    private static final Label NEW_LABEL = Label.of("new");
+    private static final Subjects SUBJECTS = Subjects.newInstance(ADDITIONAL_SUPPORT_SUBJECT);
+
+    @Override
+    SubjectModifiedStrategy getStrategyUnderTest() {
+        return new SubjectModifiedStrategy();
+    }
+
+    @Override
+    SubjectModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectModified.of(policyId, NEW_LABEL, ADDITIONAL_SUPPORT_SUBJECT, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // existing label is not touched
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+
+        // new label with subject and empty resources is created
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getSubjects)).contains(SUBJECTS);
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getResources)).contains(
+                PoliciesModelFactory.emptyResources());
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategyUpdateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectModifiedStrategyUpdateTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT_ID;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.signals.events.policies.SubjectModified;
+
+/**
+ * Tests {@link SubjectModifiedStrategy} with modified Label.
+ */
+public class SubjectModifiedStrategyUpdateTest extends AbstractPolicyEventStrategyTest<SubjectModified> {
+
+    @Override
+    SubjectModifiedStrategy getStrategyUnderTest() {
+        return new SubjectModifiedStrategy();
+    }
+
+    @Override
+    SubjectModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectModified.of(policyId, SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT, 10L, instant,
+                DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // existing subject not changed
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+
+        // new subject has access
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategyCreateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategyCreateTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Label;
+import org.eclipse.ditto.model.policies.PoliciesModelFactory;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyEntry;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Subjects;
+import org.eclipse.ditto.signals.events.policies.SubjectsModified;
+
+/**
+ * Tests {@link SubjectsModifiedStrategy} with newly created Label.
+ */
+public class SubjectsModifiedStrategyCreateTest extends AbstractPolicyEventStrategyTest<SubjectsModified> {
+
+    private static final Label NEW_LABEL = Label.of("new");
+    private static final Subjects SUBJECTS = Subjects.newInstance(ADDITIONAL_SUPPORT_SUBJECT);
+
+    @Override
+    SubjectsModifiedStrategy getStrategyUnderTest() {
+        return new SubjectsModifiedStrategy();
+    }
+
+    @Override
+    SubjectsModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectsModified.of(policyId, NEW_LABEL, SUBJECTS, 10L,
+                instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // existing label is not touched
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+
+        // new label with subject and empty resources is created
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getSubjects)).contains(SUBJECTS);
+        assertThat(policyWithEventApplied.getEntryFor(NEW_LABEL).map(PolicyEntry::getResources)).contains(
+                PoliciesModelFactory.emptyResources());
+    }
+}

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategyUpdateTest.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/events/SubjectsModifiedStrategyUpdateTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.policies.persistence.actors.strategies.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.ADDITIONAL_SUPPORT_SUBJECT_ID;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.FEATURES_RESOURCE_KEY;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.READ_WRITE_REVOKED;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_LABEL;
+import static org.eclipse.ditto.services.policies.persistence.TestConstants.Policy.SUPPORT_SUBJECT_ID;
+
+import java.time.Instant;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.policies.Resources;
+import org.eclipse.ditto.model.policies.Subjects;
+import org.eclipse.ditto.signals.events.policies.SubjectsModified;
+
+/**
+ * Tests {@link SubjectsModifiedStrategy} with modified Label.
+ */
+public class SubjectsModifiedStrategyUpdateTest extends AbstractPolicyEventStrategyTest<SubjectsModified> {
+
+    private static final Subjects NEW_SUBJECTS = Subjects.newInstance(ADDITIONAL_SUPPORT_SUBJECT);
+
+    @Override
+    SubjectsModifiedStrategy getStrategyUnderTest() {
+        return new SubjectsModifiedStrategy();
+    }
+
+    @Override
+    SubjectsModified getPolicyEvent(final Instant instant, final Policy policy) {
+        final PolicyId policyId = policy.getEntityId().orElseThrow();
+        return SubjectsModified.of(policyId, SUPPORT_LABEL, NEW_SUBJECTS, 10L, instant, DittoHeaders.empty());
+    }
+
+    @Override
+    protected void additionalAssertions(final Policy policyWithEventApplied) {
+        // existing subjects removed
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).isEmpty();
+
+        // new subjects replaced the existing ones
+        assertThat(policyWithEventApplied.getEffectedPermissionsFor(SUPPORT_LABEL, ADDITIONAL_SUPPORT_SUBJECT_ID,
+                FEATURES_RESOURCE_KEY)).contains(READ_WRITE_REVOKED);
+
+        // resources were not changed
+        assertThat(policyWithEventApplied.getEntryFor(SUPPORT_LABEL)
+                .map(pe -> pe.getResources()))
+                .contains(Resources.newInstance(FEATURES_RESOURCE));
+    }
+}

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/events/AbstractThingEventStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/events/AbstractThingEventStrategy.java
@@ -36,7 +36,7 @@ import org.eclipse.ditto.signals.events.things.ThingEvent;
 abstract class AbstractThingEventStrategy<T extends ThingEvent<T>> implements EventStrategy<T, Thing> {
 
     /**
-     * Constructs a new {@code AbstractEventStrategy} object.
+     * Constructs a new {@code AbstractThingEventStrategy} object.
      */
     protected AbstractThingEventStrategy() {
         super();


### PR DESCRIPTION
Some implementations of EventStrategy throw a NullPointerException when the passed in entity was null. They must not do this but instead do nothing and return null as well.