### PR TITLE
Bugfix: connection creation timeout

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/CreateConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/CreateConnectionStrategy.java
@@ -67,8 +67,7 @@ final class CreateConnectionStrategy extends AbstractConnectivityCommandStrategy
             context.getLog().debug("Connection <{}> has status <{}> and will therefore be opened.",
                     connection.getId(), connection.getConnectionStatus());
             final List<ConnectionAction> actions = Arrays.asList(
-                    PERSIST_AND_APPLY_EVENT, OPEN_CONNECTION_IGNORE_ERRORS, UPDATE_SUBSCRIPTIONS, SEND_RESPONSE,
-                    BECOME_CREATED);
+                    PERSIST_AND_APPLY_EVENT, SEND_RESPONSE, BECOME_CREATED, OPEN_CONNECTION_IGNORE_ERRORS, UPDATE_SUBSCRIPTIONS);
             return newMutationResult(StagedCommand.of(command, event, response, actions), event, response);
         } else {
             return newMutationResult(command, event, response, true, false);

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -125,7 +125,6 @@ import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.cluster.pubsub.DistributedPubSub;
 import akka.japi.Creator;
-import akka.japi.pf.PFBuilder;
 import akka.japi.pf.ReceiveBuilder;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -125,6 +125,7 @@ import akka.actor.Status;
 import akka.cluster.Cluster;
 import akka.cluster.pubsub.DistributedPubSub;
 import akka.japi.Creator;
+import akka.japi.pf.PFBuilder;
 import akka.japi.pf.ReceiveBuilder;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
@@ -1129,6 +1130,13 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
             underTest.tell(createConnection, getRef());
             probe.expectMsg(openConnection);
             expectMsg(createConnectionResponse);
+
+            /*
+             *  Make sure that no further messages are sent to the probe. This is done because if we enable the
+             *  connection logs before all actions of CreateConnection are finished, an additional EnableConnectionLogs
+             *  is emitted by the "UPDATE_SUBSCRIPTIONS" action.
+             */
+            probe.expectNoMsg();
 
             // enable connection logs
             underTest.tell(enableConnectionLogs, getRef());


### PR DESCRIPTION
There was an issue where sometimes the creation of a connection entity failed with a timeout just because the establishing of the actual connection took too much time.
This PR reorders the actions that are performed when creating a connection, so a successful response will be sent as soon as the connection could be created. 
The establishing of the actual connection happens after this and is not part of the success response.