### PR TITLE
http push with client certificates

### DIFF
--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
@@ -103,3 +103,47 @@ Example connection configuration to create a new HTTP connection in order to mak
   }
 }
 ```
+
+## Client-certificate authentication
+
+Ditto supports certificate-based authentication for HTTP connections. Consult 
+[Certificates for Transport Layer Security](connectivity-tls-certificates.html)
+for how to set it up.
+
+Here is an example HTTP connection that checks the server certificate and authenticates by a client certificate.
+
+```json
+{
+  "connection": {
+    "id": "http-example-connection-123",
+    "connectionType": "http-push",
+    "connectionStatus": "open",
+    "failoverEnabled": true,
+    "uri": "https://localhost:80",
+    "validateCertificates": true,
+    "ca": "-----BEGIN CERTIFICATE-----\n<localhost certificate>\n-----END CERTIFICATE-----",
+    "credentials": {
+      "type": "client-cert",
+      "cert": "-----BEGIN CERTIFICATE-----\n<signed client certificate>\n-----END CERTIFICATE-----",
+      "key": "-----BEGIN PRIVATE KEY-----\n<client private key>\n-----END PRIVATE KEY-----"
+    },
+    "specificConfig": {
+      "parallelism": "2"
+    },
+    "sources": [],
+    "targets": [
+      {
+        "address": "PUT:/api/2/some-entity/{%raw%}{{ thing:id }}{%endraw%}",
+        "topics": [
+          "_/_/things/twin/events"
+        ],
+        "authorizationContext": ["ditto:outbound-auth-subject", "..."],
+        "headerMapping": {
+          "content-type": "{%raw%}{{ header:content-type }}{%endraw%}",
+          "api-key": "this-is-a-secret-api-key-to-send-along"
+         }
+      }
+    ]
+  }
+}
+```

--- a/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-tls-certificates.md
@@ -81,7 +81,8 @@ The server identity is verified directly or indirectly.
 
 ## Authenticate by client certificate
 
-_Client-certificate authentication is available for [MQTT connections](connectivity-protocol-bindings-mqtt.html) only._
+_Client-certificate authentication is available for [MQTT connections](connectivity-protocol-bindings-mqtt.html)
+ and [HTTP connections](connectivity-protocol-bindings-http.html) only._
 
 ### Connection configuration
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActor.java
@@ -153,7 +153,9 @@ public final class HttpPushClientActor extends BaseClientActor {
             // check without HTTP proxy
             final SSLContextCreator sslContextCreator =
                     SSLContextCreator.fromConnection(connection, DittoHeaders.empty());
-            final SSLSocketFactory socketFactory = sslContextCreator.withoutClientCertificate().getSocketFactory();
+            final SSLSocketFactory socketFactory = connection.getCredentials()
+                    .map(credentials -> credentials.accept(sslContextCreator))
+                    .orElse(sslContextCreator.withoutClientCertificate()).getSocketFactory();
             try (final SSLSocket socket = (SSLSocket) socketFactory.createSocket(hostWithoutLookup, port)) {
                 socket.startHandshake();
                 return statusSuccessFuture("TLS connection to '%s:%d' established successfully.",

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractBaseClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractBaseClientActorTest.java
@@ -25,6 +25,7 @@ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.ClientCertificateCredentials;
 import org.eclipse.ditto.model.connectivity.Connection;
+import org.eclipse.ditto.model.connectivity.ConnectionBuilder;
 import org.eclipse.ditto.model.connectivity.ConnectionId;
 import org.eclipse.ditto.model.connectivity.ConnectionType;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
@@ -74,14 +75,13 @@ public abstract class AbstractBaseClientActorTest {
             .topics(Topic.TWIN_EVENTS, Topic.values())
             .build();
 
-    protected static Connection getHttpConnectionToLocalBinding(final boolean isSecure, final int port) {
+    protected static ConnectionBuilder getHttpConnectionBuilderToLocalBinding(final boolean isSecure, final int port) {
         return ConnectivityModelFactory.newConnectionBuilder(TestConstants.createRandomConnectionId(),
                 ConnectionType.HTTP_PUSH,
                 ConnectivityStatus.CLOSED,
                 (isSecure ? "https" : "http") + "://127.0.0.1:" + port)
                 .targets(singletonList(HTTP_TARGET))
-                .validateCertificate(isSecure)
-                .build();
+                .validateCertificate(isSecure);
     }
 
     private static Throwable getEventualCause(final Throwable error) {
@@ -155,7 +155,7 @@ public abstract class AbstractBaseClientActorTest {
     @Test
     public void testTLSConnectionWithoutCertificateCheck() {
         // GIVEN: server has a self-signed certificate (bind port number is random; connection port number is ignored)
-        final Connection serverConnection = getHttpConnectionToLocalBinding(true, 443);
+        final Connection serverConnection = getHttpConnectionBuilderToLocalBinding(true, 443).build();
         final ClientCertificateCredentials credentials = ClientCertificateCredentials.newBuilder()
                 .clientKey(TestConstants.Certificates.CLIENT_SELF_SIGNED_KEY)
                 .clientCertificate(TestConstants.Certificates.CLIENT_SELF_SIGNED_CRT)

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
@@ -99,7 +99,7 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
                 .bindAndHandle(handler, ConnectHttp.toHost("127.0.0.1", 0), mat)
                 .toCompletableFuture()
                 .join();
-        connection = getHttpConnectionToLocalBinding(false, binding.localAddress().getPort());
+        connection = getHttpConnectionBuilderToLocalBinding(false, binding.localAddress().getPort()).build();
     }
 
     @After
@@ -163,7 +163,7 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
     @Test
     public void testTLSConnectionFails() {
         // GIVEN: server has a self-signed certificate
-        connection = getHttpConnectionToLocalBinding(true, binding.localAddress().getPort());
+        connection = getHttpConnectionBuilderToLocalBinding(true, binding.localAddress().getPort()).build();
         final ClientCertificateCredentials credentials = ClientCertificateCredentials.newBuilder()
                 .clientKey(TestConstants.Certificates.CLIENT_SELF_SIGNED_KEY)
                 .clientCertificate(TestConstants.Certificates.CLIENT_SELF_SIGNED_CRT)
@@ -191,6 +191,41 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
             assertThat(failure.cause()).isInstanceOf(DittoRuntimeException.class);
             assertThat(((DittoRuntimeException) failure.cause()).getDescription().orElse(""))
                     .contains("unable to find valid certification path");
+            expectTerminated(underTest);
+        }};
+    }
+
+    @Test
+    public void testTLSConnection() {
+        // GIVEN: server has a self-signed certificate
+        final ClientCertificateCredentials credentials = ClientCertificateCredentials.newBuilder()
+                .clientKey(TestConstants.Certificates.CLIENT_SELF_SIGNED_KEY)
+                .clientCertificate(TestConstants.Certificates.CLIENT_SELF_SIGNED_CRT)
+                .build();
+        connection = getHttpConnectionBuilderToLocalBinding(true, binding.localAddress().getPort())
+                .credentials(credentials)
+                .trustedCertificates(TestConstants.Certificates.CLIENT_SELF_SIGNED_CRT)
+                .build();
+        final SSLContext sslContext = SSLContextCreator.fromConnection(connection, DittoHeaders.empty())
+                .clientCertificate(credentials);
+        final HttpsConnectionContext invalidHttpsContext = ConnectionContext.https(sslContext);
+
+        final int port = binding.localAddress().getPort();
+        binding.terminate(Duration.ofMillis(1L)).toCompletableFuture().join();
+        binding = Http.get(actorSystem)
+                .bindAndHandle(handler,
+                        ConnectHttp.toHostHttps("127.0.0.1", port).withCustomHttpsContext(invalidHttpsContext),
+                        mat)
+                .toCompletableFuture()
+                .join();
+
+        new TestKit(actorSystem) {{
+            // WHEN: the connection is tested
+            final ActorRef underTest = watch(actorSystem.actorOf(createClientActor(getRef(), getConnection(false))));
+            underTest.tell(TestConnection.of(connection, DittoHeaders.empty()), getRef());
+
+            // THEN: the connection is connected successfully
+            expectMsg(new Status.Success("successfully connected + initialized mapper"));
             expectTerminated(underTest);
         }};
     }


### PR DESCRIPTION
This PR implements [certificates for TLS](https://www.eclipse.org/ditto/connectivity-tls-certificates.html) with the [HTTP protocol binding](https://www.eclipse.org/ditto/connectivity-protocol-bindings-http.html).