### PR TITLE
add support for single quoted strings in RQL values

### DIFF
--- a/model/rql-parser/src/test/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParserTest.java
+++ b/model/rql-parser/src/test/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParserTest.java
@@ -53,8 +53,32 @@ public class RqlPredicateParserTest {
     }
 
     @Test
+    public void testComparisonEqualsWithStringSingleQuoteValue() throws ParserException {
+        final RootNode root = parser.parse("eq(username,'te\\'st')");
+
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final SingleComparisonNode comparison = (SingleComparisonNode) root.getChildren().get(0);
+        assertThat(comparison.getComparisonValue().getClass()).isEqualTo(String.class);
+        assertThat(comparison.getComparisonValue()).isEqualTo("te'st");
+    }
+
+    @Test
     public void testComparisonEqualsWithStringValueContainingBackslash() throws ParserException {
         final RootNode root = parser.parse("eq(username,\"abc\\nyz\")");
+
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final SingleComparisonNode comparison = (SingleComparisonNode) root.getChildren().get(0);
+        assertThat(comparison.getComparisonValue().getClass()).isEqualTo(String.class);
+        assertThat(comparison.getComparisonValue()).isEqualTo("abc\nyz");
+    }
+
+    @Test
+    public void testComparisonEqualsWithStringSingleQuoteValueContainingBackslash() throws ParserException {
+        final RootNode root = parser.parse("eq(username,'abc\\nyz')");
 
         assertThat(root).isNotNull();
         assertThat(root.getChildren().size()).isEqualTo(1);
@@ -160,6 +184,19 @@ public class RqlPredicateParserTest {
     }
 
     @Test
+    public void testComparisonLikeWithStringSingleQuoteValue() throws ParserException {
+        final RootNode root = parser.parse("like(width,'test*')");
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final SingleComparisonNode comparison = (SingleComparisonNode) root.getChildren().get(0);
+        assertThat(comparison.getComparisonType()).isEqualTo(SingleComparisonNode.Type.LIKE);
+        assertThat(comparison.getComparisonProperty()).isEqualTo("width");
+        assertThat(comparison.getComparisonValue().getClass()).isEqualTo(String.class);
+        assertThat(comparison.getComparisonValue()).isEqualTo("test*");
+    }
+
+    @Test
     public void testComparisonIn() throws ParserException {
         final RootNode root = parser.parse("in(attributes,\"test\",1,true)");
         assertThat(root).isNotNull();
@@ -253,6 +290,17 @@ public class RqlPredicateParserTest {
     @Test
     public void checkWithEmptyString() throws ParserException {
         final RootNode root = parser.parse("eq(username,\" \")");
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final SingleComparisonNode comparison = (SingleComparisonNode) root.getChildren().get(0);
+        assertThat(comparison.getComparisonValue().getClass()).isEqualTo(String.class);
+        assertThat(comparison.getComparisonValue()).isEqualTo(" ");
+    }
+
+    @Test
+    public void checkWithEmptyStringSingleQuote() throws ParserException {
+        final RootNode root = parser.parse("eq(username,' ')");
         assertThat(root).isNotNull();
         assertThat(root.getChildren().size()).isEqualTo(1);
 


### PR DESCRIPTION
e.g. in order to support nicer Java syntax for RQL filters in the Ditto client