### PR TITLE
Align timeout error in messaging

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/TimeoutInvalidException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/TimeoutInvalidException.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.exceptions;
+
+import java.net.URI;
+import java.text.MessageFormat;
+import java.time.Duration;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+/**
+ * Thrown when timeout value can not be parsed.
+ * @since 1.2.0
+ */
+@Immutable
+@JsonParsableException(errorCode = TimeoutInvalidException.ERROR_CODE)
+public final class TimeoutInvalidException extends DittoRuntimeException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = "timeout.invalid";
+
+    private static final String DEFAULT_MESSAGE = "The timeout <{0}{2}> is not inside its allowed bounds <0{2} - {1}{2}>";
+
+    private static final String DEFAULT_DESCRIPTION = "Please choose a valid timeout.";
+
+    private static final long serialVersionUID = -3108409113724423689L;
+
+
+    /**
+     * Constructs a new {@code TimeoutInvalidException} object.
+     *
+     * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+     * @param message the detail message for later retrieval with {@link #getMessage()}.
+     * @param description a description with further information about the exception.
+     * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+     * @param href a link to a resource which provides further information about the exception.
+     * @throws NullPointerException if {@code errorCode}, {@code statusCode} or {@code dittoHeaders} is {@code null}.
+     */
+    private TimeoutInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+
+        super(ERROR_CODE, HttpStatusCode.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for {@code TimeoutInvalidException}.
+     * @param timeout the received timeout.
+     * @param maxTimeout the maximum allowed timeout.
+     * @return a mutable builder.
+     */
+    public static TimeoutInvalidException.Builder newBuilder(final Duration timeout, final Duration maxTimeout) {
+        return (Builder) new Builder()
+                .message(MessageFormat.format(DEFAULT_MESSAGE, timeout.toMillis(), maxTimeout.toMillis(), "ms"))
+                .description(DEFAULT_DESCRIPTION);
+    }
+
+    /**
+     * A mutable builder for {@code TimeoutInvalidException}.
+     * @param message the message of the exception.
+     * @return a mutable builder.
+     */
+    public static TimeoutInvalidException.Builder newBuilder(final String message) {
+        return (Builder) new Builder()
+                .message(message)
+                .description(DEFAULT_DESCRIPTION);
+    }
+
+    /**
+     * Constructs a new {@code TimeoutInvalidException} object with the exception message extracted from the
+     * given JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new DittoHeaderInvalidException.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} does not have the {@link
+     * JsonFields#MESSAGE} field.
+     */
+    public static TimeoutInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .dittoHeaders(dittoHeaders)
+                .message(readMessage(jsonObject))
+                .description(readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION))
+                .href(readHRef(jsonObject).orElse(null))
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link TimeoutInvalidException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<TimeoutInvalidException> {
+
+        @Override
+        protected TimeoutInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+
+            return new TimeoutInvalidException(dittoHeaders, message, description, cause, href);
+        }
+
+    }
+
+}

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
@@ -199,7 +199,7 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
      * @since 1.1.0
      */
     TIMEOUT("timeout", DittoDuration.class, String.class, true, true,
-            HeaderValueValidators.getDittoDurationValidator()),
+            HeaderValueValidators.getTimeoutValueValidator()),
 
     /**
      * Header definition for the entity id related to the command/event/response/error.

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/HeaderValueValidators.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/HeaderValueValidators.java
@@ -129,4 +129,14 @@ public final class HeaderValueValidators {
         return DittoDurationValueValidator.getInstance();
     }
 
+    /**
+     * Returns a validator for checking if a CharSequence represents a timeout in form of a {@link DittoDuration}.
+     *
+     * @return the validator.
+     * @since 1.2.0
+     */
+    static ValueValidator getTimeoutValueValidator() {
+        return TimeoutValueValidator.getInstance();
+    }
+
 }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/TimeoutValueValidator.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/TimeoutValueValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.headers;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.model.base.exceptions.TimeoutInvalidException;
+
+/**
+ * This validator parses a CharSequence to a {@link DittoDuration}.
+ * If parsing fails, a {@link TimeoutInvalidException} is thrown.
+ * @since 1.2.0
+ */
+@Immutable
+final class TimeoutValueValidator extends AbstractHeaderValueValidator {
+
+    private TimeoutValueValidator() {
+        super(DittoDuration.class::equals);
+    }
+
+    static TimeoutValueValidator getInstance() {
+        return new TimeoutValueValidator();
+    }
+
+    @Override
+    protected void validateValue(final HeaderDefinition definition, final CharSequence value) {
+        try {
+            DittoDuration.parseDuration(value);
+        } catch (final IllegalArgumentException e) {
+            throw TimeoutInvalidException.newBuilder(e.getMessage()).build();
+        }
+    }
+
+}

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
@@ -283,7 +283,7 @@ public final class DefaultDittoHeadersBuilderTest {
 
     @Test
     public void tryToPutMapWithInvalidMessageHeader() {
-        final String key = DittoHeaderDefinition.TIMEOUT.getKey();
+        final String key = DittoHeaderDefinition.SCHEMA_VERSION.getKey();
         final String invalidValue = "bar";
 
         final Map<String, String> invalidHeaders = new HashMap<>();
@@ -292,7 +292,7 @@ public final class DefaultDittoHeadersBuilderTest {
 
         assertThatExceptionOfType(DittoHeaderInvalidException.class)
                 .isThrownBy(() -> underTest.putHeaders(invalidHeaders))
-                .withMessage("The value '%s' of the header '%s' is not a valid duration.", invalidValue, key)
+                .withMessage("The value '%s' of the header '%s' is not a valid int.", invalidValue, key)
                 .withNoCause();
     }
 

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/TimeoutValueValidatorTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/TimeoutValueValidatorTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.headers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
+import org.eclipse.ditto.model.base.exceptions.TimeoutInvalidException;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link TimeoutValueValidator}.
+ */
+public final class TimeoutValueValidatorTest {
+
+    private static CharSequence validDittoDurationString;
+
+    private TimeoutValueValidator underTest;
+
+    @BeforeClass
+    public static void setUpClass() {
+        final DittoDuration dittoDuration = DittoDuration.parseDuration("23s");
+        validDittoDurationString = dittoDuration.toString();
+    }
+
+    @Before
+    public void setUp() {
+        underTest = TimeoutValueValidator.getInstance();
+    }
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(TimeoutValueValidator.class, areImmutable());
+    }
+
+    @Test
+    public void tryToAcceptNullDefinition() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> underTest.accept(null, validDittoDurationString))
+                .withMessage("The definition must not be null!")
+                .withNoCause();
+    }
+
+    @Test
+    public void tryToAcceptNullValue() {
+        final DittoHeaderDefinition headerDefinition = DittoHeaderDefinition.TIMEOUT;
+
+        assertThatExceptionOfType(DittoHeaderInvalidException.class)
+                .isThrownBy(() -> underTest.accept(headerDefinition, null))
+                .withMessageContaining("null")
+                .withMessageContaining(headerDefinition.getKey())
+                .withMessageEndingWith("is not a valid DittoDuration.")
+                .withNoCause();
+    }
+
+    @Test
+    public void canValidateDittoDuration() {
+        assertThat(underTest.canValidate(DittoDuration.class)).isTrue();
+    }
+
+    @Test
+    public void acceptValidCharSequence() {
+        assertThatCode(() -> underTest.accept(DittoHeaderDefinition.TIMEOUT, validDittoDurationString))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void doesNotValidateAsDefinedJavaTypeIsNotDittoDuration() {
+        assertThatCode(() -> underTest.accept(DittoHeaderDefinition.RESPONSE_REQUIRED, validDittoDurationString))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void acceptNonDittoDurationString() {
+        final String invalidDittoDurationString = "true";
+
+        assertThatExceptionOfType(TimeoutInvalidException.class)
+                .isThrownBy(() -> underTest.accept(DittoHeaderDefinition.TIMEOUT, invalidDittoDurationString))
+                .withMessageContaining(invalidDittoDurationString)
+                .withNoCause();
+    }
+
+    @Test
+    public void acceptDittoDurationStringWithNegativeAmount() {
+        final String invalidDittoDurationString = "-15s";
+
+        assertThatExceptionOfType(TimeoutInvalidException.class)
+                .isThrownBy(() -> underTest.accept(DittoHeaderDefinition.TIMEOUT, invalidDittoDurationString))
+                .withMessageContaining(invalidDittoDurationString)
+                .withMessageStartingWith("The duration must not be negative")
+                .withNoCause();
+    }
+
+    @Test
+    public void acceptDittoDurationStringWithInvalidTimeUnit() {
+        final String invalidDittoDurationString = "1h";
+
+        assertThatExceptionOfType(TimeoutInvalidException.class)
+                .isThrownBy(() -> underTest.accept(DittoHeaderDefinition.TIMEOUT, invalidDittoDurationString))
+                .withMessageContaining(invalidDittoDurationString)
+                .withNoCause();
+    }
+
+}

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
@@ -68,10 +68,11 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * <p>
      * Key: {@code "timeout"}, Java type: {@code long}.
      * </p>
+     *
      * @deprecated since 1.1.0: replaced by {@link org.eclipse.ditto.model.base.headers.DittoHeaderDefinition#TIMEOUT}
      */
     @Deprecated
-    TIMEOUT("timeout", long.class, true, true, TimeoutValueValidator.getInstance()),
+    TIMEOUT("timeout", long.class, true, true, MessageHeaderTimeoutValueValidator.getInstance()),
 
     /**
      * Header containing the timestamp of the message as ISO 8601 string.

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderTimeoutValueValidator.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderTimeoutValueValidator.java
@@ -29,9 +29,9 @@ import org.eclipse.ditto.model.base.headers.ValueValidator;
  * If validation fails, a {@link DittoHeaderInvalidException} is thrown.
  */
 @Immutable
-final class TimeoutValueValidator extends AbstractHeaderValueValidator {
+final class MessageHeaderTimeoutValueValidator extends AbstractHeaderValueValidator {
 
-    private TimeoutValueValidator() {
+    private MessageHeaderTimeoutValueValidator() {
         super(valueType -> long.class.equals(valueType) || Long.class.equals(valueType));
     }
 
@@ -41,7 +41,7 @@ final class TimeoutValueValidator extends AbstractHeaderValueValidator {
      * @return the instance.
      */
     static ValueValidator getInstance() {
-        return HeaderValueValidators.getLongValidator().andThen(new TimeoutValueValidator());
+        return HeaderValueValidators.getLongValidator().andThen(new MessageHeaderTimeoutValueValidator());
     }
 
     @SuppressWarnings("squid:S2201")

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/TimeoutInvalidException.java
@@ -28,9 +28,11 @@ import org.eclipse.ditto.model.base.json.JsonParsableException;
 
 /**
  * Thrown if the timeout of a message was invalid (too low or too high).
+ * @deprecated Since 1.2.0, will be removed. Use {@link org.eclipse.ditto.model.base.exceptions.TimeoutInvalidException} instead.
  */
 @Immutable
 @JsonParsableException(errorCode = TimeoutInvalidException.ERROR_CODE)
+@Deprecated
 public final class TimeoutInvalidException extends DittoRuntimeException implements MessageException {
 
     /**

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/MessageHeaderTimeoutValueValidatorTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/MessageHeaderTimeoutValueValidatorTest.java
@@ -26,9 +26,9 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Unit test for {@link TimeoutValueValidator}.
+ * Unit test for {@link MessageHeaderTimeoutValueValidator}.
  */
-public final class TimeoutValueValidatorTest {
+public final class MessageHeaderTimeoutValueValidatorTest {
 
     private static final CharSequence VALID_TIMEOUT_STRING = "42";
 
@@ -36,12 +36,12 @@ public final class TimeoutValueValidatorTest {
 
     @Before
     public void setUp() {
-        underTest = TimeoutValueValidator.getInstance();
+        underTest = MessageHeaderTimeoutValueValidator.getInstance();
     }
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(TimeoutValueValidator.class, areImmutable());
+        assertInstancesOf(MessageHeaderTimeoutValueValidator.class, areImmutable());
     }
 
     @Test

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/MessagesRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/things/MessagesRoute.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.model.base.exceptions.TimeoutInvalidException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.messages.MessageBuilder;
@@ -28,15 +29,14 @@ import org.eclipse.ditto.model.messages.MessageDirection;
 import org.eclipse.ditto.model.messages.MessageHeaders;
 import org.eclipse.ditto.model.messages.MessagesModelFactory;
 import org.eclipse.ditto.model.messages.SubjectInvalidException;
-import org.eclipse.ditto.model.messages.TimeoutInvalidException;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.protocoladapter.HeaderTranslator;
 import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.gateway.endpoints.actors.AbstractHttpRequestActor;
+import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.CommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.HttpConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.MessageConfig;
-import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.signals.commands.messages.MessageCommand;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandSizeValidator;
 import org.eclipse.ditto.signals.commands.messages.SendClaimMessage;
@@ -380,7 +380,7 @@ final class MessagesRoute extends AbstractRoute {
     private Duration checkMessageTimeout(final Duration timeout) {
         // check if the timeout is smaller than the maximum possible message-timeout and > 0:
         if (timeout.isNegative() || timeout.getSeconds() > maxMessageTimeout.getSeconds()) {
-            throw new TimeoutInvalidException(timeout.getSeconds(), maxMessageTimeout.getSeconds());
+            throw  TimeoutInvalidException.newBuilder(timeout, maxMessageTimeout).build();
         }
         return timeout;
     }
@@ -388,7 +388,7 @@ final class MessagesRoute extends AbstractRoute {
     private Duration checkClaimTimeout(final Duration timeout) {
         // check if the timeout is smaller than the maximum possible claim-timeout and > 0:
         if (timeout.isNegative() || timeout.getSeconds() > maxClaimTimeout.getSeconds()) {
-            throw new TimeoutInvalidException(timeout.getSeconds(), maxClaimTimeout.getSeconds());
+            throw TimeoutInvalidException.newBuilder(timeout, maxClaimTimeout).build();
         }
         return timeout;
     }


### PR DESCRIPTION
When using the messages API with the timeout parameter, you'd get different error codes depending in what way your timeout was invalid. Calling
`POST /things/{thingId}/inbox/messages/{messageSubject}?timeout={timeout}`
 * with a too large timeout resulted in error code `messages:timeout.invalid`
 * with a negative timeout resulted in error code `header.invalid`.

This PR aligns the error codes to `timeout.invalid`.