### PR TITLE
#677 Do not decide based on the response if it was required

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
@@ -286,7 +286,8 @@ public final class MessageMappingProcessorActor
                                     e.getErrorCode(),
                                     e.getMessage());
                     final ErrorResponse<?> errorResponse = toErrorResponseFunction.apply(e, null);
-                    handleErrorResponse(e, errorResponse.setDittoHeaders(signal.getDittoHeaders()), ActorRef.noSender());
+                    handleErrorResponse(e, errorResponse.setDittoHeaders(signal.getDittoHeaders()),
+                            ActorRef.noSender());
                     return;
                 }
             }
@@ -586,23 +587,13 @@ public final class MessageMappingProcessorActor
         enhanceLogUtil(response);
         recordResponse(response, exception);
 
-        if (response.getDittoHeaders().isResponseRequired()) {
-
-            if (isSuccessResponse(response)) {
-                logger.withCorrelationId(response).debug("Received response <{}>.", response);
-            } else {
-                logger.withCorrelationId(response).debug("Received error response <{}>", response.toJsonString());
-            }
-
-            handleSignal(response, sender);
+        if (isSuccessResponse(response)) {
+            logger.withCorrelationId(response).debug("Received response <{}>.", response);
         } else {
-            logger.withCorrelationId(response)
-                    .debug("Requester did not require response (via DittoHeader '{}') - not mapping back to"
-                            + " ExternalMessage", DittoHeaderDefinition.RESPONSE_REQUIRED);
-            responseDroppedMonitor.success(response,
-                    "Dropped response since requester did not require response via Header {0}",
-                    DittoHeaderDefinition.RESPONSE_REQUIRED);
+            logger.withCorrelationId(response).debug("Received error response <{}>", response.toJsonString());
         }
+
+        handleSignal(response, sender);
     }
 
     private void recordResponse(final CommandResponse<?> response, @Nullable final DittoRuntimeException exception) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionConflictStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionConflictStrategy.java
@@ -41,6 +41,6 @@ final class ConnectionConflictStrategy extends AbstractConnectivityCommandStrate
                 ConnectionConflictException.newBuilder(context.getState().id())
                         .dittoHeaders(command.getDittoHeaders())
                         .build();
-        return newErrorResult(conflictException);
+        return newErrorResult(conflictException, command);
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionCreatedStrategies.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionCreatedStrategies.java
@@ -77,7 +77,7 @@ public class ConnectionCreatedStrategies
         return ResultFactory.newErrorResult(ConnectionNotAccessibleException
                 .newBuilder(context.getState().id())
                 .dittoHeaders(command.getDittoHeaders())
-                .build());
+                .build(), command);
     }
 
     @Override

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionDeletedStrategies.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ConnectionDeletedStrategies.java
@@ -59,7 +59,7 @@ public class ConnectionDeletedStrategies
         context.getLog().warning("Received command for deleted connection, rejecting: <{}>", command);
         return ResultFactory.newErrorResult(ConnectionNotAccessibleException.newBuilder(context.getState().id())
                 .dittoHeaders(command.getDittoHeaders())
-                .build());
+                .build(), command);
     }
 
     @Override

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/CreateConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/CreateConnectionStrategy.java
@@ -62,7 +62,7 @@ final class CreateConnectionStrategy extends AbstractConnectivityCommandStrategy
                 CreateConnectionResponse.of(connection, command.getDittoHeaders());
         final Optional<DittoRuntimeException> validationError = validate(context, command);
         if (validationError.isPresent()) {
-            return newErrorResult(validationError.get());
+            return newErrorResult(validationError.get(), command);
         } else if (connection.getConnectionStatus() == ConnectivityStatus.OPEN) {
             context.getLog().debug("Connection <{}> has status <{}> and will therefore be opened.",
                     connection.getId(), connection.getConnectionStatus());

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ModifyConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/ModifyConnectionStrategy.java
@@ -62,7 +62,8 @@ final class ModifyConnectionStrategy extends AbstractConnectivityCommandStrategy
                             .newBuilder("ConnectionType <" + connection.getConnectionType().getName() +
                                     "> of existing connection <" + context.getState().id() + "> cannot be changed!")
                             .dittoHeaders(command.getDittoHeaders())
-                            .build()
+                            .build(),
+                    command
             );
         }
         final ConnectivityEvent event =
@@ -75,7 +76,7 @@ final class ModifyConnectionStrategy extends AbstractConnectivityCommandStrategy
         final boolean isNextConnectionOpen = connection.getConnectionStatus() == ConnectivityStatus.OPEN;
         final Optional<DittoRuntimeException> validationError = validate(context, command);
         if (validationError.isPresent()) {
-            return newErrorResult(validationError.get());
+            return newErrorResult(validationError.get(), command);
         } else if (isNextConnectionOpen || isCurrentConnectionOpen) {
             final List<ConnectionAction> actions;
             if (isNextConnectionOpen) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/OpenConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/OpenConnectionStrategy.java
@@ -51,7 +51,7 @@ final class OpenConnectionStrategy extends AbstractConnectivityCommandStrategy<O
             @Nullable final Connection connection, final long nextRevision, final OpenConnection command) {
         final Optional<DittoRuntimeException> validationError = validate(context, command, connection);
         if (validationError.isPresent()) {
-            return newErrorResult(validationError.get());
+            return newErrorResult(validationError.get(), command);
         } else {
             final ConnectivityEvent event = ConnectionOpened.of(context.getState().id(), command.getDittoHeaders());
             final WithDittoHeaders response =

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/RetrieveConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/RetrieveConnectionStrategy.java
@@ -38,7 +38,7 @@ final class RetrieveConnectionStrategy extends AbstractConnectivityCommandStrate
             return ResultFactory.newQueryResult(command,
                     RetrieveConnectionResponse.of(entity.toJson(), command.getDittoHeaders()));
         } else {
-            return ResultFactory.newErrorResult(notAccessible(context, command));
+            return ResultFactory.newErrorResult(notAccessible(context, command), command);
         }
     }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/TestConnectionStrategy.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/strategies/commands/TestConnectionStrategy.java
@@ -51,7 +51,7 @@ final class TestConnectionStrategy extends AbstractConnectivityCommandStrategy<T
             @Nullable final Connection entity, final long nextRevision, final TestConnection command) {
         final Optional<DittoRuntimeException> validationError = validate(context, command);
         if (validationError.isPresent()) {
-            return newErrorResult(validationError.get());
+            return newErrorResult(validationError.get(), command);
         } else if (entity == null) {
             final Connection connection = command.getConnection();
             final ConnectivityEvent event = ConnectionCreated.of(connection, command.getDittoHeaders());

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/CreatePolicyStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/CreatePolicyStrategy.java
@@ -73,7 +73,7 @@ final class CreatePolicyStrategy extends AbstractPolicyCommandStrategy<CreatePol
             return ResultFactory.newMutationResult(command, policyCreated, response, true, false);
         } else {
             return ResultFactory.newErrorResult(
-                    policyInvalid(context.getState(), validator.getReason().orElse(null), dittoHeaders));
+                    policyInvalid(context.getState(), validator.getReason().orElse(null), dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeletePolicyEntryStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeletePolicyEntryStrategy.java
@@ -61,10 +61,10 @@ final class DeletePolicyEntryStrategy extends AbstractPolicyCommandStrategy<Dele
                 return ResultFactory.newMutationResult(command, policyEntryDeleted, response);
             } else {
                 return ResultFactory.newErrorResult(
-                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeleteResourceStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeleteResourceStrategy.java
@@ -69,13 +69,13 @@ final class DeleteResourceStrategy extends AbstractPolicyCommandStrategy<DeleteR
                     return ResultFactory.newMutationResult(command, resourceDeleted, response);
                 } else {
                     return ResultFactory.newErrorResult(
-                            policyEntryInvalid(policyId, label, validator.getReason().orElse(null), headers));
+                            policyEntryInvalid(policyId, label, validator.getReason().orElse(null), headers), command);
                 }
             } else {
-                return ResultFactory.newErrorResult(resourceNotFound(policyId, label, resourceKey, headers));
+                return ResultFactory.newErrorResult(resourceNotFound(policyId, label, resourceKey, headers), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, headers));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, headers), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeleteSubjectStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/DeleteSubjectStrategy.java
@@ -68,13 +68,13 @@ final class DeleteSubjectStrategy extends AbstractPolicyCommandStrategy<DeleteSu
                     return ResultFactory.newMutationResult(command, subjectDeleted, response);
                 } else {
                     return ResultFactory.newErrorResult(
-                            policyEntryInvalid(policyId, label, validator.getReason().orElse(null), headers));
+                            policyEntryInvalid(policyId, label, validator.getReason().orElse(null), headers), command);
                 }
             } else {
-                return ResultFactory.newErrorResult(subjectNotFound(policyId, label, subjectId, headers));
+                return ResultFactory.newErrorResult(subjectNotFound(policyId, label, subjectId, headers), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, headers));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, headers), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyEntriesStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyEntriesStrategy.java
@@ -59,7 +59,7 @@ final class ModifyPolicyEntriesStrategy extends AbstractPolicyCommandStrategy<Mo
                     () -> policyEntriesJsonArray.toString().length(),
                     command::getDittoHeaders);
         } catch (final PolicyTooLargeException e) {
-            return ResultFactory.newErrorResult(e);
+            return ResultFactory.newErrorResult(e, command);
         }
 
         final PolicyId policyId = context.getState();

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyEntryStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyEntryStrategy.java
@@ -77,7 +77,7 @@ final class ModifyPolicyEntryStrategy extends AbstractPolicyCommandStrategy<Modi
                     },
                     command::getDittoHeaders);
         } catch (final PolicyTooLargeException e) {
-            return ResultFactory.newErrorResult(e);
+            return ResultFactory.newErrorResult(e, command);
         }
 
         final PoliciesValidator validator = PoliciesValidator.newInstance(nonNullPolicy.setEntry(policyEntry));
@@ -103,7 +103,7 @@ final class ModifyPolicyEntryStrategy extends AbstractPolicyCommandStrategy<Modi
             return ResultFactory.newMutationResult(command, eventToPersist, response);
         } else {
             return ResultFactory.newErrorResult(
-                    policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                    policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyPolicyStrategy.java
@@ -55,7 +55,7 @@ final class ModifyPolicyStrategy extends AbstractPolicyCommandStrategy<ModifyPol
                             () -> modifiedPolicyJsonObject.toString().length(),
                             command::getDittoHeaders);
         } catch (final PolicyTooLargeException e) {
-            return ResultFactory.newErrorResult(e);
+            return ResultFactory.newErrorResult(e, command);
         }
 
         final PoliciesValidator validator = PoliciesValidator.newInstance(modifiedPolicy);
@@ -69,7 +69,7 @@ final class ModifyPolicyStrategy extends AbstractPolicyCommandStrategy<ModifyPol
             return ResultFactory.newMutationResult(command, policyModified, response);
         } else {
             return ResultFactory.newErrorResult(
-                    policyInvalid(context.getState(), validator.getReason().orElse(null), dittoHeaders));
+                    policyInvalid(context.getState(), validator.getReason().orElse(null), dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyResourceStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyResourceStrategy.java
@@ -77,10 +77,10 @@ final class ModifyResourceStrategy extends AbstractPolicyCommandStrategy<ModifyR
                         appendETagHeaderIfProvided(command, rawResponse, nonNullPolicy));
             } else {
                 return ResultFactory.newErrorResult(
-                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyResourcesStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifyResourcesStrategy.java
@@ -83,7 +83,7 @@ final class ModifyResourcesStrategy extends AbstractPolicyCommandStrategy<Modify
                     },
                     command::getDittoHeaders);
         } catch (final PolicyTooLargeException e) {
-            return ResultFactory.newErrorResult(e);
+            return ResultFactory.newErrorResult(e, command);
         }
 
         if (nonNullPolicy.getEntryFor(label).isPresent()) {
@@ -99,10 +99,10 @@ final class ModifyResourcesStrategy extends AbstractPolicyCommandStrategy<Modify
                 return ResultFactory.newMutationResult(command, event, response);
             } else {
                 return ResultFactory.newErrorResult(
-                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifySubjectStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifySubjectStrategy.java
@@ -75,10 +75,10 @@ final class ModifySubjectStrategy extends AbstractPolicyCommandStrategy<ModifySu
                         appendETagHeaderIfProvided(command, rawResponse, nonNullPolicy));
             } else {
                 return ResultFactory.newErrorResult(
-                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifySubjectsStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/ModifySubjectsStrategy.java
@@ -68,10 +68,10 @@ final class ModifySubjectsStrategy extends AbstractPolicyCommandStrategy<ModifyS
                 return ResultFactory.newMutationResult(command, subjectsModified, response);
             } else {
                 return ResultFactory.newErrorResult(
-                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders));
+                        policyEntryInvalid(policyId, label, validator.getReason().orElse(null), dittoHeaders), command);
             }
         } else {
-            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders));
+            return ResultFactory.newErrorResult(policyEntryNotFound(policyId, label, dittoHeaders), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/PolicyConflictStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/PolicyConflictStrategy.java
@@ -39,8 +39,9 @@ final class PolicyConflictStrategy extends AbstractPolicyCommandStrategy<CreateP
     protected Result<PolicyEvent> doApply(final Context<PolicyId> context, @Nullable final Policy entity,
             final long nextRevision, final CreatePolicy command) {
         return ResultFactory.newErrorResult(PolicyConflictException.newBuilder(command.getEntityId())
-                .dittoHeaders(command.getDittoHeaders())
-                .build());
+                        .dittoHeaders(command.getDittoHeaders())
+                        .build(),
+                command);
     }
 
     @Override

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyEntriesStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyEntriesStrategy.java
@@ -46,7 +46,7 @@ final class RetrievePolicyEntriesStrategy extends
                     policy);
             return ResultFactory.newQueryResult(command, response);
         } else {
-            return ResultFactory.newErrorResult(policyNotFound(policyId, command.getDittoHeaders()));
+            return ResultFactory.newErrorResult(policyNotFound(policyId, command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyEntryStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyEntryStrategy.java
@@ -51,7 +51,7 @@ final class RetrievePolicyEntryStrategy extends
             }
         }
         return ResultFactory.newErrorResult(
-                policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()));
+                policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()), command);
     }
 
     @Override

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrievePolicyStrategy.java
@@ -41,7 +41,7 @@ final class RetrievePolicyStrategy extends AbstractPolicyQueryCommandStrategy<Re
             return ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command,
                     RetrievePolicyResponse.of(context.getState(), entity, command.getDittoHeaders()), entity));
         } else {
-            return ResultFactory.newErrorResult(policyNotFound(context.getState(), command.getDittoHeaders()));
+            return ResultFactory.newErrorResult(policyNotFound(context.getState(), command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveResourceStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveResourceStrategy.java
@@ -58,11 +58,11 @@ final class RetrieveResourceStrategy extends AbstractPolicyQueryCommandStrategy<
             } else {
                 return ResultFactory.newErrorResult(
                         resourceNotFound(policyId, command.getLabel(), command.getResourceKey(),
-                                command.getDittoHeaders()));
+                                command.getDittoHeaders()), command);
             }
         } else {
             return ResultFactory.newErrorResult(
-                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()));
+                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveResourcesStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveResourcesStrategy.java
@@ -51,7 +51,7 @@ final class RetrieveResourcesStrategy extends AbstractPolicyQueryCommandStrategy
             return ResultFactory.newQueryResult(command, response);
         } else {
             return ResultFactory.newErrorResult(
-                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()));
+                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveSubjectStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveSubjectStrategy.java
@@ -58,11 +58,11 @@ final class RetrieveSubjectStrategy extends AbstractPolicyQueryCommandStrategy<R
             } else {
                 return ResultFactory.newErrorResult(
                         subjectNotFound(policyId, command.getLabel(), command.getSubjectId(),
-                                command.getDittoHeaders()));
+                                command.getDittoHeaders()), command);
             }
         } else {
             return ResultFactory.newErrorResult(
-                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()));
+                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveSubjectsStrategy.java
+++ b/services/policies/persistence/src/main/java/org/eclipse/ditto/services/policies/persistence/actors/strategies/commands/RetrieveSubjectsStrategy.java
@@ -52,7 +52,7 @@ final class RetrieveSubjectsStrategy extends AbstractPolicyQueryCommandStrategy<
             return ResultFactory.newQueryResult(command, response);
         } else {
             return ResultFactory.newErrorResult(
-                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()));
+                    policyEntryNotFound(policyId, command.getLabel(), command.getDittoHeaders()), command);
         }
     }
 

--- a/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/PersistenceActorTestBase.java
+++ b/services/policies/persistence/src/test/java/org/eclipse/ditto/services/policies/persistence/actors/PersistenceActorTestBase.java
@@ -114,7 +114,6 @@ public abstract class PersistenceActorTestBase {
 
         return DittoHeaders.newBuilder()
                 .correlationId(null)
-                .responseRequired(false)
                 .schemaVersion(schemaVersion)
                 .authorizationContext(
                         AuthorizationModelFactory.newAuthContext(DittoAuthorizationContextType.UNSPECIFIED,

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CreateThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/CreateThingStrategy.java
@@ -92,12 +92,12 @@ final class CreateThingStrategy extends AbstractThingCommandStrategy<CreateThing
                     handleCommandVersion(context, command.getImplementedSchemaVersion(), command.getThing(),
                             commandHeaders);
         } catch (final DittoRuntimeException e) {
-            return newErrorResult(e);
+            return newErrorResult(e, command);
         }
 
         // before persisting, check if the Thing is valid and reject if not:
         final Result validateThingError =
-                validateThing(context, command.getImplementedSchemaVersion(), newThing, commandHeaders);
+                validateThing(context, command.getImplementedSchemaVersion(), newThing, command);
         if (validateThingError != null) {
             return validateThingError;
         }
@@ -182,7 +182,8 @@ final class CreateThingStrategy extends AbstractThingCommandStrategy<CreateThing
 
     @Nullable
     private Result validateThing(final Context<ThingId> context, final JsonSchemaVersion version, final Thing thing,
-            final DittoHeaders headers) {
+            final CreateThing command) {
+        final DittoHeaders headers = command.getDittoHeaders();
         final Optional<AccessControlList> accessControlList = thing.getAccessControlList();
         if (JsonSchemaVersion.V_1.equals(version)) {
             if (accessControlList.isPresent()) {
@@ -194,14 +195,14 @@ final class CreateThingStrategy extends AbstractThingCommandStrategy<CreateThing
                             AclInvalidException.newBuilder(context.getState())
                                     .dittoHeaders(headers)
                                     .build();
-                    return newErrorResult(aclInvalidException);
+                    return newErrorResult(aclInvalidException, command);
                 }
             } else {
                 final AclInvalidException aclInvalidException =
                         AclInvalidException.newBuilder(context.getState())
                                 .dittoHeaders(headers)
                                 .build();
-                return newErrorResult(aclInvalidException);
+                return newErrorResult(aclInvalidException, command);
             }
         }
         return null;

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAclEntryStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAclEntryStrategy.java
@@ -56,7 +56,7 @@ final class DeleteAclEntryStrategy extends AbstractThingCommandStrategy<DeleteAc
                 .map(acl -> getDeleteAclEntryResult(acl, context, nextRevision, command, thing))
                 .orElseGet(
                         () -> ResultFactory.newErrorResult(ExceptionFactory.aclEntryNotFound(context.getState(),
-                                authSubject, dittoHeaders)));
+                                authSubject, dittoHeaders), command));
     }
 
     private Optional<AccessControlList> extractAcl(@Nullable final Thing thing, final DeleteAclEntry command) {
@@ -78,7 +78,7 @@ final class DeleteAclEntryStrategy extends AbstractThingCommandStrategy<DeleteAc
         final Validator validator = getAclValidator(aclWithoutAuthSubject);
         if (!validator.isValid()) {
             return ResultFactory.newErrorResult(
-                    ExceptionFactory.aclInvalid(thingId, validator.getReason(), dittoHeaders));
+                    ExceptionFactory.aclInvalid(thingId, validator.getReason(), dittoHeaders), command);
         }
 
         final WithDittoHeaders response = appendETagHeaderIfProvided(command,

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAttributeStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAttributeStrategy.java
@@ -56,7 +56,7 @@ final class DeleteAttributeStrategy
                 .map(attributes -> getDeleteAttributeResult(context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.attributeNotFound(context.getState(), attrPointer,
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Result<ThingEvent> getDeleteAttributeResult(final Context<ThingId> context, final long nextRevision,

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAttributesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteAttributesStrategy.java
@@ -51,7 +51,7 @@ final class DeleteAttributesStrategy
         return extractAttributes(thing)
                 .map(attributes -> getDeleteAttributesResult(context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.attributesNotFound(context.getState(), command.getDittoHeaders())));
+                        ExceptionFactory.attributesNotFound(context.getState(), command.getDittoHeaders()), command));
     }
 
     private Optional<Attributes> extractAttributes(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeatureDefinitionStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeatureDefinitionStrategy.java
@@ -53,7 +53,7 @@ final class DeleteFeatureDefinitionStrategy extends
                 .map(feature -> getDeleteFeatureDefinitionResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Result<ThingEvent> getDeleteFeatureDefinitionResult(final Feature feature, final Context<ThingId> context,
@@ -73,7 +73,7 @@ final class DeleteFeatureDefinitionStrategy extends
                     return ResultFactory.newMutationResult(command, event, response);
                 })
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featureDefinitionNotFound(thingId, featureId, dittoHeaders)));
+                        ExceptionFactory.featureDefinitionNotFound(thingId, featureId, dittoHeaders), command));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturePropertiesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturePropertiesStrategy.java
@@ -52,7 +52,7 @@ final class DeleteFeaturePropertiesStrategy extends
                 .map(feature -> getDeleteFeaturePropertiesResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final DeleteFeatureProperties command,
@@ -79,7 +79,7 @@ final class DeleteFeaturePropertiesStrategy extends
                     return ResultFactory.newMutationResult(command, event, response);
                 })
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featurePropertiesNotFound(thingId, featureId, dittoHeaders)));
+                        ExceptionFactory.featurePropertiesNotFound(thingId, featureId, dittoHeaders), command));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturePropertyStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturePropertyStrategy.java
@@ -53,7 +53,7 @@ final class DeleteFeaturePropertyStrategy extends
                 .map(feature -> getDeleteFeaturePropertyResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), command.getFeatureId(),
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final DeleteFeatureProperty command, final @Nullable Thing thing) {
@@ -80,7 +80,8 @@ final class DeleteFeaturePropertyStrategy extends
                     return ResultFactory.newMutationResult(command, event, response);
                 })
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featurePropertyNotFound(thingId, featureId, propertyPointer, dittoHeaders)));
+                        ExceptionFactory.featurePropertyNotFound(thingId, featureId, propertyPointer, dittoHeaders),
+                        command));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeatureStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeatureStrategy.java
@@ -52,7 +52,7 @@ final class DeleteFeatureStrategy extends AbstractThingCommandStrategy<DeleteFea
                 .map(feature -> getDeleteFeatureResult(context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), featureId,
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final DeleteFeature command, @Nullable final Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteFeaturesStrategy.java
@@ -55,7 +55,7 @@ final class DeleteFeaturesStrategy extends AbstractThingCommandStrategy<DeleteFe
                 )
                 .orElseGet(() ->
                         ResultFactory.newErrorResult(ExceptionFactory.featuresNotFound(context.getState(),
-                                dittoHeaders)));
+                                dittoHeaders), command));
     }
 
     private Optional<Features> extractFeatures(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteThingDefinitionStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/DeleteThingDefinitionStrategy.java
@@ -54,7 +54,7 @@ final class DeleteThingDefinitionStrategy
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ThingDefinitionNotAccessibleException.newBuilder(context.getState())
                                 .dittoHeaders(command.getDittoHeaders())
-                                .build()));
+                                .build(), command));
     }
 
     private Optional<ThingDefinition> extractDefinition(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyAclEntryStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyAclEntryStrategy.java
@@ -60,7 +60,7 @@ final class ModifyAclEntryStrategy extends AbstractThingCommandStrategy<ModifyAc
         if (!validator.isValid()) {
             return ResultFactory.newErrorResult(
                     ExceptionFactory.aclInvalid(context.getState(), validator.getReason(),
-                            command.getDittoHeaders()));
+                            command.getDittoHeaders()), command);
         }
 
         return getModifyOrCreateResult(acl, context, nextRevision, command, thing);

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyAclStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyAclStrategy.java
@@ -56,7 +56,7 @@ final class ModifyAclStrategy extends AbstractThingCommandStrategy<ModifyAcl> {
                 Thing.MIN_REQUIRED_PERMISSIONS);
         if (!aclValidator.isValid()) {
             return ResultFactory.newErrorResult(ExceptionFactory.aclInvalid(thingId, aclValidator.getReason(),
-                    dittoHeaders));
+                    dittoHeaders), command);
         }
 
         final ThingEvent event =

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeatureDefinitionStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeatureDefinitionStrategy.java
@@ -53,7 +53,7 @@ final class ModifyFeatureDefinitionStrategy extends AbstractThingCommandStrategy
                 .map(feature -> getModifyOrCreateResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), featureId,
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final ModifyFeatureDefinition command, final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeaturePropertiesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeaturePropertiesStrategy.java
@@ -76,7 +76,7 @@ final class ModifyFeaturePropertiesStrategy extends AbstractThingCommandStrategy
                 .map(feature -> getModifyOrCreateResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), featureId,
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final ModifyFeatureProperties command, @Nullable final Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeaturePropertyStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyFeaturePropertyStrategy.java
@@ -74,7 +74,7 @@ final class ModifyFeaturePropertyStrategy extends AbstractThingCommandStrategy<M
                 .map(feature -> getModifyOrCreateResult(feature, context, nextRevision, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featureNotFound(context.getState(), featureId,
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final ModifyFeatureProperty command, @Nullable final Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ModifyThingStrategy.java
@@ -163,7 +163,7 @@ final class ModifyThingStrategy extends AbstractThingCommandStrategy<ModifyThing
         } else {
             return newErrorResult(
                     PolicyIdMissingException.fromThingIdOnUpdate(context.getState(),
-                            command.getDittoHeaders()));
+                            command.getDittoHeaders()), command);
         }
     }
 
@@ -240,7 +240,7 @@ final class ModifyThingStrategy extends AbstractThingCommandStrategy<ModifyThing
     @Override
     public Result<ThingEvent> unhandled(final Context<ThingId> context, @Nullable final Thing thing,
             final long nextRevision, final ModifyThing command) {
-        return newErrorResult(new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()));
+        return newErrorResult(new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()), command);
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAclEntryStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAclEntryStrategy.java
@@ -57,7 +57,7 @@ final class RetrieveAclEntryStrategy extends AbstractThingCommandStrategy<Retrie
                     return ResultFactory.<ThingEvent>newQueryResult(command, response);
                 })
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.aclEntryNotFound(thingId, authorizationSubject, dittoHeaders)));
+                        ExceptionFactory.aclEntryNotFound(thingId, authorizationSubject, dittoHeaders), command));
     }
 
     private Optional<AclEntry> extractAclEntry(final RetrieveAclEntry command, final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAttributeStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAttributeStrategy.java
@@ -50,7 +50,7 @@ final class RetrieveAttributeStrategy extends AbstractThingCommandStrategy<Retri
         return extractAttributes(thing)
                 .map(attributes -> getAttributeValueResult(attributes, context.getState(), command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.attributesNotFound(context.getState(), command.getDittoHeaders())));
+                        ExceptionFactory.attributesNotFound(context.getState(), command.getDittoHeaders()), command));
     }
 
     private Optional<Attributes> extractAttributes(final @Nullable Thing thing) {
@@ -68,7 +68,7 @@ final class RetrieveAttributeStrategy extends AbstractThingCommandStrategy<Retri
                 .<Result<ThingEvent>>map(response ->
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.attributeNotFound(thingId, attributePointer, dittoHeaders)));
+                        ExceptionFactory.attributeNotFound(thingId, attributePointer, dittoHeaders), command));
     }
 
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAttributesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveAttributesStrategy.java
@@ -55,7 +55,7 @@ final class RetrieveAttributesStrategy extends AbstractThingCommandStrategy<Retr
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing))
                 )
                 .orElseGet(() ->
-                        ResultFactory.newErrorResult(ExceptionFactory.attributesNotFound(thingId, dittoHeaders))
+                        ResultFactory.newErrorResult(ExceptionFactory.attributesNotFound(thingId, dittoHeaders), command)
                 );
     }
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeatureDefinitionStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeatureDefinitionStrategy.java
@@ -50,7 +50,7 @@ final class RetrieveFeatureDefinitionStrategy extends AbstractThingCommandStrate
         return extractFeature(command, thing)
                 .map(feature -> getFeatureDefinition(feature, thingId, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(ExceptionFactory.featureNotFound(thingId,
-                        featureId, command.getDittoHeaders())));
+                        featureId, command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final RetrieveFeatureDefinition command, final @Nullable Thing thing) {
@@ -70,7 +70,7 @@ final class RetrieveFeatureDefinitionStrategy extends AbstractThingCommandStrate
                 .<Result<ThingEvent>>map(response ->
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featureDefinitionNotFound(thingId, featureId, dittoHeaders)));
+                        ExceptionFactory.featureDefinitionNotFound(thingId, featureId, dittoHeaders), command));
     }
 
 

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturePropertiesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturePropertiesStrategy.java
@@ -50,7 +50,7 @@ final class RetrieveFeaturePropertiesStrategy extends AbstractThingCommandStrate
         return extractFeature(command, thing)
                 .map(feature -> getFeatureProperties(feature, thingId, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featureNotFound(thingId, featureId, command.getDittoHeaders())));
+                        ExceptionFactory.featureNotFound(thingId, featureId, command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final RetrieveFeatureProperties command, final @Nullable Thing thing) {
@@ -70,7 +70,7 @@ final class RetrieveFeaturePropertiesStrategy extends AbstractThingCommandStrate
                 .<Result<ThingEvent>>map(response ->
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featurePropertiesNotFound(thingId, featureId, dittoHeaders)));
+                        ExceptionFactory.featurePropertiesNotFound(thingId, featureId, dittoHeaders), command));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturePropertyStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturePropertyStrategy.java
@@ -54,7 +54,7 @@ final class RetrieveFeaturePropertyStrategy extends AbstractThingCommandStrategy
                 .map(feature -> getRetrieveFeaturePropertyResult(feature, context, command, thing))
                 .orElseGet(
                         () -> ResultFactory.newErrorResult(ExceptionFactory.featureNotFound(context.getState(),
-                                featureId, command.getDittoHeaders())));
+                                featureId, command.getDittoHeaders()), command));
     }
 
     private Optional<Feature> extractFeature(final RetrieveFeatureProperty command, final @Nullable Thing thing) {
@@ -69,7 +69,7 @@ final class RetrieveFeaturePropertyStrategy extends AbstractThingCommandStrategy
                 .map(featureProperties -> getRetrieveFeaturePropertyResult(featureProperties, context, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featurePropertiesNotFound(context.getState(), feature.getId(),
-                                command.getDittoHeaders())));
+                                command.getDittoHeaders()), command));
     }
 
     private Result<ThingEvent> getRetrieveFeaturePropertyResult(final JsonObject featureProperties,
@@ -87,7 +87,7 @@ final class RetrieveFeaturePropertyStrategy extends AbstractThingCommandStrategy
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ExceptionFactory.featurePropertyNotFound(context.getState(), featureId, propertyPointer,
-                                dittoHeaders)));
+                                dittoHeaders), command));
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeatureStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeatureStrategy.java
@@ -51,7 +51,7 @@ final class RetrieveFeatureStrategy extends AbstractThingCommandStrategy<Retriev
         return extractFeatures(thing)
                 .map(features -> getFeatureResult(features, thingId, command, thing))
                 .orElseGet(() -> ResultFactory.newErrorResult(ExceptionFactory.featureNotFound(thingId,
-                        command.getFeatureId(), command.getDittoHeaders())));
+                        command.getFeatureId(), command.getDittoHeaders()), command));
     }
 
     private Optional<Features> extractFeatures(final @Nullable Thing thing) {
@@ -70,7 +70,7 @@ final class RetrieveFeatureStrategy extends AbstractThingCommandStrategy<Retriev
                 .<Result<ThingEvent>>map(response ->
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
                 .orElseGet(() -> ResultFactory.newErrorResult(
-                        ExceptionFactory.featureNotFound(thingId, featureId, dittoHeaders)));
+                        ExceptionFactory.featureNotFound(thingId, featureId, dittoHeaders), command));
     }
 
     private static JsonObject getFeatureJson(final Feature feature, final RetrieveFeature command) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturesStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveFeaturesStrategy.java
@@ -53,8 +53,8 @@ final class RetrieveFeaturesStrategy extends AbstractThingCommandStrategy<Retrie
                 .map(featuresJson -> RetrieveFeaturesResponse.of(thingId, featuresJson, dittoHeaders))
                 .<Result<ThingEvent>>map(response ->
                         ResultFactory.newQueryResult(command, appendETagHeaderIfProvided(command, response, thing)))
-                .orElseGet(() ->
-                        ResultFactory.newErrorResult(ExceptionFactory.featuresNotFound(thingId, dittoHeaders)));
+                .orElseGet(() -> ResultFactory
+                        .newErrorResult(ExceptionFactory.featuresNotFound(thingId, dittoHeaders), command));
     }
 
     private Optional<Features> extractFeatures(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrievePolicyIdStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrievePolicyIdStrategy.java
@@ -55,7 +55,8 @@ final class RetrievePolicyIdStrategy extends AbstractThingCommandStrategy<Retrie
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         PolicyIdNotAccessibleException.newBuilder(context.getState())
                                 .dittoHeaders(command.getDittoHeaders())
-                                .build()));
+                                .build(),
+                        command));
     }
 
     private Optional<PolicyId> extractPolicyId(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveThingDefinitionStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveThingDefinitionStrategy.java
@@ -56,7 +56,7 @@ final class RetrieveThingDefinitionStrategy extends AbstractThingCommandStrategy
                 .orElseGet(() -> ResultFactory.newErrorResult(
                         ThingDefinitionNotAccessibleException.newBuilder(context.getState())
                                 .dittoHeaders(command.getDittoHeaders())
-                                .build()));
+                                .build(), command));
     }
 
     private Optional<ThingDefinition> extractDefinition(final @Nullable Thing thing) {

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/RetrieveThingStrategy.java
@@ -86,7 +86,7 @@ final class RetrieveThingStrategy extends AbstractThingCommandStrategy<RetrieveT
     public Result<ThingEvent> unhandled(final Context<ThingId> context, @Nullable final Thing thing,
             final long nextRevision, final RetrieveThing command) {
         return ResultFactory.newErrorResult(
-                new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()));
+                new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()), command);
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/SudoRetrieveThingStrategy.java
@@ -80,7 +80,7 @@ final class SudoRetrieveThingStrategy extends AbstractThingCommandStrategy<SudoR
     public Result<ThingEvent> unhandled(final Context<ThingId> context, @Nullable final Thing thing,
             final long nextRevision, final SudoRetrieveThing command) {
         return ResultFactory.newErrorResult(
-                new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()));
+                new ThingNotAccessibleException(context.getState(), command.getDittoHeaders()), command);
     }
 
     @Override

--- a/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ThingConflictStrategy.java
+++ b/services/things/persistence/src/main/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ThingConflictStrategy.java
@@ -55,7 +55,7 @@ final class ThingConflictStrategy extends AbstractCommandStrategy<CreateThing, T
             final long nextRevision, final CreateThing command) {
         return ResultFactory.newErrorResult(ThingConflictException.newBuilder(command.getThingEntityId())
                 .dittoHeaders(command.getDittoHeaders())
-                .build());
+                .build(), command);
     }
 
 }

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/AbstractCommandStrategyTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractCommandStrategyTest {
 
         final ResultVisitor<ThingEvent> mock = mock(Dummy.class);
         applyStrategy(underTest, getDefaultContext(), thing, command).accept(mock);
-        verify(mock).onError(eq(expectedException));
+        verify(mock).onError(eq(expectedException), eq(command));
     }
 
     protected static <C extends Command> void assertQueryResult(
@@ -114,7 +114,7 @@ public abstract class AbstractCommandStrategyTest {
 
         final ResultVisitor<ThingEvent> mock = mock(Dummy.class);
         underTest.unhandled(getDefaultContext(), thing, NEXT_REVISION, command).accept(mock);
-        verify(mock).onError(eq(expectedResponse));
+        verify(mock).onError(eq(expectedResponse), eq(command));
     }
 
     private static void assertModificationResult(final Result<ThingEvent> result,

--- a/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactoryTest.java
+++ b/services/things/persistence/src/test/java/org/eclipse/ditto/services/things/persistence/actors/strategies/commands/ResultFactoryTest.java
@@ -23,6 +23,7 @@ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.services.utils.persistentactors.results.Result;
 import org.eclipse.ditto.services.utils.persistentactors.results.ResultFactory;
 import org.eclipse.ditto.services.utils.persistentactors.results.ResultVisitor;
+import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
 import org.eclipse.ditto.signals.commands.things.modify.ThingModifyCommand;
 import org.eclipse.ditto.signals.commands.things.query.ThingQueryCommand;
@@ -56,9 +57,10 @@ public final class ResultFactoryTest {
 
     @Test
     public void notifyException() {
-        final Result<ThingEvent> result = ResultFactory.newErrorResult(exception);
-        result.accept(mock);
-        verify(mock).onError(eq(exception));
+        final Command command = mock(Command.class);
+        final Result<ThingEvent> result = ResultFactory.newErrorResult(exception, command);
+        result.accept(this.mock);
+        verify(this.mock).onError(eq(exception), eq(command));
     }
 
     @Test

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/etags/AbstractConditionHeaderCheckingCommandStrategy.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/etags/AbstractConditionHeaderCheckingCommandStrategy.java
@@ -83,7 +83,7 @@ public abstract class AbstractConditionHeaderCheckingCommandStrategy<
             context.getLog().debug("Validating conditional headers succeeded.");
         } catch (final DittoRuntimeException dre) {
             context.getLog().debug("Validating conditional headers failed with exception <{}>.", dre.getMessage());
-            return ResultFactory.newErrorResult(dre);
+            return ResultFactory.newErrorResult(dre, command);
         }
 
         return super.apply(context, entity, nextRevision, command);

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ErrorResult.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ErrorResult.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.services.utils.persistentactors.results;
 
 import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.signals.commands.base.Command;
 import org.eclipse.ditto.signals.events.base.Event;
 
 /**
@@ -20,21 +21,24 @@ import org.eclipse.ditto.signals.events.base.Event;
  */
 public final class ErrorResult<E extends Event> implements Result<E> {
 
+    private final Command errorCausingCommand;
     private final DittoRuntimeException dittoRuntimeException;
 
-    ErrorResult(final DittoRuntimeException dittoRuntimeException) {
+    ErrorResult(final DittoRuntimeException dittoRuntimeException, final Command errorCausingCommand) {
         this.dittoRuntimeException = dittoRuntimeException;
+        this.errorCausingCommand = errorCausingCommand;
     }
 
     @Override
     public String toString() {
         return this.getClass().getSimpleName() + " [" +
                 "dittoRuntimeException=" + dittoRuntimeException +
+                ", errorCausingCommand=" + errorCausingCommand +
                 ']';
     }
 
     @Override
     public void accept(final ResultVisitor<E> visitor) {
-        visitor.onError(dittoRuntimeException);
+        visitor.onError(dittoRuntimeException, errorCausingCommand);
     }
 }

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ResultFactory.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ResultFactory.java
@@ -68,11 +68,13 @@ public final class ResultFactory {
      * Create an error result.
      *
      * @param dittoRuntimeException the error.
+     * @param errorCausingCommand the command that caused the error.
      * @param <E> type of events (irrelevant).
      * @return the result.
      */
-    public static <E extends Event> Result<E> newErrorResult(final DittoRuntimeException dittoRuntimeException) {
-        return new ErrorResult<>(dittoRuntimeException);
+    public static <E extends Event> Result<E> newErrorResult(final DittoRuntimeException dittoRuntimeException,
+            final Command errorCausingCommand) {
+        return new ErrorResult<>(dittoRuntimeException, errorCausingCommand);
     }
 
     /**

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ResultVisitor.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/results/ResultVisitor.java
@@ -55,5 +55,5 @@ public interface ResultVisitor<E extends Event> {
      *
      * @param error the error.
      */
-    void onError(DittoRuntimeException error);
+    void onError(DittoRuntimeException error, Command errorCausingCommand);
 }


### PR DESCRIPTION
* MessageMappingProcessorActor now doesn't check response-required anymore
* Persistence Actors do only send a response in case it was required by the
  command.
* Explicitly adding the errorCausingCommand to the ErrorResult as
  relying on the headers of the exception would be the same as interpreting
  the response. We should not rely on the fact that the ditto runtime
  exception has the header set. It could be possible that it's just
  catched and based on this exception a result is built
  (see AbstractConditionHeadercheckingCommandStrategy)

Signed-off-by: Yannic Klem <yannic.klem@bosch.io>