### PR TITLE
Append extra fields to selected fields for SSE

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonFieldSelector.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonFieldSelector.java
@@ -16,6 +16,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -108,6 +109,14 @@ final class ImmutableJsonFieldSelector implements JsonFieldSelector {
     @Override
     public Iterator<JsonPointer> iterator() {
         return pointers.iterator();
+    }
+
+    @Override
+    public JsonFieldSelector concat(final JsonFieldSelector jsonFieldSelector) {
+
+        final HashSet<JsonPointer> newPointers = new HashSet<>(pointers);
+        newPointers.addAll(jsonFieldSelector.getPointers());
+        return of(newPointers);
     }
 
     @Override

--- a/json/src/main/java/org/eclipse/ditto/json/JsonFieldSelector.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonFieldSelector.java
@@ -72,4 +72,13 @@ public interface JsonFieldSelector extends Iterable<JsonPointer> {
     @Override
     String toString();
 
+    /**
+     * Creates a new JsonFieldSelector which contains the json pointers of this instance and the pointers of the
+     * given JsonFieldSelector in the parameters.
+     *
+     * @param jsonFieldSelector The field selector to append to this selector.
+     * @return The new instance with json pointers of both selectors.
+     */
+    JsonFieldSelector concat(JsonFieldSelector jsonFieldSelector);
+
 }

--- a/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonFieldSelectorTest.java
+++ b/json/src/test/java/org/eclipse/ditto/json/ImmutableJsonFieldSelectorTest.java
@@ -113,4 +113,15 @@ public final class ImmutableJsonFieldSelectorTest {
         assertThat(underTest1.toString()).isEqualTo(inputJsonFieldSelector);
     }
 
+    @Test
+    public void concatenatingJsonPointers() {
+        final JsonFieldSelector jsonFieldSelectorA = JsonFieldSelector.newInstance("/thingId", "features/test/properties/A");
+        final JsonFieldSelector jsonFieldSelectorB = JsonFieldSelector.newInstance("features/test/properties/B");
+
+        final JsonFieldSelector newFieldSelector = jsonFieldSelectorA.concat(jsonFieldSelectorB);
+
+        assertThat(newFieldSelector.getPointers()).hasSize(3);
+        assertThat(newFieldSelector.getPointers()).containsAll(jsonFieldSelectorA.getPointers());
+        assertThat(newFieldSelector.getPointers()).containsAll(jsonFieldSelectorB.getPointers());
+    }
 }


### PR DESCRIPTION
* There was a bug where extra fields were filtered out of the json
  representation after beeing added before. Reason was that the filtering
  is based on the selected fields. To make our API easy to use we
  automatically add all extra fields to the selected fields.

Signed-off-by: Yannic Klem <yannic.klem@bosch.io>