### PR TITLE
Validate JsonKeys in commands/responses that take a plain JsonPointer

### DIFF
--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AttributesModelFactory.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AttributesModelFactory.java
@@ -18,7 +18,9 @@ import static org.eclipse.ditto.model.base.exceptions.DittoJsonException.wrapJso
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonPointerInvalidException;
 
 /**
@@ -106,4 +108,16 @@ public final class AttributesModelFactory {
         return ImmutableAttributesBuilder.of(jsonObject);
     }
 
+    /**
+     * Validates the given attribute {@link JsonPointer}.
+     *
+     * @param jsonPointer {@code jsonPointer} that is validated
+     * @return the same {@code jsonPointer} if validation was successful
+     * @throws JsonKeyInvalidException if {@code jsonPointer} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     * @since 1.2.0
+     */
+    public static JsonPointer validateAttributePointer(final JsonPointer jsonPointer) {
+        return JsonKeyValidator.validate(jsonPointer);
+    }
 }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableAttributes.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableAttributes.java
@@ -38,11 +38,8 @@ import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
-import org.eclipse.ditto.json.JsonPointerInvalidException;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.model.base.common.Validator;
-import org.eclipse.ditto.model.base.entity.validation.NoControlCharactersNoSlashesValidator;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 
 /**
@@ -73,7 +70,7 @@ final class ImmutableAttributes implements Attributes {
      * @param jsonObject provides the data to initialize the new attributes with.
      * @return the new attributes.
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
-     * @throws JsonPointerInvalidException if an attribute name in the passed {@code jsonObject} was not valid
+     * @throws JsonKeyInvalidException if an attribute name in the passed {@code jsonObject} was not valid
      * according to pattern
      * {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
@@ -83,24 +80,8 @@ final class ImmutableAttributes implements Attributes {
         if (jsonObject instanceof ImmutableAttributes) {
             return (Attributes) jsonObject;
         }
-        validateJsonKeys(jsonObject);
-        return new ImmutableAttributes(jsonObject);
-    }
 
-    private static void validateJsonKeys(final JsonObject jsonObject) {
-        for (final JsonField jsonField : jsonObject) {
-            final JsonKey key = jsonField.getKey();
-            final JsonValue value = jsonField.getValue();
-            final Validator validator = NoControlCharactersNoSlashesValidator.getInstance(key);
-            if (!validator.isValid()) {
-                throw JsonKeyInvalidException.newBuilderWithDescription(key, validator.getReason().orElse(null))
-                        .build();
-            }
-            if (value.isObject()) {
-                // recurse!
-                validateJsonKeys(value.asObject());
-            }
-        }
+        return new ImmutableAttributes(JsonKeyValidator.validateJsonKeys(jsonObject));
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableFeatureProperties.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ImmutableFeatureProperties.java
@@ -38,8 +38,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.json.SerializationContext;
-import org.eclipse.ditto.model.base.common.Validator;
-import org.eclipse.ditto.model.base.entity.validation.NoControlCharactersNoSlashesValidator;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 
 /**
@@ -80,24 +78,8 @@ final class ImmutableFeatureProperties implements FeatureProperties {
         if (jsonObject instanceof ImmutableFeatureProperties) {
             return (FeatureProperties) jsonObject;
         }
-        validateJsonKeys(jsonObject);
-        return new ImmutableFeatureProperties(jsonObject);
-    }
 
-    private static void validateJsonKeys(final JsonObject jsonObject) {
-        for (final JsonField jsonField : jsonObject) {
-            final JsonKey key = jsonField.getKey();
-            final JsonValue value = jsonField.getValue();
-            final Validator validator = NoControlCharactersNoSlashesValidator.getInstance(key);
-            if (!validator.isValid()) {
-                throw JsonKeyInvalidException.newBuilderWithDescription(key, validator.getReason().orElse(null))
-                        .build();
-            }
-            if (value.isObject()) {
-                // recurse!
-                validateJsonKeys(value.asObject());
-            }
-        }
+        return new ImmutableFeatureProperties(JsonKeyValidator.validateJsonKeys(jsonObject));
     }
 
     @Override

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/JsonKeyValidator.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/JsonKeyValidator.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.things;
+
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonKey;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.common.Validator;
+import org.eclipse.ditto.model.base.entity.validation.NoControlCharactersNoSlashesValidator;
+
+/**
+ * Validates keys of {@link JsonObject}s or {@link JsonPointer}s.
+ */
+final class JsonKeyValidator {
+
+    /**
+     * Validates all keys of a given JsonObject including all nested objects.
+     *
+     * @param jsonObject the {@link JsonObject} that is validated
+     * @return the same instance of {@link JsonObject} if validation was successful
+     * @throws JsonKeyInvalidException if a property name in the passed {@code jsonObject} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     */
+    static JsonObject validateJsonKeys(final JsonObject jsonObject) {
+        for (final JsonField jsonField : jsonObject) {
+            validate(jsonField.getKey());
+            final JsonValue value = jsonField.getValue();
+            if (value.isObject()) {
+                // recurse!
+                validateJsonKeys(value.asObject());
+            }
+        }
+        return jsonObject;
+    }
+
+    /**
+     * Validates the keys of the given {@link org.eclipse.ditto.json.JsonPointer}.
+     *
+     * @param pointer the {@link JsonPointer} that is validated
+     * @return the same {@link JsonPointer} if validation was successful
+     * @throws JsonKeyInvalidException if a key in the passed {@code jsonPointer} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     */
+    static JsonPointer validate(final JsonPointer pointer) {
+        pointer.forEach(key -> {
+            final Validator validator = NoControlCharactersNoSlashesValidator.getInstance(key);
+            if (!validator.isValid()) {
+                throw JsonKeyInvalidException.newBuilderWithDescription(key, validator.getReason().orElse(null))
+                        .build();
+            }
+        });
+        return pointer;
+    }
+
+    private static void validate(final JsonKey key) {
+        final Validator validator = NoControlCharactersNoSlashesValidator.getInstance(key);
+        if (!validator.isValid()) {
+            throw JsonKeyInvalidException.newBuilderWithDescription(key, validator.getReason().orElse(null))
+                    .build();
+        }
+    }
+}

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
@@ -26,8 +26,10 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonParseException;
+import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
@@ -539,6 +541,19 @@ public final class ThingsModelFactory {
         final FeaturesBuilder result = ImmutableFeaturesBuilder.newInstance();
         result.setAll(features);
         return result;
+    }
+
+    /**
+     * Validates the given {@link JsonPointer} to a feature property.
+     *
+     * @param jsonPointer {@code jsonPointer} that is validated
+     * @return the same {@code jsonPointer} if validation was successful
+     * @throws JsonKeyInvalidException if {@code jsonPointer} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     * @since 1.2.0
+     */
+    public static JsonPointer validateFeaturePropertyPointer(final JsonPointer jsonPointer) {
+        return JsonKeyValidator.validate(jsonPointer);
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponse.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.signals.commands.things.modify;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -31,9 +32,11 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
+import org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException;
 
 /**
  * Response to a {@link DeleteAttribute} command.
@@ -59,7 +62,17 @@ public final class DeleteAttributeResponse extends AbstractCommandResponse<Delet
             final DittoHeaders dittoHeaders) {
         super(TYPE, HttpStatusCode.NO_CONTENT, dittoHeaders);
         this.thingId = requireNonNull(thingId, "thing ID");
-        this.attributePointer = requireNonNull(attributePointer, "attribute pointer");
+        this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
+    }
+
+    private JsonPointer checkAttributePointer(final JsonPointer attributePointer, final DittoHeaders dittoHeaders) {
+        checkNotNull(attributePointer, "attribute pointer");
+        if (attributePointer.isEmpty()) {
+            throw AttributePointerInvalidException.newBuilder(attributePointer)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+        return AttributesModelFactory.validateAttributePointer(attributePointer);
     }
 
     /**
@@ -70,8 +83,13 @@ public final class DeleteAttributeResponse extends AbstractCommandResponse<Delet
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if {@code statusCode} or {@code dittoHeaders} is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -88,6 +106,10 @@ public final class DeleteAttributeResponse extends AbstractCommandResponse<Delet
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if {@code statusCode} or {@code dittoHeaders} is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteAttributeResponse of(final ThingId thingId, final JsonPointer attributePointer,
             final DittoHeaders dittoHeaders) {
@@ -104,6 +126,8 @@ public final class DeleteAttributeResponse extends AbstractCommandResponse<Delet
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteAttributeResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -118,6 +142,8 @@ public final class DeleteAttributeResponse extends AbstractCommandResponse<Delet
      * @throws NullPointerException any argument is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteAttributeResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandResponseJsonDeserializer<DeleteAttributeResponse>(TYPE, jsonObject)

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeatureProperty.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.base.WithFeatureId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -71,7 +72,12 @@ public final class DeleteFeatureProperty extends AbstractCommand<DeleteFeaturePr
         super(TYPE, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkNotNull(propertyPointer, "Property JsonPointer");
+        this.propertyPointer = checkPropertyPointer(propertyPointer);
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "Property JsonPointer");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -83,8 +89,11 @@ public final class DeleteFeatureProperty extends AbstractCommand<DeleteFeaturePr
      * @param dittoHeaders the headers of the command.
      * @return a Command for deleting the provided Property.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -103,6 +112,8 @@ public final class DeleteFeatureProperty extends AbstractCommand<DeleteFeaturePr
      * @param dittoHeaders the headers of the command.
      * @return a Command for deleting the provided Property.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeatureProperty of(final ThingId thingId, final String featureId,
             final JsonPointer propertyPointer, final DittoHeaders dittoHeaders) {
@@ -122,6 +133,8 @@ public final class DeleteFeatureProperty extends AbstractCommand<DeleteFeaturePr
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeatureProperty fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -138,6 +151,8 @@ public final class DeleteFeatureProperty extends AbstractCommand<DeleteFeaturePr
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeatureProperty fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<DeleteFeatureProperty>(TYPE, jsonObject).deserialize(() -> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyResponse.java
@@ -32,6 +32,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
 
@@ -67,7 +68,12 @@ public final class DeleteFeaturePropertyResponse extends AbstractCommandResponse
         super(TYPE, HttpStatusCode.NO_CONTENT, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkNotNull(propertyPointer, "Property JsonPointer");
+        this.propertyPointer = checkPropertyPointer(propertyPointer);
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "Property JsonPointer");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -79,14 +85,16 @@ public final class DeleteFeaturePropertyResponse extends AbstractCommandResponse
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
     public static DeleteFeaturePropertyResponse of(final String thingId, final String featureId,
-            final JsonPointer propertyPointer,
-            final DittoHeaders dittoHeaders) {
+            final JsonPointer propertyPointer, final DittoHeaders dittoHeaders) {
 
         return of(ThingId.of(thingId), featureId, propertyPointer, dittoHeaders);
     }
@@ -100,10 +108,11 @@ public final class DeleteFeaturePropertyResponse extends AbstractCommandResponse
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeaturePropertyResponse of(final ThingId thingId, final String featureId,
-            final JsonPointer propertyPointer,
-            final DittoHeaders dittoHeaders) {
+            final JsonPointer propertyPointer, final DittoHeaders dittoHeaders) {
 
         return new DeleteFeaturePropertyResponse(thingId, featureId, propertyPointer, dittoHeaders);
     }
@@ -118,6 +127,8 @@ public final class DeleteFeaturePropertyResponse extends AbstractCommandResponse
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeaturePropertyResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -132,6 +143,8 @@ public final class DeleteFeaturePropertyResponse extends AbstractCommandResponse
      * @throws NullPointerException if any argument is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static DeleteFeaturePropertyResponse fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
@@ -32,6 +32,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -89,7 +90,7 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
                     .dittoHeaders(dittoHeaders)
                     .build();
         }
-        return pointer;
+        return AttributesModelFactory.validateAttributePointer(pointer);
     }
 
     /**
@@ -103,8 +104,11 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
      * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
      * {@code attributeJsonPointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributeJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -127,6 +131,8 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
      * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
      * {@code attributeJsonPointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributeJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttribute of(final ThingId thingId,
             final JsonPointer attributeJsonPointer,
@@ -150,6 +156,8 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
      * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
      * {@link #JSON_ATTRIBUTE} contains an empty pointer.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttribute fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -168,6 +176,8 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
      * {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
      * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
      * {@link #JSON_ATTRIBUTE} contains an empty pointer.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttribute fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<ModifyAttribute>(TYPE, jsonObject).deserialize(() -> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeResponse.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
-import static java.util.Objects.requireNonNull;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.util.Objects;
@@ -34,9 +33,11 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
+import org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException;
 
 /**
  * Response to a {@link ModifyAttribute} command.
@@ -64,12 +65,22 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
     @Nullable private final JsonValue attributeValue;
 
     private ModifyAttributeResponse(final ThingId thingId, final HttpStatusCode statusCode,
-            final JsonPointer attributePointer,
-            @Nullable final JsonValue attributeValue, final DittoHeaders dittoHeaders) {
+            final JsonPointer attributePointer, @Nullable final JsonValue attributeValue,
+            final DittoHeaders dittoHeaders) {
         super(TYPE, statusCode, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
-        this.attributePointer = requireNonNull(attributePointer, "The Attribute Pointer must not be null!");
+        this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
         this.attributeValue = attributeValue;
+    }
+
+    private JsonPointer checkAttributePointer(final JsonPointer attributePointer, final DittoHeaders dittoHeaders) {
+        checkNotNull(attributePointer, "The Attribute Pointer must not be null!");
+        if (attributePointer.isEmpty()) {
+            throw AttributePointerInvalidException.newBuilder(attributePointer)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+        return AttributesModelFactory.validateAttributePointer(attributePointer);
     }
 
     /**
@@ -82,8 +93,13 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @param dittoHeaders the headers of the ThingCommand which caused the new response.
      * @return a command response for a created FeatureProperties.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #created(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #created(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -103,10 +119,13 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @param dittoHeaders the headers of the ThingCommand which caused the new response.
      * @return a command response for a created FeatureProperties.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttributeResponse created(final ThingId thingId, final JsonPointer attributePointer,
-            final JsonValue attributeValue,
-            final DittoHeaders dittoHeaders) {
+            final JsonValue attributeValue, final DittoHeaders dittoHeaders) {
         return new ModifyAttributeResponse(thingId, HttpStatusCode.CREATED, attributePointer, attributeValue,
                 dittoHeaders);
     }
@@ -120,8 +139,13 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @param dittoHeaders the headers of the ThingCommand which caused the new response.
      * @return a command response for a modified FeatureProperties.
      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #modified(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #modified(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -139,6 +163,10 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @param dittoHeaders the headers of the ThingCommand which caused the new response.
      * @return a command response for a modified FeatureProperties.
      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+     * @throws org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException if
+     * {@code attributePointer} is empty.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttributeResponse modified(final ThingId thingId, final JsonPointer attributePointer,
             final DittoHeaders dittoHeaders) {
@@ -155,6 +183,8 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttributeResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -169,6 +199,8 @@ public final class ModifyAttributeResponse extends AbstractCommandResponse<Modif
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyAttributeResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandResponseJsonDeserializer<ModifyAttributeResponse>(TYPE, jsonObject)

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -33,6 +33,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.base.WithFeatureId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -79,13 +80,18 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
         super(TYPE, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkNotNull(propertyPointer, "Property JsonPointer");
+        this.propertyPointer = checkPropertyPointer(propertyPointer);
         this.propertyValue = checkNotNull(propertyValue, "Property Value");
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 propertyValue::getUpperBoundForStringSize,
                 () -> propertyValue.toString().length(),
                 () -> dittoHeaders);
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "Property JsonPointer");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -98,8 +104,11 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
      * @param dittoHeaders the headers of the command.
      * @return a Command for modifying the provided Property.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -119,6 +128,8 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
      * @param dittoHeaders the headers of the command.
      * @return a Command for modifying the provided Property.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyFeatureProperty of(final ThingId thingId, final String featureId,
             final JsonPointer propertyJsonPointer, final JsonValue propertyValue, final DittoHeaders dittoHeaders) {
@@ -138,6 +149,8 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyFeatureProperty fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -154,6 +167,8 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyFeatureProperty fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<ModifyFeatureProperty>(TYPE, jsonObject).deserialize(() -> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyResponse.java
@@ -35,6 +35,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
 
@@ -78,9 +79,13 @@ public final class ModifyFeaturePropertyResponse extends AbstractCommandResponse
         super(TYPE, statusCode, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = requireNonNull(featureId, "The Feature ID must not be null!");
-        this.featurePropertyPointer =
-                requireNonNull(featurePropertyPointer, "The FeatureProperty Pointer must not be null!");
+        this.featurePropertyPointer = checkPropertyPointer(featurePropertyPointer);
         this.featurePropertyValue = featurePropertyValue;
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "The FeatureProperty Pointer must not be null!");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -181,6 +186,8 @@ public final class ModifyFeaturePropertyResponse extends AbstractCommandResponse
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyFeaturePropertyResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -195,6 +202,8 @@ public final class ModifyFeaturePropertyResponse extends AbstractCommandResponse
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static ModifyFeaturePropertyResponse fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttribute.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -62,10 +63,14 @@ public final class RetrieveAttribute extends AbstractCommand<RetrieveAttribute>
 
     private RetrieveAttribute(final JsonPointer attributePointer, final ThingId thingId,
             final DittoHeaders dittoHeaders) {
-
         super(TYPE, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
-        this.attributePointer = checkNotNull(attributePointer, "JSON pointer which attribute to retrieve");
+        this.attributePointer = checkAttributePointer(attributePointer);
+    }
+
+    private JsonPointer checkAttributePointer(final JsonPointer attributePointer) {
+        checkNotNull(attributePointer, "JSON pointer which attribute to retrieve");
+        return AttributesModelFactory.validateAttributePointer(attributePointer);
     }
 
     /**
@@ -77,8 +82,11 @@ public final class RetrieveAttribute extends AbstractCommand<RetrieveAttribute>
      * @return a Command for retrieving a single attribute of the Thing with the {@code thingId} as its ID which is
      * readable from the passed authorization context.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributeJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -97,6 +105,8 @@ public final class RetrieveAttribute extends AbstractCommand<RetrieveAttribute>
      * @return a Command for retrieving a single attribute of the Thing with the {@code thingId} as its ID which is
      * readable from the passed authorization context.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributeJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveAttribute of(final ThingId thingId, final JsonPointer attributeJsonPointer,
             final DittoHeaders dittoHeaders) {
@@ -116,6 +126,8 @@ public final class RetrieveAttribute extends AbstractCommand<RetrieveAttribute>
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveAttribute fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -132,6 +144,8 @@ public final class RetrieveAttribute extends AbstractCommand<RetrieveAttribute>
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveAttribute fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<RetrieveAttribute>(TYPE, jsonObject).deserialize(() -> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeResponse.java
@@ -32,6 +32,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
@@ -69,9 +70,13 @@ public final class RetrieveAttributeResponse extends AbstractCommandResponse<Ret
 
         super(TYPE, statusCode, dittoHeaders);
         this.thingId = checkNotNull(thingId, "thing ID");
-        this.attributePointer = Objects.requireNonNull(attributePointer,
-                "The JSON pointer which attribute to retrieve must not be null!");
+        this.attributePointer = checkAttributePointer(attributePointer);
         this.attributeValue = checkNotNull(attributeValue, "Attribute Value");
+    }
+
+    private JsonPointer checkAttributePointer(final JsonPointer attributePointer) {
+        checkNotNull(attributePointer, "The JSON pointer which attribute to retrieve must not be null!");
+        return AttributesModelFactory.validateAttributePointer(attributePointer);
     }
 
     /**
@@ -83,16 +88,16 @@ public final class RetrieveAttributeResponse extends AbstractCommandResponse<Ret
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
-    public static RetrieveAttributeResponse of(final String thingId,
-            final JsonPointer attributePointer,
-            final JsonValue attributeValue,
-            final DittoHeaders dittoHeaders) {
-
+    public static RetrieveAttributeResponse of(final String thingId, final JsonPointer attributePointer,
+            final JsonValue attributeValue, final DittoHeaders dittoHeaders) {
         return of(ThingId.of(thingId), attributePointer, attributeValue, dittoHeaders);
     }
 
@@ -105,12 +110,11 @@ public final class RetrieveAttributeResponse extends AbstractCommandResponse<Ret
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code attributePointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
-    public static RetrieveAttributeResponse of(final ThingId thingId,
-            final JsonPointer attributePointer,
-            final JsonValue attributeValue,
-            final DittoHeaders dittoHeaders) {
-
+    public static RetrieveAttributeResponse of(final ThingId thingId, final JsonPointer attributePointer,
+            final JsonValue attributeValue, final DittoHeaders dittoHeaders) {
         return new RetrieveAttributeResponse(thingId, attributePointer, attributeValue, HttpStatusCode.OK,
                 dittoHeaders);
     }
@@ -125,6 +129,8 @@ public final class RetrieveAttributeResponse extends AbstractCommandResponse<Ret
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveAttributeResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -139,6 +145,8 @@ public final class RetrieveAttributeResponse extends AbstractCommandResponse<Ret
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of attribute pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveAttributeResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandResponseJsonDeserializer<RetrieveAttributeResponse>(TYPE, jsonObject)

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeatureProperty.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.base.WithFeatureId;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -73,7 +74,12 @@ public final class RetrieveFeatureProperty extends AbstractCommand<RetrieveFeatu
         super(TYPE, dittoHeaders);
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkNotNull(propertyPointer, "Property JsonPointer");
+        this.propertyPointer = checkPropertyPointer(propertyPointer);
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "propertyPointer");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -85,8 +91,11 @@ public final class RetrieveFeatureProperty extends AbstractCommand<RetrieveFeatu
      * @param dittoHeaders the headers of the command.
      * @return a Command for retrieving the Property at the specified Pointer.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -107,6 +116,8 @@ public final class RetrieveFeatureProperty extends AbstractCommand<RetrieveFeatu
      * @param dittoHeaders the headers of the command.
      * @return a Command for retrieving the Property at the specified Pointer.
      * @throws NullPointerException if any argument but {@code thingId} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code propertyJsonPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeatureProperty of(final ThingId thingId,
             final String featureId,
@@ -128,6 +139,8 @@ public final class RetrieveFeatureProperty extends AbstractCommand<RetrieveFeatu
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeatureProperty fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
         return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
@@ -144,6 +157,8 @@ public final class RetrieveFeatureProperty extends AbstractCommand<RetrieveFeatu
      * format.
      * @throws org.eclipse.ditto.model.things.ThingIdInvalidException if the parsed thing ID did not comply to {@link
      * org.eclipse.ditto.model.base.entity.id.RegexPatterns#ID_REGEX}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeatureProperty fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new CommandJsonDeserializer<RetrieveFeatureProperty>(TYPE, jsonObject).deserialize(() -> {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyResponse.java
@@ -33,6 +33,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
 
@@ -72,8 +73,13 @@ public final class RetrieveFeaturePropertyResponse extends AbstractCommandRespon
         super(TYPE, statusCode, dittoHeaders);
         this.thingId = checkNotNull(thingId, "thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkNotNull(propertyPointer, "Property Pointer");
+        this.propertyPointer = checkPropertyPointer(propertyPointer);
         this.propertyValue = checkNotNull(propertyValue, "Property Value");
+    }
+
+    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
+        checkNotNull(propertyPointer, "Property Pointer");
+        return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
     /**
@@ -86,8 +92,11 @@ public final class RetrieveFeaturePropertyResponse extends AbstractCommandRespon
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code featurePropertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @deprecated Thing ID is now typed. Use
-     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer, org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
+     * {@link #of(org.eclipse.ditto.model.things.ThingId, String, org.eclipse.ditto.json.JsonPointer,
+     * org.eclipse.ditto.json.JsonValue, org.eclipse.ditto.model.base.headers.DittoHeaders)}
      * instead.
      */
     @Deprecated
@@ -108,6 +117,8 @@ public final class RetrieveFeaturePropertyResponse extends AbstractCommandRespon
      * @param dittoHeaders the headers of the preceding command.
      * @return the response.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of {@code featurePropertyPointer} are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeaturePropertyResponse of(final ThingId thingId, final String featureId,
             final JsonPointer featurePropertyPointer,
@@ -126,6 +137,8 @@ public final class RetrieveFeaturePropertyResponse extends AbstractCommandRespon
      * @throws IllegalArgumentException if {@code jsonString} is empty.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeaturePropertyResponse fromJson(final String jsonString,
             final DittoHeaders dittoHeaders) {
@@ -141,6 +154,8 @@ public final class RetrieveFeaturePropertyResponse extends AbstractCommandRespon
      * @throws NullPointerException if {@code jsonObject} is {@code null}.
      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
      * format.
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if keys of property pointer are not valid
+     * according to pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      */
     public static RetrieveFeaturePropertyResponse fromJson(final JsonObject jsonObject,
             final DittoHeaders dittoHeaders) {

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/TestConstants.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/TestConstants.java
@@ -505,4 +505,11 @@ public final class TestConstants {
         }
     }
 
+    public static class Pointer {
+
+        public static final JsonPointer EMPTY_JSON_POINTER = JsonFactory.emptyPointer();
+        public static final JsonPointer VALID_JSON_POINTER = JsonFactory.newPointer("properties/foo");
+        public static final JsonPointer INVALID_JSON_POINTER = JsonFactory.newPointer("key1/äöü/foo");
+    }
+
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponseTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.EMPTY_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -27,6 +29,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
+import org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -35,6 +38,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  * Unit test for {@link DeleteAttributeResponse}.
  */
 public final class DeleteAttributeResponseTest {
+
+    private static final JsonPointer INVALID_JSON_POINTER = JsonFactory.newPointer("key1/äöü/foo");
 
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommandResponse.JsonFields.TYPE, DeleteAttributeResponse.TYPE)
@@ -51,14 +56,12 @@ public final class DeleteAttributeResponseTest {
                 provided(JsonPointer.class, JsonValue.class, ThingId.class).areAlsoImmutable());
     }
 
-
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(DeleteAttributeResponse.class)
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -70,7 +73,6 @@ public final class DeleteAttributeResponseTest {
         assertThat(actualJsonUpdated).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final DeleteAttributeResponse underTest = DeleteAttributeResponse.fromJson(KNOWN_JSON, DittoHeaders.empty());
@@ -78,4 +80,14 @@ public final class DeleteAttributeResponseTest {
         assertThat(underTest).isNotNull();
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceWithInvalidArguments() {
+        DeleteAttributeResponse.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = AttributePointerInvalidException.class)
+    public void createInstanceWithEmptyPointer() {
+        DeleteAttributeResponse.of(TestConstants.Thing.THING_ID, EMPTY_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeResponseTest.java
@@ -39,8 +39,6 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class DeleteAttributeResponseTest {
 
-    private static final JsonPointer INVALID_JSON_POINTER = JsonFactory.newPointer("key1/äöü/foo");
-
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommandResponse.JsonFields.TYPE, DeleteAttributeResponse.TYPE)
             .set(ThingCommandResponse.JsonFields.STATUS, HttpStatusCode.NO_CONTENT.toInt())
@@ -82,7 +80,7 @@ public final class DeleteAttributeResponseTest {
 
     @Test(expected = JsonKeyInvalidException.class)
     public void createInstanceWithInvalidArguments() {
-        DeleteAttributeResponse.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER,
+        DeleteAttributeResponse.of(TestConstants.Thing.THING_ID, TestConstants.Pointer.INVALID_JSON_POINTER,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeTest.java
@@ -37,13 +37,10 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public final class DeleteAttributeTest {
 
-    private static final JsonPointer KNOWN_JSON_POINTER = JsonFactory.newPointer("key1");
-    private static final JsonPointer INVALID_JSON_POINTER = JsonFactory.newPointer("key1/äöü/foo");
-
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommand.JsonFields.TYPE, DeleteAttribute.TYPE)
             .set(ThingCommand.JsonFields.JSON_THING_ID, TestConstants.Thing.THING_ID.toString())
-            .set(DeleteAttribute.JSON_ATTRIBUTE, KNOWN_JSON_POINTER.toString())
+            .set(DeleteAttribute.JSON_ATTRIBUTE, TestConstants.Pointer.VALID_JSON_POINTER.toString())
             .build();
 
 
@@ -63,12 +60,12 @@ public final class DeleteAttributeTest {
 
     @Test(expected = ThingIdInvalidException.class)
     public void tryToCreateInstanceWithNullThingIdString() {
-        DeleteAttribute.of((String) null, KNOWN_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+        DeleteAttribute.of((String) null, TestConstants.Pointer.VALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullThingId() {
-        DeleteAttribute.of((ThingId) null, KNOWN_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+        DeleteAttribute.of((ThingId) null, TestConstants.Pointer.VALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
 
@@ -80,15 +77,15 @@ public final class DeleteAttributeTest {
     @Test
     public void createInstanceWithValidArguments() {
         final DeleteAttribute underTest = DeleteAttribute.of(TestConstants.Thing.THING_ID,
-                KNOWN_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+                TestConstants.Pointer.VALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
 
         assertThat(underTest).isNotNull();
-        assertThat(underTest.getAttributePointer()).isEqualTo(KNOWN_JSON_POINTER);
+        assertThat(underTest.getAttributePointer()).isEqualTo(TestConstants.Pointer.VALID_JSON_POINTER);
     }
 
     @Test(expected = JsonKeyInvalidException.class)
     public void createInstanceWithInvalidArguments() {
-        DeleteAttribute.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+        DeleteAttribute.of(TestConstants.Thing.THING_ID, TestConstants.Pointer.INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
     @Test(expected = AttributePointerInvalidException.class)
@@ -99,7 +96,7 @@ public final class DeleteAttributeTest {
     @Test
     public void toJsonReturnsExpected() {
         final DeleteAttribute underTest = DeleteAttribute.of(TestConstants.Thing.THING_ID,
-                KNOWN_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+                TestConstants.Pointer.VALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
         final JsonObject actualJson = underTest.toJson(FieldType.regularOrSpecial());
 
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
@@ -112,7 +109,7 @@ public final class DeleteAttributeTest {
 
         assertThat(underTest).isNotNull();
         assertThat((CharSequence) underTest.getEntityId()).isEqualTo(TestConstants.Thing.THING_ID);
-        assertThat(underTest.getAttributePointer()).isEqualTo(KNOWN_JSON_POINTER);
+        assertThat(underTest.getAttributePointer()).isEqualTo(TestConstants.Pointer.VALID_JSON_POINTER);
     }
 
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteAttributeTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.EMPTY_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.json.FieldType;
@@ -25,6 +27,7 @@ import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommand;
+import org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -35,6 +38,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class DeleteAttributeTest {
 
     private static final JsonPointer KNOWN_JSON_POINTER = JsonFactory.newPointer("key1");
+    private static final JsonPointer INVALID_JSON_POINTER = JsonFactory.newPointer("key1/äöü/foo");
 
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommand.JsonFields.TYPE, DeleteAttribute.TYPE)
@@ -73,7 +77,6 @@ public final class DeleteAttributeTest {
         DeleteAttribute.of(TestConstants.Thing.THING_ID, null, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void createInstanceWithValidArguments() {
         final DeleteAttribute underTest = DeleteAttribute.of(TestConstants.Thing.THING_ID,
@@ -83,6 +86,15 @@ public final class DeleteAttributeTest {
         assertThat(underTest.getAttributePointer()).isEqualTo(KNOWN_JSON_POINTER);
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceWithInvalidArguments() {
+        DeleteAttribute.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = AttributePointerInvalidException.class)
+    public void createInstanceWithEmptyPointer() {
+        DeleteAttribute.of(TestConstants.Thing.THING_ID, EMPTY_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 
     @Test
     public void toJsonReturnsExpected() {
@@ -92,7 +104,6 @@ public final class DeleteAttributeTest {
 
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
-
 
     @Test
     public void createInstanceFromValidJson() {

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyResponseTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
@@ -52,14 +54,12 @@ public final class DeleteFeaturePropertyResponseTest {
                 provided(JsonPointer.class, ThingId.class).isAlsoImmutable());
     }
 
-
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(DeleteFeaturePropertyResponse.class)
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -71,7 +71,6 @@ public final class DeleteFeaturePropertyResponseTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final DeleteFeaturePropertyResponse underTest =
@@ -80,4 +79,9 @@ public final class DeleteFeaturePropertyResponseTest {
         assertThat(underTest).isNotNull();
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceWithInvalidArguments() {
+        DeleteFeaturePropertyResponse.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeaturePropertyTest.java
@@ -18,6 +18,7 @@ import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstance
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -36,6 +37,8 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class DeleteFeaturePropertyTest {
 
     private static final JsonPointer PROPERTY_JSON_POINTER = JsonFactory.newPointer("properties/target_year_1");
+    private static final JsonPointer INVALID_PROPERTY_JSON_POINTER = JsonFactory.newPointer("properties/target_year_1" +
+            "/füü/bar");
 
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommand.JsonFields.TYPE, DeleteFeatureProperty.TYPE)
@@ -73,7 +76,6 @@ public final class DeleteFeaturePropertyTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullFeatureId() {
         DeleteFeatureProperty.of(TestConstants.Thing.THING_ID, null, PROPERTY_JSON_POINTER,
@@ -87,7 +89,6 @@ public final class DeleteFeaturePropertyTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void createInstanceWithValidArguments() {
         final DeleteFeatureProperty underTest = DeleteFeatureProperty.of(TestConstants.Thing.THING_ID,
@@ -96,6 +97,12 @@ public final class DeleteFeaturePropertyTest {
         assertThat(underTest).isNotNull();
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceWithInvalidArgument() {
+        DeleteFeatureProperty.of(TestConstants.Thing.THING_ID,
+                TestConstants.Feature.FLUX_CAPACITOR_ID, INVALID_PROPERTY_JSON_POINTER,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
 
     @Test
     public void toJsonReturnsExpected() {
@@ -105,7 +112,6 @@ public final class DeleteFeaturePropertyTest {
 
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
-
 
     @Test
     public void createInstanceFromValidJson() {

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeatureResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/DeleteFeatureResponseTest.java
@@ -41,7 +41,6 @@ public final class DeleteFeatureResponseTest {
             .set(DeleteFeatureResponse.JSON_FEATURE_ID, TestConstants.Feature.FLUX_CAPACITOR_ID)
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(DeleteFeatureResponse.class,
@@ -49,14 +48,12 @@ public final class DeleteFeatureResponseTest {
                 provided(Feature.class, ThingId.class).isAlsoImmutable());
     }
 
-
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(DeleteFeatureResponse.class)
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -67,7 +64,6 @@ public final class DeleteFeatureResponseTest {
 
         assertThat(actualJsonUpdated).isEqualTo(KNOWN_JSON);
     }
-
 
     @Test
     public void createInstanceFromValidJson() {

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeResponseTest.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.EMPTY_JSON_POINTER;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -26,6 +29,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
+import org.eclipse.ditto.signals.commands.things.exceptions.AttributePointerInvalidException;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -50,7 +54,6 @@ public class ModifyAttributeResponseTest {
             .set(ModifyAttributeResponse.JSON_ATTRIBUTE, TestConstants.Thing.LOCATION_ATTRIBUTE_POINTER.toString())
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(ModifyAttributeResponse.class,
@@ -58,14 +61,12 @@ public class ModifyAttributeResponseTest {
                 provided(JsonValue.class, JsonPointer.class, ThingId.class).isAlsoImmutable());
     }
 
-
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(ModifyAttributeResponse.class)
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -86,7 +87,6 @@ public class ModifyAttributeResponseTest {
         assertThat(actualJsonUpdated).isEqualTo(KNOWN_JSON_UPDATED);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final ModifyAttributeResponse underTestCreated =
@@ -102,4 +102,15 @@ public class ModifyAttributeResponseTest {
         assertThat(underTestUpdated.getAttributeValue()).isEmpty();
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithValidArguments() {
+        ModifyAttributeResponse.modified(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = AttributePointerInvalidException.class)
+    public void createInstanceWithEmptyPointer() {
+        ModifyAttributeResponse.modified(TestConstants.Thing.THING_ID, EMPTY_JSON_POINTER,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
@@ -14,12 +14,16 @@ package org.eclipse.ditto.signals.commands.things.modify;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.EMPTY_JSON_POINTER;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.VALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -93,9 +97,21 @@ public final class ModifyAttributeTest {
                 .withNoCause();
     }
 
-    @Test
+    @Test()
     public void tryToCreateInstanceWithValidArguments() {
-        ModifyAttribute.of(TestConstants.Thing.THING_ID, KNOWN_JSON_POINTER, KNOWN_ATTRIBUTE,
+        ModifyAttribute.of(TestConstants.Thing.THING_ID, VALID_JSON_POINTER, KNOWN_ATTRIBUTE,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithInvalidAttributePointer() {
+        ModifyAttribute.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER, KNOWN_ATTRIBUTE,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = AttributePointerInvalidException.class)
+    public void createInstanceWithEmptyPointer() {
+        ModifyAttribute.of(TestConstants.Thing.THING_ID, EMPTY_JSON_POINTER, KNOWN_ATTRIBUTE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributesTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributesTest.java
@@ -20,7 +20,9 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.things.Attributes;
@@ -70,7 +72,6 @@ public final class ModifyAttributesTest {
         ModifyAttributes.of(TestConstants.Thing.THING_ID, null, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void toJsonReturnsExpected() {
         final ModifyAttributes underTest = ModifyAttributes.of(TestConstants.Thing.THING_ID,
@@ -80,7 +81,6 @@ public final class ModifyAttributesTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final ModifyAttributes underTest =
@@ -89,6 +89,18 @@ public final class ModifyAttributesTest {
         assertThat(underTest).isNotNull();
         assertThat((CharSequence) underTest.getEntityId()).isEqualTo(TestConstants.Thing.THING_ID);
         Assertions.assertThat(underTest.getAttributes()).isEqualTo(TestConstants.Thing.ATTRIBUTES);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidAttributePointer() {
+
+        final Attributes attributesWithInvalidPointer =
+                TestConstants.Thing.ATTRIBUTES.toBuilder().set("valid", JsonFactory.newObjectBuilder().set("invälid",
+                        JsonValue.of(42)).build()).build();
+
+        ModifyAttributes.fromJson(KNOWN_JSON.toBuilder()
+                .set(ModifyAttributes.JSON_ATTRIBUTES, attributesWithInvalidPointer)
+                .toString(), TestConstants.EMPTY_DITTO_HEADERS);
     }
 
     @Test
@@ -104,7 +116,7 @@ public final class ModifyAttributesTest {
     @Test
     public void modifyTooLargeAttributes() {
         final StringBuilder sb = new StringBuilder();
-        for(int i=0; i<TestConstants.THING_SIZE_LIMIT_BYTES; i++) {
+        for (int i = 0; i < TestConstants.THING_SIZE_LIMIT_BYTES; i++) {
             sb.append('a');
         }
 

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyResponseTest.java
@@ -12,12 +12,15 @@
  */
 package org.eclipse.ditto.signals.commands.things.modify;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.VALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -54,7 +57,6 @@ public class ModifyFeaturePropertyResponseTest {
                     TestConstants.Feature.FLUX_CAPACITOR_PROPERTY_POINTER.toString())
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(ModifyFeaturePropertyResponse.class,
@@ -62,14 +64,12 @@ public class ModifyFeaturePropertyResponseTest {
                 provided(JsonValue.class, JsonPointer.class, ThingId.class).isAlsoImmutable());
     }
 
-
     @Test
     public void testHashCodeAndEquals() {
         EqualsVerifier.forClass(ModifyFeaturePropertyResponse.class)
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -90,7 +90,6 @@ public class ModifyFeaturePropertyResponseTest {
         assertThat(actualJsonUpdated).isEqualTo(KNOWN_JSON_UPDATED);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final ModifyFeaturePropertyResponse underTestCreated =
@@ -105,5 +104,17 @@ public class ModifyFeaturePropertyResponseTest {
 
         assertThat(underTestUpdated).isNotNull();
         assertThat(underTestUpdated.getFeaturePropertyValue()).isEmpty();
+    }
+
+    @Test
+    public void tryToCreateInstanceWithValidArguments() {
+        ModifyFeaturePropertyResponse.modified(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                VALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithInvalidArguments() {
+        ModifyFeaturePropertyResponse.modified(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
@@ -13,12 +13,14 @@
 package org.eclipse.ditto.signals.commands.things.modify;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -70,14 +72,16 @@ public final class ModifyFeaturePropertyTest {
 
     @Test(expected = ThingIdInvalidException.class)
     public void tryToCreateInstanceWithNullThingIdString() {
-        ModifyFeatureProperty.of((String) null, TestConstants.Feature.FLUX_CAPACITOR_ID, PROPERTY_JSON_POINTER, PROPERTY_VALUE,
+        ModifyFeatureProperty.of((String) null, TestConstants.Feature.FLUX_CAPACITOR_ID, PROPERTY_JSON_POINTER,
+                PROPERTY_VALUE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
 
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullThingId() {
-        ModifyFeatureProperty.of((ThingId) null, TestConstants.Feature.FLUX_CAPACITOR_ID, PROPERTY_JSON_POINTER, PROPERTY_VALUE,
+        ModifyFeatureProperty.of((ThingId) null, TestConstants.Feature.FLUX_CAPACITOR_ID, PROPERTY_JSON_POINTER,
+                PROPERTY_VALUE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
@@ -115,9 +119,28 @@ public final class ModifyFeaturePropertyTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
+    @Test
+    public void tryToCreateInstanceWithValidArguments() {
+        ModifyFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                PROPERTY_JSON_POINTER, PROPERTY_VALUE, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithInvalidArguments() {
+        ModifyFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                INVALID_JSON_POINTER, PROPERTY_VALUE, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromValidJson() {
+        final JsonObject invalidJson = KNOWN_JSON.toBuilder()
+                .set(ModifyFeatureProperty.JSON_PROPERTY, INVALID_JSON_POINTER.toString()).build();
+
+        ModifyFeatureProperty.fromJson(invalidJson.toString(), TestConstants.EMPTY_DITTO_HEADERS);
+    }
 
     @Test
-    public void createInstanceFromValidJson() {
+    public void createInstanceFromJsonWithInvalidPropertyPath() {
         final ModifyFeatureProperty underTest =
                 ModifyFeatureProperty.fromJson(KNOWN_JSON.toString(), TestConstants.EMPTY_DITTO_HEADERS);
 
@@ -131,7 +154,7 @@ public final class ModifyFeaturePropertyTest {
     @Test
     public void modifyTooLargeFeatureProperty() {
         final StringBuilder sb = new StringBuilder();
-        for(int i=0; i<TestConstants.THING_SIZE_LIMIT_BYTES; i++) {
+        for (int i = 0; i < TestConstants.THING_SIZE_LIMIT_BYTES; i++) {
             sb.append('a');
         }
         sb.append('b');

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeResponseTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.query;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -43,13 +45,11 @@ public class RetrieveAttributeResponseTest {
             .set(RetrieveAttributeResponse.JSON_VALUE, TestConstants.Thing.LOCATION_ATTRIBUTE_VALUE)
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(RetrieveAttributeResponse.class, areImmutable(),
                 provided(JsonPointer.class, JsonValue.class, ThingId.class).areAlsoImmutable());
     }
-
 
     @Test
     public void testHashCodeAndEquals() {
@@ -58,13 +58,11 @@ public class RetrieveAttributeResponseTest {
                 .verify();
     }
 
-
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullAttribute() {
         RetrieveAttributeResponse.of(TestConstants.Thing.THING_ID, TestConstants.Thing.LOCATION_ATTRIBUTE_POINTER, null,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -77,7 +75,6 @@ public class RetrieveAttributeResponseTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final RetrieveAttributeResponse underTest =
@@ -87,4 +84,17 @@ public class RetrieveAttributeResponseTest {
         assertThat(underTest.getAttributeValue()).isEqualTo(TestConstants.Thing.LOCATION_ATTRIBUTE_VALUE);
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJson() {
+        final JsonObject invalidJson = KNOWN_JSON.toBuilder()
+                .set(RetrieveAttribute.JSON_ATTRIBUTE, INVALID_JSON_POINTER.toString())
+                .build();
+        RetrieveAttributeResponse.fromJson(invalidJson, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidArguments() {
+        RetrieveAttributeResponse.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER,
+                TestConstants.Thing.LOCATION_ATTRIBUTE_VALUE, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveAttributeTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.query;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.json.FieldType;
@@ -42,13 +44,11 @@ public final class RetrieveAttributeTest {
             .set(RetrieveAttribute.JSON_ATTRIBUTE, KNOWN_JSON_POINTER.toString())
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(RetrieveAttribute.class, areImmutable(),
                 provided(JsonPointer.class, ThingId.class).isAlsoImmutable());
     }
-
 
     @Test
     public void testHashCodeAndEquals() {
@@ -56,7 +56,6 @@ public final class RetrieveAttributeTest {
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test(expected = ThingIdInvalidException.class)
     public void tryToCreateInstanceWithNullThingIdString() {
@@ -74,12 +73,10 @@ public final class RetrieveAttributeTest {
         RetrieveAttribute.of(TestConstants.Thing.THING_ID, null, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void tryToCreateInstanceWithValidArguments() {
         RetrieveAttribute.of(TestConstants.Thing.THING_ID, KNOWN_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -91,7 +88,6 @@ public final class RetrieveAttributeTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final RetrieveAttribute underTest =
@@ -102,4 +98,16 @@ public final class RetrieveAttributeTest {
         assertThat(underTest.getAttributePointer()).isEqualTo(KNOWN_JSON_POINTER);
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJson() {
+        final JsonObject invalidJson = KNOWN_JSON.toBuilder()
+                .set(RetrieveAttribute.JSON_ATTRIBUTE, INVALID_JSON_POINTER.toString())
+                .build();
+        RetrieveAttribute.fromJson(invalidJson, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidArguments() {
+        RetrieveAttribute.of(TestConstants.Thing.THING_ID, INVALID_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyResponseTest.java
@@ -12,12 +12,14 @@
  */
 package org.eclipse.ditto.signals.commands.things.query;
 
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
@@ -45,13 +47,11 @@ public class RetrieveFeaturePropertyResponseTest {
             .set(RetrieveFeaturePropertyResponse.JSON_VALUE, TestConstants.Feature.FLUX_CAPACITOR_PROPERTY_VALUE)
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(RetrieveFeaturePropertyResponse.class, areImmutable(),
                 provided(JsonPointer.class, JsonValue.class, ThingId.class).areAlsoImmutable());
     }
-
 
     @Test
     public void testHashCodeAndEquals() {
@@ -60,13 +60,11 @@ public class RetrieveFeaturePropertyResponseTest {
                 .verify();
     }
 
-
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullFeatureProperty() {
         RetrieveFeaturePropertyResponse.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
                 TestConstants.Feature.FLUX_CAPACITOR_PROPERTY_POINTER, null, TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -79,7 +77,6 @@ public class RetrieveFeaturePropertyResponseTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final RetrieveFeaturePropertyResponse underTest =
@@ -89,4 +86,18 @@ public class RetrieveFeaturePropertyResponseTest {
         assertThat(underTest.getPropertyValue()).isEqualTo(TestConstants.Feature.FLUX_CAPACITOR_PROPERTY_VALUE);
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithInvalidArguments() {
+        RetrieveFeaturePropertyResponse.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                INVALID_JSON_POINTER, TestConstants.Feature.FLUX_CAPACITOR_PROPERTY_VALUE,
+                TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJson() {
+        final JsonObject invalidJson = KNOWN_JSON.toBuilder()
+                .set(RetrieveFeatureProperty.JSON_PROPERTY_JSON_POINTER, INVALID_JSON_POINTER.toString())
+                .build();
+        RetrieveFeaturePropertyResponse.fromJson(invalidJson, TestConstants.EMPTY_DITTO_HEADERS);
+    }
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeaturePropertyTest.java
@@ -19,6 +19,7 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonKeyInvalidException;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.json.FieldType;
@@ -39,6 +40,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class RetrieveFeaturePropertyTest {
 
     private static final JsonPointer PROPERTY_JSON_POINTER = JsonFactory.newPointer("properties/foo");
+    private static final JsonPointer INVALID_PROPERTY_JSON_POINTER = JsonFactory.newPointer("properties/bar/füü");
 
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(ThingCommand.JsonFields.TYPE, RetrieveFeatureProperty.TYPE)
@@ -62,7 +64,6 @@ public final class RetrieveFeaturePropertyTest {
                 .withRedefinedSuperclass()
                 .verify();
     }
-
 
     @Test(expected = ThingIdInvalidException.class)
     public void tryToCreateInstanceWithNullThingIdString() {
@@ -90,14 +91,11 @@ public final class RetrieveFeaturePropertyTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void tryToCreateInstanceWithValidArguments() {
         RetrieveFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
-                PROPERTY_JSON_POINTER,
-                TestConstants.EMPTY_DITTO_HEADERS);
+                PROPERTY_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test
     public void jsonSerializationWorksAsExpected() {
@@ -109,7 +107,6 @@ public final class RetrieveFeaturePropertyTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final RetrieveFeatureProperty underTest =
@@ -118,6 +115,20 @@ public final class RetrieveFeaturePropertyTest {
         assertThat(underTest).isNotNull();
         assertThat((CharSequence) underTest.getEntityId()).isEqualTo(TestConstants.Thing.THING_ID);
         assertThat(underTest.getFeatureId()).isEqualTo(TestConstants.Feature.FLUX_CAPACITOR_ID);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void tryToCreateInstanceWithInvalidArguments() {
+        RetrieveFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                INVALID_PROPERTY_JSON_POINTER, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJson() {
+        final JsonObject invalidJson = KNOWN_JSON.toBuilder()
+                .set(RetrieveFeatureProperty.JSON_PROPERTY_JSON_POINTER, INVALID_PROPERTY_JSON_POINTER.toString())
+                .build();
+        RetrieveFeatureProperty.fromJson(invalidJson, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
 }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeatureResponseTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/query/RetrieveFeatureResponseTest.java
@@ -23,8 +23,8 @@ import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.things.Feature;
-import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.things.TestConstants;
 import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
 import org.junit.Test;
@@ -44,13 +44,11 @@ public final class RetrieveFeatureResponseTest {
             .set(RetrieveFeatureResponse.JSON_FEATURE, TestConstants.Feature.FLUX_CAPACITOR.toJson())
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(RetrieveFeatureResponse.class, areImmutable(),
                 provided(Feature.class, ThingId.class).isAlsoImmutable());
     }
-
 
     @Test
     public void testHashCodeAndEquals() {
@@ -59,12 +57,10 @@ public final class RetrieveFeatureResponseTest {
                 .verify();
     }
 
-
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullFeature() {
         RetrieveFeatureResponse.of(TestConstants.Thing.THING_ID, null, TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test
     public void toJsonReturnsExpected() {
@@ -76,7 +72,6 @@ public final class RetrieveFeatureResponseTest {
         assertThat(actualJson).isEqualTo(KNOWN_JSON);
     }
 
-
     @Test
     public void createInstanceFromValidJson() {
         final RetrieveFeatureResponse underTest =
@@ -85,7 +80,6 @@ public final class RetrieveFeatureResponseTest {
         assertThat(underTest).isNotNull();
         assertThat(underTest.getFeature()).isEqualTo(TestConstants.Feature.FLUX_CAPACITOR);
     }
-
 
     @Test
     public void createInstanceFromJsonWithNullFeature() {


### PR DESCRIPTION
Some commands e.g. ModifyAttribute take a JsonPointer as an constructor argument. These pointers must be validated to fail early in case they contain illegal characters.