### PR TITLE
Deleted Kafka compression to support publishing to older Kafka brokers

### DIFF
--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -171,9 +171,6 @@ ditto {
           # This avoids repeatedly connecting to a host in a tight loop.
           reconnect.backoff.ms = 500 # default: 50
 
-          # Compression type for producer
-          compression.type = "gzip" # default: "none"
-
           # Request acknowledgement
           acks = "1"
 


### PR DESCRIPTION
Deletes Kafka compression to prevent connections to Kafka brokers, not supporting compression, to fail with message format version invalid exception.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>