### PR TITLE
Allow configuring max pool size

### DIFF
--- a/documentation/src/main/resources/pages/ditto/release_notes_120.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_120.md
@@ -19,3 +19,11 @@ permalink: release_notes_120.html
 * in `gateway.conf`: `ditto.gateway.http.redirect-to-https-blocklist-pattern`
 * in `ditto-cluster.conf`: `ditto.cluster.cluster-status-roles-blocklist`
 * in `ditto-protocol.conf`: `ditto.protocol.blocklist`
+
+### added config key for setting the max pool size for connections
+The pool is used for mapping inbound and outbound messages in the connectivity service. It is configured
+per connection in the attribute `processorPoolSize`.
+
+To provide a meaningful max per-connection pool size, you can now configure a service-wide maximum
+in the connectivity service using the key `ditto.connectivity.mapping.max-pool-size` (or its corresponding
+environment variable `CONNECTIVITY_MESSAGE_MAPPING_MAX_POOL_SIZE`).

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMappingConfig.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMappingConfig.java
@@ -33,12 +33,14 @@ public final class DefaultMappingConfig implements MappingConfig {
 
     private final int bufferSize;
     private final int parallelism;
+    private final int maxPoolSize;
     private final JavaScriptConfig javaScriptConfig;
     private final MapperLimitsConfig mapperLimitsConfig;
 
     private DefaultMappingConfig(final ScopedConfig config) {
         bufferSize = config.getInt(MappingConfigValue.BUFFER_SIZE.getConfigPath());
         parallelism = config.getInt(MappingConfigValue.PARALLELISM.getConfigPath());
+        maxPoolSize = config.getInt(MappingConfigValue.MAX_POOL_SIZE.getConfigPath());
         mapperLimitsConfig = DefaultMapperLimitsConfig.of(config);
         javaScriptConfig = DefaultJavaScriptConfig.of(config);
     }
@@ -68,6 +70,11 @@ public final class DefaultMappingConfig implements MappingConfig {
     }
 
     @Override
+    public int getMaxPoolSize() {
+        return maxPoolSize;
+    }
+
+    @Override
     public JavaScriptConfig getJavaScriptConfig() {
         return javaScriptConfig;
     }
@@ -88,13 +95,14 @@ public final class DefaultMappingConfig implements MappingConfig {
         final DefaultMappingConfig that = (DefaultMappingConfig) o;
         return bufferSize == that.bufferSize &&
                 parallelism == that.parallelism &&
+                maxPoolSize == that.maxPoolSize &&
                 Objects.equals(javaScriptConfig, that.javaScriptConfig) &&
                 Objects.equals(mapperLimitsConfig, that.mapperLimitsConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bufferSize, parallelism, javaScriptConfig, mapperLimitsConfig);
+        return Objects.hash(bufferSize, parallelism, maxPoolSize, javaScriptConfig, mapperLimitsConfig);
     }
 
     @Override
@@ -102,6 +110,7 @@ public final class DefaultMappingConfig implements MappingConfig {
         return getClass().getSimpleName() + " [" +
                 "bufferSize=" + bufferSize +
                 ", parallelism=" + parallelism +
+                ", maxPoolSize=" + maxPoolSize +
                 ", javaScriptConfig=" + javaScriptConfig +
                 ", mapperLimitsConfig=" + mapperLimitsConfig +
                 "]";

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MappingConfig.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MappingConfig.java
@@ -32,12 +32,18 @@ public interface MappingConfig {
     int getBufferSize();
 
     /**
-     * Returns the parallelism used for processing messages in parallel in message mapping processor actor responsible
-     * for doing the enrichment.
+     * Returns the parallelism used for enriching messages in parallel in message mapping processor actor.
      *
      * @return the parallelism.
      */
     int getParallelism();
+
+    /**
+     * Returns the max pool size (parallelism) for mapping inbound and outbound messages. This limits the user-settable
+     * configuration {@link org.eclipse.ditto.model.connectivity.Connection#getProcessorPoolSize()}.
+     * @return the max pool size.
+     */
+    int getMaxPoolSize();
 
     /**
      * Returns the config of the JavaScript message mapping.
@@ -65,9 +71,14 @@ public interface MappingConfig {
         BUFFER_SIZE("buffer-size", 500),
 
         /**
-         * The parallelism used for processing messages in parallel in message mapping processor actor.
+         * The parallelism used for enriching messages in parallel in message mapping processor actor.
          */
-        PARALLELISM("parallelism", 64);
+        PARALLELISM("parallelism", 64),
+
+        /**
+         * The maximum parallelism used for mapping inbound and outbound messages in mapping processor actor.
+         */
+        MAX_POOL_SIZE("max-pool-size", 5);
 
         private final String path;
         private final Object defaultValue;

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMappingConfigTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/DefaultMappingConfigTest.java
@@ -62,7 +62,7 @@ public final class DefaultMappingConfigTest {
 
         softly.assertThat(underTest.toString())
                 .contains(underTest.getClass().getSimpleName())
-                .contains("javaScriptConfig", "mapperLimitsConfig", "bufferSize", "parallelism");
+                .contains("javaScriptConfig", "mapperLimitsConfig", "bufferSize", "parallelism", "maxPoolSize");
     }
 
     @Test
@@ -76,6 +76,10 @@ public final class DefaultMappingConfigTest {
         softly.assertThat(underTest.getParallelism())
                 .describedAs(MappingConfig.MappingConfigValue.PARALLELISM.getConfigPath())
                 .isEqualTo(67890);
+
+        softly.assertThat(underTest.getMaxPoolSize())
+                .describedAs(MappingConfig.MappingConfigValue.PARALLELISM.getConfigPath())
+                .isEqualTo(37);
     }
 
 }

--- a/services/connectivity/mapping/src/test/resources/mapping-test.conf
+++ b/services/connectivity/mapping/src/test/resources/mapping-test.conf
@@ -4,6 +4,8 @@ mapping {
 
   parallelism = 67890
 
+  max-pool-size = 37
+
   javascript {
     maxScriptSizeBytes = 42000
     maxScriptExecutionTime = 815ms

--- a/services/connectivity/starter/src/main/resources/connectivity.conf
+++ b/services/connectivity/starter/src/main/resources/connectivity.conf
@@ -198,10 +198,15 @@ ditto {
       buffer-size = 100
       buffer-size = ${?CONNECTIVITY_SIGNAL_ENRICHMENT_BUFFER_SIZE}
 
-      # parallelism to use for processing messages in parallel in the message mapping processor actor
+      # parallelism to use for signal enriching a single message in the message mapping processor actor
       # when configured too low, throughput of signal enrichment will be low
       parallelism = 100
       parallelism = ${?CONNECTIVITY_SIGNAL_ENRICHMENT_PARALLELISM}
+
+      # maximum parallelism for mapping incoming and outgoing messages for a connection. This setting limits the
+      # poolSize that users can configure on their connections.
+      max-pool-size = 5
+      max-pool-size = ${?CONNECTIVITY_MESSAGE_MAPPING_MAX_POOL_SIZE}
 
       javascript {
         # the maximum script size in bytes of a mapping script to run

--- a/services/connectivity/util/src/main/java/org/eclipse/ditto/services/connectivity/util/ConnectionLogUtil.java
+++ b/services/connectivity/util/src/main/java/org/eclipse/ditto/services/connectivity/util/ConnectionLogUtil.java
@@ -63,6 +63,15 @@ public final class ConnectionLogUtil {
     }
 
     /**
+     * Removes the connectionId from the "MDC" of the passed {@link DiagnosticLoggingAdapter}.
+     *
+     * @param loggingAdapter the DiagnosticLoggingAdapter to remove the "MDC" from.
+     */
+    public static void removeConnectionId(final DiagnosticLoggingAdapter loggingAdapter) {
+        LogUtil.removeCustomField(loggingAdapter, MDC_CONNECTION_ID);
+    }
+
+    /**
      * Enhances the passed {@link DiagnosticLoggingAdapter} with an "MDC" map entry for the passed {@code connectionId}
      * and the correlation ID (if present).
      *

--- a/services/connectivity/util/src/test/java/org/eclipse/ditto/services/connectivity/util/ConnectionLogUtilTest.java
+++ b/services/connectivity/util/src/test/java/org/eclipse/ditto/services/connectivity/util/ConnectionLogUtilTest.java
@@ -66,6 +66,22 @@ public final class ConnectionLogUtilTest {
     }
 
     @Test
+    public void removeLogWithConnectionId() {
+        final String connectionId = "theConnection";
+        final Map<String, Object> expectedMap = new HashMap<>(DEFAULT_MDC);
+
+        expectedMap.put("connection-id", connectionId);
+
+        ConnectionLogUtil.enhanceLogWithConnectionId(log, connectionId);
+
+        Mockito.verify(log).setMDC(expectedMap);
+
+        ConnectionLogUtil.removeConnectionId(log);
+
+        Mockito.verify(log).setMDC(new HashMap<>(DEFAULT_MDC));
+    }
+
+    @Test
     public void enhanceLogWithCorrelationIdAndConnectionId() {
         final String connectionId = "theConnection";
         final String correlationId = "theCorrelationId";


### PR DESCRIPTION
The pool is used for mapping inbound and outbound messages in the connectivity service. It is configured
per connection in the attribute `processorPoolSize`.