### PR TITLE
Fix that blank `ca` in connection leads to an empty truststore

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
@@ -507,6 +507,10 @@ final class ImmutableConnection implements Connection {
             this.connectionType = checkNotNull(connectionType, "Connection Type");
         }
 
+        private static boolean isBlankOrNull(@Nullable final String toTest) {
+            return null == toTest || toTest.trim().isEmpty();
+        }
+
         @Override
         public ConnectionBuilder id(final ConnectionId id) {
             this.id = checkNotNull(id, "ID");
@@ -527,7 +531,11 @@ final class ImmutableConnection implements Connection {
 
         @Override
         public Builder trustedCertificates(@Nullable final String trustedCertificates) {
-            this.trustedCertificates = trustedCertificates;
+            if (isBlankOrNull(trustedCertificates)) {
+                this.trustedCertificates = null;
+            } else {
+                this.trustedCertificates = trustedCertificates;
+            }
             return this;
         }
 

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
@@ -376,6 +376,27 @@ public final class ImmutableConnectionTest {
     }
 
     @Test
+    public void emptyCertificatesLeadToEmptyOptional() {
+        final Connection underTest = ConnectivityModelFactory.newConnectionBuilder(ID, TYPE, STATUS, URI)
+                .targets(TARGETS)
+                .validateCertificate(true)
+                .trustedCertificates("")
+                .build();
+
+        assertThat(underTest.getTrustedCertificates()).isEmpty();
+    }
+
+    @Test
+    public void emptyCertificatesFromJsonLeadToEmptyOptional() {
+        final JsonObject connectionJsonWithEmptyCa = KNOWN_JSON
+                .set(Connection.JsonFields.VALIDATE_CERTIFICATES, true)
+                .set(Connection.JsonFields.TRUSTED_CERTIFICATES, "");
+        final Connection underTest = ConnectivityModelFactory.connectionFromJson(connectionJsonWithEmptyCa);
+
+        assertThat(underTest.getTrustedCertificates()).isEmpty();
+    }
+
+    @Test
     public void parseUriAsExpected() {
         final ConnectionUri underTest = ConnectionUri.of("amqps://foo:bar@hono.eclipse.org:5671/vhost");
 


### PR DESCRIPTION
Instead of falling back to the JDK truststore, all certificates were rejected. With this PR, a blank `ca` field is handled as if it wouldn't exist.