### PR TITLE
prevent "correlation-id" DittoHeader to be ever empty

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaderDefinition.java
@@ -41,12 +41,12 @@ public enum DittoHeaderDefinition implements HeaderDefinition {
             HeaderValueValidators.getJsonObjectValidator()),
 
     /**
-     * Header definition for correlation Id value.
+     * Header definition for correlation Id value which MUST NOT be empty.
      * <p>
      * Key: {@code "correlation-id"}, Java type: {@link String}.
      * </p>
      */
-    CORRELATION_ID("correlation-id", String.class, true, true, HeaderValueValidators.getNoOpValidator()),
+    CORRELATION_ID("correlation-id", String.class, true, true, HeaderValueValidators.getNonEmptyValidator()),
 
     /**
      * Header definition for schema version value.

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/HeaderValueValidators.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/HeaderValueValidators.java
@@ -45,6 +45,16 @@ public final class HeaderValueValidators {
     }
 
     /**
+     * Returns a validator for checking that a CharSequence was non-empty.
+     *
+     * @return the validator.
+     * @since 1.3.0
+     */
+    public static ValueValidator getNonEmptyValidator() {
+        return NonEmptyValueValidator.getInstance();
+    }
+
+    /**
      * Returns a validator for checking if a CharSequence is an integer value.
      *
      * @return the validator.

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/NonEmptyValueValidator.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/NonEmptyValueValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.headers;
+
+import java.text.MessageFormat;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
+
+/**
+ * This validator parses a CharSequence value and ensures that it was non-empty.
+ * If it was empty, a {@link org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException} is thrown.
+ *
+ * @since 1.3.0
+ */
+@Immutable
+final class NonEmptyValueValidator extends AbstractHeaderValueValidator {
+
+    private static final String MESSAGE_TEMPLATE = "The value of the header ''{0}'' must not be empty.";
+
+    private static final NonEmptyValueValidator INSTANCE = new NonEmptyValueValidator();
+
+    private NonEmptyValueValidator() {
+        super(CharSequence.class::isAssignableFrom);
+    }
+
+    static NonEmptyValueValidator getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    protected void validateValue(final HeaderDefinition definition, final CharSequence value) {
+        if (value.length() < 1) {
+            final String message = MessageFormat.format(MESSAGE_TEMPLATE, definition.getKey());
+            throw DittoHeaderInvalidException.newCustomMessageBuilder(message).build();
+        }
+    }
+
+}

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/DefaultDittoHeadersBuilderTest.java
@@ -147,6 +147,20 @@ public final class DefaultDittoHeadersBuilderTest {
     }
 
     @Test
+    public void buildWithEmptyCorrelationIdThrowsIllegalArgumentException() {
+        DittoBaseAssertions.assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
+                DittoHeaders.newBuilder().correlationId(""));
+    }
+
+    @Test
+    public void buildWithEmptyCorrelationIdFromMapThrowsDittoHeaderInvalidException() {
+        final Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), "");
+        DittoBaseAssertions.assertThatExceptionOfType(DittoHeaderInvalidException.class)
+                .isThrownBy(() -> DittoHeaders.of(headerMap));
+    }
+
+    @Test
     public void jsonRepresentationOfEmptyDittoHeadersIsExpected() {
         final DittoHeaders emptyDittoHeaders = DittoHeaders.empty();
         final JsonObject jsonObject = emptyDittoHeaders.toJson();

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/NonEmptyValueValidatorTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/NonEmptyValueValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.headers;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link NonEmptyValueValidator}.
+ */
+public final class NonEmptyValueValidatorTest {
+
+    private NonEmptyValueValidator underTest;
+
+    @Before
+    public void setUp() {
+        underTest = NonEmptyValueValidator.getInstance();
+    }
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(NonEmptyValueValidator.class, areImmutable());
+    }
+
+    @Test
+    public void tryToAcceptNullDefinition() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> underTest.accept(null, "5"))
+                .withMessage("The definition must not be null!")
+                .withNoCause();
+    }
+
+    @Test
+    public void tryToAcceptNullValue() {
+        final DittoHeaderDefinition headerDefinition = DittoHeaderDefinition.CORRELATION_ID;
+
+        assertThatExceptionOfType(DittoHeaderInvalidException.class)
+                .isThrownBy(() -> underTest.accept(headerDefinition, null))
+                .withMessageContaining("null")
+                .withMessageContaining(headerDefinition.getKey())
+                .withMessageEndingWith("is not a valid String.")
+                .withNoCause();
+    }
+
+    @Test
+    public void acceptValidCharSequence() {
+        assertThatCode(() -> underTest.accept(DittoHeaderDefinition.CORRELATION_ID, "foobar"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void doesNotValidateAsValueIsEmpty() {
+        assertThatExceptionOfType(DittoHeaderInvalidException.class)
+                .isThrownBy(() -> underTest.accept(DittoHeaderDefinition.CORRELATION_ID, ""))
+                .withMessageContaining(DittoHeaderDefinition.CORRELATION_ID.getKey())
+                .withMessageEndingWith("must not be empty.")
+                .withNoCause();
+    }
+
+}


### PR DESCRIPTION
 by validating its value with a new NonEmptyValueValidator
* that ensures that even when the DittoHeaders are being built from a JsonObject or Map, non-emptiness is ensured