### PR TITLE
Enable cross channel live responses

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -299,7 +299,7 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
                 .map(ResponseType::fromName)
                 .filter(Optional::isPresent)
                 .map(Optional::get)
-                .collect(Collectors.toSet());
+                .collect(Collectors.toList()); // toList() to keep original order
     }
 
     @Override

--- a/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfig.java
+++ b/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/DefaultEnforcementConfig.java
@@ -31,10 +31,13 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
 
     private final Duration askTimeout;
     private final int bufferSize;
+    private final boolean globalLiveResponseDispatching;
 
     private DefaultEnforcementConfig(final ConfigWithFallback configWithFallback) {
         askTimeout = configWithFallback.getDuration(EnforcementConfigValue.ASK_TIMEOUT.getConfigPath());
         bufferSize = configWithFallback.getInt(EnforcementConfigValue.BUFFER_SIZE.getConfigPath());
+        globalLiveResponseDispatching =
+                configWithFallback.getBoolean(EnforcementConfigValue.GLOBAL_LIVE_RESPONSE_DISPATCHING.getConfigPath());
     }
 
     /**
@@ -60,6 +63,11 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
     }
 
     @Override
+    public boolean shouldDispatchLiveResponsesGlobally() {
+        return globalLiveResponseDispatching;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -68,12 +76,13 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
             return false;
         }
         final DefaultEnforcementConfig that = (DefaultEnforcementConfig) o;
-        return bufferSize == that.bufferSize && askTimeout.equals(that.askTimeout);
+        return bufferSize == that.bufferSize && askTimeout.equals(that.askTimeout) &&
+                globalLiveResponseDispatching == that.globalLiveResponseDispatching;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(askTimeout, bufferSize);
+        return Objects.hash(askTimeout, bufferSize, globalLiveResponseDispatching);
     }
 
     @Override
@@ -81,6 +90,7 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
         return getClass().getSimpleName() + " [" +
                 "askTimeout=" + askTimeout +
                 ", bufferSize=" + bufferSize +
+                ", globalLiveResponseDispatching=" + globalLiveResponseDispatching +
                 "]";
     }
 

--- a/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/EnforcementConfig.java
+++ b/services/concierge/common/src/main/java/org/eclipse/ditto/services/concierge/common/EnforcementConfig.java
@@ -39,6 +39,13 @@ public interface EnforcementConfig {
     int getBufferSize();
 
     /**
+     * Returns whether live responses from channels other than their subscribers should be dispatched.
+     *
+     * @return whether global live response dispatching is enabled.
+     */
+    boolean shouldDispatchLiveResponsesGlobally();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code EnforcementConfig}.
      */
@@ -52,12 +59,17 @@ public interface EnforcementConfig {
         /**
          * The buffer size used for the queue in the enforcer actor.
          */
-        BUFFER_SIZE("buffer-size", 1_000);
+        BUFFER_SIZE("buffer-size", 1_000),
+
+        /**
+         * Whether to enable dispatching live responses from channels other than the subscribers.
+         */
+        GLOBAL_LIVE_RESPONSE_DISPATCHING("global-live-response-dispatching", false);
 
         private final String path;
         private final Object defaultValue;
 
-        private EnforcementConfigValue(final String thePath, final Object theDefaultValue) {
+        EnforcementConfigValue(final String thePath, final Object theDefaultValue) {
             path = thePath;
             defaultValue = theDefaultValue;
         }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -51,7 +51,7 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
     /**
      * Context of the enforcement step: sender, self, signal and so forth.
      */
-    private final Contextual<T> context;
+    protected final Contextual<T> context;
 
     /**
      * Create an enforcement step from its context.

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcerActor.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcerActor.java
@@ -12,14 +12,18 @@
  */
 package org.eclipse.ditto.services.concierge.enforcement;
 
+import java.time.Duration;
+
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.enforcers.Enforcer;
+import org.eclipse.ditto.services.concierge.common.ConciergeConfig;
 import org.eclipse.ditto.services.concierge.common.DittoConciergeConfig;
 import org.eclipse.ditto.services.concierge.common.EnforcementConfig;
 import org.eclipse.ditto.services.utils.akka.controlflow.AbstractGraphActor;
 import org.eclipse.ditto.services.utils.cache.Cache;
+import org.eclipse.ditto.services.utils.cache.CaffeineCache;
 import org.eclipse.ditto.services.utils.cache.EntityIdWithResourceType;
 import org.eclipse.ditto.services.utils.cache.InvalidateCacheEntry;
 import org.eclipse.ditto.services.utils.cache.entry.Entry;
@@ -30,6 +34,8 @@ import org.eclipse.ditto.services.utils.metrics.instruments.timer.ExpiringTimerB
 import org.eclipse.ditto.services.utils.metrics.instruments.timer.StartedTimer;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.base.Command;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -76,16 +82,18 @@ public abstract class AbstractEnforcerActor extends AbstractGraphActor<Contextua
 
         super(WithDittoHeaders.class);
 
-        enforcementConfig = DittoConciergeConfig.of(
+        final ConciergeConfig conciergeConfig = DittoConciergeConfig.of(
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
-        ).getEnforcementConfig();
+        );
+        enforcementConfig = conciergeConfig.getEnforcementConfig();
 
         this.thingIdCache = thingIdCache;
         this.aclEnforcerCache = aclEnforcerCache;
         this.policyEnforcerCache = policyEnforcerCache;
 
         contextual = Contextual.forActor(getSelf(), getContext().getSystem().deadLetters(),
-                pubSubMediator, conciergeForwarder, enforcementConfig.getAskTimeout(), logger
+                pubSubMediator, conciergeForwarder, enforcementConfig.getAskTimeout(), logger,
+                createResponseReceiverCache(conciergeConfig)
         );
 
         // register for sending messages via pub/sub to this enforcer
@@ -151,6 +159,15 @@ public abstract class AbstractEnforcerActor extends AbstractGraphActor<Contextua
     @Override
     protected Contextual<WithDittoHeaders> mapMessage(final WithDittoHeaders message) {
         return contextual.withReceivedMessage(message, getSender());
+    }
+
+    @Nullable
+    private static Cache<String, ActorRef> createResponseReceiverCache(final ConciergeConfig conciergeConfig) {
+        if (conciergeConfig.getEnforcementConfig().shouldDispatchLiveResponsesGlobally()) {
+            return CaffeineCache.of(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(120L)));
+        } else {
+            return null;
+        }
     }
 
 }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/Contextual.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/Contextual.java
@@ -27,6 +27,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.services.utils.akka.controlflow.WithSender;
 import org.eclipse.ditto.services.utils.akka.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.services.utils.cache.Cache;
 import org.eclipse.ditto.services.utils.cache.EntityIdWithResourceType;
 import org.eclipse.ditto.services.utils.metrics.instruments.timer.StartedTimer;
 import org.eclipse.ditto.signals.base.WithId;
@@ -68,6 +69,10 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
     @Nullable
     private final Function<Object, Object> receiverWrapperFunction;
 
+    // for live signal enforcement
+    @Nullable
+    private final Cache<String, ActorRef> responseReceivers;
+
     @Nullable
     private final Supplier<CompletionStage<Object>> askFuture;
 
@@ -80,6 +85,7 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
             @Nullable final StartedTimer startedTimer,
             @Nullable final ActorRef receiver,
             @Nullable final Function<Object, Object> receiverWrapperFunction,
+            @Nullable final Cache<String, ActorRef> responseReceivers,
             @Nullable final Supplier<CompletionStage<Object>> askFuture,
             final boolean changesAuthorization) {
         this.message = message;
@@ -93,6 +99,7 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
         this.startedTimer = startedTimer;
         this.receiver = receiver;
         this.receiverWrapperFunction = receiverWrapperFunction;
+        this.responseReceivers = responseReceivers;
         this.askFuture = askFuture;
         this.changesAuthorization = changesAuthorization;
     }
@@ -102,11 +109,12 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
             final ActorRef pubSubMediator,
             final ActorRef conciergeForwarder,
             final Duration askTimeout,
-            final DittoDiagnosticLoggingAdapter log) {
+            final DittoDiagnosticLoggingAdapter log,
+            @Nullable final Cache<String, ActorRef> responseReceivers) {
 
-        return new Contextual<T>(null, self, deadLetters, pubSubMediator, conciergeForwarder, askTimeout, log, null,
+        return new Contextual<>(null, self, deadLetters, pubSubMediator, conciergeForwarder, askTimeout, log, null,
                 null,
-                null, null, null, false);
+                null, null, responseReceivers, null, false);
     }
 
     /**
@@ -119,7 +127,7 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
      */
     Contextual<T> withAskFuture(final Supplier<CompletionStage<Object>> askFuture) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout, log, entityId,
-                startedTimer, receiver, receiverWrapperFunction, askFuture, changesAuthorization);
+                startedTimer, receiver, receiverWrapperFunction, responseReceivers, askFuture, changesAuthorization);
     }
 
     /**
@@ -221,6 +229,10 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
         return receiverWrapperFunction != null ? receiverWrapperFunction : Function.identity();
     }
 
+    Optional<Cache<String, ActorRef>> getResponseReceivers() {
+        return Optional.ofNullable(responseReceivers);
+    }
+
     boolean changesAuthorization() {
         return changesAuthorization;
     }
@@ -231,31 +243,31 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
 
     <S extends WithDittoHeaders> Contextual<S> withReceivedMessage(@Nullable final S message, final ActorRef sender) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout,
-                log, entityIdFor(message), startedTimer, receiver, receiverWrapperFunction,
+                log, entityIdFor(message), startedTimer, receiver, receiverWrapperFunction, responseReceivers,
                 askFuture, changesAuthorization);
     }
 
     Contextual<T> withTimer(final StartedTimer startedTimer) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout,
-                log, entityId, startedTimer, receiver, receiverWrapperFunction,
+                log, entityId, startedTimer, receiver, receiverWrapperFunction, responseReceivers,
                 askFuture, changesAuthorization);
     }
 
     Contextual<T> withReceiver(@Nullable final ActorRef receiver) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout,
-                log, entityId, startedTimer, receiver, receiverWrapperFunction,
+                log, entityId, startedTimer, receiver, receiverWrapperFunction, responseReceivers,
                 askFuture, changesAuthorization);
     }
 
     Contextual<T> withReceiverWrapperFunction(final Function<Object, Object> receiverWrapperFunction) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout,
-                log, entityId, startedTimer, receiver, receiverWrapperFunction,
+                log, entityId, startedTimer, receiver, receiverWrapperFunction, responseReceivers,
                 askFuture, changesAuthorization);
     }
 
     Contextual<T> changesAuthorization(final boolean changesAuthorization) {
         return new Contextual<>(message, self, sender, pubSubMediator, conciergeForwarder, askTimeout,
-                log, entityId, startedTimer, receiver, receiverWrapperFunction,
+                log, entityId, startedTimer, receiver, receiverWrapperFunction, responseReceivers,
                 askFuture, changesAuthorization);
     }
 
@@ -290,6 +302,7 @@ public final class Contextual<T extends WithDittoHeaders> implements WithSender<
                 ", entityId=" + entityId +
                 ", receiver=" + receiver +
                 ", receiverWrapperFunction=" + receiverWrapperFunction +
+                ", responseReceivers=" + responseReceivers +
                 ", changesAuthorization=" + changesAuthorization +
                 "]";
     }

--- a/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/EnforcementSchedulerTest.java
+++ b/services/concierge/enforcement/src/test/java/org/eclipse/ditto/services/concierge/enforcement/EnforcementSchedulerTest.java
@@ -76,7 +76,8 @@ public final class EnforcementSchedulerTest {
             final TestProbe receiverProbe = TestProbe.apply(actorSystem);
             final Contextual<WithDittoHeaders> baseContextual = Contextual.forActor(getRef(), deadLetterProbe.ref(),
                     pubSubProbe.ref(), conciergeForwarderProbe.ref(),
-                    Duration.ofSeconds(10), Mockito.mock(DittoDiagnosticLoggingAdapter.class)
+                    Duration.ofSeconds(10), Mockito.mock(DittoDiagnosticLoggingAdapter.class),
+                    null
             );
             final ThingId thingId = ThingId.of("busy", "thing");
             final PolicyId policyId = PolicyId.of("some", "policy");

--- a/services/concierge/starter/src/main/resources/concierge.conf
+++ b/services/concierge/starter/src/main/resources/concierge.conf
@@ -26,6 +26,10 @@ ditto {
       # the buffer size used for the queue in the enforcement actor
       buffer-size = 100
       buffer-size = ${?ENFORCEMENT_BUFFER_SIZE}
+
+      # whether to dispatch live response from channels other than subscribers of live messages.
+      global-live-response-dispatching = true
+      global-live-response-dispatching = ${?ENFORCEMENT_GLOBAL_LIVE_RESPONSE_DISPATCHING}
     }
 
     caches {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorHeaderInteractionTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorHeaderInteractionTest.java
@@ -138,11 +138,10 @@ public final class MessageMappingProcessorActorHeaderInteractionTest extends Abs
     }
 
     private Object getModifyThingResponse(final ModifyThing modifyThing) {
-        return isSuccess
+        return (isSuccess
                 ? ModifyThingResponse.modified(modifyThing.getThingEntityId(), modifyThing.getDittoHeaders())
-                : ThingNotAccessibleException.newBuilder(modifyThing.getThingEntityId())
-                .dittoHeaders(modifyThing.getDittoHeaders())
-                .build();
+                : ThingNotAccessibleException.newBuilder(modifyThing.getThingEntityId()).build())
+                .setDittoHeaders(modifyThing.getDittoHeaders()); // use setDittoHeaders to lose concrete exception type
     }
 
     private Optional<HttpStatusCode> getExpectedOutcome() {

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
@@ -428,14 +428,21 @@ final class StreamingSessionActor extends AbstractActorWithTimers {
     }
 
     private void forwardAcknowledgementOrLiveCommandResponse(final CommandResponse<?> response) {
-        // the Acknowledgement / live CommandResponse is meant for someone else:
         final ActorContext context = getContext();
         context.findChild(AcknowledgementForwarderActor.determineActorName(response.getDittoHeaders()))
                 .ifPresentOrElse(
                         forwarder -> forwarder.forward(response, context),
-                        () -> logger.withCorrelationId(response)
-                                .info("Received Acknowledgement / live CommandResponse but no " +
-                                        "AcknowledgementForwarderActor was present: <{}>", response)
+                        () -> {
+                            // the Acknowledgement / live CommandResponse is meant for someone else:
+                            final String template =
+                                    "No AcknowledgementForwarderActor found, forwarding to concierge: <{}>";
+                            if (logger.isDebugEnabled()) {
+                                logger.withCorrelationId(response).debug(template, response);
+                            } else {
+                                logger.withCorrelationId(response).info(template, response.getType());
+                            }
+                            commandRouter.tell(response, ActorRef.noSender());
+                        }
                 );
     }
 

--- a/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementForwarderActorStarter.java
+++ b/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementForwarderActorStarter.java
@@ -30,6 +30,8 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.models.acks.config.AcknowledgementConfig;
+import org.eclipse.ditto.services.utils.akka.logging.DittoLogger;
+import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
 import org.eclipse.ditto.signals.acks.base.Acknowledgement;
 import org.eclipse.ditto.signals.acks.base.AcknowledgementRequestDuplicateCorrelationIdException;
 import org.eclipse.ditto.signals.base.Signal;
@@ -52,6 +54,7 @@ import akka.japi.Pair;
 final class AcknowledgementForwarderActorStarter implements Supplier<Optional<ActorRef>> {
 
     private static final String PREFIX_COUNTER_SEPARATOR = "#";
+    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(AcknowledgementForwarderActorStarter.class);
 
     private final ActorContext actorContext;
     private final EntityIdWithType entityId;


### PR DESCRIPTION
E.g. answering to a HTTP push message via a WebSocket message having the same correlation-id.

This is a configurable behavior.