### PR TITLE
Add warnings to health of BackgroundSyncActor

### DIFF
--- a/services/thingsearch/updater-actors/pom.xml
+++ b/services/thingsearch/updater-actors/pom.xml
@@ -125,6 +125,11 @@
             <artifactId>akka-testkit_${scala.version}</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.services.thingsearch.updater.actors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.awaitility.Awaitility;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.entity.id.DefaultNamespacedEntityId;
+import org.eclipse.ditto.model.base.entity.id.EntityId;
+import org.eclipse.ditto.model.base.entity.id.NamespacedEntityId;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.FieldType;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.query.Query;
+import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.services.models.streaming.StreamedSnapshot;
+import org.eclipse.ditto.services.models.streaming.SudoStreamSnapshots;
+import org.eclipse.ditto.services.models.thingsearch.SearchNamespaceReportResult;
+import org.eclipse.ditto.services.models.thingsearch.commands.sudo.UpdateThing;
+import org.eclipse.ditto.services.thingsearch.common.config.BackgroundSyncConfig;
+import org.eclipse.ditto.services.thingsearch.common.config.DefaultBackgroundSyncConfig;
+import org.eclipse.ditto.services.thingsearch.common.model.ResultList;
+import org.eclipse.ditto.services.thingsearch.persistence.read.ThingsSearchPersistence;
+import org.eclipse.ditto.services.thingsearch.persistence.write.model.Metadata;
+import org.eclipse.ditto.services.utils.akka.streaming.TimestampPersistence;
+import org.eclipse.ditto.services.utils.health.RetrieveHealth;
+import org.eclipse.ditto.services.utils.health.RetrieveHealthResponse;
+import org.eclipse.ditto.services.utils.health.StatusDetailMessage;
+import org.eclipse.ditto.services.utils.health.StatusInfo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import akka.Done;
+import akka.NotUsed;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.cluster.pubsub.DistributedPubSubMediator;
+import akka.japi.Pair;
+import akka.stream.ActorMaterializer;
+import akka.stream.javadsl.Source;
+import akka.stream.javadsl.StreamRefs;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Unit test for {@link BackgroundSyncActor}.
+ */
+public final class BackgroundSyncActorTest {
+
+    private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(2);
+    private static final ThingId THING_ID = ThingId.of("org.eclipse:ditto");
+    private static final Instant TAGGED_TIMESTAMP = Instant.now().minus(5, ChronoUnit.MINUTES);
+
+    private static final long REVISION_INDEXED = 1;
+    private static final long REVISION_PERSISTED = REVISION_INDEXED + 1;
+    private static final List<NamespacedEntityId> KNOWN_IDs = List.of(
+            DefaultNamespacedEntityId.of("org.eclipse:ditto1"),
+            DefaultNamespacedEntityId.of("org.eclipse:ditto2"),
+            DefaultNamespacedEntityId.of("org.eclipse:ditto3"),
+            DefaultNamespacedEntityId.of("org.eclipse:ditto4")
+    );
+    private static final List<Metadata> THINGS_INDEXED =
+            KNOWN_IDs.stream()
+                    .map(id -> Metadata.of(ThingId.of(id), REVISION_INDEXED, PolicyId.of(id), REVISION_INDEXED))
+                    .collect(Collectors.toList());
+    private static final List<StreamedSnapshot> THINGS_PERSISTED = KNOWN_IDs.stream()
+            .map(id -> StreamedSnapshot.of(ThingId.of(id), Thing.newBuilder()
+                    .setId(ThingId.of(id))
+                    .setRevision(REVISION_PERSISTED)
+                    .setPolicyId(PolicyId.of(id))
+                    .build()
+                    .toJson(FieldType.all())))
+            .collect(Collectors.toList());
+    private static final Config TEST_CONFIG = ConfigFactory.load("test");
+
+    private ActorSystem actorSystem;
+    private TestKit thingsUpdater;
+    private TestKit pubSub;
+    private TestKit policiesShardRegion;
+    private MockThingsSearchPersistence searchPersistence;
+    private MockTimestampPersistence timestampPersistence;
+    private BackgroundSyncConfig backgroundSyncConfig;
+
+    @Before
+    public void setUp() {
+        actorSystem = ActorSystem.create("AkkaTestSystem", TEST_CONFIG);
+        thingsUpdater = new TestKit(actorSystem);
+        pubSub = new TestKit(actorSystem);
+        policiesShardRegion = new TestKit(actorSystem);
+        searchPersistence = new MockThingsSearchPersistence();
+        timestampPersistence = new MockTimestampPersistence();
+        backgroundSyncConfig = DefaultBackgroundSyncConfig.parse(ConfigFactory.load("background-sync-test.conf"));
+    }
+
+    @After
+    public void tearDown() {
+        if (Objects.nonNull(actorSystem)) {
+            TestKit.shutdownActorSystem(actorSystem);
+        }
+    }
+
+    @Test
+    public void synchronizesThings() {
+        new TestKit(actorSystem) {{
+            whenSearchPersistenceHasIndexedThings();
+            whenTimestampPersistenceProvidesTaggedTimestamp();
+
+            final ActorRef underTest = thenCreateBackgroundSyncActor(this);
+
+            expectSyncActorToStartStreaming(pubSub);
+            thenRespondWithPersistedThingsStream(pubSub);
+
+            expectSyncActorToRequestThingUpdatesInSearch(thingsUpdater);
+
+            expectSyncActorToBeUpAndHealthy(underTest, this);
+        }};
+    }
+
+    @Test
+    public void providesHealthWarningWhenSyncStreamFails() {
+
+        new TestKit(actorSystem) {{
+            whenSearchPersistenceHasIndexedThings();
+            whenTimestampPersistenceProvidesTaggedTimestamp();
+
+            final ActorRef underTest = thenCreateBackgroundSyncActor(this);
+
+            expectSyncActorToStartStreaming(pubSub);
+
+            thenRespondWithFailingPersistedThingsStream(pubSub);
+
+            expectSyncActorToBeUpWithWarning(underTest, this);
+        }};
+
+    }
+
+    private ActorRef thenCreateBackgroundSyncActor(final TestKit system) {
+        return system.childActorOf(BackgroundSyncActor.props(
+                backgroundSyncConfig,
+                pubSub.getRef(),
+                searchPersistence,
+                timestampPersistence,
+                policiesShardRegion.getRef(),
+                thingsUpdater.getRef()
+        ));
+    }
+
+    private void expectSyncActorToStartStreaming(final TestKit pubSub) {
+        final DistributedPubSubMediator.Send startStream =
+                pubSub.expectMsgClass(DistributedPubSubMediator.Send.class);
+        assertThat(startStream.msg()).isInstanceOf(SudoStreamSnapshots.class);
+    }
+
+    private void thenRespondWithFailingPersistedThingsStream(final TestKit pubSub) {
+        final CompletableFuture<StreamedSnapshot> failingSnapshot = new CompletableFuture<>();
+        final Source<StreamedSnapshot, NotUsed> persistedThingSource = Source.fromCompletionStage(failingSnapshot);
+        persistedThingSource.runWith(StreamRefs.sourceRef(), ActorMaterializer.create(actorSystem))
+                .thenAccept(pubSub::reply)
+                .thenRun(() -> failingSnapshot.completeExceptionally(
+                        new IllegalStateException("Fail the stream with error")));
+    }
+
+    private void thenRespondWithPersistedThingsStream(final TestKit pubSub) {
+        thenRespondWithPersistedThingsStream(pubSub, THINGS_PERSISTED);
+    }
+
+    private void thenRespondWithPersistedThingsStream(final TestKit pubSub, final List<StreamedSnapshot> things) {
+        Source.from(things)
+                .runWith(StreamRefs.sourceRef(), ActorMaterializer.create(actorSystem))
+                .thenAccept(pubSub::reply);
+    }
+
+    private void expectSyncActorToRequestThingUpdatesInSearch(final TestKit thingsUpdater) {
+        expectSyncActorToRequestThingUpdatesInSearch(thingsUpdater, KNOWN_IDs);
+    }
+
+    private void expectSyncActorToRequestThingUpdatesInSearch(final TestKit thingsUpdater,
+            final List<? extends EntityId> ids) {
+        ids.stream()
+                .map(id -> UpdateThing.of(ThingId.of(id), DittoHeaders.empty()))
+                .forEach(thingsUpdater::expectMsg);
+    }
+
+    private void expectSyncActorToBeUpAndHealthy(final ActorRef syncActor, final TestKit sender) {
+        syncActorShouldHaveHealth(syncActor, sender, StatusInfo.Status.UP, List.of(StatusDetailMessage.Level.INFO),
+                detailMessages -> {
+                    KNOWN_IDs.forEach(thingId -> assertThat(detailMessages.stream()
+                            .anyMatch(message -> message.getMessage().toString().contains(thingId))));
+                    assertThat(detailMessages).allMatch(
+                            message -> StatusDetailMessage.Level.INFO.equals(message.getLevel()));
+                });
+    }
+
+    private void expectSyncActorToBeUpWithWarning(final ActorRef syncActor, final TestKit sender) {
+        syncActorShouldHaveHealth(syncActor, sender, StatusInfo.Status.UP, List.of(StatusDetailMessage.Level.WARN),
+                statusDetailMessages -> {
+                    // expect one of the messages contains an non-empty-error
+                    assertThat(statusDetailMessages.stream()
+                            .map(StatusDetailMessage::getMessage)
+                            .map(JsonValue::toString)
+                            .collect(Collectors.toList()))
+                            .anyMatch(message -> !message.contains("Error=<>"));
+                }
+        );
+    }
+
+    private void syncActorShouldHaveHealth(final ActorRef syncActor, final TestKit sender,
+            final StatusInfo.Status status,
+            final List<StatusDetailMessage.Level> expectedMessageLevels,
+            final Consumer<List<? extends StatusDetailMessage>> statusMessagesMatch) {
+        // using awaitility since the stream doesn't finish instantly
+        Awaitility.waitAtMost(DEFAULT_TIMEOUT.getSeconds(), TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    syncActor.tell(RetrieveHealth.newInstance(), sender.getRef());
+                    final RetrieveHealthResponse response = sender.expectMsgClass(RetrieveHealthResponse.class);
+                    assertThat(response.getStatusInfo().getStatus()).isEqualTo(status);
+                    assertThat(response.getStatusInfo().getDetails()).satisfies(statusMessagesMatch);
+                    assertThat(response.getStatusInfo().getDetails().stream()
+                            .map(StatusDetailMessage::getLevel).collect(Collectors.toList()))
+                            .containsExactlyInAnyOrderElementsOf(expectedMessageLevels);
+                });
+    }
+
+    private void whenSearchPersistenceHasIndexedThings() {
+        whenSearchPersistenceHasIndexedThings(THINGS_INDEXED);
+    }
+
+    private void whenSearchPersistenceHasIndexedThings(final List<Metadata> indexed) {
+        searchPersistence.provideMetadata(indexed);
+    }
+
+    private void whenTimestampPersistenceProvidesTaggedTimestamp() {
+        whenTimestampPersistenceProvidesTaggedTimestamp(TAGGED_TIMESTAMP, THING_ID.toString());
+    }
+
+    private void whenTimestampPersistenceProvidesTaggedTimestamp(final Instant timestamp, final String tag) {
+        timestampPersistence.setTaggedTimestamp(timestamp, tag);
+    }
+
+    private static class MockThingsSearchPersistence implements ThingsSearchPersistence {
+
+        private List<Metadata> metadata;
+
+        private void provideMetadata(final List<Metadata> toProvide) {
+            this.metadata = toProvide;
+        }
+
+        @Override
+        public CompletionStage<Void> initializeIndices() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<SearchNamespaceReportResult, NotUsed> generateNamespaceCountReport() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<Long, NotUsed> count(final Query query, final List<String> authorizationSubjectIds) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<Long, NotUsed> sudoCount(final Query query) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<ResultList<ThingId>, NotUsed> findAll(final Query query,
+                final List<String> authorizationSubjectIds,
+                @Nullable final Set<String> namespaces) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<ThingId, NotUsed> findAllUnlimited(final Query query, final List<String> authorizationSubjectIds,
+                @Nullable final Set<String> namespaces) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Source<Metadata, NotUsed> sudoStreamMetadata(final EntityId lowerBound) {
+            checkNotNull(this.metadata,
+                    "Metadata may not be null when #sudoStreamMetadata is called. Use #provideMetadata beforehand.");
+            return Source.from(this.metadata);
+        }
+
+    }
+
+    private static class MockTimestampPersistence implements TimestampPersistence {
+
+        private Instant timestamp;
+        private String tag;
+
+        @Override
+        public Source<NotUsed, NotUsed> setTimestamp(final Instant timestamp) {
+            this.timestamp = timestamp;
+            return Source.empty();
+        }
+
+        @Override
+        public Source<Done, NotUsed> setTaggedTimestamp(final Instant timestamp, @Nullable final String tag) {
+            this.timestamp = timestamp;
+            this.tag = tag;
+            return Source.single(Done.done());
+        }
+
+        @Override
+        public Source<Optional<Instant>, NotUsed> getTimestampAsync() {
+            return Source.single(Optional.ofNullable(timestamp));
+        }
+
+        @Override
+        public Source<Optional<Pair<Instant, String>>, NotUsed> getTaggedTimestamp() {
+            return Source.single(Optional.ofNullable(Pair.create(timestamp, tag)));
+        }
+
+    }
+
+}

--- a/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
@@ -1,8 +1,8 @@
 enabled = true
 quiet-period = 0s
-idle-timeout = 5s
+idle-timeout = 500ms
 keep {
-  events = 3
+  events = 10
 }
 throttle {
   throughput = 100

--- a/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
@@ -1,0 +1,17 @@
+enabled = true
+quiet-period = 0s
+idle-timeout = 5s
+keep {
+  events = 3
+}
+throttle {
+  throughput = 100
+  period = 1s
+}
+min-backoff = 6h
+max-backoff = 7h
+# needs to be 0 for failures to get through
+max-restarts = 0
+recovery = 9h
+tolerance-window = 10h
+policy-ask-timeout = 11h

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
@@ -231,6 +231,9 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
         getContext().become(sleeping());
     }
 
+    protected Stream<Pair<Instant, Event>> getEventStream() {
+        return events.stream();
+    }
 
     private void scheduleWakeUp() {
         scheduleWakeUp(config.getQuietPeriod());


### PR DESCRIPTION
The `BackgroundSyncActor` synchronizes things from the twin persistence to the search index. It's current health is provided at the `/status/health` route.
To be more aware of inconsistent states in the health response, this PR changes the level of two state messages of the actor to `WARN` (instead of `INFO`):
* when the stream between things and the `BackgroundSyncActor` sync actor fails with an error
* when the same thing with the same revision is processed twice