### PR TITLE
[WIP] Enable setting commandHeaders to ImplicitThingCreationMessageMapper

### DIFF
--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapper.java
@@ -156,7 +156,7 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         }
 
         if (Placeholders.containsAnyPlaceholder(thingTemplate)) {
-            commandHeaders = evaluateCommandHeaders(message, commandHeaders);
+            commandHeaders = resolveCommandHeaders(message, commandHeaders);
         }
 
         final Signal<CreateThing> createThing = getCreateThingSignal(message, resolvedTemplate);
@@ -189,10 +189,9 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         return CreateThing.of(newThing, inlinePolicyJson, copyPolicyFrom, dittoHeaders);
     }
 
-    private static Map<String, String> evaluateCommandHeaders(final ExternalMessage externalMessage,
+    private static Map<String, String> resolveCommandHeaders(final ExternalMessage externalMessage,
             final Map<String, String> errorResponseHeaders) {
-        final ExpressionResolver resolver =
-                getExpressionResolver(externalMessage.getHeaders());
+        final ExpressionResolver resolver = getExpressionResolver(externalMessage.getHeaders());
         final Map<String, String> resolvedHeaders = new HashMap<>();
         errorResponseHeaders.forEach((key, value) ->
                 resolver.resolve(value).toOptional().ifPresent(resolvedHeaderValue ->


### PR DESCRIPTION
Allows to set commandHeaders as an option for the ImplicitThingCreationMessageMapper to allow setting custom headers to the generated createThing signal.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>

Fix for Issue #760 