### PR TITLE
Missing JsonKey Validation for ModifyAttribute and ModifyFeatureProperty

### DIFF
--- a/model/things/src/main/java/org/eclipse/ditto/model/things/AttributesModelFactory.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/AttributesModelFactory.java
@@ -120,4 +120,16 @@ public final class AttributesModelFactory {
     public static JsonPointer validateAttributePointer(final JsonPointer jsonPointer) {
         return JsonKeyValidator.validate(jsonPointer);
     }
+
+    /**
+     * Validates the given attribute {@link JsonObject}.
+     *
+     * @param jsonObject {@code jsonObject} that is validated
+     * @throws JsonKeyInvalidException if {@code jsonObject} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     * @since 1.3.0
+     */
+    public static void validateAttributeKeys(final JsonObject jsonObject) {
+        JsonKeyValidator.validateJsonKeys(jsonObject);
+    }
 }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
@@ -560,6 +560,18 @@ public final class ThingsModelFactory {
     }
 
     /**
+     * Validates the given {@link JsonObject} containing only valid keys.
+     *
+     * @param jsonObject {@code jsonObject} that is validated
+     * @throws org.eclipse.ditto.json.JsonKeyInvalidException if {@code jsonObject} was not valid according to
+     * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
+     * @since 1.3.0
+     */
+    public static void validateFeaturePropertyValue(final JsonObject jsonObject) {
+        JsonKeyValidator.validateJsonKeys(jsonObject);
+    }
+
+    /**
      * Returns a new immutable empty {@link Metadata}.
      *
      * @return the new immutable empty {@code Metadata}.

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingsModelFactory.java
@@ -567,7 +567,7 @@ public final class ThingsModelFactory {
      * pattern {@link org.eclipse.ditto.model.base.entity.id.RegexPatterns#NO_CONTROL_CHARS_NO_SLASHES_PATTERN}.
      * @since 1.3.0
      */
-    public static void validateFeaturePropertyValue(final JsonObject jsonObject) {
+    public static void validateJsonKeys(final JsonObject jsonObject) {
         JsonKeyValidator.validateJsonKeys(jsonObject);
     }
 

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
@@ -34,7 +34,6 @@ import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
-import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
 import org.eclipse.ditto.signals.commands.things.ThingCommandSizeValidator;
@@ -76,11 +75,7 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
         super(TYPE, dittoHeaders);
         this.thingId = thingId;
         this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
-        if (attributeValue.isObject()) {
-            checkAttributeValue(attributeValue.asObject());
-        }
-
-        this.attributeValue = checkNotNull(attributeValue, "new attribute");
+        this.attributeValue = checkAttributeValue(attributeValue);
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 attributeValue::getUpperBoundForStringSize,
@@ -98,8 +93,12 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
         return AttributesModelFactory.validateAttributePointer(pointer);
     }
 
-    private static void checkAttributeValue(final JsonObject object) {
-        ThingsModelFactory.validateJsonKeys(object);
+    private static JsonValue checkAttributeValue(final JsonValue value) {
+        checkNotNull(value, "new attribute");
+        if (value.isObject()) {
+            AttributesModelFactory.validateAttributeKeys(value.asObject());
+        }
+        return value;
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
@@ -74,8 +74,8 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
 
         super(TYPE, dittoHeaders);
         this.thingId = thingId;
-        this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
-        this.attributeValue = checkAttributeValue(attributeValue);
+        this.attributePointer = checkAttributePointer(checkNotNull(attributePointer, "attributePointer"), dittoHeaders);
+        this.attributeValue = checkAttributeValue(checkNotNull(attributeValue, "attributeValue"));
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 attributeValue::getUpperBoundForStringSize,
@@ -84,7 +84,6 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
     }
 
     private static JsonPointer checkAttributePointer(final JsonPointer pointer, final DittoHeaders dittoHeaders) {
-        checkNotNull(pointer, "key of the attribute to be modified");
         if (pointer.isEmpty()) {
             throw AttributePointerInvalidException.newBuilder(pointer)
                     .dittoHeaders(dittoHeaders)
@@ -94,7 +93,6 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
     }
 
     private static JsonValue checkAttributeValue(final JsonValue value) {
-        checkNotNull(value, "new attribute");
         if (value.isObject()) {
             AttributesModelFactory.validateAttributeKeys(value.asObject());
         }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
@@ -34,6 +34,7 @@ import org.eclipse.ditto.model.base.json.JsonParsableCommand;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.AttributesModelFactory;
 import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.model.things.ThingsModelFactory;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
 import org.eclipse.ditto.signals.commands.things.ThingCommandSizeValidator;
@@ -75,7 +76,11 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
         super(TYPE, dittoHeaders);
         this.thingId = thingId;
         this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
-        this.attributeValue = checkNotNull(attributeValue, "new attribute");
+        try {
+            checkAttributeValue(attributeValue.asObject());
+        } finally {
+            this.attributeValue = checkNotNull(attributeValue, "new attribute");
+        }
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 attributeValue::getUpperBoundForStringSize,
@@ -91,6 +96,10 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
                     .build();
         }
         return AttributesModelFactory.validateAttributePointer(pointer);
+    }
+
+    private static void checkAttributeValue(final JsonObject object) {
+        ThingsModelFactory.validateJsonKeys(object);
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttribute.java
@@ -76,11 +76,11 @@ public final class ModifyAttribute extends AbstractCommand<ModifyAttribute>
         super(TYPE, dittoHeaders);
         this.thingId = thingId;
         this.attributePointer = checkAttributePointer(attributePointer, dittoHeaders);
-        try {
+        if (attributeValue.isObject()) {
             checkAttributeValue(attributeValue.asObject());
-        } finally {
-            this.attributeValue = checkNotNull(attributeValue, "new attribute");
         }
+
+        this.attributeValue = checkNotNull(attributeValue, "new attribute");
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 attributeValue::getUpperBoundForStringSize,

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -39,6 +39,7 @@ import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
 import org.eclipse.ditto.signals.commands.things.ThingCommandSizeValidator;
 
+
 /**
  * This command modifies a single Property of a {@link org.eclipse.ditto.model.things.Feature}'s properties.
  */
@@ -81,7 +82,11 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
         this.propertyPointer = checkPropertyPointer(propertyPointer);
-        this.propertyValue = checkNotNull(propertyValue, "Property Value");
+        try {
+            checkPropertyValue(propertyValue.asObject());
+        } finally {
+            this.propertyValue = checkNotNull(propertyValue);
+        }
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 propertyValue::getUpperBoundForStringSize,
@@ -92,6 +97,10 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
     private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
         checkNotNull(propertyPointer, "Property JsonPointer");
         return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
+    }
+
+    private void checkPropertyValue(final JsonObject propertyValue) {
+        ThingsModelFactory.validateFeaturePropertyValue(propertyValue);
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -100,7 +100,7 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
     }
 
     private void checkPropertyValue(final JsonObject propertyValue) {
-        ThingsModelFactory.validateFeaturePropertyValue(propertyValue);
+        ThingsModelFactory.validateJsonKeys(propertyValue);
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -82,11 +82,10 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
         this.propertyPointer = checkPropertyPointer(propertyPointer);
-        try {
+        if (propertyValue.isObject()) {
             checkPropertyValue(propertyValue.asObject());
-        } finally {
-            this.propertyValue = checkNotNull(propertyValue);
         }
+        this.propertyValue = checkNotNull(propertyValue);
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 propertyValue::getUpperBoundForStringSize,

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -82,10 +82,7 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
         this.thingId = checkNotNull(thingId, "Thing ID");
         this.featureId = checkNotNull(featureId, "Feature ID");
         this.propertyPointer = checkPropertyPointer(propertyPointer);
-        if (propertyValue.isObject()) {
-            checkPropertyValue(propertyValue.asObject());
-        }
-        this.propertyValue = checkNotNull(propertyValue);
+        this.propertyValue = checkPropertyValue(propertyValue);
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 propertyValue::getUpperBoundForStringSize,
@@ -98,8 +95,12 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
         return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
-    private void checkPropertyValue(final JsonObject propertyValue) {
-        ThingsModelFactory.validateJsonKeys(propertyValue);
+    private JsonValue checkPropertyValue(final JsonValue value) {
+        checkNotNull(value, "new feature property");
+        if (value.isObject()) {
+            ThingsModelFactory.validateJsonKeys(value.asObject());
+        }
+        return value;
     }
 
     /**

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeatureProperty.java
@@ -39,7 +39,6 @@ import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
 import org.eclipse.ditto.signals.commands.things.ThingCommandSizeValidator;
 
-
 /**
  * This command modifies a single Property of a {@link org.eclipse.ditto.model.things.Feature}'s properties.
  */
@@ -79,10 +78,10 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
             final JsonValue propertyValue, final DittoHeaders dittoHeaders) {
 
         super(TYPE, dittoHeaders);
-        this.thingId = checkNotNull(thingId, "Thing ID");
-        this.featureId = checkNotNull(featureId, "Feature ID");
-        this.propertyPointer = checkPropertyPointer(propertyPointer);
-        this.propertyValue = checkPropertyValue(propertyValue);
+        this.thingId = checkNotNull(thingId, "thingId");
+        this.featureId = checkNotNull(featureId, "featureId");
+        this.propertyPointer = checkPropertyPointer(checkNotNull(propertyPointer, "propertyPointer"));
+        this.propertyValue = checkPropertyValue(checkNotNull(propertyValue, "propertyValue"));
 
         ThingCommandSizeValidator.getInstance().ensureValidSize(
                 propertyValue::getUpperBoundForStringSize,
@@ -90,13 +89,11 @@ public final class ModifyFeatureProperty extends AbstractCommand<ModifyFeaturePr
                 () -> dittoHeaders);
     }
 
-    private JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
-        checkNotNull(propertyPointer, "Property JsonPointer");
+    private static JsonPointer checkPropertyPointer(final JsonPointer propertyPointer) {
         return ThingsModelFactory.validateFeaturePropertyPointer(propertyPointer);
     }
 
-    private JsonValue checkPropertyValue(final JsonValue value) {
-        checkNotNull(value, "new feature property");
+    private static JsonValue checkPropertyValue(final JsonValue value) {
         if (value.isObject()) {
             ThingsModelFactory.validateJsonKeys(value.asObject());
         }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
@@ -75,7 +75,6 @@ public final class ModifyAttributeTest {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> ModifyAttribute.of(TestConstants.Thing.THING_ID, KNOWN_JSON_POINTER, null,
                         TestConstants.EMPTY_DITTO_HEADERS))
-                .withMessage("The %s must not be null!", "new attribute")
                 .withNoCause();
     }
 
@@ -84,7 +83,6 @@ public final class ModifyAttributeTest {
         assertThatExceptionOfType(NullPointerException.class)
                 .isThrownBy(() -> ModifyAttribute.of(TestConstants.Thing.THING_ID, null, KNOWN_ATTRIBUTE,
                         TestConstants.EMPTY_DITTO_HEADERS))
-                .withMessage("The %s must not be null!", "key of the attribute to be modified")
                 .withNoCause();
 
     }

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyAttributeTest.java
@@ -109,6 +109,22 @@ public final class ModifyAttributeTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJsonValue() {
+        final JsonValue invalid = JsonValue.of(JsonObject.of("{\"bar/baz\":false}"));
+
+        ModifyAttribute.of(TestConstants.Thing.THING_ID, VALID_JSON_POINTER,
+                invalid, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test
+    public void tryToCreateInstanceWithValidJsonObjectAsValue() {
+        final JsonValue valid = JsonValue.of(JsonObject.of("{\"bar.baz\":false}"));
+
+        ModifyAttribute.of(TestConstants.Thing.THING_ID, VALID_JSON_POINTER,
+                valid, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
     @Test(expected = AttributePointerInvalidException.class)
     public void createInstanceWithEmptyPointer() {
         ModifyAttribute.of(TestConstants.Thing.THING_ID, EMPTY_JSON_POINTER, KNOWN_ATTRIBUTE,

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.signals.commands.things.modify;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.INVALID_JSON_POINTER;
+import static org.eclipse.ditto.signals.commands.things.TestConstants.Pointer.VALID_JSON_POINTER;
 import static org.eclipse.ditto.signals.commands.things.assertions.ThingCommandAssertions.assertThat;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
@@ -34,7 +35,6 @@ import org.eclipse.ditto.signals.commands.things.ThingCommand;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
-
 
 /**
  * Unit test for {@link ModifyFeatureProperty}.
@@ -108,7 +108,6 @@ public final class ModifyFeaturePropertyTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test
     public void toJsonReturnsExpected() {
         final ModifyFeatureProperty underTest =
@@ -137,6 +136,22 @@ public final class ModifyFeaturePropertyTest {
                 .set(ModifyFeatureProperty.JSON_PROPERTY, INVALID_JSON_POINTER.toString()).build();
 
         ModifyFeatureProperty.fromJson(invalidJson.toString(), TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test(expected = JsonKeyInvalidException.class)
+    public void createInstanceFromInvalidJsonValue() {
+        final JsonValue invalid = JsonValue.of(JsonObject.of("{\"bar/baz\":false}"));
+
+        ModifyFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                VALID_JSON_POINTER, invalid, TestConstants.EMPTY_DITTO_HEADERS);
+    }
+
+    @Test
+    public void tryToCreateInstanceWithValidPropertyJsonObject() {
+        final JsonValue valid = JsonValue.of(JsonObject.of("{\"bar.baz\":false}"));
+
+        ModifyFeatureProperty.of(TestConstants.Thing.THING_ID, TestConstants.Feature.FLUX_CAPACITOR_ID,
+                VALID_JSON_POINTER, valid, TestConstants.EMPTY_DITTO_HEADERS);
     }
 
     @Test

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/modify/ModifyFeaturePropertyTest.java
@@ -53,14 +53,12 @@ public final class ModifyFeaturePropertyTest {
             .set(ModifyFeatureProperty.JSON_PROPERTY_VALUE, PROPERTY_VALUE)
             .build();
 
-
     @Test
     public void assertImmutability() {
         assertInstancesOf(ModifyFeatureProperty.class,
                 areImmutable(),
                 provided(JsonPointer.class, JsonValue.class, ThingId.class).areAlsoImmutable());
     }
-
 
     @Test
     public void testHashCodeAndEquals() {
@@ -69,14 +67,12 @@ public final class ModifyFeaturePropertyTest {
                 .verify();
     }
 
-
     @Test(expected = ThingIdInvalidException.class)
     public void tryToCreateInstanceWithNullThingIdString() {
         ModifyFeatureProperty.of((String) null, TestConstants.Feature.FLUX_CAPACITOR_ID, PROPERTY_JSON_POINTER,
                 PROPERTY_VALUE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullThingId() {
@@ -85,13 +81,11 @@ public final class ModifyFeaturePropertyTest {
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
 
-
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullFeatureId() {
         ModifyFeatureProperty.of(TestConstants.Thing.THING_ID, null, PROPERTY_JSON_POINTER, PROPERTY_VALUE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullPropertyJsonPointer() {
@@ -99,7 +93,6 @@ public final class ModifyFeaturePropertyTest {
                 PROPERTY_VALUE,
                 TestConstants.EMPTY_DITTO_HEADERS);
     }
-
 
     @Test(expected = NullPointerException.class)
     public void tryToCreateInstanceWithNullPropertyValue() {


### PR DESCRIPTION
Due to the missing validation of the JsonValue in the constructor of ModifyAttribute and ModifyFeatureProperty, it was possible to populate the thing with not valid JsonKeys.