### PR TITLE
Deprecated getHeaders which returns Optional<DittoHeaders> instead of DittoHeaders

### DIFF
--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractAdapter.java
@@ -56,7 +56,7 @@ public abstract class AbstractAdapter<T extends Jsonifiable.WithPredicate<JsonOb
      * @return the headers of the message.
      */
     protected static DittoHeaders dittoHeadersFrom(final Adaptable adaptable) {
-        return adaptable.getHeaders().orElseGet(DittoHeaders::empty);
+        return adaptable.getDittoHeaders();
     }
 
     protected static TopicPath.Action getAction(final TopicPath topicPath) {
@@ -75,7 +75,7 @@ public abstract class AbstractAdapter<T extends Jsonifiable.WithPredicate<JsonOb
         final String type = getType(externalAdaptable);
 
         // filter headers by header translator, then inject any missing information from topic path
-        final DittoHeaders externalHeaders = externalAdaptable.getHeaders().orElse(DittoHeaders.empty());
+        final DittoHeaders externalHeaders = externalAdaptable.getDittoHeaders();
         final DittoHeaders filteredHeaders = addTopicPathInfo(
                 DittoHeaders.of(headerTranslator.fromExternalHeaders(externalHeaders)),
                 externalAdaptable.getTopicPath());

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractErrorResponseAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractErrorResponseAdapter.java
@@ -65,7 +65,7 @@ public abstract class AbstractErrorResponseAdapter<T extends ErrorResponse<T>> i
     @Override
     public T fromAdaptable(final Adaptable adaptable) {
         final DittoHeaders dittoHeaders = DittoHeaders.of(
-                headerTranslator.fromExternalHeaders(adaptable.getHeaders().orElse(DittoHeaders.empty())));
+                headerTranslator.fromExternalHeaders(adaptable.getDittoHeaders()));
         final TopicPath topicPath = adaptable.getTopicPath();
 
         final DittoRuntimeException dittoRuntimeException = adaptable.getPayload()

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Adaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Adaptable.java
@@ -52,7 +52,7 @@ public interface Adaptable extends WithDittoHeaders<Adaptable> {
      * Returns the {@code DittoHeaders} of this {@code Adaptable} if present.
      *
      * @return the optional headers.
-     * @deprecated this is deprecated. Use getDittoHeaders instead.
+     * @deprecated since 1.3.0, will be removed in a future release. Use {@link #getDittoHeaders()} instead.
      */
     @Deprecated
     Optional<DittoHeaders> getHeaders();

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Adaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/Adaptable.java
@@ -52,7 +52,9 @@ public interface Adaptable extends WithDittoHeaders<Adaptable> {
      * Returns the {@code DittoHeaders} of this {@code Adaptable} if present.
      *
      * @return the optional headers.
+     * @deprecated this is deprecated. Use getDittoHeaders instead.
      */
+    @Deprecated
     Optional<DittoHeaders> getHeaders();
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableAdaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableAdaptable.java
@@ -68,6 +68,7 @@ final class ImmutableAdaptable implements Adaptable {
     }
 
     @Override
+    @Deprecated
     public Optional<DittoHeaders> getHeaders() {
         return Optional.ofNullable(headers);
     }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableJsonifiableAdaptable.java
@@ -88,6 +88,7 @@ final class ImmutableJsonifiableAdaptable implements JsonifiableAdaptable {
     }
 
     @Override
+    @Deprecated
     public Optional<DittoHeaders> getHeaders() {
         return delegateAdaptable.getHeaders();
     }
@@ -99,7 +100,7 @@ final class ImmutableJsonifiableAdaptable implements JsonifiableAdaptable {
 
     @Override
     public JsonObject toJson() {
-        return toJson(getHeaders().orElse(ProtocolFactory.emptyHeaders()));
+        return toJson(getDittoHeaders());
     }
 
     @Override

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ProtocolFactory.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ProtocolFactory.java
@@ -60,7 +60,7 @@ public final class ProtocolFactory {
     public static AdaptableBuilder newAdaptableBuilder(final Adaptable existingAdaptable) {
         return ImmutableAdaptableBuilder.of(existingAdaptable.getTopicPath())
                 .withPayload(existingAdaptable.getPayload())
-                .withHeaders(existingAdaptable.getHeaders().orElse(null));
+                .withHeaders(existingAdaptable.getDittoHeaders());
     }
 
     /**
@@ -76,7 +76,7 @@ public final class ProtocolFactory {
     public static AdaptableBuilder newAdaptableBuilder(final Adaptable existingAdaptable,
             final TopicPath overwriteTopicPath) {
         return ImmutableAdaptableBuilder.of(overwriteTopicPath).withPayload(existingAdaptable.getPayload())
-                .withHeaders(existingAdaptable.getHeaders().orElse(null));
+                .withHeaders(existingAdaptable.getDittoHeaders());
     }
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMappingStrategies.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMappingStrategies.java
@@ -58,7 +58,7 @@ abstract class AbstractMappingStrategies<T extends Jsonifiable.WithPredicate<Jso
      * @return the headers of the message.
      */
     protected static DittoHeaders dittoHeadersFrom(final Adaptable adaptable) {
-        return adaptable.getHeaders().orElseGet(DittoHeaders::empty);
+        return adaptable.getDittoHeaders();
     }
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMessageMappingStrategies.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMessageMappingStrategies.java
@@ -23,12 +23,12 @@ import java.util.Map;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
 import org.eclipse.ditto.model.messages.Message;
 import org.eclipse.ditto.model.messages.MessageHeaderDefinition;
 import org.eclipse.ditto.model.messages.MessageHeaders;
-import org.eclipse.ditto.model.messages.MessageHeadersBuilder;
 import org.eclipse.ditto.model.messages.MessagesModelFactory;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.JsonifiableMapper;
@@ -95,27 +95,28 @@ abstract class AbstractMessageMappingStrategies<T extends Jsonifiable.WithPredic
      * value for {@link MessageHeaderDefinition#SUBJECT}.
      */
     protected static MessageHeaders messageHeadersFrom(final Adaptable adaptable) {
-        return adaptable.getHeaders()
-                .map(headers -> {
-                    final TopicPath topicPath = adaptable.getTopicPath();
-                    final DittoHeadersBuilder<?, ?> dittoHeadersBuilder = headers.toBuilder();
 
-                    // these headers are used to store message attributes of Message that are not fields.
-                    // their content comes from elsewhere; overwrite message headers of the same names.
-                    dittoHeadersBuilder.putHeader(THING_ID.getKey(),
-                            topicPath.getNamespace() + ":" + topicPath.getId());
-                    dittoHeadersBuilder.putHeader(SUBJECT.getKey(), topicPath.getSubject().orElse(""));
-                    adaptable.getPayload().getPath().getDirection().ifPresent(direction ->
-                            dittoHeadersBuilder.putHeader(DIRECTION.getKey(), direction.name()));
-                    adaptable.getPayload().getPath().getFeatureId().ifPresent(featureId ->
-                            dittoHeadersBuilder.putHeader(FEATURE_ID.getKey(), featureId));
-                    adaptable.getPayload().getStatus().ifPresent(statusCode ->
-                            dittoHeadersBuilder.putHeader(STATUS_CODE.getKey(), String.valueOf(statusCode.toInt())));
-                    return dittoHeadersBuilder.build();
-                })
-                .map(MessagesModelFactory::newHeadersBuilder)
-                .map(MessageHeadersBuilder::build)
-                .orElseThrow(() -> new IllegalArgumentException("Adaptable did not have headers at all!"));
+        if (adaptable.getDittoHeaders().isEmpty()) {
+            throw new IllegalArgumentException("Adaptable did not have headers at all!");
+        }
+
+        final TopicPath topicPath = adaptable.getTopicPath();
+        final DittoHeadersBuilder<?, ?> dittoHeadersBuilder = adaptable.getDittoHeaders().toBuilder();
+
+        // these headers are used to store message attributes of Message that are not fields.
+        // their content comes from elsewhere; overwrite message headers of the same names.
+        dittoHeadersBuilder.putHeader(THING_ID.getKey(),
+                topicPath.getNamespace() + ":" + topicPath.getId());
+        dittoHeadersBuilder.putHeader(SUBJECT.getKey(), topicPath.getSubject().orElse(""));
+        adaptable.getPayload().getPath().getDirection().ifPresent(direction ->
+                dittoHeadersBuilder.putHeader(DIRECTION.getKey(), direction.name()));
+        adaptable.getPayload().getPath().getFeatureId().ifPresent(featureId ->
+                dittoHeadersBuilder.putHeader(FEATURE_ID.getKey(), featureId));
+        adaptable.getPayload().getStatus().ifPresent(statusCode ->
+                dittoHeadersBuilder.putHeader(STATUS_CODE.getKey(), String.valueOf(statusCode.toInt())));
+        final DittoHeaders newDittoHeaders = dittoHeadersBuilder.build();
+
+        return MessagesModelFactory.newHeadersBuilder(newDittoHeaders).build();
     }
 
     /**

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMessageMappingStrategies.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/adaptables/AbstractMessageMappingStrategies.java
@@ -87,7 +87,6 @@ abstract class AbstractMessageMappingStrategies<T extends Jsonifiable.WithPredic
      * @throws NullPointerException if {@code adaptable} is {@code null}.
      * @throws IllegalArgumentException if {@code adaptable}
      * <ul>
-     * <li>has no headers,</li>
      * <li>contains headers with a value that did not represent its appropriate Java type or</li>
      * <li>if the headers of {@code adaptable} did lack a mandatory header.</li>
      * </ul>
@@ -95,11 +94,6 @@ abstract class AbstractMessageMappingStrategies<T extends Jsonifiable.WithPredic
      * value for {@link MessageHeaderDefinition#SUBJECT}.
      */
     protected static MessageHeaders messageHeadersFrom(final Adaptable adaptable) {
-
-        if (adaptable.getDittoHeaders().isEmpty()) {
-            throw new IllegalArgumentException("Adaptable did not have headers at all!");
-        }
-
         final TopicPath topicPath = adaptable.getTopicPath();
         final DittoHeadersBuilder<?, ?> dittoHeadersBuilder = adaptable.getDittoHeaders().toBuilder();
 

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/MessageMapper.java
@@ -18,7 +18,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.connectivity.MessageMapperConfigurationInvalidException;
@@ -124,10 +123,10 @@ public interface MessageMapper {
      */
     static Optional<String> findContentType(final Adaptable adaptable) {
         checkNotNull(adaptable);
-        return adaptable.getHeaders().flatMap(h -> h.entrySet()
+        return adaptable.getDittoHeaders().entrySet()
                 .stream()
                 .filter(e -> ExternalMessage.CONTENT_TYPE_HEADER.equalsIgnoreCase(e.getKey()))
                 .findFirst()
-                .map(Map.Entry::getValue));
+                .map(Map.Entry::getValue);
     }
 }

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapper.java
@@ -133,7 +133,7 @@ public final class NormalizedMessageMapper extends AbstractMessageMapper {
         builder.set(Payload.JsonFields.PATH, payload.getPath().toString());
         payload.getFields().ifPresent(fields -> builder.set(Payload.JsonFields.FIELDS, fields.toString()));
         builder.set(JsonifiableAdaptable.JsonFields.HEADERS,
-                dittoHeadersToJson(adaptable.getHeaders().orElse(DittoHeaders.empty())));
+                dittoHeadersToJson(adaptable.getDittoHeaders()));
         return builder.build();
     }
 

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
@@ -41,7 +41,7 @@ public class DefaultOutgoingMapping implements MappingFunction<Adaptable, List<E
     public List<ExternalMessage> apply(final Adaptable adaptable) {
         final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable);
         final ExternalMessageBuilder messageBuilder = ExternalMessageFactory.newExternalMessageBuilder(
-                adaptable.getHeaders().orElseGet(adaptable::getDittoHeaders))
+                adaptable.getDittoHeaders())
                         .withTopicPath(adaptable.getTopicPath());
         messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
                 DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedOutgoingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/ScriptedOutgoingMapping.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.script.Bindings;
 
-import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
@@ -98,11 +97,11 @@ public final class ScriptedOutgoingMapping implements MappingFunction<Adaptable,
             });
         } catch (final RhinoException e) {
             throw buildMessageMappingFailedException(e, MessageMapper.findContentType(adaptable).orElse(""),
-                    adaptable.getHeaders().orElseGet(DittoHeaders::empty));
+                    adaptable.getDittoHeaders());
         } catch (final Throwable e) {
             throw MessageMappingFailedException.newBuilder(MessageMapper.findContentType(adaptable).orElse(""))
                     .description(e.getMessage())
-                    .dittoHeaders(adaptable.getHeaders().orElseGet(DittoHeaders::empty))
+                    .dittoHeaders(adaptable.getDittoHeaders())
                     .cause(e)
                     .build();
         }
@@ -139,7 +138,7 @@ public final class ScriptedOutgoingMapping implements MappingFunction<Adaptable,
         } else {
             throw MessageMappingFailedException.newBuilder("")
                     .description("Neither <bytePayload> nor <textPayload> were defined in the outgoing script")
-                    .dittoHeaders(adaptable.getHeaders().orElse(DittoHeaders.empty()))
+                    .dittoHeaders(adaptable.getDittoHeaders())
                     .build();
         }
 

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/WrappingMessageMapperTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/WrappingMessageMapperTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.json.JsonObject;
@@ -68,7 +67,7 @@ public class WrappingMessageMapperTest {
         when(mockMapper.getId()).thenReturn("mockMapper");
         when(mockMapper.getDefaultOptions()).thenReturn(DEFAULT_OPTIONS);
         when(mockAdaptable.getTopicPath()).thenReturn(ProtocolFactory.emptyTopicPath());
-        when(mockAdaptable.getHeaders()).thenReturn(Optional.of(DittoHeaders.empty()));
+        when(mockAdaptable.getDittoHeaders()).thenReturn(DittoHeaders.empty());
         when(mockAdaptable.getPayload()).thenReturn(ProtocolFactory.newPayload("{\"path\":\"/\"}"));
         mapperLimitsConfig = DefaultMappingConfig.of(ConfigFactory.load("mapping-test"));
         underTest = WrappingMessageMapper.wrap(mockMapper);
@@ -98,7 +97,7 @@ public class WrappingMessageMapperTest {
     public void mapAdaptable() {
         final DittoHeaders headers =
                 DittoHeaders.of(Collections.singletonMap(ExternalMessage.CONTENT_TYPE_HEADER, "contentType"));
-        when(mockAdaptable.getHeaders()).thenReturn(Optional.of(headers));
+        when(mockAdaptable.getDittoHeaders()).thenReturn(headers);
 
         underTest.configure(mapperLimitsConfig, mockConfiguration);
         underTest.map(mockAdaptable);
@@ -127,7 +126,7 @@ public class WrappingMessageMapperTest {
 
         underTest.configure(mapperLimitsConfig, mockConfiguration);
         underTest.map(mockAdaptable);
-        verify(mockAdaptable, VerificationModeFactory.atLeastOnce()).getHeaders();
+        verify(mockAdaptable, VerificationModeFactory.atLeastOnce()).getDittoHeaders();
         verify(mockMapper).map(mockAdaptable);
     }
 

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMappingTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMappingTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
@@ -62,7 +63,7 @@ public class DefaultIncomingMappingTest {
 
         assertThat(adaptableList).isNotEmpty();
         final Adaptable adaptable = adaptableList.get(0);
-        assertThat(adaptable.getHeaders()).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
+        assertThat(Optional.of(adaptable.getDittoHeaders())).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
         assertThat(adaptable.getTopicPath()).isEqualTo(expectedTopicPath);
         assertThat((CharSequence) adaptable.getPayload().getPath()).isEqualTo(expectedPath);
     }
@@ -83,7 +84,7 @@ public class DefaultIncomingMappingTest {
 
         assertThat(adaptableList).isNotEmpty();
         final Adaptable adaptable = adaptableList.get(0);
-        assertThat(adaptable.getHeaders()).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
+        assertThat(Optional.of(adaptable.getDittoHeaders())).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
         assertThat(adaptable.getTopicPath()).isEqualTo(expectedTopicPath);
         assertThat((CharSequence) adaptable.getPayload().getPath()).isEqualTo(expectedPath);
     }

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMappingTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultIncomingMappingTest.java
@@ -63,7 +63,7 @@ public class DefaultIncomingMappingTest {
 
         assertThat(adaptableList).isNotEmpty();
         final Adaptable adaptable = adaptableList.get(0);
-        assertThat(Optional.of(adaptable.getDittoHeaders())).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
+        assertThat(adaptable.getDittoHeaders()).isEqualTo(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
         assertThat(adaptable.getTopicPath()).isEqualTo(expectedTopicPath);
         assertThat((CharSequence) adaptable.getPayload().getPath()).isEqualTo(expectedPath);
     }
@@ -84,7 +84,7 @@ public class DefaultIncomingMappingTest {
 
         assertThat(adaptableList).isNotEmpty();
         final Adaptable adaptable = adaptableList.get(0);
-        assertThat(Optional.of(adaptable.getDittoHeaders())).contains(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
+        assertThat(adaptable.getDittoHeaders()).isEqualTo(DittoHeaders.newBuilder().contentType(CONTENT_TYPE).build());
         assertThat(adaptable.getTopicPath()).isEqualTo(expectedTopicPath);
         assertThat((CharSequence) adaptable.getPayload().getPath()).isEqualTo(expectedPath);
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessor.java
@@ -19,7 +19,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -372,11 +371,10 @@ public final class MessageMappingProcessor {
         } catch (final DittoRuntimeException e) {
             result = resultHandler.combineResults(result, resultHandler.onException(e));
         } catch (final Exception e) {
-            final Optional<DittoHeaders> headers = adaptable.getHeaders();
-            final String contentType = headers.map(h -> h.get(ExternalMessage.CONTENT_TYPE_HEADER)).orElse("");
+            final DittoHeaders headers = adaptable.getDittoHeaders();
+            final String contentType = headers.getOrDefault(ExternalMessage.CONTENT_TYPE_HEADER, "");
             final MessageMappingFailedException mappingFailedException =
-                    buildMappingFailedException("outbound", contentType, mapper.getId(),
-                            headers.orElseGet(DittoHeaders::empty), e);
+                    buildMappingFailedException("outbound", contentType, mapper.getId(), headers, e);
             result = resultHandler.combineResults(result, resultHandler.onException(mappingFailedException));
         }
         return result;

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/Resolvers.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/Resolvers.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
-import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.placeholders.ExpressionResolver;
 import org.eclipse.ditto.model.placeholders.Placeholder;
 import org.eclipse.ditto.model.placeholders.PlaceholderFactory;
@@ -83,7 +82,7 @@ public final class Resolvers {
         final Adaptable adaptable = mappedOutboundSignal.getAdaptable();
         return PlaceholderFactory.newExpressionResolver(
                 RESOLVER_CREATORS.stream()
-                        .map(creator -> creator.create(adaptable.getHeaders().orElse(DittoHeaders.empty()), signal,
+                        .map(creator -> creator.create(adaptable.getDittoHeaders(), signal,
                                 externalMessage.getTopicPath().orElse(null),
                                 signal.getDittoHeaders().getAuthorizationContext()))
                         .toArray(PlaceholderResolver[]::new)


### PR DESCRIPTION
Adaptable.getHeaders returns unnecessary Optional<DittoHeaders> instead of DittoHeaders.