### PR TITLE
Use response of HTTP push connections as live message response

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-acknowledgements.md
+++ b/documentation/src/main/resources/pages/ditto/basic-acknowledgements.md
@@ -286,9 +286,8 @@ successful update of twin in Ditto's managed database, [request the acknowledgem
 the [built-in "twin-persisted"](#built-in-acknowledgement-labels) acknowledgement label.
 
 ### Assure QoS until processing of a live command/message by a subscriber - live-response
-In order to ensure that a live command or live message is processed by a subscriber,
-[request the acknowledgement](#requesting-acks) for
-the [built-in "live-response"](#built-in-acknowledgement-labels) acknowledgement label.
+In order to ensure that a live command or live message is processed by a subscriber, set `response-required` to true.
+This way the [built-in "live-response" acknowledgement label](#built-in-acknowledgement-labels) is [automatically requested](#requesting-acks) for the live command/message.
 This acknowledgement request is fulfilled when the subscriber sends a live response or message response.
 
 ### Assure QoS until processing of a twin event or live command/message by subscribers - custom label
@@ -300,7 +299,7 @@ without any live or message response, [request the acknowledgement](#requesting-
 ## Interaction between headers
 Three headers control how Ditto responds to a command: `response-required`, `requested-acks`, `timeout`.
 * `response-required`: `true` or `false`.
-   It governs whether the user gets a (detailed) reply.
+   It governs whether the user gets a (detailed) reply. In case of a live message or a live command it also has impact on the `requested-acks`. If `response-required` is `true`, the acknowledgement label `live-response` will be added to `requested-acks` if not present. If it is `false`, the acknowledgement label `live-response` will be removed from `requested-acks` if present.
 * `requested-acks`: JSON array of acknowledgement requests.
    It determines the content of the response and transport-layer message settlement.
 * `timeout`: Duration.

--- a/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
@@ -305,7 +305,7 @@ The following example connection defines a `ConnectionStatus` mapping with the I
 The following example connection defines `incomingConditions` and `outgoingConditions`for the ConnectionStatus mapping engine.<br/>
  Optional incomingConditions are validated before the mapping of inbound messages.<br/> 
  Optional outgoingConditions are validated before the mapping of outbound messages.<br/>
- Conditional Mapping can be achieved by using [function expressions](basic-placeholder.html#function-expressions).
+ Conditional Mapping can be achieved by using [function expressions](basic-placeholders.html#function-expressions).
  When multiple incoming or outgoing conditions are set for one `mappingEngine`, all have to equal true for the mapping to be executed.  
 
 ```json

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
@@ -70,6 +70,15 @@ automatically created [acknowledement](protocol-specification-acks.html#acknowle
 * Acknowledgement.status: the HTTP response status code is used as acknowledgement status.
 * Acknowledgement.value: the HTTP response body is used as acknowledgement value - if the response body was of 
   `content-type: application/json`, the JSON is inlined into the acknowledgment, otherwise the payload is added as JSON string.
+  
+##### Responding to Messages
+
+For Messages that are sent via a HTTP target you have two different options to respond:
+
+* Respond to the HTTP request with a valid [Ditto Protocol Message Response](protocol-specification-things-messages.html#responding-to-a-message). This requires to set the content-type to `application/vnd.eclipse.ditto+json`.
+* Configure the `live-response` acknowledgement label [as automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label). In this case there are again two options:
+  * Provide the response as ditto protocol message as described as first option.
+  * Use the payload you want to have in the Message response as payload of the HTTP response. The content type, HTTP status and payload of the HTTP response will be used to generate the Message response.
 
 
 ### Specific configuration properties

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
@@ -71,14 +71,17 @@ automatically created [acknowledement](protocol-specification-acks.html#acknowle
 * Acknowledgement.value: the HTTP response body is used as acknowledgement value - if the response body was of 
   `content-type: application/json`, the JSON is inlined into the acknowledgment, otherwise the payload is added as JSON string.
   
-##### Responding to Messages
+#### Responding to Messages
 
-For Messages that are sent via a HTTP target you have two different options to respond:
+For [Messages](basic-messages.html) that are sent via an HTTP target you have two different options to respond:
 
-* Respond to the HTTP request with a valid [Ditto Protocol Message Response](protocol-specification-things-messages.html#responding-to-a-message). This requires to set the content-type to `application/vnd.eclipse.ditto+json`.
-* Configure the `live-response` acknowledgement label [as automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label). In this case there are again two options:
-  * Provide the response as ditto protocol message as described as first option.
-  * Use the payload you want to have in the Message response as payload of the HTTP response. The content type, HTTP status and payload of the HTTP response will be used to generate the Message response.
+* Respond to the HTTP request with a HTTP response containing a valid [Ditto Protocol Message Response](protocol-specification-things-messages.html#responding-to-a-message). 
+  This requires to set the `Content-Type` header of the HTTP response to `application/vnd.eclipse.ditto+json`.
+* Configure the `live-response` acknowledgement label [as automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label). 
+  In this case there are again two options:
+  * Provide the response as Ditto Protocol Message as described in the first option above.
+  * Use the payload you want to have in the Message response as payload of the HTTP response. 
+    The `Content-Type`, HTTP status and payload of the HTTP response will be used to generate the Message response.
 
 
 ### Specific configuration properties
@@ -87,7 +90,7 @@ The specific configuration properties contain the following optional keys:
 * `parallelism` (optional): Configures how many parallel requests per connection to perform, each takes one outgoing 
 TCP connection. Default (if not provided): 1
 
-# Establishing connecting to an HTTP endpoint
+## Establishing connecting to an HTTP endpoint
 
 Ditto's [Connectivity service](architecture-services-connectivity.html) is responsible for creating new and managing 
 existing connections.
@@ -126,7 +129,7 @@ Example connection configuration to create a new HTTP connection in order to mak
 }
 ```
 
-## Client-certificate authentication
+### Client-certificate authentication
 
 Ditto supports certificate-based authentication for HTTP connections. Consult 
 [Certificates for Transport Layer Security](connectivity-tls-certificates.html)

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabelExternalUseForbiddenException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabelExternalUseForbiddenException.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.base.acks;
+
+import java.net.URI;
+import java.text.MessageFormat;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+/**
+ * Thrown if an AcknowledgementLabel was not allowed to be used (e.g. in ditto-protocol-adapter) because it is an Ditto
+ * internal {@link DittoAcknowledgementLabel}.
+ *
+ * @since 1.3.0
+ */
+@Immutable
+@JsonParsableException(errorCode = DittoAcknowledgementLabelExternalUseForbiddenException.ERROR_CODE)
+public final class DittoAcknowledgementLabelExternalUseForbiddenException extends DittoRuntimeException
+        implements AcknowledgementException {
+
+    /**
+     * Error code of this exception.
+     */
+    public static final String ERROR_CODE = ERROR_CODE_PREFIX + "ditto.acklabel.forbidden";
+
+    private static final String MESSAGE_TEMPLATE = "The Ditto internal Acknowledgement label <{0}> is not allowed " +
+            "to be issued externally!";
+
+    private static final String DEFAULT_DESCRIPTION = "Make sure to not issue an Ditto internal Acknowledgement label.";
+
+    private static final long serialVersionUID = 7892643278643243248L;
+
+    private DittoAcknowledgementLabelExternalUseForbiddenException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+
+        super(ERROR_CODE,
+                HttpStatusCode.BAD_REQUEST,
+                dittoHeaders,
+                message,
+                description,
+                cause,
+                href);
+    }
+
+    /**
+     * Constructs a new {@code DittoAcknowledgementLabelExternalUseForbiddenException} object.
+     *
+     * @param label the label that causes the exception.
+     */
+    public DittoAcknowledgementLabelExternalUseForbiddenException(final CharSequence label) {
+        this(DittoHeaders.empty(),
+                MessageFormat.format(MESSAGE_TEMPLATE, label),
+                DEFAULT_DESCRIPTION,
+                null,
+                null);
+    }
+
+    /**
+     * Constructs a new {@code DittoAcknowledgementLabelExternalUseForbiddenException} object with the exception
+     * message extracted from the given JSON object.
+     *
+     * @param jsonObject the JSON object representation of the returned exception.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new exception.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if the {@code jsonObject} misses a required field.
+     * @throws org.eclipse.ditto.json.JsonParseException if {@code jsonObject} contained an unexpected value type.
+     */
+    public static DittoAcknowledgementLabelExternalUseForbiddenException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+
+        return new DittoAcknowledgementLabelExternalUseForbiddenException(dittoHeaders,
+                readMessage(jsonObject),
+                readDescription(jsonObject).orElse(DEFAULT_DESCRIPTION),
+                null,
+                null);
+    }
+
+}

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -44,6 +44,7 @@ import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.auth.AuthorizationModelFactory;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.common.ResponseType;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTag;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.model.base.headers.metadata.MetadataHeaders;
@@ -121,6 +122,11 @@ public abstract class AbstractDittoHeaders extends AbstractMap<String, String> i
     @Override
     public Optional<String> getContentType() {
         return getStringForDefinition(DittoHeaderDefinition.CONTENT_TYPE);
+    }
+
+    @Override
+    public Optional<ContentType> getDittoContentType() {
+        return getContentType().map(ContentType::of);
     }
 
     @Override

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
@@ -367,7 +367,11 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
 
     @Override
     public S contentType(@Nullable final ContentType contentType) {
-        putCharSequence(DittoHeaderDefinition.CONTENT_TYPE, contentType.getValue());
+        if (null != contentType) {
+            putCharSequence(DittoHeaderDefinition.CONTENT_TYPE, contentType.getValue());
+        } else {
+            removeHeader(DittoHeaderDefinition.CONTENT_TYPE.getKey());
+        }
         return myself;
     }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeadersBuilder.java
@@ -42,6 +42,7 @@ import org.eclipse.ditto.model.base.auth.AuthorizationModelFactory;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.common.ResponseType;
 import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTag;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.model.base.headers.metadata.MetadataHeader;
@@ -361,6 +362,12 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
     @Override
     public S contentType(@Nullable final CharSequence contentType) {
         putCharSequence(DittoHeaderDefinition.CONTENT_TYPE, contentType);
+        return myself;
+    }
+
+    @Override
+    public S contentType(@Nullable final ContentType contentType) {
+        putCharSequence(DittoHeaderDefinition.CONTENT_TYPE, contentType.getValue());
         return myself;
     }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaders.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.model.base.acks.AcknowledgementRequest;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.common.ResponseType;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTag;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.model.base.headers.metadata.MetadataHeaders;
@@ -146,6 +147,13 @@ public interface DittoHeaders extends Jsonifiable<JsonObject>, Map<String, Strin
      * @return the content-type.
      */
     Optional<String> getContentType();
+
+    /**
+     * Returns the parsed content-type of the entity.
+     *
+     * @return the parsed content-type.
+     */
+    Optional<ContentType> getDittoContentType();
 
     /**
      * Returns the json schema version.

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeaders.java
@@ -152,6 +152,7 @@ public interface DittoHeaders extends Jsonifiable<JsonObject>, Map<String, Strin
      * Returns the parsed content-type of the entity.
      *
      * @return the parsed content-type.
+     * @since 1.3.0
      */
     Optional<ContentType> getDittoContentType();
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeadersBuilder.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeadersBuilder.java
@@ -180,10 +180,11 @@ public interface DittoHeadersBuilder<B extends DittoHeadersBuilder<B, R>, R exte
     B contentType(@Nullable CharSequence contentType);
 
     /**
-     * Sets the contentType value.
+     * Sets the Ditto typed contentType value.
      *
-     * @param contentType the contentType value to be set.
+     * @param contentType the Ditto typed contentType value to be set.
      * @return this builder for Method Chaining.
+     * @since 1.3.0
      */
     B contentType(@Nullable ContentType contentType);
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeadersBuilder.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/DittoHeadersBuilder.java
@@ -25,6 +25,7 @@ import org.eclipse.ditto.model.base.acks.AcknowledgementRequest;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
 import org.eclipse.ditto.model.base.common.ResponseType;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTag;
 import org.eclipse.ditto.model.base.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.model.base.headers.metadata.MetadataHeaderKey;
@@ -177,6 +178,14 @@ public interface DittoHeadersBuilder<B extends DittoHeadersBuilder<B, R>, R exte
      * @return this builder for Method Chaining.
      */
     B contentType(@Nullable CharSequence contentType);
+
+    /**
+     * Sets the contentType value.
+     *
+     * @param contentType the contentType value to be set.
+     * @return this builder for Method Chaining.
+     */
+    B contentType(@Nullable ContentType contentType);
 
     /**
      * Sets the ETag value.

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -10,7 +10,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-package org.eclipse.ditto.services.utils.protocol.contenttype;
+package org.eclipse.ditto.model.base.headers.contenttype;
 
 import java.util.Arrays;
 import java.util.List;
@@ -43,14 +43,15 @@ public class ContentType {
 
     public static ContentType of(final String value) {
         final String lowerCaseValue = value.toLowerCase();
+        final String mediaType = lowerCaseValue.split(";")[0];
         final boolean isText;
         final boolean isJson;
         final boolean isBinary;
-        if (TEXT_PATTERN.matcher(lowerCaseValue).matches()) {
+        if (TEXT_PATTERN.matcher(mediaType).matches()) {
             isText = true;
             isJson = false;
             isBinary = false;
-        } else if (JSON_PATTERN.matcher(lowerCaseValue).matches()) {
+        } else if (JSON_PATTERN.matcher(mediaType).matches()) {
             isText = false;
             isJson = true;
             isBinary = false;

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -12,13 +12,16 @@
  */
 package org.eclipse.ditto.model.base.headers.contenttype;
 
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
+
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
- * Parses a string as content type and provides information about how ditto should treat the payload based in its
- * content type.
+ * Parses a string as content-type and provides information about how Ditto should treat the payload based in its
+ * content-type.
  *
  * @since 1.3.0
  */
@@ -33,65 +36,109 @@ public final class ContentType {
 
     private static final Pattern JSON_PATTERN = Pattern.compile("(application/(vnd\\..+\\+)?json)");
 
+    /**
+     * The well known content-type "application/json".
+     */
     public static final ContentType APPLICATION_JSON = ContentType.of("application/json");
 
     private final String value;
-    private final ParsingStrategyType parsingStrategy;
+    private final ParsingStrategy parsingStrategy;
 
-    private ContentType(final String value, final ParsingStrategyType parsingStrategy) {
+    private ContentType(final String value, final ParsingStrategy parsingStrategy) {
         this.value = value;
         this.parsingStrategy = parsingStrategy;
     }
 
     /**
-     * Parses the given content type value into an instance of {@link ContentType}.
+     * Parses the given contentTypeValue into an instance of {@link ContentType}.
      *
-     * @param value the content-type header value.
+     * @param contentTypeValue the content-type header value.
+     * @throws NullPointerException if {@code contentTypeValue} was {@code null}.
      * @return the new instance
      */
-    public static ContentType of(final String value) {
-        final String lowerCaseValue = value.toLowerCase();
+    public static ContentType of(final CharSequence contentTypeValue) {
+        final String lowerCaseValue = checkNotNull(contentTypeValue, "contentTypeValue").toString()
+                .toLowerCase();
         final String mediaType = lowerCaseValue.split(";")[0];
-        final ParsingStrategyType parsingStrategy;
+        final ParsingStrategy parsingStrategy;
         if (TEXT_PATTERN.matcher(mediaType).matches()) {
-            parsingStrategy = ParsingStrategyType.TEXT;
+            parsingStrategy = ParsingStrategy.TEXT;
         } else if (JSON_PATTERN.matcher(mediaType).matches()) {
-            parsingStrategy = ParsingStrategyType.JSON;
+            parsingStrategy = ParsingStrategy.JSON;
         } else {
-            parsingStrategy = ParsingStrategyType.BINARY;
+            parsingStrategy = ParsingStrategy.BINARY;
         }
         return new ContentType(lowerCaseValue, parsingStrategy);
     }
 
-    public ParsingStrategyType getParsingStrategyType() {
+    /**
+     * @return the strategy of how to parse the content-type.
+     */
+    public ParsingStrategy getParsingStrategy() {
         return parsingStrategy;
     }
 
+    /**
+     * @return the actual content-type string value.
+     */
     public String getValue() {
         return value;
     }
 
+    /**
+     * @return whether this content-type is to be parsed as text.
+     */
     public boolean isText() {
-        return parsingStrategy == ParsingStrategyType.TEXT;
-    }
-
-    public boolean isJson() {
-        return parsingStrategy == ParsingStrategyType.JSON;
-    }
-
-    public boolean isBinary() {
-        return parsingStrategy == ParsingStrategyType.BINARY;
+        return parsingStrategy == ParsingStrategy.TEXT;
     }
 
     /**
-     * Known types of payload parsing in ditto.
-     *
-     * @since 1.3.0
+     * @return whether this content-type is to be parsed as JSON.
      */
-    public enum ParsingStrategyType {
+    public boolean isJson() {
+        return parsingStrategy == ParsingStrategy.JSON;
+    }
+
+    /**
+     * @return whether this content-type is to be parsed as binary.
+     */
+    public boolean isBinary() {
+        return parsingStrategy == ParsingStrategy.BINARY;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ContentType that = (ContentType) o;
+        return value.equals(that.value) &&
+                parsingStrategy == that.parsingStrategy;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(value, parsingStrategy);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "value=" + value +
+                ", parsingStrategy=" + parsingStrategy +
+                "]";
+    }
+
+    /**
+     * Known strategies of payload parsing in Ditto.
+     */
+    public enum ParsingStrategy {
         TEXT,
         JSON,
-        BINARY;
+        BINARY
     }
 
 }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -16,7 +16,13 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Pattern;
 
-public class ContentType {
+/**
+ * Parses a string as content type and provides information about how ditto should treat the payload based in its
+ * content type.
+ *
+ * @since 1.3.0
+ */
+public final class ContentType {
 
     // all types of application content types that are considered to be text (application/javascript, application/ecmascript)
     private static final List<String> APPLICATION_TYPES_CONSIDERED_TO_BE_STRING =
@@ -30,53 +36,57 @@ public class ContentType {
     public static final ContentType APPLICATION_JSON = ContentType.of("application/json");
 
     private final String value;
-    private final boolean isText;
-    private final boolean isJson;
-    private final boolean isBinary;
+    private final ParsingStrategyType parsingStrategy;
 
-    private ContentType(final String value, final boolean isText, final boolean isJson, final boolean isBinary) {
+    private ContentType(final String value, final ParsingStrategyType parsingStrategy) {
         this.value = value;
-        this.isText = isText;
-        this.isJson = isJson;
-        this.isBinary = isBinary;
+        this.parsingStrategy = parsingStrategy;
     }
 
+    /**
+     * Parses the given content type value into an instance of {@link ContentType}.
+     *
+     * @param value the content-type header value.
+     * @return the new instance
+     */
     public static ContentType of(final String value) {
         final String lowerCaseValue = value.toLowerCase();
         final String mediaType = lowerCaseValue.split(";")[0];
-        final boolean isText;
-        final boolean isJson;
-        final boolean isBinary;
+        final ParsingStrategyType parsingStrategy;
         if (TEXT_PATTERN.matcher(mediaType).matches()) {
-            isText = true;
-            isJson = false;
-            isBinary = false;
+            parsingStrategy = ParsingStrategyType.TEXT;
         } else if (JSON_PATTERN.matcher(mediaType).matches()) {
-            isText = false;
-            isJson = true;
-            isBinary = false;
+            parsingStrategy = ParsingStrategyType.JSON;
         } else {
-            isText = false;
-            isJson = false;
-            isBinary = true;
+            parsingStrategy = ParsingStrategyType.BINARY;
         }
-        return new ContentType(lowerCaseValue, isText, isJson, isBinary);
+        return new ContentType(lowerCaseValue, parsingStrategy);
     }
 
-    public boolean isText() {
-        return isText;
-    }
-
-    public boolean isJson() {
-        return isJson;
-    }
-
-    public boolean isBinary() {
-        return isBinary;
+    public ParsingStrategyType getParsingStrategyType() {
+        return parsingStrategy;
     }
 
     public String getValue() {
         return value;
+    }
+
+    public boolean isText() {
+        return parsingStrategy == ParsingStrategyType.TEXT;
+    }
+
+    public boolean isJson() {
+        return parsingStrategy == ParsingStrategyType.JSON;
+    }
+
+    public boolean isBinary() {
+        return parsingStrategy == ParsingStrategyType.BINARY;
+    }
+
+    public enum ParsingStrategyType {
+        TEXT,
+        JSON,
+        BINARY;
     }
 
 }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -19,6 +19,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.regex.Pattern;
 
+import org.eclipse.ditto.model.base.common.DittoConstants;
+
 /**
  * Parses a string as content-type and provides information about how Ditto should treat the payload based in its
  * content-type.
@@ -83,6 +85,14 @@ public final class ContentType {
      */
     public String getValue() {
         return value;
+    }
+
+    /**
+     * @return whether this content-type matches the Ditto Protocol {@link DittoConstants#DITTO_PROTOCOL_CONTENT_TYPE}.
+     */
+    public boolean isDittoContentType() {
+        final String mediaType = value.split(";")[0];
+        return DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE.equals(mediaType);
     }
 
     /**

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -90,7 +90,7 @@ public final class ContentType {
     /**
      * @return whether this content-type matches the Ditto Protocol {@link DittoConstants#DITTO_PROTOCOL_CONTENT_TYPE}.
      */
-    public boolean isDittoContentType() {
+    public boolean isDittoProtocol() {
         final String mediaType = value.split(";")[0];
         return DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE.equals(mediaType);
     }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -44,10 +44,12 @@ public final class ContentType {
     public static final ContentType APPLICATION_JSON = ContentType.of("application/json");
 
     private final String value;
+    private final String mediaType;
     private final ParsingStrategy parsingStrategy;
 
-    private ContentType(final String value, final ParsingStrategy parsingStrategy) {
+    private ContentType(final String value, final String mediaType, final ParsingStrategy parsingStrategy) {
         this.value = value;
+        this.mediaType = mediaType;
         this.parsingStrategy = parsingStrategy;
     }
 
@@ -55,8 +57,8 @@ public final class ContentType {
      * Parses the given contentTypeValue into an instance of {@link ContentType}.
      *
      * @param contentTypeValue the content-type header value.
-     * @throws NullPointerException if {@code contentTypeValue} was {@code null}.
      * @return the new instance
+     * @throws NullPointerException if {@code contentTypeValue} was {@code null}.
      */
     public static ContentType of(final CharSequence contentTypeValue) {
         final String lowerCaseValue = checkNotNull(contentTypeValue, "contentTypeValue").toString()
@@ -70,7 +72,7 @@ public final class ContentType {
         } else {
             parsingStrategy = ParsingStrategy.BINARY;
         }
-        return new ContentType(lowerCaseValue, parsingStrategy);
+        return new ContentType(lowerCaseValue, mediaType, parsingStrategy);
     }
 
     /**
@@ -91,7 +93,6 @@ public final class ContentType {
      * @return whether this content-type matches the Ditto Protocol {@link DittoConstants#DITTO_PROTOCOL_CONTENT_TYPE}.
      */
     public boolean isDittoProtocol() {
-        final String mediaType = value.split(";")[0];
         return DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE.equals(mediaType);
     }
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/ContentType.java
@@ -83,6 +83,11 @@ public final class ContentType {
         return parsingStrategy == ParsingStrategyType.BINARY;
     }
 
+    /**
+     * Known types of payload parsing in ditto.
+     *
+     * @since 1.3.0
+     */
     public enum ParsingStrategyType {
         TEXT,
         JSON,

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/package-info.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/contenttype/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault
+package org.eclipse.ditto.model.base.headers.contenttype;
+

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
@@ -16,42 +16,45 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 
+/**
+ * Unit tests for {@link ContentType}.
+ */
 public final class ContentTypeTest {
 
     @Test
     public void applicationJsonIsJson() {
         final ContentType applicationJson = ContentType.of("application/json");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.JSON);
     }
 
     @Test
     public void applicationJsonWithCharsetIsJson() {
         final ContentType applicationJson = ContentType.of("application/json;charset=UTF-8");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.JSON);
     }
 
     @Test
     public void vendorSpecificApplicationJsonIsJson() {
         final ContentType applicationJson = ContentType.of("application/vnd.eclipse.ditto+json");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.JSON);
     }
 
     @Test
     public void applicationJavascriptIsText() {
         final ContentType applicationJson = ContentType.of("application/javascript");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.TEXT);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.TEXT);
     }
 
     @Test
     public void applicationOctetStreamIsBinary() {
         final ContentType applicationJson = ContentType.of("application/octet-stream");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.BINARY);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.BINARY);
     }
 
     @Test
     public void imageJpegIsBinary() {
         final ContentType applicationJson = ContentType.of("image/jpeg");
-        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.BINARY);
+        assertThat(applicationJson.getParsingStrategy()).isEqualTo(ContentType.ParsingStrategy.BINARY);
     }
 
 }

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
@@ -21,49 +21,37 @@ public final class ContentTypeTest {
     @Test
     public void applicationJsonIsJson() {
         final ContentType applicationJson = ContentType.of("application/json");
-        assertThat(applicationJson.isText()).isFalse();
-        assertThat(applicationJson.isJson()).isTrue();
-        assertThat(applicationJson.isBinary()).isFalse();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
     }
 
     @Test
     public void applicationJsonWithCharsetIsJson() {
         final ContentType applicationJson = ContentType.of("application/json;charset=UTF-8");
-        assertThat(applicationJson.isText()).isFalse();
-        assertThat(applicationJson.isJson()).isTrue();
-        assertThat(applicationJson.isBinary()).isFalse();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
     }
 
     @Test
     public void vendorSpecificApplicationJsonIsJson() {
         final ContentType applicationJson = ContentType.of("application/vnd.eclipse.ditto+json");
-        assertThat(applicationJson.isText()).isFalse();
-        assertThat(applicationJson.isJson()).isTrue();
-        assertThat(applicationJson.isBinary()).isFalse();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.JSON);
     }
 
     @Test
     public void applicationJavascriptIsText() {
         final ContentType applicationJson = ContentType.of("application/javascript");
-        assertThat(applicationJson.isText()).isTrue();
-        assertThat(applicationJson.isJson()).isFalse();
-        assertThat(applicationJson.isBinary()).isFalse();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.TEXT);
     }
 
     @Test
     public void applicationOctetStreamIsBinary() {
         final ContentType applicationJson = ContentType.of("application/octet-stream");
-        assertThat(applicationJson.isText()).isFalse();
-        assertThat(applicationJson.isJson()).isFalse();
-        assertThat(applicationJson.isBinary()).isTrue();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.BINARY);
     }
 
     @Test
     public void imageJpegIsBinary() {
         final ContentType applicationJson = ContentType.of("image/jpeg");
-        assertThat(applicationJson.isText()).isFalse();
-        assertThat(applicationJson.isJson()).isFalse();
-        assertThat(applicationJson.isBinary()).isTrue();
+        assertThat(applicationJson.getParsingStrategyType()).isEqualTo(ContentType.ParsingStrategyType.BINARY);
     }
 
 }

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/contenttype/ContentTypeTest.java
@@ -10,7 +10,7 @@
 *
 * SPDX-License-Identifier: EPL-2.0
 */
-package org.eclipse.ditto.services.utils.protocol.contenttype;
+package org.eclipse.ditto.model.base.headers.contenttype;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +21,14 @@ public final class ContentTypeTest {
     @Test
     public void applicationJsonIsJson() {
         final ContentType applicationJson = ContentType.of("application/json");
+        assertThat(applicationJson.isText()).isFalse();
+        assertThat(applicationJson.isJson()).isTrue();
+        assertThat(applicationJson.isBinary()).isFalse();
+    }
+
+    @Test
+    public void applicationJsonWithCharsetIsJson() {
+        final ContentType applicationJson = ContentType.of("application/json;charset=UTF-8");
         assertThat(applicationJson.isText()).isFalse();
         assertThat(applicationJson.isJson()).isTrue();
         assertThat(applicationJson.isBinary()).isFalse();

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
@@ -186,19 +186,6 @@ public final class MessageHeadersBuilder extends AbstractDittoHeadersBuilder<Mes
         return myself;
     }
 
-    /**
-     * Sets the MIME contentType of the payload of the Message.
-     *
-     * @param contentType the MIME contentType of the payload of the message.
-     * @return this builder to allow method chaining.
-     * @throws IllegalArgumentException if {@code contentType} is empty.
-     */
-    @Override
-    public MessageHeadersBuilder contentType(@Nullable final CharSequence contentType) {
-        putCharSequence(DittoHeaderDefinition.CONTENT_TYPE, contentType);
-        return myself;
-    }
-
     @Override
     public MessageHeadersBuilder timeout(final Duration timeout) {
         return super.timeout(timeout);

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeadersBuilder.java
@@ -30,7 +30,6 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.headers.AbstractDittoHeadersBuilder;
-import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.things.ThingId;
 
@@ -184,6 +183,18 @@ public final class MessageHeadersBuilder extends AbstractDittoHeadersBuilder<Mes
     public MessageHeadersBuilder featureId(@Nullable final CharSequence featureId) {
         putCharSequence(MessageHeaderDefinition.FEATURE_ID, featureId);
         return myself;
+    }
+
+    /**
+     * Sets the MIME contentType of the payload of the Message.
+     *
+     * @param contentType the MIME contentType of the payload of the message.
+     * @return this builder to allow method chaining.
+     * @throws IllegalArgumentException if {@code contentType} is empty.
+     */
+    @Override
+    public MessageHeadersBuilder contentType(@Nullable final CharSequence contentType) {
+        return super.contentType(contentType);
     }
 
     @Override

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/signals/AbstractMessageSignalMapper.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/signals/AbstractMessageSignalMapper.java
@@ -95,7 +95,7 @@ abstract class AbstractMessageSignalMapper<T extends Signal<?> & WithThingId> ex
     DittoHeaders enhanceHeaders(final T command) {
         final MessageHeaders messageHeaders = extractMessageHeaders(command);
         final DittoHeaders dittoHeaders = command.getDittoHeaders();
-        // merge inner message headers and ditto headers (ditto headers win in case of a conflict)
-        return messageHeaders.toBuilder().putHeaders(dittoHeaders).build();
+        // merge inner message headers and ditto headers (message headers win in case of a conflict)
+        return dittoHeaders.toBuilder().putHeaders(messageHeaders).build();
     }
 }

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoAckRequestsFilterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoAckRequestsFilterTest.java
@@ -99,6 +99,7 @@ public final class DittoAckRequestsFilterTest {
                 .collect(JsonCollectors.valuesToArray());
         final String value = allAcknowledgementRequestsJsonArray.toString();
         final JsonArray externalAcknowledgementRequests = allAcknowledgementRequestsJsonArray.toBuilder()
+                .remove(2) // "live-response"
                 .remove(1) // "twin-persisted"
                 .build();
         final String expected = externalAcknowledgementRequests.toString();

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
@@ -422,12 +422,12 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
     @Test
     public void acknowledgementToAdaptable() {
         final Acknowledgement acknowledgement =
-                Acknowledgement.of(TWIN_PERSISTED, ThingId.of("thing:id"), HttpStatusCode.CONTINUE, DittoHeaders.empty());
+                Acknowledgement.of(AcknowledgementLabel.of("my-twin-persisted"), ThingId.of("thing:id"), HttpStatusCode.CONTINUE, DittoHeaders.empty());
 
         final Adaptable adaptable = underTest.toAdaptable((Signal<?>) acknowledgement);
 
         assertThat(adaptable.getTopicPath())
-                .isEqualTo(ProtocolFactory.newTopicPath("thing/id/things/twin/acks/twin-persisted"));
+                .isEqualTo(ProtocolFactory.newTopicPath("thing/id/things/twin/acks/my-twin-persisted"));
         assertThat((Iterable<?>) adaptable.getPayload().getPath()).isEmpty();
         assertThat(adaptable.getPayload().getStatus()).contains(HttpStatusCode.CONTINUE);
     }

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/things/MessageCommandAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/things/MessageCommandAdapterTest.java
@@ -33,6 +33,7 @@ import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.messages.KnownMessageSubjects;
 import org.eclipse.ditto.model.messages.Message;
@@ -161,7 +162,7 @@ public final class MessageCommandAdapterTest implements ProtocolAdapterTest {
         } else if (payload.asJson == null) {
             return null;
         } else {
-            final boolean isJson = MessageDeserializer.shouldBeInterpretedAsJson(payload.contentType);
+            final boolean isJson = ContentType.of(payload.contentType).isJson();
             final String representation = isJson ? payload.asJson.toString() : payload.asJson.formatAsString();
             return ByteBuffer.wrap(representation.getBytes());
         }

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/things/MessageCommandResponseAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/things/MessageCommandResponseAdapterTest.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.messages.KnownMessageSubjects;
 import org.eclipse.ditto.model.messages.Message;
+import org.eclipse.ditto.model.messages.MessageBuilder;
 import org.eclipse.ditto.model.messages.MessageDirection;
 import org.eclipse.ditto.model.messages.MessageHeaderDefinition;
 import org.eclipse.ditto.model.messages.MessageHeaders;
@@ -162,7 +163,9 @@ public final class MessageCommandResponseAdapterTest implements ProtocolAdapterT
                 .messages()
                 .subject(subject)
                 .build();
-        final JsonPointer path = JsonPointer.of("/outbox/messages/" + subject);
+        final String box = "outbox";
+        final String preamble = isFeatureResponse() ? String.format("features/%s/%s", FEATURE_ID, box) : box;
+        final JsonPointer path = JsonPointer.of(String.format("/%s/messages/%s", preamble, subject));
 
         final DittoHeaders expectedHeaders = TestConstants.DITTO_HEADERS_V_2.toBuilder()
                 .contentType(contentType)
@@ -178,6 +181,7 @@ public final class MessageCommandResponseAdapterTest implements ProtocolAdapterT
         final Message<Object> theMessage = Message.newBuilder(
                 MessageHeaders.newBuilder(messageDirection, TestConstants.THING_ID, subject)
                         .contentType(contentType)
+                        .featureId(isFeatureResponse() ? FEATURE_ID : null)
                         .correlationId(CORRELATION_ID)
                         .statusCode(statusCode)
                         .schemaVersion(JsonSchemaVersion.V_2)

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapper.java
@@ -17,6 +17,7 @@ import static java.util.Collections.singletonList;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -24,8 +25,11 @@ import java.util.Optional;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.CharsetDeterminer;
+import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.model.base.exceptions.DittoJsonException;
+import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.MappingContext;
 import org.eclipse.ditto.model.connectivity.MessageMappingFailedException;
@@ -79,8 +83,12 @@ public final class DittoMessageMapper extends AbstractMessageMapper {
 
         final boolean isError = TopicPath.Criterion.ERRORS.equals(adaptable.getTopicPath().getCriterion());
         final boolean isResponse = adaptable.getPayload().getStatus().isPresent();
+        final DittoHeadersBuilder<?, ?> dittoHeadersBuilder = DittoHeaders.newBuilder()
+                .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);
+        adaptable.getHeaders().flatMap(DittoHeaders::getCorrelationId)
+                .ifPresent(dittoHeadersBuilder::correlationId);
         return singletonList(
-                ExternalMessageFactory.newExternalMessageBuilder(Collections.emptyMap())
+                ExternalMessageFactory.newExternalMessageBuilder(dittoHeadersBuilder.build())
                         .withTopicPath(adaptable.getTopicPath())
                         .withText(jsonString)
                         .asResponse(isResponse)

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActor.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -611,7 +612,8 @@ public final class MessageMappingProcessorActor
             final DittoHeaders mappedHeaders =
                     applyInboundHeaderMapping(errorResponse, message, authorizationContext,
                             message.getTopicPath().orElse(null), message.getInternalHeaders());
-            logger.info("Resolved mapped headers of {} : with HeaderMapping {} : and external headers {}", mappedHeaders, message.getHeaderMapping(), message.getHeaders());
+            logger.info("Resolved mapped headers of {} : with HeaderMapping {} : and external headers {}",
+                    mappedHeaders, message.getHeaderMapping(), message.getHeaders());
             handleErrorResponse(dittoRuntimeException, errorResponse.setDittoHeaders(mappedHeaders),
                     ActorRef.noSender());
         } else {
@@ -1178,6 +1180,36 @@ public final class MessageMappingProcessorActor
 
         private Mapped asMapped() {
             return (Mapped) delegate;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + " [" +
+                    "delegate=" + delegate +
+                    ", entityId=" + entityId +
+                    ", sender=" + sender +
+                    ", extra=" + extra +
+                    "]";
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            final OutboundSignalWithId that = (OutboundSignalWithId) o;
+            return Objects.equals(delegate, that.delegate) &&
+                    Objects.equals(entityId, that.entityId) &&
+                    Objects.equals(sender, that.sender) &&
+                    Objects.equals(extra, that.extra);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(delegate, entityId, sender, extra);
         }
 
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -174,27 +174,28 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
     }
 
     @Override
-    protected CompletionStage<Acknowledgement> publishMessage(final Signal<?> signal,
+    protected CompletionStage<CommandResponseOrAcknowledgement> publishMessage(final Signal<?> signal,
             @Nullable final Target autoAckTarget,
             final AmqpTarget publishTarget,
             final ExternalMessage message,
+            final int maxTotalMessageSize,
             final int ackSizeQuota) {
 
         if (!isInBackOffMode) {
             return doPublishMessage(signal, autoAckTarget, publishTarget, message);
         } else {
-            final CompletableFuture<Acknowledgement> backOffModeFuture = new CompletableFuture<>();
+            final CompletableFuture<CommandResponseOrAcknowledgement> backOffModeFuture = new CompletableFuture<>();
             backOffModeFuture.completeExceptionally(getBackOffModeError(message, publishTarget.getJmsDestination()));
             return backOffModeFuture;
         }
     }
 
-    private CompletionStage<Acknowledgement> doPublishMessage(@Nullable final Signal<?> signal,
+    private CompletionStage<CommandResponseOrAcknowledgement> doPublishMessage(@Nullable final Signal<?> signal,
             @Nullable final Target autoAckTarget,
             final AmqpTarget publishTarget,
             final ExternalMessage message) {
 
-        final CompletableFuture<Acknowledgement> sendResult = new CompletableFuture<>();
+        final CompletableFuture<CommandResponseOrAcknowledgement> sendResult = new CompletableFuture<>();
         try {
             final MessageProducer producer = getProducer(publishTarget.getJmsDestination());
             if (producer != null) {
@@ -209,7 +210,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
                             sendResult.complete(null);
                         } else {
                             final Acknowledgement ack = toAcknowledgement(signal, autoAckTarget);
-                            sendResult.complete(ack);
+                            sendResult.complete(new CommandResponseOrAcknowledgement(null, ack));
                         }
                         log.withCorrelationId(message.getInternalHeaders()).debug("Sent: <{}>", jmsMessage);
                     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -124,6 +124,11 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
     }
 
     @Override
+    protected boolean shouldPublishAcknowledgement(final Acknowledgement acknowledgement) {
+        return !NO_ACK_LABEL.equals(acknowledgement.getLabel());
+    }
+
+    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         receiveBuilder.match(ProducerClosedStatusReport.class, this::handleProducerClosedStatusReport)
                 .matchEquals(START_PRODUCER, this::handleStartProducer);

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -164,6 +164,11 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
     }
 
     @Override
+    protected boolean shouldPublishAcknowledgement(final Acknowledgement acknowledgement) {
+        return !NO_ACK_LABEL.equals(acknowledgement.getLabel());
+    }
+
+    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         // noop
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -325,9 +325,8 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                     acknowledgement = null; // Response is expected to be the live-response.
                 } else if (NO_ACK_LABEL.equals(label)) {
                     // No Acks declared as issued acks => Handle response either as live response or as acknowledgement.
-                    final boolean isDittoProtocolMessage = dittoHeaders.getContentType()
-                            .map(org.eclipse.ditto.model.base.headers.contenttype.ContentType::of)
-                            .filter(org.eclipse.ditto.model.base.headers.contenttype.ContentType::isDittoContentType)
+                    final boolean isDittoProtocolMessage = dittoHeaders.getDittoContentType()
+                            .filter(org.eclipse.ditto.model.base.headers.contenttype.ContentType::isDittoProtocol)
                             .isPresent();
                     if (isDittoProtocolMessage && body.isObject()) {
                         final CommandResponse<?> parsedResponse = toCommandResponse(body.asObject());
@@ -434,9 +433,8 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
             final JsonValue jsonValue,
             final HttpStatusCode status) {
 
-        final boolean isDittoProtocolMessage = dittoHeaders.getContentType()
-                .map(org.eclipse.ditto.model.base.headers.contenttype.ContentType::of)
-                .filter(org.eclipse.ditto.model.base.headers.contenttype.ContentType::isDittoContentType)
+        final boolean isDittoProtocolMessage = dittoHeaders.getDittoContentType()
+                .filter(org.eclipse.ditto.model.base.headers.contenttype.ContentType::isDittoProtocol)
                 .isPresent();
         if (isDittoProtocolMessage && jsonValue.isObject()) {
             final CommandResponse<?> commandResponse = toCommandResponse(jsonValue.asObject());

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublisherActor.java
@@ -124,10 +124,11 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
     }
 
     @Override
-    protected CompletionStage<Acknowledgement> publishMessage(final Signal<?> signal,
+    protected CompletionStage<CommandResponseOrAcknowledgement> publishMessage(final Signal<?> signal,
             @Nullable final Target autoAckTarget,
             final KafkaPublishTarget publishTarget,
             final ExternalMessage message,
+            final int maxTotalMessageSize,
             final int ackSizeQuota) {
 
         if (producer == null) {
@@ -139,7 +140,7 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
             return CompletableFuture.failedFuture(error);
         } else {
             final ProducerRecord<String, String> record = producerRecord(publishTarget, message);
-            final CompletableFuture<Acknowledgement> resultFuture = new CompletableFuture<>();
+            final CompletableFuture<CommandResponseOrAcknowledgement> resultFuture = new CompletableFuture<>();
             final Callback callBack = new ProducerCallBack(signal, autoAckTarget, ackSizeQuota, resultFuture,
                     this::escalateIfNotRetryable, connection);
             producer.send(record, callBack);
@@ -254,7 +255,7 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
         private final Signal<?> signal;
         @Nullable private final Target autoAckTarget;
         private final int ackSizeQuota;
-        private final CompletableFuture<Acknowledgement> resultFuture;
+        private final CompletableFuture<CommandResponseOrAcknowledgement> resultFuture;
         private final Consumer<Exception> checkException;
         private int currentQuota;
         private final Connection connection;
@@ -262,7 +263,7 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
         private ProducerCallBack(final Signal<?> signal,
                 @Nullable final Target autoAckTarget,
                 final int ackSizeQuota,
-                final CompletableFuture<Acknowledgement> resultFuture,
+                final CompletableFuture<CommandResponseOrAcknowledgement> resultFuture,
                 final Consumer<Exception> checkException,
                 final Connection connection) {
 
@@ -280,7 +281,7 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
                 resultFuture.completeExceptionally(exception);
                 checkException.accept(exception);
             } else {
-                resultFuture.complete(ackFromMetadata(metadata));
+                resultFuture.complete(new CommandResponseOrAcknowledgement(null, ackFromMetadata(metadata)));
             }
         }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublisherActor.java
@@ -114,6 +114,11 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
     }
 
     @Override
+    protected boolean shouldPublishAcknowledgement(final Acknowledgement acknowledgement) {
+        return !NO_ACK_LABEL.equals(acknowledgement.getLabel());
+    }
+
+    @Override
     protected void postEnhancement(final ReceiveBuilder receiveBuilder) {
         // noop
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttPublisherActor.java
@@ -127,6 +127,11 @@ abstract class AbstractMqttPublisherActor<P, R> extends BasePublisherActor<MqttP
     }
 
     @Override
+    protected boolean shouldPublishAcknowledgement(final Acknowledgement acknowledgement) {
+        return !NO_ACK_LABEL.equals(acknowledgement.getLabel());
+    }
+
+    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         receiveBuilder.match(OutboundSignal.Mapped.class, this::isDryRun,
                 outbound -> log().info("Message dropped in dry run mode: {}", outbound));

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttPublisherActor.java
@@ -148,10 +148,12 @@ abstract class AbstractMqttPublisherActor<P, R> extends BasePublisherActor<MqttP
     }
 
     @Override
-    protected CompletionStage<Acknowledgement> publishMessage(final Signal<?> signal,
+    protected CompletionStage<CommandResponseOrAcknowledgement> publishMessage(final Signal<?> signal,
             @Nullable final Target autoAckTarget,
             final MqttPublishTarget publishTarget,
-            final ExternalMessage message, int ackSizeQuota) {
+            final ExternalMessage message,
+            final int maxTotalMessageSize,
+            final int ackSizeQuota) {
 
         try {
             final MqttQos qos = determineQos(autoAckTarget);
@@ -160,7 +162,8 @@ abstract class AbstractMqttPublisherActor<P, R> extends BasePublisherActor<MqttP
                 log().debug("Publishing MQTT message to topic <{}>: {}", getTopic(mqttMessage),
                         decodeAsHumanReadable(getPayload(mqttMessage).orElse(null), message));
             }
-            return client.apply(mqttMessage).thenApply(result -> toAcknowledgement(signal, autoAckTarget, result));
+            return client.apply(mqttMessage).thenApply(result ->
+                    new CommandResponseOrAcknowledgement(null, toAcknowledgement(signal, autoAckTarget, result)));
         } catch (final Exception e) {
             return CompletableFuture.failedFuture(e);
         }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/rabbitmq/RabbitMQPublisherActor.java
@@ -127,6 +127,11 @@ public final class RabbitMQPublisherActor extends BasePublisherActor<RabbitMQTar
     }
 
     @Override
+    protected boolean shouldPublishAcknowledgement(final Acknowledgement acknowledgement) {
+        return !NO_ACK_LABEL.equals(acknowledgement.getLabel());
+    }
+
+    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         receiveBuilder
                 .match(ChannelCreated.class, channelCreated -> {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
@@ -325,7 +325,7 @@ public final class MessageMappingProcessorActorTest extends AbstractMessageMappi
 
             // THEN: the first mapped signal is without enrichment
             expectPublishedMappedMessage(publishMappedMessage, i++, signal, targetWithoutEnrichment,
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
 
             // THEN: the second mapped signal is without enrichment and applied 1 payload mapper arrives
@@ -344,17 +344,17 @@ public final class MessageMappingProcessorActorTest extends AbstractMessageMappi
             );
             expectPublishedMappedMessage(publishMappedMessage, i++, signal,
                     targetWithoutEnrichmentAnd2PayloadMappers,
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
             expectPublishedMappedMessage(publishMappedMessage, i++, signal,
                     targetWithoutEnrichmentAnd2PayloadMappers,
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
 
             // THEN: Receive an outbound signal with extra fields.
             expectPublishedMappedMessage(publishMappedMessage, i++, signal, targetWithEnrichment,
                     mapped -> assertThat(mapped.getAdaptable().getPayload().getExtra()).contains(extra),
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
 
             // THEN: Receive an outbound signal with extra fields and with mapped payload.
@@ -370,12 +370,12 @@ public final class MessageMappingProcessorActorTest extends AbstractMessageMappi
             expectPublishedMappedMessage(publishMappedMessage, i++, signal,
                     targetWithEnrichmentAnd2PayloadMappers,
                     mapped -> assertThat(mapped.getAdaptable().getPayload().getExtra()).contains(extra),
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
             expectPublishedMappedMessage(publishMappedMessage, i++, signal,
                     targetWithEnrichmentAnd2PayloadMappers,
                     mapped -> assertThat(mapped.getAdaptable().getPayload().getExtra()).contains(extra),
-                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).isEmpty()
+                    mapped -> assertThat(mapped.getExternalMessage().getHeaders()).containsOnlyKeys("content-type")
             );
             expectPublishedMappedMessage(publishMappedMessage, i, signal,
                     targetWithEnrichmentAnd2PayloadMappers,

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPushClientActorTest.java
@@ -59,6 +59,7 @@ import akka.http.javadsl.Http;
 import akka.http.javadsl.HttpsConnectionContext;
 import akka.http.javadsl.ServerBinding;
 import akka.http.javadsl.model.ContentTypes;
+import akka.http.javadsl.model.HttpHeader;
 import akka.http.javadsl.model.HttpMethods;
 import akka.http.javadsl.model.HttpRequest;
 import akka.http.javadsl.model.HttpResponse;
@@ -237,11 +238,13 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
             final ActorRef underTest = actorSystem.actorOf(createClientActor(getRef(), getConnection(false)));
             underTest.tell(OpenConnection.of(connection.getId(), DittoHeaders.empty()), getRef());
             expectMsg(new Status.Success(BaseClientState.CONNECTED));
-
+            final String customHeaderKey = "custom-header";
+            final String customHeaderValue = "custom-value";
             // WHEN: a thing event is sent to a target with header mapping content-type=application/json
             final ThingModifiedEvent thingModifiedEvent = TestConstants.thingModified(Collections.emptyList())
                     .setDittoHeaders(DittoHeaders.newBuilder()
                             .correlationId("internal-correlation-id")
+                            .putHeader(customHeaderKey, customHeaderValue)
                             .build());
             final OutboundSignal outboundSignal =
                     OutboundSignalFactory.newOutboundSignal(thingModifiedEvent, singletonList(HTTP_TARGET));
@@ -255,7 +258,9 @@ public final class HttpPushClientActorTest extends AbstractBaseClientActorTest {
 
             // THEN: only headers in the header mapping are retained
             assertThat(thingModifiedRequest.entity().getContentType()).isEqualTo(ContentTypes.APPLICATION_JSON);
-            assertThat(thingModifiedRequest.getHeader("correlation-id")).isEmpty();
+            assertThat(thingModifiedRequest.getHeader("correlation-id"))
+                    .contains(HttpHeader.parse("correlation-id", "internal-correlation-id"));
+            assertThat(thingModifiedRequest.getHeader(customHeaderKey)).isEmpty();
 
             // THEN: the payload is the JSON string of the event as a Ditto protocol message
             assertThat(thingModifiedRequest.entity()

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
@@ -14,7 +14,7 @@ package org.eclipse.ditto.services.gateway.endpoints.actors;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +51,7 @@ import org.eclipse.ditto.services.models.acks.AcknowledgementAggregatorActorStar
 import org.eclipse.ditto.services.models.acks.config.AcknowledgementConfig;
 import org.eclipse.ditto.services.utils.akka.logging.DittoDiagnosticLoggingAdapter;
 import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.services.utils.protocol.contenttype.ContentType;
 import org.eclipse.ditto.signals.acks.base.Acknowledgement;
 import org.eclipse.ditto.signals.acks.base.Acknowledgements;
 import org.eclipse.ditto.signals.base.Signal;
@@ -71,7 +72,6 @@ import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.ReceiveTimeout;
 import akka.actor.Status;
-import akka.http.javadsl.model.ContentType;
 import akka.http.javadsl.model.ContentTypes;
 import akka.http.javadsl.model.HttpEntities;
 import akka.http.javadsl.model.HttpHeader;
@@ -100,8 +100,8 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
      */
     public static final String COMPLETE_MESSAGE = "complete";
 
-    private static final ContentType CONTENT_TYPE_JSON = ContentTypes.APPLICATION_JSON;
-    private static final ContentType CONTENT_TYPE_TEXT = ContentTypes.TEXT_PLAIN_UTF8;
+    private static final akka.http.javadsl.model.ContentType CONTENT_TYPE_JSON = ContentTypes.APPLICATION_JSON;
+    private static final akka.http.javadsl.model.ContentType CONTENT_TYPE_TEXT = ContentTypes.TEXT_PLAIN_UTF8;
 
     private final DittoDiagnosticLoggingAdapter logger = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
 
@@ -389,10 +389,11 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
 
         // if statusCode is != NO_CONTENT
         if (responseStatusCode.map(status -> status != HttpStatusCode.NO_CONTENT).orElse(true)) {
-            final Optional<ContentType> optionalContentType = message.getContentType().map(ContentType$.MODULE$::parse)
-                    .filter(Either::isRight)
-                    .map(Either::right)
-                    .map(Either.RightProjection::get);
+            final Optional<akka.http.scaladsl.model.ContentType> optionalContentType =
+                    message.getContentType().map(ContentType$.MODULE$::parse)
+                            .filter(Either::isRight)
+                            .map(Either::right)
+                            .map(Either.RightProjection::get);
 
             httpResponse = HttpResponse.create().withStatus(responseStatusCode.orElse(HttpStatusCode.OK).toInt());
 
@@ -464,8 +465,16 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
         }
 
         logger.debug("Enhancing response with external headers <{}>.", externalHeaders);
-        final List<HttpHeader> externalHttpHeaders = new ArrayList<>(externalHeaders.size());
-        externalHeaders.forEach((k, v) -> externalHttpHeaders.add(RawHeader.create(k, v)));
+        final List<HttpHeader> externalHttpHeaders = externalHeaders
+                .entrySet()
+                .stream()
+                /*
+                 * Content type is set by the entity. See response.entity().getContentType().
+                 * If we set it here this will cause a WARN log.
+                 */
+                .filter(entry -> !entry.getKey().equalsIgnoreCase(DittoHeaderDefinition.CONTENT_TYPE.getKey()))
+                .map(entry -> RawHeader.create(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList());
         logger.discardCorrelationId();
 
         return response.withHeaders(externalHttpHeaders);
@@ -500,14 +509,38 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
     private static HttpResponse addEntityAccordingToContentType(final HttpResponse response, final String entityPlain,
             final DittoHeaders dittoHeaders) {
 
-        return response.withEntity(getContentType(dittoHeaders), ByteString.fromString(entityPlain));
+        final ContentType contentType = getContentType(dittoHeaders);
+        final ByteString byteString;
+
+        if (contentType.isBinary()) {
+            byteString = ByteString.fromArray(Base64.getDecoder().decode(entityPlain));
+        } else {
+            byteString = ByteString.fromString(entityPlain);
+        }
+
+        return response.withEntity(ContentTypes.parse(contentType.getValue()), byteString);
+    }
+
+    private static HttpResponse addEntityAccordingToContentType(final HttpResponse response, final JsonValue entity,
+            final DittoHeaders dittoHeaders) {
+
+        final ContentType contentType = getContentType(dittoHeaders);
+
+        final String entityString;
+
+        if (contentType.isJson()) {
+            entityString = entity.toString();
+        } else {
+            entityString = entity.asString();
+        }
+
+        return addEntityAccordingToContentType(response, entityString, dittoHeaders);
     }
 
     private static ContentType getContentType(final DittoHeaders dittoHeaders) {
-        if ("text/plain".equalsIgnoreCase(dittoHeaders.get(DittoHeaderDefinition.CONTENT_TYPE.name()))) {
-            return CONTENT_TYPE_TEXT;
-        }
-        return CONTENT_TYPE_JSON;
+        return dittoHeaders.getContentType()
+                .map(ContentType::of)
+                .orElse(ContentType.APPLICATION_JSON);
     }
 
     private HttpResponse createCommandResponse(final DittoHeaders dittoHeaders, final HttpStatusCode statusCode,
@@ -538,14 +571,6 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
                     .map(entity -> addEntityAccordingToContentType(response, entity, dittoHeaders))
                     .orElse(response);
         };
-    }
-
-    private static HttpResponse addEntityAccordingToContentType(final HttpResponse response, final JsonValue entity,
-            final DittoHeaders dittoHeaders) {
-
-        final ContentType contentType = getContentType(dittoHeaders);
-        final String entityString = CONTENT_TYPE_TEXT.equals(contentType) ? entity.asString() : entity.toString();
-        return response.withEntity(contentType, ByteString.fromString(entityString));
     }
 
     private static HttpResponse createHttpResponseWithHeadersAndBody(final HttpStatusCode statusCode,

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorTest.java
@@ -247,6 +247,7 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     .build();
             // headers shall be same:
             final DittoHeaders expectedHeaders = dittoHeaders.toBuilder()
+                    .acknowledgementRequests(Collections.emptyList())
                     .build();
 
             final ModifyAttributeResponse probeResponse =
@@ -360,6 +361,7 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     .build();
             // headers shall be same:
             final DittoHeaders expectedHeaders = dittoHeaders.toBuilder()
+                    .acknowledgementRequests(Collections.emptyList())
                     .build();
 
             final String contentType = "application/json";

--- a/services/utils/protocol/src/main/java/org/eclipse/ditto/services/utils/protocol/contenttype/ContentType.java
+++ b/services/utils/protocol/src/main/java/org/eclipse/ditto/services/utils/protocol/contenttype/ContentType.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.protocol.contenttype;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class ContentType {
+
+    // all types of application content types that are considered to be text (application/javascript, application/ecmascript)
+    private static final List<String> APPLICATION_TYPES_CONSIDERED_TO_BE_STRING =
+            Arrays.asList("javascript", "ecmascript");
+
+    private static final Pattern TEXT_PATTERN = Pattern.compile("^(text/.*)|" +
+            "(application/(vnd\\..+\\+)?(" + String.join("|", APPLICATION_TYPES_CONSIDERED_TO_BE_STRING) + "))$");
+
+    private static final Pattern JSON_PATTERN = Pattern.compile("(application/(vnd\\..+\\+)?json)");
+
+    public static final ContentType APPLICATION_JSON = ContentType.of("application/json");
+
+    private final String value;
+    private final boolean isText;
+    private final boolean isJson;
+    private final boolean isBinary;
+
+    private ContentType(final String value, final boolean isText, final boolean isJson, final boolean isBinary) {
+        this.value = value;
+        this.isText = isText;
+        this.isJson = isJson;
+        this.isBinary = isBinary;
+    }
+
+    public static ContentType of(final String value) {
+        final String lowerCaseValue = value.toLowerCase();
+        final boolean isText;
+        final boolean isJson;
+        final boolean isBinary;
+        if (TEXT_PATTERN.matcher(lowerCaseValue).matches()) {
+            isText = true;
+            isJson = false;
+            isBinary = false;
+        } else if (JSON_PATTERN.matcher(lowerCaseValue).matches()) {
+            isText = false;
+            isJson = true;
+            isBinary = false;
+        } else {
+            isText = false;
+            isJson = false;
+            isBinary = true;
+        }
+        return new ContentType(lowerCaseValue, isText, isJson, isBinary);
+    }
+
+    public boolean isText() {
+        return isText;
+    }
+
+    public boolean isJson() {
+        return isJson;
+    }
+
+    public boolean isBinary() {
+        return isBinary;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/services/utils/protocol/src/test/java/org/eclipse/ditto/services/utils/protocol/contenttype/ContentTypeTest.java
+++ b/services/utils/protocol/src/test/java/org/eclipse/ditto/services/utils/protocol/contenttype/ContentTypeTest.java
@@ -1,0 +1,61 @@
+/*
+* Copyright (c) 2020 Contributors to the Eclipse Foundation
+*
+* See the NOTICE file(s) distributed with this work for additional
+* information regarding copyright ownership.
+*
+* This program and the accompanying materials are made available under the
+* terms of the Eclipse Public License 2.0 which is available at
+* http://www.eclipse.org/legal/epl-2.0
+*
+* SPDX-License-Identifier: EPL-2.0
+*/
+package org.eclipse.ditto.services.utils.protocol.contenttype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public final class ContentTypeTest {
+
+    @Test
+    public void applicationJsonIsJson() {
+        final ContentType applicationJson = ContentType.of("application/json");
+        assertThat(applicationJson.isText()).isFalse();
+        assertThat(applicationJson.isJson()).isTrue();
+        assertThat(applicationJson.isBinary()).isFalse();
+    }
+
+    @Test
+    public void vendorSpecificApplicationJsonIsJson() {
+        final ContentType applicationJson = ContentType.of("application/vnd.eclipse.ditto+json");
+        assertThat(applicationJson.isText()).isFalse();
+        assertThat(applicationJson.isJson()).isTrue();
+        assertThat(applicationJson.isBinary()).isFalse();
+    }
+
+    @Test
+    public void applicationJavascriptIsText() {
+        final ContentType applicationJson = ContentType.of("application/javascript");
+        assertThat(applicationJson.isText()).isTrue();
+        assertThat(applicationJson.isJson()).isFalse();
+        assertThat(applicationJson.isBinary()).isFalse();
+    }
+
+    @Test
+    public void applicationOctetStreamIsBinary() {
+        final ContentType applicationJson = ContentType.of("application/octet-stream");
+        assertThat(applicationJson.isText()).isFalse();
+        assertThat(applicationJson.isJson()).isFalse();
+        assertThat(applicationJson.isBinary()).isTrue();
+    }
+
+    @Test
+    public void imageJpegIsBinary() {
+        final ContentType applicationJson = ContentType.of("image/jpeg");
+        assertThat(applicationJson.isText()).isFalse();
+        assertThat(applicationJson.isJson()).isFalse();
+        assertThat(applicationJson.isBinary()).isTrue();
+    }
+
+}

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
@@ -41,12 +41,12 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.acks.AcknowledgementLabel;
-import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.model.base.common.HttpStatusCode;
 import org.eclipse.ditto.model.base.entity.id.EntityIdWithType;
 import org.eclipse.ditto.model.base.entity.type.EntityType;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 
@@ -279,7 +279,8 @@ final class ImmutableAcknowledgements implements Acknowledgements {
     private static JsonObject buildHeadersJson(final DittoHeaders dittoHeaders) {
 
         final boolean containsDittoContentType = dittoHeaders.getContentType()
-                .filter(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE::equals)
+                .map(ContentType::of)
+                .filter(ContentType::isDittoContentType)
                 .isPresent();
         if (containsDittoContentType) {
             return dittoHeaders.toBuilder()

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
@@ -278,9 +278,8 @@ final class ImmutableAcknowledgements implements Acknowledgements {
 
     private static JsonObject buildHeadersJson(final DittoHeaders dittoHeaders) {
 
-        final boolean containsDittoContentType = dittoHeaders.getContentType()
-                .map(ContentType::of)
-                .filter(ContentType::isDittoContentType)
+        final boolean containsDittoContentType = dittoHeaders.getDittoContentType()
+                .filter(ContentType::isDittoProtocol)
                 .isPresent();
         if (containsDittoContentType) {
             return dittoHeaders.toBuilder()

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
@@ -220,6 +220,9 @@ final class ImmutableAcknowledgements implements Acknowledgements {
 
     @Override
     public DittoHeaders getDittoHeaders() {
+        if (acknowledgements.size() == 1) {
+            return acknowledgements.get(0).getDittoHeaders();
+        }
         return dittoHeaders;
     }
 

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
@@ -221,7 +221,7 @@ final class ImmutableAcknowledgements implements Acknowledgements {
     @Override
     public DittoHeaders getDittoHeaders() {
         if (acknowledgements.size() == 1) {
-            return acknowledgements.get(0).getDittoHeaders();
+            return acknowledgements.get(0).getDittoHeaders().toBuilder().putHeaders(dittoHeaders).build();
         }
         return dittoHeaders;
     }

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommand.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/AbstractMessageCommand.java
@@ -134,7 +134,7 @@ abstract class AbstractMessageCommand<T, C extends AbstractMessageCommand<T, C>>
 
     @Override
     public String toString() {
-        return "thingId=" + thingId + ", message=" + message;
+        return super.toString() + ", thingId=" + thingId + ", message=" + message;
     }
 
     @Override

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessageDeserializer.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessageDeserializer.java
@@ -68,31 +68,10 @@ public final class MessageDeserializer {
      * @return whether the message payload should be interpreted as text or JSON.
      * @since 1.3.0
      */
-    public static boolean shouldBeInterpretedAsTextOrJson(final String contentTypeHeader) {
-        return shouldBeInterpretedAsText(contentTypeHeader) || shouldBeInterpretedAsJson(contentTypeHeader);
+    public static boolean shouldBeInterpretedAsTextOrJson(final ContentType contentTypeHeader) {
+        return contentTypeHeader.isText() || contentTypeHeader.isJson();
     }
 
-    /**
-     * Check if a content type header value indicates that the message payload should be interpreted as JSON.
-     *
-     * @param contentTypeHeader the content type header.
-     * @return whether the message payload should be interpreted as JSON.
-     * @since 1.3.0
-     */
-    public static boolean shouldBeInterpretedAsJson(final String contentTypeHeader) {
-        return ContentType.of(contentTypeHeader).isJson();
-    }
-
-    /**
-     * Check if a content type header value indicates that the message payload should be interpreted as text.
-     *
-     * @param contentTypeHeader the content type header.
-     * @return whether the message payload should be interpreted as text.
-     * @since 1.3.0
-     */
-    public static boolean shouldBeInterpretedAsText(final String contentTypeHeader) {
-        return ContentType.of(contentTypeHeader).isText();
-    }
 }
 
 

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessageDeserializer.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessageDeserializer.java
@@ -16,6 +16,7 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.messages.Message;
 import org.eclipse.ditto.model.messages.MessageBuilder;
 import org.eclipse.ditto.model.messages.MessageHeaders;
@@ -26,11 +27,6 @@ import org.eclipse.ditto.model.messages.MessageHeaders;
  * @since 1.2.0
  */
 public final class MessageDeserializer {
-
-    private static final String TEXT_ANY = "text/";
-    private static final String APPLICATION_JSON = "application/json";
-    private static final String APPLICATION_VND = "application/vnd.";
-    private static final String VND_JSON_SUFFIX = "+json";
 
     private MessageDeserializer() {
         // Empty because this is a utility class.
@@ -84,9 +80,7 @@ public final class MessageDeserializer {
      * @since 1.3.0
      */
     public static boolean shouldBeInterpretedAsJson(final String contentTypeHeader) {
-        final String contentType = contentTypeHeader.toLowerCase();
-        return contentType.startsWith(APPLICATION_JSON) ||
-                (contentType.startsWith(APPLICATION_VND) && contentType.endsWith(VND_JSON_SUFFIX));
+        return ContentType.of(contentTypeHeader).isJson();
     }
 
     /**
@@ -97,7 +91,7 @@ public final class MessageDeserializer {
      * @since 1.3.0
      */
     public static boolean shouldBeInterpretedAsText(final String contentTypeHeader) {
-        return contentTypeHeader.toLowerCase().startsWith(TEXT_ANY);
+        return ContentType.of(contentTypeHeader).isText();
     }
 }
 

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/acks/MessageCommandAckRequestSetter.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/acks/MessageCommandAckRequestSetter.java
@@ -59,4 +59,9 @@ public final class MessageCommandAckRequestSetter extends AbstractCommandAckRequ
     public Class<MessageCommand<?, ?>> getMatchedClass() {
         return (Class) MessageCommand.class;
     }
+
+    @Override
+    protected boolean isBindResponseRequiredToAddingRemovingImplicitLabel() {
+        return true;
+    }
 }

--- a/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/SendFeatureMessageResponseTest.java
+++ b/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/SendFeatureMessageResponseTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.signals.commands.messages;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.messages.FeatureIdInvalidException;
+import org.eclipse.ditto.model.messages.Message;
+import org.eclipse.ditto.model.messages.MessageDirection;
+import org.eclipse.ditto.model.messages.MessageHeaders;
+import org.eclipse.ditto.model.things.ThingId;
+import org.junit.Test;
+
+
+public final class SendFeatureMessageResponseTest {
+
+    @Test
+    public void validatesThatFeatureIDIsPresentInMessageHeaders() {
+        final String featureId = "foo";
+        final ThingId thingId = ThingId.generateRandom();
+        final String subject = "bar";
+        final MessageHeaders messageHeadersWithoutFeatureId =
+                MessageHeaders.newBuilder(MessageDirection.TO, thingId, subject).build();
+        final Message<Object> message = Message.newBuilder(messageHeadersWithoutFeatureId).build();
+        final DittoHeaders dittoHeaders = DittoHeaders.empty();
+        assertThatExceptionOfType(FeatureIdInvalidException.class)
+                .isThrownBy(() ->
+                        SendFeatureMessageResponse.of(thingId, featureId, message, HttpStatusCode.MULTI_STATUS,
+                                dittoHeaders))
+                .withMessage("The Message did not contain a feature ID at all! Expected was feature ID <foo>.");
+    }
+
+    @Test
+    public void validatesThatFeatureIDIsEqualInHeadersAndWrappingCommand() {
+        final String featureId = "foo";
+        final ThingId thingId = ThingId.generateRandom();
+        final String subject = "bar";
+        final MessageHeaders messageHeadersWithDifferentFeatureId =
+                MessageHeaders.newBuilder(MessageDirection.TO, thingId, subject)
+                        .featureId("bumlux")
+                        .build();
+        final Message<Object> message = Message.newBuilder(messageHeadersWithDifferentFeatureId).build();
+        final DittoHeaders dittoHeaders = DittoHeaders.empty();
+        assertThatExceptionOfType(FeatureIdInvalidException.class)
+                .isThrownBy(() ->
+                        SendFeatureMessageResponse.of(thingId, featureId, message, HttpStatusCode.MULTI_STATUS,
+                                dittoHeaders))
+                .withMessage("The Message contained feature ID <bumlux>. Expected was feature ID <foo>.");
+    }
+
+    @Test
+    public void instantiatingAFeatureMessageResponseWorksWithEqualFeatureIds() {
+        final String featureId = "foo";
+        final ThingId thingId = ThingId.generateRandom();
+        final String subject = "bar";
+        final MessageHeaders messageHeadersWithDifferentFeatureId =
+                MessageHeaders.newBuilder(MessageDirection.TO, thingId, subject)
+                        .featureId("foo")
+                        .build();
+        final Message<Object> message = Message.newBuilder(messageHeadersWithDifferentFeatureId).build();
+        final DittoHeaders dittoHeaders = DittoHeaders.empty();
+        assertThatCode(() -> SendFeatureMessageResponse.of(thingId, featureId, message, HttpStatusCode.MULTI_STATUS,
+                                dittoHeaders))
+                .doesNotThrowAnyException();
+    }
+
+}

--- a/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/acks/MessageCommandAckRequestSetterDefaultHeaderTest.java
+++ b/signals/commands/messages/src/test/java/org/eclipse/ditto/signals/commands/messages/acks/MessageCommandAckRequestSetterDefaultHeaderTest.java
@@ -73,8 +73,8 @@ public final class MessageCommandAckRequestSetterDefaultHeaderTest {
         final Validity ofOutput = new Validity(output.getDittoHeaders());
         if (ofInput.isHeaderValid) {
             assertThat(ofOutput.isHeaderValid)
-                    .describedAs(String.format("isTimeoutZero=%b isResponseRequired=%b areAcksNonempty=%b",
-                            ofOutput.isTimeoutZero, ofOutput.isResponseRequired, ofOutput.areAcksNonempty))
+                    .describedAs(String.format("isTimeoutZero=%b isResponseRequired=%b areAcksNonempty=%b\noutput.dittoHeaders=%s",
+                            ofOutput.isTimeoutZero, ofOutput.isResponseRequired, ofOutput.areAcksNonempty, output.getDittoHeaders()))
                     .isTrue();
         }
     }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingLiveCommandAckRequestSetter.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingLiveCommandAckRequestSetter.java
@@ -60,4 +60,8 @@ public final class ThingLiveCommandAckRequestSetter extends AbstractCommandAckRe
         return (Class) ThingCommand.class;
     }
 
+    @Override
+    protected boolean isBindResponseRequiredToAddingRemovingImplicitLabel() {
+        return true;
+    }
 }

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetter.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetter.java
@@ -76,4 +76,8 @@ public final class ThingModifyCommandAckRequestSetter extends AbstractCommandAck
         return (Class) ThingModifyCommand.class;
     }
 
+    @Override
+    protected boolean isBindResponseRequiredToAddingRemovingImplicitLabel() {
+        return false;
+    }
 }


### PR DESCRIPTION
Ditto "Live messages" (e.g. `SendThingMessage`) may be published via "HTTP push" connections to foreign HTTP endpoints (Webhooks).
The HTTP responses may also currently be used in order to issue an acknowledgement (configured via the "issued acknowledgement" at the connection target).

However the expected and more intuitive approach to handling "HTTP push" responses to live messages would be to use the HTTP response as live message response (e.g. `SendThingMessageResponse`).

This PR makes this possible by either:
* returning a Ditto Protocol "live message response" JSON message at the foreign HTTP endpoint (with conten-type `application/vnd.eclipse.ditto+json`)
* or by configuring the "issued acknowledgement" `live-response` at the HTTP target which is invoked with the live message
   * this will automatically convert the HTTP endpoint's response to a live message response and send it back to the originating caller

Together with this enhancement several bugs around Content-Type for Live Message processing were fixed - at several places they were not considered or e.g. binary content-types were serialized wrong.