### PR TITLE
enhanced documentation for HTTP push responses

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-messages.md
+++ b/documentation/src/main/resources/pages/ditto/basic-messages.md
@@ -56,11 +56,11 @@ Ditto messages always have to have at least this elements:
 * **Thing ID**: the ID of the `Thing` (actual device) which should receive/send the message and
 * **Subject**: the custom subject/topic.
 
-Additionally they can contain more information:
+Additionally, they can contain more information:
 * **Feature ID**: if a message should be addressed to the [Feature](basic-feature.html) of a Thing, this specifies 
   its ID.
 * **content-type**: defines which content-type the optional payload has.
-* **correlation-id**: Ditto can route message responses back to the issuer of a message. Therefore a correlation-id has
+* **correlation-id**: Ditto can route message responses back to the issuer of a message. Therefore, a correlation-id has
   to be present in the message.
 
 
@@ -84,29 +84,28 @@ Messages can, however, be received only via the [WebSocket API](httpapi-protocol
 ## Receiving Messages
 
 To be able to receive Messages for a Thing, you need to have `READ` access on that Thing.
-When a Message is sent to or from a Thing, **every** connected WebSocket with the correct
-access rights will receive the Message. If there is more than one response, only the
-first one will be routed back to the initial issuer of a Message.
+When a Message is sent to or from a Thing, **every** connected WebSocket or 
+[connection target](basic-connections.html#targets) with the correct
+access rights will receive the Message.
 
-{% include note.html content="Currently, Messages can only be received using the
- Ditto Protocol WebSocket binding" %}
+If there is more than one response to a message received by multiple consumers, only the
+first response will be routed back to the initial issuer of a Message.
 
 
 ## Sending Messages
 
 If you want to send a Message to or from a Thing, you need `WRITE` permissions on that Thing.
-Every WebSocket that is able to receive Messages for the Thing (`READ` permission), will receive your message.
+Every WebSocket or [connection target](basic-connections.html#targets) that is able to receive Messages for the 
+Thing (`READ` permission), will receive your message.
 
 
 ## Responding to Messages
 
-Since WebSocket messages are stateless there is no *direct* response to a Message.<br/>
+Since messages are stateless there is no *direct* response to a Message.
+
 For Ditto to be able to route the response of a Message back to the issuer, the
 correlation-ids need to match. E.g. when the sender uses correlation-id `random-aa98s`,
 any receiver can reply by using the same correlation-id `random-aa98s`.
-
-{% include note.html content="Currently, you can only respond to Messages using the
- Ditto Protocol WebSocket binding" %}
 
 
 ## Permissions
@@ -118,7 +117,7 @@ you need `READ` access on the Thing. To be able to send Messages to or from a Th
 you need to have `WRITE` permissions.
 
 There is one sole exception, which are [Claim Messages](#claim-messages). You do
-not need access rights for sending them.
+not need the access rights for sending them.
 
 ### API version 2
 
@@ -130,7 +129,7 @@ The same applies for being able to send Messages, here a `WRITE` permission is r
 all messages via the `message:/` resource or only for specific ones.
 
 There is one sole exception, which are [Claim Messages](#claim-messages). You do
-not need access rights for sending them.
+not need the access rights for sending them.
 
 
 ## Claim Messages

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
@@ -72,6 +72,11 @@ responds with a [Ditto Protocol Acknowledgement](protocol-specification-acks.htm
 `Content-Type` header of the HTTP response to `application/vnd.eclipse.ditto+json`, this received message is treated
 as custom [acknowledgement](basic-acknowledgements.html).
 
+This however is only the case if no 
+[automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label) was configured
+for that target (see section below). If such an issued acknowledgement label was configured, this one always gets
+issued instead of a custom sent back Ditto Protocol Acknowledgement.
+
 ##### Implicitly create acknowledgement from HTTP response 
 
 When for the target an 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-http.md
@@ -61,27 +61,62 @@ has READ permission on the thing, which is associated with a message.
 
 #### Target acknowledgement handling
 
-For HTTP targets, when configuring 
-[automatically issued acknowledgement labels](basic-connections.html#target-issued-acknowledgement-label), requested 
-acknowledgements are produced in the following way:
+For HTTP targets, whenever a message is published to the HTTP endpoint, you have two different options in order to 
+acknowledge receiving the message:
 
-The HTTP response for the HTTP target URL is consumed and following HTTP response information is mapped to the 
-automatically created [acknowledement](protocol-specification-acks.html#acknowledgement):
-* Acknowledgement.status: the HTTP response status code is used as acknowledgement status.
-* Acknowledgement.value: the HTTP response body is used as acknowledgement value - if the response body was of 
-  `content-type: application/json`, the JSON is inlined into the acknowledgment, otherwise the payload is added as JSON string.
+##### Explicitly responding with Ditto Protocol acknowledgement message
+
+Whenever an HTTP endpoint, which received a message 
+[requesting acknowledgements](basic-acknowledgements.html#requesting-acks),
+responds with a [Ditto Protocol Acknowledgement](protocol-specification-acks.html#acknowledgement) and sets the 
+`Content-Type` header of the HTTP response to `application/vnd.eclipse.ditto+json`, this received message is treated
+as custom [acknowledgement](basic-acknowledgements.html).
+
+##### Implicitly create acknowledgement from HTTP response 
+
+When for the target an 
+[automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label) was configured 
+and the HTTP response was not a Ditto Protocol message (with Content-Type header `application/vnd.eclipse.ditto+json`), 
+an acknowledgement is produced automatically in the following way:
+
+The HTTP response and following HTTP response information is mapped to the 
+automatically created [acknowledgement](protocol-specification-acks.html#acknowledgement):
+* `Acknowledgement.headers`: the HTTP response headers are added.
+* `Acknowledgement.status`: the HTTP response status code is used.
+* `Acknowledgement.value`: the HTTP response body is used - if the response body was of 
+  `content-type: application/json`, the JSON is inlined into the acknowledgement, otherwise the payload is added as 
+  JSON string.
   
-#### Responding to Messages
+#### Responding to messages
 
-For [Messages](basic-messages.html) that are sent via an HTTP target you have two different options to respond:
+For [live messages](basic-messages.html) that are published via an HTTP target you have two different options to 
+respond to that message:
 
-* Respond to the HTTP request with a HTTP response containing a valid [Ditto Protocol Message Response](protocol-specification-things-messages.html#responding-to-a-message). 
-  This requires to set the `Content-Type` header of the HTTP response to `application/vnd.eclipse.ditto+json`.
-* Configure the `live-response` acknowledgement label [as automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label). 
-  In this case there are again two options:
-  * Provide the response as Ditto Protocol Message as described in the first option above.
-  * Use the payload you want to have in the Message response as payload of the HTTP response. 
-    The `Content-Type`, HTTP status and payload of the HTTP response will be used to generate the Message response.
+##### Explicitly responding with Ditto Protocol message response
+
+Whenever an HTTP endpoint, which received a [live message](basic-messages.html),
+responds with a [Ditto Protocol Message Response](protocol-specification-things-messages.html#responding-to-a-message) 
+and sets the `Content-Type` header of the HTTP response to `application/vnd.eclipse.ditto+json`, this received message 
+is treated as custom [live message response](basic-messages.html#responding-to-messages).
+
+In this case, the `correlation-id`, `thing-id` and potentially `feature-id` of the response have to match the 
+message properties to respond to.
+
+##### Implicitly responding via HTTP response 
+
+When for the target an 
+[automatically issued acknowledgement label](basic-connections.html#target-issued-acknowledgement-label) with the label 
+`live-response` was configured and the HTTP response was not a Ditto Protocol message 
+(with Content-Type header `application/vnd.eclipse.ditto+json`), a message response is produced automatically in the 
+following way:
+
+The HTTP response and following HTTP response information is mapped to the 
+automatically created [message response](protocol-specification-things-messages.html#responding-to-a-message):
+* `Message.headers`: the HTTP response headers are added.
+* `Message.status`: the HTTP response status code is used.
+* `Message.value`: the HTTP response body is used - if the response body was of 
+  `content-type: application/json`, the JSON is inlined into the acknowledgement, otherwise the payload is added as 
+  JSON string.
 
 
 ### Specific configuration properties


### PR DESCRIPTION
* described Ditto Protocol acknowledgment responses
* use the same structure for both acks and message responses
* added more clearly what is mapped for a message response from the HTTP response
* fixed some outdated information in basic-messages.md
