### PR TITLE
Changes topic path documentation to use entity name instead of id

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-placeholders.md
+++ b/documentation/src/main/resources/pages/ditto/basic-placeholders.md
@@ -36,7 +36,7 @@ In [connections](basic-connections.html), the following placeholders are availab
 | `{%raw%}{{ request:subjectId }}{%endraw%}` | primary authorization subject of a command, or primary authorization subject that caused an event |
 | `{%raw%}{{ topic:full }}{%endraw%}` | full [Ditto Protocol topic path](protocol-specification-topic.html)<br/>in the form `{namespace}/{entityId}/{group}/`<br/>`{channel}/{criterion}/{action-subject}` |
 | `{%raw%}{{ topic:namespace }}{%endraw%}` | Ditto Protocol [Namespace](protocol-specification-topic.html#namespace) |
-| `{%raw%}{{ topic:entityId }}{%endraw%}` | Ditto Protocol [Entity ID](protocol-specification-topic.html#entity-id) |
+| `{%raw%}{{ topic:entityId }}{%endraw%}` | Ditto Protocol [Entity ID](protocol-specification-topic.html#entity-name) |
 | `{%raw%}{{ topic:group }}{%endraw%}` | Ditto Protocol [Group](protocol-specification-topic.html#group) |
 | `{%raw%}{{ topic:channel }}{%endraw%}` | Ditto Protocol [Channel](protocol-specification-topic.html#channel) |
 | `{%raw%}{{ topic:criterion }}{%endraw%}` | Ditto Protocol [Criterion](protocol-specification-topic.html#criterion) |

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
@@ -7,7 +7,7 @@ permalink: protocol-specification-topic.html
 
 The Ditto Protocol defines a **Topic** for each Protocol message having following structure:
 
-_[{namespace}](#namespace)/[{entityId}](#entity-id)/[{group}](#group)/[{channel}](#channel)/[{criterion}](#criterion)/[{action}](#action-optional)_
+_[{namespace}](#namespace)/[{entity-name}](#entity-name)/[{group}](#group)/[{channel}](#channel)/[{criterion}](#criterion)/[{action}](#action-optional)_
 
 Examples for valid topic paths are:
 * `org.eclipse.ditto/fancy-car-1/things/twin/commands/create`

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
@@ -21,9 +21,9 @@ Examples for valid topic paths are:
 
 The entity's namespace in which the entity is located.
 
-## Entity ID
+## Entity Name
 
-The entity's identifier (e.g. a `Thing ID`) to address.
+The entity's name (e.g. a `Thing Name`) to address.
 
 ## Group
 


### PR DESCRIPTION
For the topic path an entity name should be used instead of a namespaced entity id. The documentation in this regard was misleading.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>