### PR TITLE
Make documentation clearer about the usage of like operator

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -4389,8 +4389,8 @@ paths:
           result contains all things which the logged in user is allowed to read.
 
         * The search is case sensitive. In case you don't know how exactly the
-          spelling of the namespace, name, attribute, feature etc. is, use the *like*
-          notation for filtering
+          spelling of value of the namespace, name, attribute, feature etc. is, use the *like*
+          notation instead of *eq* for filtering.
 
         * The resource supports sorting and paging. If paging is not explicitly
           specified by means of the `size` option, a default count of `25`


### PR DESCRIPTION
The original text could be interpreted as if *like* could be used to match attribute/features/etc's name (not value).
See https://github.com/eclipse/ditto/issues/818

This change aims to make the documentation clearer that it is not possible.