### PR TITLE
Issue #773: Catching ConcurrentModificationException at even more places in loggers.

### DIFF
--- a/documentation/src/main/resources/jsonschema/protocol-envelope.json
+++ b/documentation/src/main/resources/jsonschema/protocol-envelope.json
@@ -43,7 +43,7 @@
           "items": {
             "type": "string",
             "description": "A single acknowledgement label containing at least 3 characters.",
-            "pattern": "[a-zA-Z0-9-_]{3,64}"
+            "pattern": "[a-zA-Z0-9-_:]{3,100}"
           }
         },
         "timeout": {

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-topic.md
@@ -168,6 +168,6 @@ The action of a command or an event of the [search protocol](protocol-specificat
 ### Acknowledgement criterion actions
 
 For *acks* criterion, the *action* segment specifies the identifier, which is defined by the system which issued the ACK.
-The criterion has to match the regular expression `[a-zA-Z0-9-_]{3,64}`, i.e. letters of the Latin alphabet, numbers,
+The criterion has to match the regular expression `[a-zA-Z0-9-_:]{3,100}`, i.e. letters of the Latin alphabet, numbers,
 dashes, and underscores.
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AcknowledgementLabels.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AcknowledgementLabels.java
@@ -30,7 +30,7 @@ final class AcknowledgementLabels {
     /**
      * Regular expression which determines the value of a valid AcknowledgementLabel.
      */
-    public static final String ACK_LABEL_REGEX = "[a-zA-Z0-9-_]{3,64}";
+    public static final String ACK_LABEL_REGEX = "[a-zA-Z0-9-_:]{3,100}";
 
     private static final Pattern ACK_LABEL_PATTERN = Pattern.compile(ACK_LABEL_REGEX);
 

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/acks/AcknowledgementLabelsTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/acks/AcknowledgementLabelsTest.java
@@ -77,17 +77,18 @@ public final class AcknowledgementLabelsTest {
                     RegexValidationParameter.invalid("A"),
                     RegexValidationParameter.invalid("AB"),
                     RegexValidationParameter.valid("ABC"),
-                    RegexValidationParameter.valid(IntStream.range(0, 64)
+                    RegexValidationParameter.valid(IntStream.range(0, 100)
                             .mapToObj(i -> "a")
                             .collect(Collectors.joining())),
-                    RegexValidationParameter.invalid(IntStream.range(0, 65)
+                    RegexValidationParameter.invalid(IntStream.range(0, 101)
                             .mapToObj(i -> "b")
                             .collect(Collectors.joining())),
                     RegexValidationParameter.invalid("ab?"),
                     RegexValidationParameter.valid("---"),
                     RegexValidationParameter.valid("___"),
                     RegexValidationParameter.valid("FOO-BAR"),
-                    RegexValidationParameter.valid("0123456789")
+                    RegexValidationParameter.valid("0123456789"),
+                    RegexValidationParameter.valid("0123456789:")
             );
         }
 


### PR DESCRIPTION
Javadoc of java.util.Map does not fully reveal where ConcurrentModificationExceptions are thrown, thus catching the exception for all interactions with 'localMdc' map.

Signed-off-by: Juergen Fickel <juergen.fickel@bosch.io>