### PR TITLE
Fix recording of timer duration above 1s

### DIFF
--- a/services/utils/metrics/src/main/java/org/eclipse/ditto/services/utils/metrics/instruments/timer/StoppedKamonTimer.java
+++ b/services/utils/metrics/src/main/java/org/eclipse/ditto/services/utils/metrics/instruments/timer/StoppedKamonTimer.java
@@ -55,7 +55,7 @@ public class StoppedKamonTimer implements StoppedTimer {
                 tags.get(SEGMENT_TAG), getDuration());
         onStopHandlers
                 .forEach(stoppedTimerConsumer -> stoppedTimerConsumer.handleStoppedTimer(this));
-        getKamonInternalTimer().record(getDuration().getNano());
+        getKamonInternalTimer().record(endTimestamp - startTimestamp);
     }
 
     static StoppedTimer fromStartedTimer(final StartedTimer startedTimer) {
@@ -81,7 +81,7 @@ public class StoppedKamonTimer implements StoppedTimer {
     }
 
 
-    private kamon.metric.Timer getKamonInternalTimer() {
+    kamon.metric.Timer getKamonInternalTimer() {
         return Kamon.timer(name).withTags(TagSet.from(new HashMap<>(this.tags)));
     }
 

--- a/services/utils/metrics/src/main/java/org/eclipse/ditto/services/utils/metrics/instruments/timer/StoppedKamonTimer.java
+++ b/services/utils/metrics/src/main/java/org/eclipse/ditto/services/utils/metrics/instruments/timer/StoppedKamonTimer.java
@@ -51,11 +51,11 @@ public class StoppedKamonTimer implements StoppedTimer {
             }
         });
 
+        final long durationNano = getElapsedNano();
         LOGGER.trace("Timer with name <{}> and segment <{}> was stopped after <{}> nanoseconds", name,
-                tags.get(SEGMENT_TAG), getDuration());
-        onStopHandlers
-                .forEach(stoppedTimerConsumer -> stoppedTimerConsumer.handleStoppedTimer(this));
-        getKamonInternalTimer().record(endTimestamp - startTimestamp);
+                tags.get(SEGMENT_TAG), durationNano);
+        onStopHandlers.forEach(stoppedTimerConsumer -> stoppedTimerConsumer.handleStoppedTimer(this));
+        getKamonInternalTimer().record(durationNano);
     }
 
     static StoppedTimer fromStartedTimer(final StartedTimer startedTimer) {
@@ -66,7 +66,7 @@ public class StoppedKamonTimer implements StoppedTimer {
 
     @Override
     public Duration getDuration() {
-        return Duration.ofNanos(this.endTimestamp - this.startTimestamp);
+        return Duration.ofNanos(getElapsedNano());
     }
 
     @Override
@@ -99,5 +99,9 @@ public class StoppedKamonTimer implements StoppedTimer {
                 ", startTimestamp=" + startTimestamp +
                 ", endTimestamp=" + endTimestamp +
                 "]";
+    }
+
+    private long getElapsedNano() {
+        return this.endTimestamp - this.startTimestamp;
     }
 }


### PR DESCRIPTION
StoppedKamonTimer discarded the seconds part of its duration before reporting to Kamon. This patch fixes that.