### PR TITLE
Make protocol of OAuth providers configurable.

### DIFF
--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DittoPublicKeyProvider.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DittoPublicKeyProvider.java
@@ -73,7 +73,6 @@ public final class DittoPublicKeyProvider implements PublicKeyProvider {
 
     private static final long JWK_REQUEST_TIMEOUT_MILLISECONDS = 5000;
     private static final String OPENID_CONNECT_DISCOVERY_PATH = "/.well-known/openid-configuration";
-    private static final String HTTPS = "https://";
     private static final JsonFieldDefinition<String> JSON_JWKS_URI = JsonFieldDefinition.ofString("jwks_uri");
 
     private final JwtSubjectIssuersConfig jwtSubjectIssuersConfig;
@@ -154,7 +153,7 @@ public final class DittoPublicKeyProvider implements PublicKeyProvider {
         } else {
             iss = issuer;
         }
-        return HTTPS + iss + OPENID_CONNECT_DISCOVERY_PATH;
+        return jwtSubjectIssuersConfig.getProtocolPrefix() + iss + OPENID_CONNECT_DISCOVERY_PATH;
     }
 
     private CompletableFuture<JsonArray> mapResponseToJsonArray(final HttpResponse response) {

--- a/services/gateway/starter/src/main/resources/gateway-dev.conf
+++ b/services/gateway/starter/src/main/resources/gateway-dev.conf
@@ -34,6 +34,11 @@ ditto {
         securestatus = false # for development, the /status resource is not secured
         securestatus = ${?DEVOPS_SECURE_STATUS}
       }
+
+      oauth {
+        # use unencrypted http for local oauth providers.
+        protocol = "http"
+      }
     }
   }
 }

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -159,6 +159,9 @@ ditto {
       }
 
       oauth {
+        # force protocol to HTTPS for security
+        protocol = "https"
+
         # map <subject-issuer, issuer> of all supported OpenID Connect authorization servers
         # issuer should not contain the protocol (e.g. https://)
         openid-connect-issuers = {

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/security/DefaultOAuthConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/security/DefaultOAuthConfig.java
@@ -31,6 +31,7 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.model.policies.SubjectIssuer;
 import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
@@ -39,14 +40,17 @@ import com.typesafe.config.ConfigValue;
  * This class is the default implementation of the OAuth config.
  */
 @Immutable
+@AllValuesAreNonnullByDefault
 public final class DefaultOAuthConfig implements OAuthConfig {
 
     private static final String CONFIG_PATH = "oauth";
 
+    private final String protocol;
     private final Map<SubjectIssuer, String> openIdConnectIssuers;
     private final Map<SubjectIssuer, String> openIdConnectIssuersExtension;
 
     private DefaultOAuthConfig(final ConfigWithFallback configWithFallback) {
+        protocol = configWithFallback.getString(OAuthConfigValue.PROTOCOL.getConfigPath());
         openIdConnectIssuers = loadIssuers(configWithFallback, OAuthConfigValue.OPENID_CONNECT_ISSUERS);
         openIdConnectIssuersExtension =
                 loadIssuers(configWithFallback, OAuthConfigValue.OPENID_CONNECT_ISSUERS_EXTENSION);
@@ -70,6 +74,11 @@ public final class DefaultOAuthConfig implements OAuthConfig {
     }
 
     @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
     public Map<SubjectIssuer, String> getOpenIdConnectIssuers() {
         return openIdConnectIssuers;
     }
@@ -84,18 +93,20 @@ public final class DefaultOAuthConfig implements OAuthConfig {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final DefaultOAuthConfig that = (DefaultOAuthConfig) o;
-        return Objects.equals(openIdConnectIssuers, that.openIdConnectIssuers)
+        return Objects.equals(protocol, that.protocol)
+                && Objects.equals(openIdConnectIssuers, that.openIdConnectIssuers)
                 && Objects.equals(openIdConnectIssuersExtension, that.openIdConnectIssuersExtension);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(openIdConnectIssuers, openIdConnectIssuersExtension);
+        return Objects.hash(protocol, openIdConnectIssuers, openIdConnectIssuersExtension);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
+                ", protocol=" + protocol +
                 ", openIdConnectIssuers=" + openIdConnectIssuers +
                 ", openIdConnectIssuersExtension=" + openIdConnectIssuersExtension +
                 "]";

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/security/OAuthConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/security/OAuthConfig.java
@@ -19,12 +19,21 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.model.policies.SubjectIssuer;
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
 
 /**
  * Provides configuration settings for OAuth.
  */
 @Immutable
+@AllValuesAreNonnullByDefault
 public interface OAuthConfig {
+
+    /**
+     * Returns the protocol to access all OAuth endpoints.
+     *
+     * @return the protocol with which to access all OAuth endpoints.
+     */
+    String getProtocol();
 
     /**
      * Returns all supported openid connect issuers.
@@ -42,6 +51,7 @@ public interface OAuthConfig {
     Map<SubjectIssuer, String> getOpenIdConnectIssuersExtension();
 
     enum OAuthConfigValue implements KnownConfigValue {
+        PROTOCOL("protocol", "https"),
         OPENID_CONNECT_ISSUERS("openid-connect-issuers", Collections.emptyMap()),
         OPENID_CONNECT_ISSUERS_EXTENSION("openid-connect-issuers-extension", Collections.emptyMap());
 

--- a/services/gateway/util/src/test/java/org/eclipse/ditto/services/gateway/util/config/security/DefaultOAuthConfigTest.java
+++ b/services/gateway/util/src/test/java/org/eclipse/ditto/services/gateway/util/config/security/DefaultOAuthConfigTest.java
@@ -66,6 +66,8 @@ public final class DefaultOAuthConfigTest {
     public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
         final DefaultOAuthConfig underTest = DefaultOAuthConfig.of(ConfigFactory.empty());
 
+        softly.assertThat(underTest.getProtocol()).isEqualTo("https");
+
         softly.assertThat(underTest.getOpenIdConnectIssuers())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getConfigPath())
                 .isEqualTo(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getDefaultValue());
@@ -79,9 +81,12 @@ public final class DefaultOAuthConfigTest {
     public void underTestReturnsValuesOfConfigFile() {
         final DefaultOAuthConfig underTest = DefaultOAuthConfig.of(oauthConfig);
 
+        softly.assertThat(underTest.getProtocol()).isEqualTo("http");
+
         softly.assertThat(underTest.getOpenIdConnectIssuers())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getConfigPath())
-                .isEqualTo(Collections.singletonMap(SubjectIssuer.newInstance("google"), "https://accounts.google.com"));
+                .isEqualTo(
+                        Collections.singletonMap(SubjectIssuer.newInstance("google"), "https://accounts.google.com"));
 
         softly.assertThat(underTest.getOpenIdConnectIssuersExtension())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS_EXTENSION.getConfigPath())

--- a/services/gateway/util/src/test/resources/oauth-test.conf
+++ b/services/gateway/util/src/test/resources/oauth-test.conf
@@ -1,4 +1,5 @@
 oauth {
+  protocol = "http"
   openid-connect-issuers = {
     google = "https://accounts.google.com"
   }


### PR DESCRIPTION
Added an OAuth configuration to set the protocol with which to access all OAuth endpoints, to enforce HTTPS for production and to use unencrypted HTTP for development and test.