### PR TITLE
Bugfix/response required for events and responses

### DIFF
--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
@@ -422,7 +422,8 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
     @Test
     public void acknowledgementToAdaptable() {
         final Acknowledgement acknowledgement =
-                Acknowledgement.of(AcknowledgementLabel.of("my-twin-persisted"), ThingId.of("thing:id"), HttpStatusCode.CONTINUE, DittoHeaders.empty());
+                Acknowledgement.of(AcknowledgementLabel.of("my-twin-persisted"), ThingId.of("thing:id"),
+                        HttpStatusCode.CONTINUE, DittoHeaders.empty());
 
         final Adaptable adaptable = underTest.toAdaptable((Signal<?>) acknowledgement);
 
@@ -451,7 +452,8 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
     @Test
     public void acknowledgementsToAdaptable() {
         final Acknowledgement ack1 =
-                Acknowledgement.of(TWIN_PERSISTED, ThingId.of("thing:id"), HttpStatusCode.CONTINUE, DittoHeaders.empty());
+                Acknowledgement.of(TWIN_PERSISTED, ThingId.of("thing:id"), HttpStatusCode.CONTINUE,
+                        DittoHeaders.empty());
         final Acknowledgement ack2 =
                 Acknowledgement.of(AcknowledgementLabel.of("the-ack-label"), ThingId.of("thing:id"),
                         HttpStatusCode.LOOP_DETECTED, DittoHeaders.empty());
@@ -460,8 +462,8 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
         final Adaptable adaptable = underTest.toAdaptable((Signal<?>) acks);
 
         final JsonObject expectedPayloadJson = JsonObject.of("{\n" +
-                "  \"twin-persisted\":{\"status\":100},\n" +
-                "  \"the-ack-label\":{\"status\":508}\n" +
+                "  \"twin-persisted\":{\"status\":100,\"headers\":{\"response-required\":false}},\n" +
+                "  \"the-ack-label\":{\"status\":508,\"headers\":{\"response-required\":false}}\n" +
                 "}");
 
         assertThat(adaptable.getTopicPath())
@@ -477,11 +479,11 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
                 "  \"topic\": \"thing/id/things/twin/acks\",\n" +
                 "  \"path\": \"/\",\n" +
                 "  \"value\": {\n" +
-                "    \"twin-persisted\": { \"status\": 100 },\n" +
-                "    \"the-ack-label\": { \"status\": 508 }\n" +
+                "    \"twin-persisted\": { \"status\": 100,\"headers\":{\"response-required\":false} },\n" +
+                "    \"the-ack-label\": { \"status\": 508,\"headers\":{\"response-required\":false} }\n" +
                 "  },\n" +
                 "  \"status\": 424,\n" +
-                "  \"headers\": { \"content-type\": \"" + DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE + "\" }\n" +
+                "  \"headers\": { \"content-type\": \"" + DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE + "\",\"response-required\":false }\n" +
                 "}"));
 
         final Signal<?> acknowledgement = underTest.fromAdaptable(adaptable);

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementsAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementsAdapterTest.java
@@ -44,6 +44,7 @@ public final class AcknowledgementsAdapterTest implements ProtocolAdapterTest {
     private static final HttpStatusCode KNOWN_STATUS = HttpStatusCode.CREATED;
     private static final DittoHeaders KNOWN_HEADERS = DittoHeaders.newBuilder()
             .correlationId("foobar")
+            .responseRequired(false)
             .build();
     private static final JsonValue KNOWN_PAYLOAD = JsonObject.newBuilder()
             .set("foo", 42)
@@ -59,6 +60,7 @@ public final class AcknowledgementsAdapterTest implements ProtocolAdapterTest {
     private static final HttpStatusCode KNOWN_STATUS_2 = HttpStatusCode.CONFLICT;
     private static final DittoHeaders KNOWN_HEADERS_2 = DittoHeaders.newBuilder()
             .correlationId("foobar")
+            .responseRequired(false)
             .build();
     private static final JsonValue KNOWN_PAYLOAD_2 = null;
     private static final Acknowledgement KNOWN_ACK_2_ERROR =
@@ -72,6 +74,7 @@ public final class AcknowledgementsAdapterTest implements ProtocolAdapterTest {
     private static final HttpStatusCode KNOWN_STATUS_3 = HttpStatusCode.NO_CONTENT;
     private static final DittoHeaders KNOWN_HEADERS_3 = DittoHeaders.newBuilder()
             .correlationId("foobar")
+            .responseRequired(false)
             .build();
     private static final JsonValue KNOWN_PAYLOAD_3 = JsonValue.of("Hello world!");
     private static final Acknowledgement KNOWN_ACK_3_SUCCESS = ThingAcknowledgementFactory.newAcknowledgement(

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapperTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapperTest.java
@@ -103,6 +103,7 @@ public final class NormalizedMessageMapperTest {
                         "    \"topic\": \"thing/created/things/twin/events/created\",\n" +
                         "    \"path\": \"/\",\n" +
                         "    \"headers\": {\n" +
+                        "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/vnd.eclipse.ditto+json\"\n" +
                         "    }\n" +
                         "  }\n" +
@@ -137,6 +138,7 @@ public final class NormalizedMessageMapperTest {
                         "    \"topic\": \"thing/id/things/twin/events/modified\",\n" +
                         "    \"path\": \"/features/featureId/properties/the/quick/brown/fox/jumps/over/the/lazy/dog\",\n" +
                         "    \"headers\": {\n" +
+                        "      \"response-required\": \"false\",\n" +
                         "      \"content-type\": \"application/vnd.eclipse.ditto+json\"\n" +
                         "    }\n" +
                         "  }\n" +

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorHeaderInteractionTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorHeaderInteractionTest.java
@@ -84,7 +84,7 @@ public final class HttpRequestActorHeaderInteractionTest extends AbstractHttpReq
             final StatusCode expectedHttpStatusCode = StatusCodes.get(getExpectedStatusCode().toInt());
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, dittoHeaders,
-                    probeResponse, expectedHttpStatusCode, false);
+                    probeResponse, expectedHttpStatusCode, null);
         }};
     }
 

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/actors/HttpRequestActorTest.java
@@ -141,10 +141,9 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.NO_CONTENT;
-            final boolean expectHttpResponseHeaders = true;
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders);
+                    probeResponse, expectedHttpStatusCode, expectedHeaders.toBuilder().responseRequired(false).build());
         }};
     }
 
@@ -168,10 +167,9 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.NO_CONTENT;
-            final boolean expectHttpResponseHeaders = true;
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders);
+                    probeResponse, expectedHttpStatusCode, expectedHeaders.toBuilder().responseRequired(false).build());
         }};
     }
 
@@ -198,10 +196,9 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     ModifyAttributeResponse.modified(thingId, attributePointer, responseRequiredFalseHeaders);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.NO_CONTENT;
-            final boolean expectHttpResponseHeaders = false; // response headers are different
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders);
+                    probeResponse, expectedHttpStatusCode, null);
         }};
 
     }
@@ -225,10 +222,9 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
             final ModifyAttributeResponse probeResponse = null;
 
             final StatusCode expectedHttpStatusCode = StatusCodes.ACCEPTED;
-            final boolean expectHttpResponseHeaders = false;
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders);
+                    probeResponse, expectedHttpStatusCode, null);
         }};
     }
 
@@ -254,10 +250,9 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                     ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.ACCEPTED;
-            final boolean expectHttpResponseHeaders = false;
 
             testThingModifyCommand(thingId, attributeName, attributePointer, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders);
+                    probeResponse, expectedHttpStatusCode, null);
         }};
     }
 
@@ -286,13 +281,13 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                             responsePayload);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.IMUSED;
-            final boolean expectHttpResponseHeaders = true;
             final ResponseEntity expectedHttpResponseEntity = HttpEntities.create(
                     ContentTypes.parse(contentType), ByteString.ByteStrings.fromString(responsePayload.toString(),
                             Charset.defaultCharset()));
 
             testMessageCommand(thingId, messageSubject, dittoHeaders, expectedHeaders, probeResponse,
-                    expectedHttpStatusCode, expectHttpResponseHeaders, expectedHttpResponseEntity);
+                    expectedHttpStatusCode, expectedHeaders.toBuilder().responseRequired(false).build(),
+                    expectedHttpResponseEntity);
         }};
     }
 
@@ -371,11 +366,10 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
                             responsePayload);
 
             final StatusCode expectedHttpStatusCode = StatusCodes.ACCEPTED;
-            final boolean expectHttpResponseHeaders = false;
             final ResponseEntity expectedHttpResponseEntity = null;
 
             testMessageCommand(thingId, messageSubject, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders, expectedHttpResponseEntity);
+                    probeResponse, expectedHttpStatusCode, null, expectedHttpResponseEntity);
         }};
     }
 
@@ -398,11 +392,10 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
             final SendThingMessageResponse<?> probeResponse = null;
 
             final StatusCode expectedHttpStatusCode = StatusCodes.ACCEPTED;
-            final boolean expectHttpResponseHeaders = false;
             final ResponseEntity expectedHttpResponseEntity = null;
 
             testMessageCommand(thingId, messageSubject, dittoHeaders, expectedHeaders,
-                    probeResponse, expectedHttpStatusCode, expectHttpResponseHeaders, expectedHttpResponseEntity);
+                    probeResponse, expectedHttpStatusCode, null, expectedHttpResponseEntity);
         }};
     }
 }

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/whoami/WhoamiResponseTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/whoami/WhoamiResponseTest.java
@@ -47,7 +47,10 @@ public final class WhoamiResponseTest {
 
     private static final UserInformation USER_INFORMATION =
             DefaultUserInformation.fromAuthorizationContext(AUTHORIZATION_CONTEXT);
-    private static final DittoHeaders DITTO_HEADERS = DittoHeaders.newBuilder().correlationId("any").build();
+    private static final DittoHeaders DITTO_HEADERS = DittoHeaders.newBuilder()
+            .correlationId("any")
+            .responseRequired(false)
+            .build();
     private static final JsonObject KNOWN_JSON = JsonFactory.newObjectBuilder()
             .set(CommonCommandResponse.JsonFields.TYPE, WhoamiResponse.TYPE)
             .set(CommonCommandResponse.JsonFields.STATUS, HttpStatusCode.OK.toInt())

--- a/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
+++ b/services/gateway/proxy/src/main/java/org/eclipse/ditto/services/gateway/proxy/actors/QueryThingsPerRequestActor.java
@@ -125,7 +125,7 @@ final class QueryThingsPerRequestActor extends AbstractActor {
                     } else {
                         final Optional<JsonFieldSelector> selectedFieldsWithThingId = getSelectedFieldsWithThingId();
                         final RetrieveThings retrieveThings = RetrieveThings.getBuilder(queryThingsResponseThingIds)
-                                .dittoHeaders(qtr.getDittoHeaders())
+                                .dittoHeaders(qtr.getDittoHeaders().toBuilder().responseRequired(true).build())
                                 .selectedFields(selectedFieldsWithThingId)
                                 .build();
                         // delegate to the ThingsAggregatorProxyActor which receives the results via a cluster stream:
@@ -215,7 +215,7 @@ final class QueryThingsPerRequestActor extends AbstractActor {
 
         if (!outOfSyncThingIds.isEmpty()) {
             final ThingsOutOfSync thingsOutOfSync =
-                    ThingsOutOfSync.of(outOfSyncThingIds, queryThingsResponse.getDittoHeaders());
+                    ThingsOutOfSync.of(outOfSyncThingIds, queryThings.getDittoHeaders());
             pubSubMediator.tell(DistPubSubAccess.publishViaGroup(ThingsOutOfSync.TYPE, thingsOutOfSync),
                     ActorRef.noSender());
         }

--- a/services/models/acks/src/test/java/org/eclipse/ditto/services/models/acks/AcknowledgementAggregatorActorTest.java
+++ b/services/models/acks/src/test/java/org/eclipse/ditto/services/models/acks/AcknowledgementAggregatorActorTest.java
@@ -180,7 +180,8 @@ public final class AcknowledgementAggregatorActorTest {
 
             // THEN
             final Acknowledgements acks = expectMsgClass(Acknowledgements.class);
-            assertThat(acks.getDittoHeaders()).isEqualTo(command.getDittoHeaders());
+            assertThat(acks.getDittoHeaders()).isEqualTo(
+                    command.getDittoHeaders().toBuilder().responseRequired(false).build());
             assertThat(acks.getSize()).isEqualTo(2);
         }};
     }

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgement.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgement.java
@@ -59,7 +59,10 @@ final class ImmutableAcknowledgement<T extends EntityIdWithType> implements Ackn
         this.label = checkNotNull(label, "label");
         this.entityId = checkNotNull(entityId, "entityId");
         this.statusCode = checkNotNull(statusCode, "statusCode");
-        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders").isResponseRequired() ? dittoHeaders
+                .toBuilder()
+                .responseRequired(false)
+                .build() : dittoHeaders;
         this.payload = payload;
     }
 

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgements.java
@@ -69,7 +69,10 @@ final class ImmutableAcknowledgements implements Acknowledgements {
         this.entityId = entityId;
         this.acknowledgements = Collections.unmodifiableList(new ArrayList<>(acknowledgements));
         this.statusCode = checkNotNull(statusCode, "statusCode");
-        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders").isResponseRequired() ? dittoHeaders
+                .toBuilder()
+                .responseRequired(false)
+                .build() : dittoHeaders;
     }
 
     /**

--- a/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementTest.java
+++ b/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementTest.java
@@ -53,7 +53,10 @@ public final class ImmutableAcknowledgementTest {
 
     @Before
     public void setUp() {
-        dittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
+        dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(testName.getMethodName())
+                .responseRequired(false)
+                .build();
     }
 
     @Test
@@ -256,8 +259,19 @@ public final class ImmutableAcknowledgementTest {
     }
 
     @Test
+    public void responseRequiredIsSetToFalse() {
+        final ImmutableAcknowledgement<ThingId> underTest =
+                ImmutableAcknowledgement.of(KNOWN_ACK_LABEL, KNOWN_ENTITY_ID, KNOWN_STATUS_CODE, DittoHeaders.empty(),
+                        KNOWN_PAYLOAD);
+
+        assertThat(underTest.getDittoHeaders().isResponseRequired()).isFalse();
+    }
+
+    @Test
     public void setDittoHeadersWorksAsExpected() {
-        final DittoHeaders newDittoHeaders = DittoHeaders.newBuilder().randomCorrelationId().build();
+        final DittoHeaders newDittoHeaders = DittoHeaders.newBuilder().randomCorrelationId().
+                responseRequired(false)
+                .build();
         final ImmutableAcknowledgement<ThingId> underTest =
                 ImmutableAcknowledgement.of(KNOWN_ACK_LABEL, KNOWN_ENTITY_ID, KNOWN_STATUS_CODE, dittoHeaders,
                         KNOWN_PAYLOAD);

--- a/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementsTest.java
+++ b/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementsTest.java
@@ -50,7 +50,10 @@ public final class ImmutableAcknowledgementsTest {
     private static final ThingId KNOWN_ENTITY_ID = ThingId.generateRandom();
     private static final HttpStatusCode KNOWN_STATUS_CODE = HttpStatusCode.OK;
     private static final JsonValue KNOWN_PAYLOAD = JsonObject.newBuilder().set("known", "payload").build();
-    private static final DittoHeaders KNOWN_DITTO_HEADERS = DittoHeaders.newBuilder().randomCorrelationId().build();
+    private static final DittoHeaders KNOWN_DITTO_HEADERS = DittoHeaders.newBuilder()
+            .randomCorrelationId()
+            .responseRequired(false)
+            .build();
     private static final Acknowledgement KNOWN_ACK_1 =
             ImmutableAcknowledgement.of(AcknowledgementLabel.of("welcome-ack"), KNOWN_ENTITY_ID, KNOWN_STATUS_CODE,
                     KNOWN_DITTO_HEADERS, KNOWN_PAYLOAD);
@@ -271,7 +274,7 @@ public final class ImmutableAcknowledgementsTest {
                         HttpStatusCode.REQUEST_TIMEOUT, KNOWN_DITTO_HEADERS, null);
         final AcknowledgementLabel customAckLabel = AcknowledgementLabel.of("foo");
         final Acknowledgement customAcknowledgement = ImmutableAcknowledgement.of(customAckLabel, KNOWN_ENTITY_ID,
-                        HttpStatusCode.OK, KNOWN_DITTO_HEADERS, null);
+                HttpStatusCode.OK, KNOWN_DITTO_HEADERS, null);
         final List<Acknowledgement> acknowledgements =
                 Lists.list(KNOWN_ACK_1, timeoutAcknowledgement, customAcknowledgement);
         final ImmutableAcknowledgements underTest = ImmutableAcknowledgements.of(acknowledgements, KNOWN_DITTO_HEADERS);
@@ -283,16 +286,26 @@ public final class ImmutableAcknowledgementsTest {
 
     @Test
     public void getDittoHeadersReturnsExpected() {
-        final DittoHeaders dittoHeaders = KNOWN_DITTO_HEADERS;
         final ImmutableAcknowledgements underTest =
-                ImmutableAcknowledgements.of(knownAcknowledgements, dittoHeaders);
+                ImmutableAcknowledgements.of(knownAcknowledgements, KNOWN_DITTO_HEADERS);
 
-        assertThat(underTest.getDittoHeaders()).isEqualTo(dittoHeaders);
+        assertThat(underTest.getDittoHeaders()).isEqualTo(KNOWN_DITTO_HEADERS);
+    }
+
+    @Test
+    public void responseRequiredIsSetToFalse() {
+        final ImmutableAcknowledgements underTest =
+                ImmutableAcknowledgements.of(knownAcknowledgements, DittoHeaders.empty());
+
+        assertThat(underTest.getDittoHeaders().isResponseRequired()).isFalse();
     }
 
     @Test
     public void setDittoHeadersWorksAsExpected() {
-        final DittoHeaders newDittoHeaders = DittoHeaders.newBuilder().randomCorrelationId().build();
+        final DittoHeaders newDittoHeaders = DittoHeaders.newBuilder()
+                .randomCorrelationId()
+                .responseRequired(false)
+                .build();
         final ImmutableAcknowledgements underTest =
                 ImmutableAcknowledgements.of(knownAcknowledgements, KNOWN_DITTO_HEADERS);
 

--- a/signals/acks/things/src/test/java/org/eclipse/ditto/signals/acks/things/ThingAcknowledgementFactoryTest.java
+++ b/signals/acks/things/src/test/java/org/eclipse/ditto/signals/acks/things/ThingAcknowledgementFactoryTest.java
@@ -46,7 +46,10 @@ public final class ThingAcknowledgementFactoryTest {
 
     @Before
     public void setUp() {
-        dittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
+        dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(testName.getMethodName())
+                .responseRequired(false)
+                .build();
     }
 
     @Test

--- a/signals/acks/things/src/test/java/org/eclipse/ditto/signals/acks/things/ThingAcknowledgementsFactoryTest.java
+++ b/signals/acks/things/src/test/java/org/eclipse/ditto/signals/acks/things/ThingAcknowledgementsFactoryTest.java
@@ -46,7 +46,10 @@ public final class ThingAcknowledgementsFactoryTest {
 
     @Before
     public void setUp() {
-        dittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
+        dittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(testName.getMethodName())
+                .responseRequired(false)
+                .build();
         final ThingId thingId = ThingId.generateRandom();
         knownAcknowledgement =
                 Acknowledgement.of(AcknowledgementLabel.of("foo"), thingId, HttpStatusCode.OK, dittoHeaders);

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/AbstractCommand.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/AbstractCommand.java
@@ -12,7 +12,7 @@
  */
 package org.eclipse.ditto.signals.commands.base;
 
-import static java.util.Objects.requireNonNull;
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.text.MessageFormat;
 import java.util.Objects;
@@ -45,13 +45,33 @@ public abstract class AbstractCommand<T extends AbstractCommand<T>> implements C
      *
      * @param type the name of this command.
      * @param dittoHeaders the headers of the command.
+     * @param category used for validation of response required header.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws CommandHeaderInvalidException if category is {@link Category#QUERY} and response is not required.
+     */
+    protected AbstractCommand(final String type, final DittoHeaders dittoHeaders, final Category category) {
+        this.type = checkNotNull(type, "type");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders");
+        validateHeaders(category);
+    }
+
+    /**
+     * Constructs a new {@code AbstractCommand} object.
+     *
+     * @param type the name of this command.
+     * @param dittoHeaders the headers of the command.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws CommandHeaderInvalidException if {@link #getCategory()} is {@link Category#QUERY} and response is
+     * not required.
      */
     protected AbstractCommand(final String type, final DittoHeaders dittoHeaders) {
-        this.type = requireNonNull(type, "The type must not be null!");
-        this.dittoHeaders = requireNonNull(dittoHeaders, "The command headers must not be null!");
+        this.type = checkNotNull(type, "type");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders");
+        validateHeaders(getCategory());
+    }
 
-        if (Category.QUERY == getCategory() && !dittoHeaders.isResponseRequired()) {
+    private void validateHeaders(final Category category) {
+        if (Category.QUERY == category && !dittoHeaders.isResponseRequired()) {
             final String headerKey = DittoHeaderDefinition.RESPONSE_REQUIRED.getKey();
             throw CommandHeaderInvalidException.newBuilder(headerKey)
                     .message(MessageFormat.format(

--- a/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/AbstractCommandResponse.java
+++ b/signals/commands/base/src/main/java/org/eclipse/ditto/signals/commands/base/AbstractCommandResponse.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.signals.commands.base;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.util.Objects;
 import java.util.function.Predicate;
@@ -51,9 +52,12 @@ public abstract class AbstractCommandResponse<T extends AbstractCommandResponse<
      */
     protected AbstractCommandResponse(final String responseType, final HttpStatusCode statusCode,
             final DittoHeaders dittoHeaders) {
-        this.responseType = requireNonNull(responseType, "The response type must not be null!");
-        this.statusCode = requireNonNull(statusCode, "The status code must not be null!");
-        this.dittoHeaders = requireNonNull(dittoHeaders, "The command headers must not be null!");
+        this.responseType = requireNonNull(responseType, "responseType");
+        this.statusCode = requireNonNull(statusCode, "statusCode");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders").isResponseRequired() ? dittoHeaders
+                .toBuilder()
+                .responseRequired(false)
+                .build() : dittoHeaders;
     }
 
     @Override

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/CreateThingLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/CreateThingLiveCommandAnswerBuilderImplTest.java
@@ -86,7 +86,7 @@ public final class CreateThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.CONFLICT)
                 .withDittoRuntimeExceptionOfType(ThingConflictException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteAttributeLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteAttributeLiveCommandAnswerBuilderImplTest.java
@@ -88,7 +88,7 @@ public final class DeleteAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributeNotAccessibleException.class);
     }
@@ -106,7 +106,7 @@ public final class DeleteAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(AttributeNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteAttributesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteAttributesLiveCommandAnswerBuilderImplTest.java
@@ -87,7 +87,7 @@ public final class DeleteAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributesNotAccessibleException.class);
     }
@@ -105,7 +105,7 @@ public final class DeleteAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(AttributesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
@@ -82,7 +82,7 @@ public final class DeleteFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureDefinitionNotAccessibleException.class);
     }
@@ -99,7 +99,7 @@ public final class DeleteFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeatureDefinitionNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeatureLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeatureLiveCommandAnswerBuilderImplTest.java
@@ -88,7 +88,7 @@ public final class DeleteFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureNotAccessibleException.class);
     }
@@ -106,7 +106,7 @@ public final class DeleteFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeatureNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
@@ -88,7 +88,7 @@ public final class DeleteFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertiesNotAccessibleException.class);
     }
@@ -106,7 +106,7 @@ public final class DeleteFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturePropertiesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturePropertyLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturePropertyLiveCommandAnswerBuilderImplTest.java
@@ -90,7 +90,7 @@ public final class DeleteFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertyNotAccessibleException.class);
     }
@@ -108,7 +108,7 @@ public final class DeleteFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturePropertyNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteFeaturesLiveCommandAnswerBuilderImplTest.java
@@ -87,7 +87,7 @@ public final class DeleteFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturesNotAccessibleException.class);
     }
@@ -105,7 +105,7 @@ public final class DeleteFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteThingLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/DeleteThingLiveCommandAnswerBuilderImplTest.java
@@ -86,7 +86,7 @@ public final class DeleteThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(ThingNotAccessibleException.class);
     }
@@ -103,7 +103,7 @@ public final class DeleteThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(ThingNotDeletableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyAttributeLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyAttributeLiveCommandAnswerBuilderImplTest.java
@@ -102,7 +102,7 @@ public final class ModifyAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributeNotAccessibleException.class);
     }
@@ -120,7 +120,7 @@ public final class ModifyAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(AttributeNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyAttributesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyAttributesLiveCommandAnswerBuilderImplTest.java
@@ -101,7 +101,7 @@ public final class ModifyAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributesNotAccessibleException.class);
     }
@@ -119,7 +119,7 @@ public final class ModifyAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(AttributesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
@@ -95,7 +95,7 @@ public final class ModifyFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureDefinitionNotAccessibleException.class);
     }
@@ -112,7 +112,7 @@ public final class ModifyFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeatureDefinitionNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeatureLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeatureLiveCommandAnswerBuilderImplTest.java
@@ -101,7 +101,7 @@ public final class ModifyFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureNotAccessibleException.class);
     }
@@ -118,7 +118,7 @@ public final class ModifyFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeatureNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
@@ -102,7 +102,7 @@ public final class ModifyFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertiesNotAccessibleException.class);
     }
@@ -120,7 +120,7 @@ public final class ModifyFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturePropertiesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturePropertyLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturePropertyLiveCommandAnswerBuilderImplTest.java
@@ -104,7 +104,7 @@ public final class ModifyFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertyNotAccessibleException.class);
     }
@@ -122,7 +122,7 @@ public final class ModifyFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturePropertyNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyFeaturesLiveCommandAnswerBuilderImplTest.java
@@ -101,7 +101,7 @@ public final class ModifyFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturesNotAccessibleException.class);
     }
@@ -119,7 +119,7 @@ public final class ModifyFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(FeaturesNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyThingLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/modify/ModifyThingLiveCommandAnswerBuilderImplTest.java
@@ -100,7 +100,7 @@ public final class ModifyThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(ThingNotAccessibleException.class);
     }
@@ -117,7 +117,7 @@ public final class ModifyThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.FORBIDDEN)
                 .withDittoRuntimeExceptionOfType(ThingNotModifiableException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveAttributeLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveAttributeLiveCommandAnswerBuilderImplTest.java
@@ -87,7 +87,7 @@ public final class RetrieveAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveAttributeResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("/attributes" + TestConstants.Thing.LOCATION_ATTRIBUTE_POINTER));
     }
 
@@ -103,7 +103,7 @@ public final class RetrieveAttributeLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributeNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveAttributesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveAttributesLiveCommandAnswerBuilderImplTest.java
@@ -86,7 +86,7 @@ public final class RetrieveAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveAttributesResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("attributes"));
     }
 
@@ -102,7 +102,7 @@ public final class RetrieveAttributesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(AttributesNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeatureDefinitionLiveCommandAnswerBuilderImplTest.java
@@ -83,7 +83,7 @@ public final class RetrieveFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveFeatureDefinitionResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("features/" + TestConstants.Feature.FLUX_CAPACITOR_ID + "/definition"));
     }
 
@@ -98,7 +98,7 @@ public final class RetrieveFeatureDefinitionLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureDefinitionNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeatureLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeatureLiveCommandAnswerBuilderImplTest.java
@@ -87,7 +87,7 @@ public final class RetrieveFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveFeatureResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("features/" + feature.getId()));
     }
 
@@ -103,7 +103,7 @@ public final class RetrieveFeatureLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeatureNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturePropertiesLiveCommandAnswerBuilderImplTest.java
@@ -87,7 +87,7 @@ public final class RetrieveFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveFeaturePropertiesResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("features/" + TestConstants.Feature.FLUX_CAPACITOR_ID + "/properties"));
     }
 
@@ -103,7 +103,7 @@ public final class RetrieveFeaturePropertiesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertiesNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturePropertyLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturePropertyLiveCommandAnswerBuilderImplTest.java
@@ -89,7 +89,7 @@ public final class RetrieveFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveFeaturePropertyResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of(
                         "features/" + TestConstants.Feature.FLUX_CAPACITOR_ID + "/properties/target_year_1"));
     }
@@ -106,7 +106,7 @@ public final class RetrieveFeaturePropertyLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturePropertyNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturesLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveFeaturesLiveCommandAnswerBuilderImplTest.java
@@ -86,7 +86,7 @@ public final class RetrieveFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveFeaturesResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.of("features"));
     }
 
@@ -102,7 +102,7 @@ public final class RetrieveFeaturesLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(FeaturesNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveThingLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveThingLiveCommandAnswerBuilderImplTest.java
@@ -86,7 +86,7 @@ public final class RetrieveThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveThingResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.empty());
     }
 
@@ -102,7 +102,7 @@ public final class RetrieveThingLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingErrorResponse()
                 .withType(ThingErrorResponse.TYPE)
-                .withDittoHeaders(DittoHeaders.empty())
+                .withDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .withStatus(HttpStatusCode.NOT_FOUND)
                 .withDittoRuntimeExceptionOfType(ThingNotAccessibleException.class);
     }

--- a/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveThingsLiveCommandAnswerBuilderImplTest.java
+++ b/signals/commands/live/src/test/java/org/eclipse/ditto/signals/commands/live/query/RetrieveThingsLiveCommandAnswerBuilderImplTest.java
@@ -100,7 +100,7 @@ public final class RetrieveThingsLiveCommandAnswerBuilderImplTest {
                 .hasNoEvent()
                 .hasThingQueryCommandResponse()
                 .hasType(RetrieveThingsResponse.TYPE)
-                .hasDittoHeaders(DittoHeaders.empty())
+                .hasDittoHeaders(DittoHeaders.newBuilder().responseRequired(false).build())
                 .hasResourcePath(JsonPointer.empty());
     }
 

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/AbstractThingEvent.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/AbstractThingEvent.java
@@ -72,7 +72,10 @@ public abstract class AbstractThingEvent<T extends AbstractThingEvent<T>> implem
         this.thingId = checkNotNull(thingId, "Thing identifier");
         this.revision = revision;
         this.timestamp = timestamp;
-        this.dittoHeaders = checkNotNull(dittoHeaders, "command headers");
+        this.dittoHeaders = checkNotNull(dittoHeaders, "dittoHeaders").isResponseRequired() ? dittoHeaders
+                .toBuilder()
+                .responseRequired(false)
+                .build() : dittoHeaders;
         this.metadata = metadata;
     }
 


### PR DESCRIPTION
Responses to events and responses are not supported in ditto. Therefore it makes sense to enforce that a published response or event does always have the header value of response-required set to false.