### PR TITLE
Topic entity name

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-placeholders.md
+++ b/documentation/src/main/resources/pages/ditto/basic-placeholders.md
@@ -36,7 +36,8 @@ In [connections](basic-connections.html), the following placeholders are availab
 | `{%raw%}{{ request:subjectId }}{%endraw%}` | primary authorization subject of a command, or primary authorization subject that caused an event |
 | `{%raw%}{{ topic:full }}{%endraw%}` | full [Ditto Protocol topic path](protocol-specification-topic.html)<br/>in the form `{namespace}/{entityId}/{group}/`<br/>`{channel}/{criterion}/{action-subject}` |
 | `{%raw%}{{ topic:namespace }}{%endraw%}` | Ditto Protocol [Namespace](protocol-specification-topic.html#namespace) |
-| `{%raw%}{{ topic:entityId }}{%endraw%}` | Ditto Protocol [Entity ID](protocol-specification-topic.html#entity-name) |
+| `{%raw%}{{ topic:entityId }}{%endraw%}` | Deprecated. Use `{%raw%}{{ topic:entityName }}{%endraw%}` instead. |
+| `{%raw%}{{ topic:entityName }}{%endraw%}` | Ditto Protocol [Entity Name](protocol-specification-topic.html#entity-name) |
 | `{%raw%}{{ topic:group }}{%endraw%}` | Ditto Protocol [Group](protocol-specification-topic.html#group) |
 | `{%raw%}{{ topic:channel }}{%endraw%}` | Ditto Protocol [Channel](protocol-specification-topic.html#channel) |
 | `{%raw%}{{ topic:criterion }}{%endraw%}` | Ditto Protocol [Criterion](protocol-specification-topic.html#criterion) |
@@ -54,7 +55,7 @@ _org.eclipse.ditto/device-123/things/twin/commands/create_ these placeholders wo
 |-------------|----------------|
 | `topic:full` | _org.eclipse.ditto/device-123/things/twin/commands/create_ |
 | `topic:namespace` | _org.eclipse.ditto_ |
-| `topic:entityId` | _device-123_ |
+| `topic:entityName` | _device-123_ |
 | `topic:group` | _things_ |
 | `topic:channel` | _twin_ |
 | `topic:criterion` | _commands_ |
@@ -69,7 +70,7 @@ _org.eclipse.ditto/device-123/things/live/messages/hello.world_ these placeholde
 |-------------|----------------|
 | `topic:full`  | _org.eclipse.ditto/device-123/things/live/messages/hello.world_ |
 | `topic:namespace` | _org.eclipse.ditto_ |
-| `topic:entityId` | _device-123_ |
+| `topic:entityName` | _device-123_ |
 | `topic:group` | _things_ |
 | `topic:channel` | _live_ |
 | `topic:criterion` | _messages_ |

--- a/model/placeholders/src/main/java/org/eclipse/ditto/model/placeholders/ImmutableTopicPathPlaceholder.java
+++ b/model/placeholders/src/main/java/org/eclipse/ditto/model/placeholders/ImmutableTopicPathPlaceholder.java
@@ -27,7 +27,7 @@ import org.eclipse.ditto.protocoladapter.TopicPath;
  * <ul>
  * <li>{@code topic:full} -> {@code {namespace}/{entityId}/{group}/{channel}/{criterion}/{action-subject}}</li>
  * <li>{@code topic:namespace}</li>
- * <li>{@code topic:entityId}</li>
+ * <li>{@code topic:entityName}</li>
  * <li>{@code topic:group}</li>
  * <li>{@code topic:channel}</li>
  * <li>{@code topic:criterion}</li>
@@ -47,7 +47,8 @@ final class ImmutableTopicPathPlaceholder implements TopicPathPlaceholder {
 
     private static final String FULL_PLACEHOLDER = "full";
     private static final String NAMESPACE_PLACEHOLDER = "namespace";
-    private static final String ENTITYID_PLACEHOLDER = "entityId";
+    @Deprecated private static final String ENTITYID_PLACEHOLDER = "entityId";
+    private static final String ENTITY_NAME_PLACEHOLDER = "entityName";
     private static final String GROUP_PLACEHOLDER = "group";
     private static final String CHANNEL_PLACEHOLDER = "channel";
     private static final String CRITERION_PLACEHOLDER = "criterion";
@@ -56,9 +57,9 @@ final class ImmutableTopicPathPlaceholder implements TopicPathPlaceholder {
     private static final String ACTION_OR_SUBJECT_PLACEHOLDER = "action-subject";
 
     private static final List<String> SUPPORTED = Collections.unmodifiableList(
-            Arrays.asList(FULL_PLACEHOLDER, NAMESPACE_PLACEHOLDER, ENTITYID_PLACEHOLDER, GROUP_PLACEHOLDER,
-                    CHANNEL_PLACEHOLDER, CRITERION_PLACEHOLDER, ACTION_PLACEHOLDER, SUBJECT_PLACEHOLDER,
-                    ACTION_OR_SUBJECT_PLACEHOLDER));
+            Arrays.asList(FULL_PLACEHOLDER, NAMESPACE_PLACEHOLDER, ENTITY_NAME_PLACEHOLDER, ENTITYID_PLACEHOLDER,
+                    GROUP_PLACEHOLDER, CHANNEL_PLACEHOLDER, CRITERION_PLACEHOLDER, ACTION_PLACEHOLDER,
+                    SUBJECT_PLACEHOLDER, ACTION_OR_SUBJECT_PLACEHOLDER));
 
     private ImmutableTopicPathPlaceholder() {
     }
@@ -84,6 +85,8 @@ final class ImmutableTopicPathPlaceholder implements TopicPathPlaceholder {
         switch (placeholder) {
             case NAMESPACE_PLACEHOLDER:
                 return Optional.of(topicPath.getNamespace());
+            case ENTITY_NAME_PLACEHOLDER:
+                return Optional.of(topicPath.getEntityName());
             case ENTITYID_PLACEHOLDER:
                 return Optional.of(topicPath.getId());
             case GROUP_PLACEHOLDER:

--- a/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/ImmutableExpressionResolverTest.java
+++ b/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/ImmutableExpressionResolverTest.java
@@ -102,7 +102,7 @@ public class ImmutableExpressionResolverTest {
         // verify different whitespace
         assertThat(underTest.resolve("{{topic:entityId }}"))
                 .contains(THING_NAME);
-        assertThat(underTest.resolve("{{topic:entityId}}"))
+        assertThat(underTest.resolve("{{topic:entityName}}"))
                 .contains(THING_NAME);
         assertThat(underTest.resolve("{{        topic:entityId}}"))
                 .contains(THING_NAME);

--- a/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/ImmutableTopicPathPlaceholderTest.java
+++ b/model/placeholders/src/test/java/org/eclipse/ditto/model/placeholders/ImmutableTopicPathPlaceholderTest.java
@@ -29,7 +29,7 @@ import nl.jqno.equalsverifier.Warning;
 public class ImmutableTopicPathPlaceholderTest {
 
     private static final String KNOWN_NAMESPACE = "org.eclipse.ditto.test";
-    private static final String KNOWN_ID = "myThing";
+    private static final String KNOWN_NAME = "myThing";
     private static final TopicPath.Channel KNOWN_CHANNEL = TopicPath.Channel.TWIN;
     private static final TopicPath.Group KNOWN_GROUP = TopicPath.Group.THINGS;
     private static final TopicPath.Criterion KNOWN_CRITERION = TopicPath.Criterion.COMMANDS;
@@ -37,14 +37,16 @@ public class ImmutableTopicPathPlaceholderTest {
     private static final String KNOWN_SUBJECT = "mySubject";
     private static final String KNOWN_SUBJECT2 = "$set.configuration/steps";
 
-    private static final TopicPath KNOWN_TOPIC_PATH = TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_ID))
-        .twin().things().commands().modify().build();
+    private static final TopicPath KNOWN_TOPIC_PATH = TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_NAME))
+            .twin().things().commands().modify().build();
 
-    private static final TopicPath KNOWN_TOPIC_PATH_SUBJECT1 = TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_ID))
-        .live().things().messages().subject(KNOWN_SUBJECT).build();
+    private static final TopicPath KNOWN_TOPIC_PATH_SUBJECT1 =
+            TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_NAME))
+                    .live().things().messages().subject(KNOWN_SUBJECT).build();
 
-    private static final TopicPath KNOWN_TOPIC_PATH_SUBJECT2 = TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_ID))
-        .live().things().messages().subject(KNOWN_SUBJECT2).build();
+    private static final TopicPath KNOWN_TOPIC_PATH_SUBJECT2 =
+            TopicPath.newBuilder(ThingId.of(KNOWN_NAMESPACE, KNOWN_NAME))
+                    .live().things().messages().subject(KNOWN_SUBJECT2).build();
 
     private static final ImmutableTopicPathPlaceholder UNDER_TEST = ImmutableTopicPathPlaceholder.INSTANCE;
 
@@ -79,7 +81,12 @@ public class ImmutableTopicPathPlaceholderTest {
 
     @Test
     public void testReplaceEntityId() {
-        assertThat(UNDER_TEST.resolve(KNOWN_TOPIC_PATH, "entityId")).contains(KNOWN_ID);
+        assertThat(UNDER_TEST.resolve(KNOWN_TOPIC_PATH, "entityId")).contains(KNOWN_NAME);
+    }
+
+    @Test
+    public void testReplaceEntityName() {
+        assertThat(UNDER_TEST.resolve(KNOWN_TOPIC_PATH, "entityName")).contains(KNOWN_NAME);
     }
 
     @Test

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableTopicPath.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableTopicPath.java
@@ -29,13 +29,13 @@ import javax.annotation.concurrent.Immutable;
 final class ImmutableTopicPath implements TopicPath {
 
     static final String PROP_NAME_NAMESPACE = "namespace";
-    static final String PROP_NAME_ID = "id";
+    static final String PROP_NAME_ID = "entityName";
     private static final String PROP_NAME_GROUP = "group";
     private static final String PROP_NAME_CHANNEL = "channel";
     private static final String PROP_NAME_CRITERION = "criterion";
 
     private final String namespace;
-    private final String id;
+    private final String name;
     private final Group group;
     private final Channel channel;
     private final Criterion criterion;
@@ -44,11 +44,11 @@ final class ImmutableTopicPath implements TopicPath {
     @Nullable private final SearchAction searchAction;
     private final String path;
 
-    private ImmutableTopicPath(final String namespace, final String id, final Group group,
+    private ImmutableTopicPath(final String namespace, final String name, final Group group,
             @Nullable final Channel channel, final Criterion criterion, @Nullable final Action action, @Nullable final SearchAction searchAction,
             @Nullable final String subject) {
         this.namespace = checkNotNull(namespace, PROP_NAME_NAMESPACE);
-        this.id = checkNotNull(id, PROP_NAME_ID);
+        this.name = checkNotNull(name, PROP_NAME_ID);
         this.group = checkNotNull(group, PROP_NAME_GROUP);
         this.channel = checkChannelArgument(channel, group);
         this.criterion = checkNotNull(criterion, PROP_NAME_CRITERION);
@@ -71,28 +71,28 @@ final class ImmutableTopicPath implements TopicPath {
     }
 
     /**
-     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code id}, {@code group} and
+     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code entityname}, {@code group} and
      * {@code criterion}.
      *
      * @param namespace the namespace.
-     * @param id the id.
+     * @param entityname the entityname.
      * @param group the group.
      * @param channel the channel.
      * @param criterion the criterion.
      * @return the TopicPath.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static ImmutableTopicPath of(final String namespace, final String id, final Group group,
+    public static ImmutableTopicPath of(final String namespace, final String entityname, final Group group,
             final Channel channel, final Criterion criterion) {
-        return new ImmutableTopicPath(namespace, id, group, channel, criterion, null, null, null);
+        return new ImmutableTopicPath(namespace, entityname, group, channel, criterion, null, null, null);
     }
 
     /**
-     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code id}, {@code group},
+     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code entityName}, {@code group},
      * {@code criterion} and {@code action}.
      *
      * @param namespace the namespace.
-     * @param id the id.
+     * @param entityName the entityName.
      * @param group the group.
      * @param channel the channel.
      * @param criterion the criterion.
@@ -100,19 +100,19 @@ final class ImmutableTopicPath implements TopicPath {
      * @return the TopicPath.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static ImmutableTopicPath of(final String namespace, final String id, final Group group,
+    public static ImmutableTopicPath of(final String namespace, final String entityName, final Group group,
             final Channel channel, final Criterion criterion, final Action action) {
         checkNotNull(action, "action");
-        return new ImmutableTopicPath(namespace, id, group, channel, criterion, action, null, null);
+        return new ImmutableTopicPath(namespace, entityName, group, channel, criterion, action, null, null);
     }
 
 
     /**
-     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code id}, {@code group},
+     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code entityName}, {@code group},
      * {@code criterion} and {@code action}
      *
      * @param namespace the namespace.
-     * @param id the id.
+     * @param entityName the entityName.
      * @param group the group.
      * @param channel the channel.
      * @param criterion the criterion.
@@ -120,18 +120,18 @@ final class ImmutableTopicPath implements TopicPath {
      * @return the TopicPath.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static ImmutableTopicPath of(final String namespace, final String id, final Group group,
+    public static ImmutableTopicPath of(final String namespace, final String entityName, final Group group,
             final Channel channel, final Criterion criterion, final String subject) {
         checkNotNull(subject, "subject");
-        return new ImmutableTopicPath(namespace, id, group, channel, criterion, null, null, subject);
+        return new ImmutableTopicPath(namespace, entityName, group, channel, criterion, null, null, subject);
     }
 
     /**
-     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code id}, {@code group},
+     * Returns a new ImmutableTopicPath for the specified {@code namespace}, {@code entityName}, {@code group},
      * {@code criterion} and {@code action}
      *
      * @param namespace the namespace.
-     * @param id the id.
+     * @param entityName the entityName.
      * @param group the group.
      * @param channel the channel.
      * @param criterion the criterion.
@@ -139,10 +139,10 @@ final class ImmutableTopicPath implements TopicPath {
      * @return the TopicPath.
      * @throws NullPointerException if any argument is {@code null}.
      */
-    public static ImmutableTopicPath of(final String namespace, final String id, final Group group,
+    public static ImmutableTopicPath of(final String namespace, final String entityName, final Group group,
             final Channel channel, final Criterion criterion, final SearchAction searchAction) {
         checkNotNull(searchAction, "searchAction");
-        return new ImmutableTopicPath(namespace, id, group, channel, criterion, null, searchAction, null);
+        return new ImmutableTopicPath(namespace, entityName, group, channel, criterion, null, searchAction, null);
     }
 
     @Override
@@ -182,7 +182,12 @@ final class ImmutableTopicPath implements TopicPath {
 
     @Override
     public String getId() {
-        return id;
+        return name;
+    }
+
+    @Override
+    public String getEntityName() {
+        return name;
     }
 
     @Override
@@ -200,7 +205,7 @@ final class ImmutableTopicPath implements TopicPath {
             return false;
         }
         final ImmutableTopicPath that = (ImmutableTopicPath) o;
-        return Objects.equals(namespace, that.namespace) && Objects.equals(id, that.id) && group == that.group
+        return Objects.equals(namespace, that.namespace) && Objects.equals(name, that.name) && group == that.group
                 && channel == that.channel && criterion == that.criterion && Objects.equals(action, that.action) &&
                 Objects.equals(searchAction, that.searchAction) &&
                 Objects.equals(subject, that.subject) && Objects.equals(path, that.path);
@@ -208,19 +213,19 @@ final class ImmutableTopicPath implements TopicPath {
 
     @Override
     public int hashCode() {
-        return Objects.hash(namespace, id, group, channel, criterion, action, searchAction, path, subject);
+        return Objects.hash(namespace, name, group, channel, criterion, action, searchAction, path, subject);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + "namespace=" + namespace + ", id=" + id + ", group=" + group +
+        return getClass().getSimpleName() + " [" + "namespace=" + namespace + ", id=" + name + ", group=" + group +
                 ", channel=" + channel
                 + ", criterion=" + criterion + ", action=" + action + ", searchAction=" + searchAction + ", subject=" + subject + ", path=" + path + ']';
     }
 
     private String buildPath() {
 
-        final String namespaceIdGroup = MessageFormat.format("{0}/{1}/{2}", namespace, id, group);
+        final String namespaceIdGroup = MessageFormat.format("{0}/{1}/{2}", namespace, name, group);
         final StringBuilder builder = new StringBuilder(namespaceIdGroup);
 
         // e.g. policy commands do not have a channel

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableTopicPathBuilder.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ImmutableTopicPathBuilder.java
@@ -68,18 +68,18 @@ final class ImmutableTopicPathBuilder implements TopicPathBuilder, MessagesTopic
     }
 
     /**
-     * Returns a new TopicPathBuilder for the specified {@code namespace} and {@code id}.
+     * Returns a new TopicPathBuilder for the specified {@code namespace} and {@code entityName}.
      *
      * @param namespace the Namespace.
-     * @param id the Id.
+     * @param entityName the Id.
      * @return the builder.
-     * @throws NullPointerException if {@code namespace} or {@code id} is {@code null}.
+     * @throws NullPointerException if {@code namespace} or {@code entityName} is {@code null}.
      */
-    public static TopicPathBuilder of(final String namespace, final String id) {
+    public static TopicPathBuilder of(final String namespace, final String entityName) {
         requireNonNull(namespace, ImmutableTopicPath.PROP_NAME_NAMESPACE);
-        requireNonNull(id, ImmutableTopicPath.PROP_NAME_ID);
+        requireNonNull(entityName, ImmutableTopicPath.PROP_NAME_ID);
 
-        return new ImmutableTopicPathBuilder(namespace, id);
+        return new ImmutableTopicPathBuilder(namespace, entityName);
     }
 
     @Override
@@ -278,6 +278,11 @@ final class ImmutableTopicPathBuilder implements TopicPathBuilder, MessagesTopic
 
         @Override
         public String getNamespace() {
+            return null;
+        }
+
+        @Override
+        public String getEntityName() {
             return null;
         }
 

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/TopicPath.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/TopicPath.java
@@ -139,8 +139,17 @@ public interface TopicPath {
      * Returns the id part of this {@code TopicPath}.
      *
      * @return the id.
+     * @deprecated Since 1.4.0. Use {@link #getEntityName()} instead.
      */
+    @Deprecated
     String getId();
+
+    /**
+     * Returns the entity name part of this {@code TopicPath}.
+     *
+     * @return the entity name.
+     */
+    String getEntityName();
 
     /**
      * Returns the path of this {@code TopicPath}.


### PR DESCRIPTION
Deprecate topic:entityId placeholder and introduce topic:entityName placeholder

* entityId placeholder was not named correctly. It was resolved with the
      name of an entity and not the complete ID. Therefore a new placeholder
      entityName is introduced which reflects correctly what it means.