### PR TITLE
Have AmqpPublisherActor wait for message settlement in stream.

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpMessageContext.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpMessageContext.java
@@ -12,6 +12,8 @@
   */
  package org.eclipse.ditto.services.connectivity.messaging.amqp;
 
+ import java.util.concurrent.CompletionStage;
+
  import org.eclipse.ditto.services.models.connectivity.ExternalMessage;
 
  /**
@@ -21,5 +23,5 @@
  @FunctionalInterface
  interface AmqpMessageContext {
 
-     void onPublishMessage(final ExternalMessage message);
+     CompletionStage<?> onPublishMessage(final ExternalMessage message);
  }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -60,7 +61,6 @@ import org.eclipse.ditto.signals.acks.base.Acknowledgement;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.base.CommandResponse;
 
-import akka.Done;
 import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.japi.Pair;
@@ -143,9 +143,9 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
             final Executor jmsDispatcher) {
         final ExternalMessage message = messageToPublish.first();
         final AmqpMessageContext context = messageToPublish.second();
-        return CompletableFuture
-                .runAsync(() -> context.onPublishMessage(message), jmsDispatcher)
-                .thenApply(aVoid -> Done.done());
+        return CompletableFuture.supplyAsync(() -> context.onPublishMessage(message), jmsDispatcher)
+                .thenCompose(Function.identity())
+                .thenApply(x -> x);
     }
 
     /**
@@ -328,6 +328,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
             } catch (final JMSException e) {
                 resultFuture.completeExceptionally(getMessageSendingException(message, e));
             }
+            return resultFuture;
         };
     }
 
@@ -345,6 +346,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
                             .dittoHeaders(message.getInternalHeaders())
                             .build();
             resultFuture.completeExceptionally(sendFailedException);
+            return resultFuture;
         };
     }
 
@@ -360,7 +362,8 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
                 escalate(error, errorDescription);
             } else if (Objects.equals(queueOfferResult, QueueOfferResult.dropped())) {
                 resultFuture.completeExceptionally(MessageSendingFailedException.newBuilder()
-                        .message("Outgoing AMQP message dropped: There are too many unsettled messages.")
+                        .message("Outgoing AMQP message dropped: There are too many unsettled messages " +
+                                "or too few credits.")
                         .description("Please improve the performance of the AMQP consumer, " +
                                 "reduce the rate of outgoing signals or make sure the messages are correctly consumed.")
                         .dittoHeaders(message.getInternalHeaders())

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
@@ -132,7 +132,6 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             publisherCreated(this, publisherActor);
 
             final int queueSize = connectionConfig.getMaxQueueSize() + connectionConfig.getPublisherParallelism();
-            LOGGER.warn(connectionConfig.toString());
 
             //Act
             final OutboundSignal.MultiMapped multiMapped = newMultiMappedThingDeleted(dittoHeaders, ack, getRef());

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
@@ -111,7 +111,6 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
      * @throws Exception should not be thrown
      */
     @Test
-    @Ignore("TODO: fix this")
     public void testMsgPublishedOntoFullQueueShallBeDropped() throws Exception {
 
         new TestKit(actorSystem) {{
@@ -133,6 +132,7 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             publisherCreated(this, publisherActor);
 
             final int queueSize = connectionConfig.getMaxQueueSize() + connectionConfig.getPublisherParallelism();
+            LOGGER.warn(connectionConfig.toString());
 
             //Act
             final OutboundSignal.MultiMapped multiMapped = newMultiMappedThingDeleted(dittoHeaders, ack, getRef());
@@ -153,7 +153,8 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
                     assertThat(msg).contains("AMQP message dropped")
             );
 
-            verify(messageProducer, times(queueSize)).send(any(JmsMessage.class), any(CompletionListener.class));
+            verify(messageProducer, times(connectionConfig.getPublisherParallelism()))
+                    .send(any(JmsMessage.class), any(CompletionListener.class));
         }};
 
     }


### PR DESCRIPTION
This prevents message sending when the number of unsettled messages
grows too large, in addition to when messages are not settled.
The error message is adjusted to reflect the fact.