### PR TITLE
fixed exception handling in AbstractEnforcement

### DIFF
--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -100,6 +100,8 @@ public abstract class AbstractEnforcement<C extends Signal<?>> {
 
         if (error != null) {
             return reportError(hint, error);
+        } else if(response instanceof Throwable){
+          return reportError(hint, (Throwable) response);
         } else if (response != null) {
             return reportUnknownResponse(hint, response);
         } else {

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -345,26 +345,4 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
         return context.getConciergeForwarder();
     }
 
-    /**
-     * Handle the passed {@code throwable} by sending it to the {@link #context}'s sender.
-     *
-     * @param throwable the occurred throwable (most likely a {@link DittoRuntimeException}) to send to the sender.
-     * @return the built contextual including the DittoRuntimeException.
-     */
-    protected Contextual<WithDittoHeaders> handleExceptionally(final Throwable throwable) {
-        final Contextual<T> newContext = context.withReceiver(context.getSender());
-
-        final DittoRuntimeException dittoRuntimeException =
-                DittoRuntimeException.asDittoRuntimeException(throwable,
-                        cause -> {
-                            log().error(cause, "Unexpected non-DittoRuntimeException");
-                            return GatewayInternalErrorException.newBuilder()
-                                    .cause(cause)
-                                    .dittoHeaders(context.getDittoHeaders())
-                                    .build();
-                        });
-
-        return newContext.withMessage(dittoRuntimeException);
-    }
-
 }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.services.concierge.enforcement;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -45,19 +44,19 @@ import akka.pattern.AskTimeoutException;
  * check if the passed in {@code signal} is authorized and forward it accordingly or respond with an error to the passed
  * in {@code sender}.
  */
-public abstract class AbstractEnforcement<T extends Signal<?>> {
+public abstract class AbstractEnforcement<C extends Signal<?>> {
 
     /**
      * Context of the enforcement step: sender, self, signal and so forth.
      */
-    protected final Contextual<T> context;
+    protected final Contextual<C> context;
 
     /**
      * Create an enforcement step from its context.
      *
      * @param context the context of the enforcement step.
      */
-    protected AbstractEnforcement(final Contextual<T> context) {
+    protected AbstractEnforcement(final Contextual<C> context) {
         this.context = context;
     }
 
@@ -83,70 +82,62 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
         return enforce().handle(handleEnforcementCompletion());
     }
 
-    /**
-     * Handle error for a future message such that failed futures become a completed future with DittoRuntimeException.
-     *
-     * @param throwable error of the future on failure.
-     * @return the DittoRuntimeException.
-     */
-    private DittoRuntimeException convertError(@Nullable final Throwable throwable) {
-        final Throwable error = throwable instanceof CompletionException
-                ? throwable.getCause()
-                : throwable != null
-                ? throwable
-                : new NullPointerException("Result and error are both null");
-        return reportError("Error thrown during enforcement", error);
-    }
-
     private BiFunction<Contextual<WithDittoHeaders>, Throwable, Contextual<WithDittoHeaders>> handleEnforcementCompletion() {
         return (result, throwable) -> {
             context.getStartedTimer()
                     .map(startedTimer -> startedTimer.tag("outcome", throwable != null ? "fail" : "success"))
                     .ifPresent(StartedTimer::stop);
             return Objects.requireNonNullElseGet(result,
-                    () -> withMessageToReceiver(convertError(throwable), sender()));
+                    () -> withMessageToReceiver(reportError("Error thrown during enforcement", throwable), sender()));
         };
     }
 
     /**
      * Report unexpected error or unknown response.
      */
-    protected DittoRuntimeException reportUnexpectedErrorOrResponse(final String hint, final Object response,
+    protected DittoRuntimeException reportErrorOrResponse(final String hint, @Nullable final Object response,
             @Nullable final Throwable error) {
 
         if (error != null) {
-            return reportUnexpectedError(hint, error);
-        } else {
+            return reportError(hint, error);
+        } else if (response != null) {
             return reportUnknownResponse(hint, response);
+        } else {
+            return reportError(hint, new NullPointerException("Response and error were null."));
         }
     }
 
     /**
      * Reports an error differently based on type of the error. If the error is of type
-     * {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException}, it is send to the {@code sender}
-     * without modification, otherwise it is wrapped inside a {@link GatewayInternalErrorException}.
+     * {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException}, it is returned as is
+     * (without modification), otherwise it is wrapped inside a {@link GatewayInternalErrorException}.
      *
      * @param hint hint about the nature of the error.
-     * @param error the error.
+     * @param throwable the error.
      * @return DittoRuntimeException suitable for transmission of the error.
      */
-    protected DittoRuntimeException reportError(final String hint, final Throwable error) {
-        if (error instanceof DittoRuntimeException) {
-            log().info("{} - {}: {}", hint, error.getClass().getSimpleName(), error.getMessage());
-            return (DittoRuntimeException) error;
-        } else {
-            return reportUnexpectedError(hint, error);
-        }
+    protected DittoRuntimeException reportError(final String hint, @Nullable final Throwable throwable) {
+        final Throwable error = throwable == null
+                ? new NullPointerException("Result and error are both null")
+                : throwable;
+        final DittoRuntimeException dre = DittoRuntimeException
+                .asDittoRuntimeException(error, cause -> reportUnexpectedError(hint, cause));
+        log().info("{} - {}: {}", hint, dre.getClass().getSimpleName(), dre.getMessage());
+        return dre;
     }
+
 
     /**
      * Report unexpected error.
      */
-    protected DittoRuntimeException reportUnexpectedError(final String hint, final Throwable error) {
+    private DittoRuntimeException reportUnexpectedError(final String hint, final Throwable error) {
         log().error(error, "Unexpected error {} - {}: {}", hint, error.getClass().getSimpleName(),
                 error.getMessage());
 
-        return mapToExternalException(error);
+        return GatewayInternalErrorException.newBuilder()
+                .cause(error)
+                .dittoHeaders(dittoHeaders())
+                .build();
     }
 
     /**
@@ -156,19 +147,6 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
         log().error("Unexpected response {}: <{}>", hint, response);
 
         return GatewayInternalErrorException.newBuilder().dittoHeaders(dittoHeaders()).build();
-    }
-
-    private DittoRuntimeException mapToExternalException(final Throwable error) {
-        if (error instanceof GatewayInternalErrorException) {
-            return (GatewayInternalErrorException) error;
-        } else {
-            log().error(error, "Unexpected non-DittoRuntimeException error - responding with " +
-                    "GatewayInternalErrorException - {} :{}", error.getClass().getSimpleName(), error.getMessage());
-            return GatewayInternalErrorException.newBuilder()
-                    .cause(error)
-                    .dittoHeaders(dittoHeaders())
-                    .build();
-        }
     }
 
     /**
@@ -263,7 +241,7 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
     /**
      * @return the sent Signal of subtype {@code <T>}
      */
-    protected T signal() {
+    protected C signal() {
         return context.getMessage();
     }
 
@@ -300,7 +278,7 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
         return withMessageToReceiver(message, receiver)
                 .withAskFuture(() -> askFutureWithoutErrorHandling.get()
                         .<Object>thenApply(x -> x)
-                        .exceptionally(this::convertError)
+                        .exceptionally(error -> this.reportError("Error thrown during enforcement", error))
                 );
     }
 
@@ -319,16 +297,6 @@ public abstract class AbstractEnforcement<T extends Signal<?>> {
             final Function<Object, Object> wrapperFunction) {
 
         return context.withMessage(message).withReceiver(receiver).withReceiverWrapperFunction(wrapperFunction);
-    }
-
-    /**
-     * Sets the {@code null} receiver to the {@link #context} meaning that no message at all is emitted. Therefore
-     * the {@code message} may also stay {@code null}.
-     *
-     * @return the adjusted context.
-     */
-    protected <S extends WithDittoHeaders> Contextual<S> withoutReceiver(final S message) {
-        return context.withMessage(message).withReceiver(null);
     }
 
     /**

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcementWithAsk.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcementWithAsk.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.concierge.enforcement;
+
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.enforcers.Enforcer;
+import org.eclipse.ditto.signals.base.Signal;
+import org.eclipse.ditto.signals.commands.base.CommandResponse;
+import org.eclipse.ditto.signals.commands.base.ErrorResponse;
+
+import akka.actor.ActorRef;
+import akka.pattern.AskTimeoutException;
+import akka.pattern.Patterns;
+
+public abstract class AbstractEnforcementWithAsk<C extends Signal<?>, R extends CommandResponse>
+        extends AbstractEnforcement<C> {
+
+    private final Class<R> responseClass;
+
+    /**
+     * Create an enforcement step from its context.
+     *
+     * @param context the context of the enforcement step.
+     */
+    protected AbstractEnforcementWithAsk(final Contextual<C> context, final Class<R> responseClass) {
+        super(context);
+        this.responseClass = responseClass;
+    }
+
+
+    protected CompletionStage<R> askAndBuildJsonView(
+            final ActorRef actorToAsk,
+            final C commandWithReadSubjects,
+            final Enforcer enforcer) {
+
+        return ask(actorToAsk, commandWithReadSubjects, "before building JsonView")
+                .thenApply(response -> reportJsonViewForQueryResponse(response, enforcer));
+    }
+
+    protected Object wrapBeforeAsk(final C command) {
+        return command;
+    }
+
+    @SuppressWarnings("unchecked") // We can ignore this warning since it is tested that response class is assignable
+    protected CompletionStage<R> ask(
+            final ActorRef actorToAsk,
+            final C commandWithReadSubjects,
+            final String hint) {
+
+        return Patterns.ask(actorToAsk, wrapBeforeAsk(commandWithReadSubjects), getAskTimeout())
+                .handle((response, error) ->
+                {
+                    if (response != null && responseClass.isAssignableFrom(response.getClass())) {
+                        return (R) response;
+                    } else if (response instanceof AskTimeoutException) {
+                        throw reportTimeoutException(commandWithReadSubjects, (AskTimeoutException) response);
+                    } else if (error instanceof AskTimeoutException) {
+                        throw reportTimeoutException(commandWithReadSubjects, (AskTimeoutException) error);
+                    } else if (response instanceof ErrorResponse) {
+                        throw ((ErrorResponse<?>) response).getDittoRuntimeException();
+                    } else {
+                        throw reportErrorOrResponse(hint, response, error);
+                    }
+                });
+    }
+
+    protected abstract DittoRuntimeException reportTimeoutException(C command, AskTimeoutException askTimeoutException);
+
+    protected abstract R reportJsonViewForQueryResponse(R commandResponse, Enforcer enforcer);
+}

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
@@ -133,10 +133,9 @@ public final class LiveSignalEnforcement extends AbstractEnforcement<Signal<?>> 
         LogUtil.enhanceLogWithCorrelationIdOrRandom(liveSignal);
         return enforcerRetriever.retrieve(entityId(), (enforcerKeyEntry, enforcerEntry) -> {
             try {
-                return doEnforce(liveSignal, enforcerEntry)
-                        .exceptionally(this::handleExceptionally);
+                return doEnforce(liveSignal, enforcerEntry);
             } catch (final RuntimeException e) {
-                return CompletableFuture.completedFuture(handleExceptionally(e));
+                return CompletableFuture.failedStage(e);
             }
         });
     }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
@@ -183,7 +183,7 @@ public final class PolicyCommandEnforcement extends AbstractEnforcement<PolicyCo
             try {
                 return CompletableFuture.completedFuture(doEnforce(enforcerEntry));
             } catch (final RuntimeException e) {
-                return CompletableFuture.completedFuture(handleExceptionally(e));
+                return CompletableFuture.failedStage(e);
             }
         });
     }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/PolicyCommandEnforcement.java
@@ -267,16 +267,16 @@ public final class PolicyCommandEnforcement
     }
 
     @Override
-    protected DittoRuntimeException reportTimeoutException(final PolicyCommand<?> command,
-            final AskTimeoutException askTimeoutException) {
-        log(command).error(askTimeoutException, "Timeout before building JsonView");
+    protected DittoRuntimeException handleAskTimeoutForCommand(final PolicyCommand<?> command,
+            final AskTimeoutException askTimeout) {
+        log(command).error(askTimeout, "Timeout before building JsonView");
         return PolicyUnavailableException.newBuilder(command.getEntityId())
                 .dittoHeaders(command.getDittoHeaders())
                 .build();
     }
 
     @Override
-    protected PolicyQueryCommandResponse reportJsonViewForQueryResponse(
+    protected PolicyQueryCommandResponse filterJsonView(
             final PolicyQueryCommandResponse policyQueryCommandResponse,
             final Enforcer enforcer) {
         try {

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -115,7 +115,8 @@ import akka.pattern.Patterns;
 /**
  * Authorize {@code ThingCommand}.
  */
-public final class ThingCommandEnforcement extends AbstractEnforcement<ThingCommand<?>> {
+public final class ThingCommandEnforcement
+        extends AbstractEnforcementWithAsk<ThingCommand<?>, ThingQueryCommandResponse> {
 
     private static final ThreadSafeDittoLogger LOGGER =
             DittoLoggerFactory.getThreadSafeLogger(ThingCommandEnforcement.class);
@@ -151,7 +152,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
             final PreEnforcer preEnforcer,
             final List<SubjectIssuer> subjectIssuersForPolicyMigration) {
 
-        super(data);
+        super(data, ThingQueryCommandResponse.class);
         this.thingsShardRegion = requireNonNull(thingsShardRegion);
         this.policiesShardRegion = requireNonNull(policiesShardRegion);
         this.subjectIssuersForPolicyMigration = requireNonNull(subjectIssuersForPolicyMigration);
@@ -309,7 +310,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                             } else if (isAskTimeoutException(response, error)) {
                                 throw reportThingUnavailable();
                             } else {
-                                throw reportUnexpectedErrorOrResponse("retrieving thing for ACL migration", response,
+                                throw reportErrorOrResponse("retrieving thing for ACL migration", response,
                                         error);
                             }
                         });
@@ -340,41 +341,12 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                         () -> retrieveThingAndPolicy(retrieveThing, policyId, enforcer));
             } else {
                 result = withMessageToReceiverViaAskFuture(thingQueryCommand, sender(),
-                        () -> askThingsShardRegionAndBuildJsonView(thingQueryCommand, enforcer));
+                        () -> askAndBuildJsonView(thingsShardRegion, thingQueryCommand, enforcer));
             }
         } else {
             result = forwardToThingsShardRegion(commandWithReadSubjects);
         }
         return result;
-    }
-
-    /**
-     * Retrieve for response of a query command and limit the response according to a policy enforcer.
-     *
-     * @param commandWithReadSubjects the command to ask.
-     * @param enforcer enforcer to build JsonView with.
-     * @return always {@code true}.
-     */
-    private CompletionStage<WithDittoHeaders> askThingsShardRegionAndBuildJsonView(
-            final ThingQueryCommand commandWithReadSubjects, final Enforcer enforcer) {
-
-        return Patterns.ask(thingsShardRegion, commandWithReadSubjects, getAskTimeout())
-                .handle((response, error) -> {
-                    if (response instanceof ThingQueryCommandResponse) {
-                        return reportJsonViewForThingQuery((ThingQueryCommandResponse) response, enforcer);
-                    } else if (response instanceof DittoRuntimeException) {
-                        return (DittoRuntimeException) response;
-                    } else if (isAskTimeoutException(response, error)) {
-                        final AskTimeoutException askTimeoutException = error instanceof AskTimeoutException
-                                ? (AskTimeoutException) error
-                                : (AskTimeoutException) response;
-                        return reportTimeoutForThingQuery(commandWithReadSubjects, askTimeoutException);
-                    } else if (error != null) {
-                        return reportUnexpectedError("before building JsonView", error);
-                    } else {
-                        return reportUnknownResponse("before building JsonView", response);
-                    }
-                });
     }
 
     /**
@@ -385,13 +357,13 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
      * @param enforcer the enforcer for the command.
      * @return always {@code true}.
      */
-    private CompletionStage<WithDittoHeaders> retrieveThingAndPolicy(final RetrieveThing retrieveThing,
+    private CompletionStage<ThingQueryCommandResponse> retrieveThingAndPolicy(final RetrieveThing retrieveThing,
             final PolicyId policyId, final Enforcer enforcer) {
 
         final DittoHeaders dittoHeadersWithoutPreconditionHeaders =
                 DittoHeaders.newBuilder(retrieveThing.getDittoHeaders())
-                .removePreconditionHeaders()
-                .build();
+                        .removePreconditionHeaders()
+                        .build();
 
         final Optional<RetrievePolicy> retrievePolicyOptional = PolicyCommandEnforcement.authorizePolicyCommand(
                 RetrievePolicy.of(policyId, dittoHeadersWithoutPreconditionHeaders), enforcer);
@@ -420,7 +392,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                     });
         } else {
             // sender is not authorized to view the policy, ignore the request to embed policy.
-            return askThingsShardRegionAndBuildJsonView(retrieveThing, enforcer);
+            return askAndBuildJsonView(thingsShardRegion, retrieveThing, enforcer);
         }
     }
 
@@ -430,18 +402,8 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
      * @param command the command.
      * @return future response from things-shard-region.
      */
-    private CompletionStage<WithDittoHeaders> retrieveThingBeforePolicy(final RetrieveThing command) {
-        return Patterns.ask(thingsShardRegion, command, getAskTimeout())
-                .handle((response, error) -> {
-                    if (response instanceof WithDittoHeaders) {
-                        return (WithDittoHeaders) response;
-                    } else if (isAskTimeoutException(response, error)) {
-                        return reportThingUnavailable();
-                    } else {
-                        return reportUnexpectedErrorOrResponse("retrieving thing before inlined policy", response,
-                                error);
-                    }
-                });
+    private CompletionStage<ThingQueryCommandResponse> retrieveThingBeforePolicy(final RetrieveThing command) {
+        return ask(thingsShardRegion, command, "retrieving thing before inlined policy");
     }
 
     private ThingUnavailableException reportThingUnavailable() {
@@ -532,9 +494,9 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
      * @param command the original command.
      * @param askTimeoutException the timeout exception.
      */
-    private ThingUnavailableException reportTimeoutForThingQuery(final ThingQueryCommand command,
+    @Override
+    protected DittoRuntimeException reportTimeoutException(final ThingCommand<?> command,
             final AskTimeoutException askTimeoutException) {
-
         LOGGER.withCorrelationId(dittoHeaders()).error("Timeout before building JsonView", askTimeoutException);
         return ThingUnavailableException.newBuilder(command.getThingEntityId())
                 .dittoHeaders(command.getDittoHeaders())
@@ -544,14 +506,14 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
     /**
      * Mixin-private: report thing query response with view on entity restricted by enforcer.
      *
-     * @param thingQueryCommandResponse response of query.
+     * @param commandResponse response of query.
      * @param enforcer the enforcer.
      */
-    private ThingQueryCommandResponse reportJsonViewForThingQuery(
-            final ThingQueryCommandResponse<?> thingQueryCommandResponse, final Enforcer enforcer) {
-
+    @Override
+    protected ThingQueryCommandResponse reportJsonViewForQueryResponse(final ThingQueryCommandResponse commandResponse,
+            final Enforcer enforcer) {
         try {
-            return buildJsonViewForThingQueryCommandResponse(thingQueryCommandResponse, enforcer);
+            return buildJsonViewForThingQueryCommandResponse(commandResponse, enforcer);
         } catch (final RuntimeException e) {
             throw reportError("Error after building JsonView", e);
         }
@@ -1112,7 +1074,7 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
                 final String hint =
                         String.format("creating initial policy during creation of Thing <%s>",
                                 createThing.getThingEntityId());
-                throw reportUnexpectedErrorOrResponse(hint, policyResponse, null);
+                throw reportErrorOrResponse(hint, policyResponse, null);
             }
         }
     }
@@ -1128,8 +1090,8 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
 
         LOGGER.withCorrelationId(command)
                 .info("Failed to create Policy with ID <{}> because it already exists." +
-                                " The CreateThing command which would have created a Policy for the Thing with ID <{}>" +
-                                " is therefore not handled.", policyId, command.getThingEntityId());
+                        " The CreateThing command which would have created a Policy for the Thing with ID <{}>" +
+                        " is therefore not handled.", policyId, command.getThingEntityId());
         return ThingNotCreatableException.newBuilderForPolicyExisting(command.getThingEntityId(), policyId)
                 .dittoHeaders(command.getDittoHeaders())
                 .build();

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -174,9 +174,9 @@ public final class ThingCommandEnforcement extends AbstractEnforcement<ThingComm
 
         return thingEnforcerRetriever.retrieve(entityId(), (enforcerKeyEntry, enforcerEntry) -> {
             try {
-                return doEnforce(enforcerKeyEntry, enforcerEntry).exceptionally(this::handleExceptionally);
+                return doEnforce(enforcerKeyEntry, enforcerEntry);
             } catch (final RuntimeException e) {
-                return CompletableFuture.completedFuture(handleExceptionally(e));
+                return CompletableFuture.failedStage(e);
             }
         });
     }

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -492,12 +492,12 @@ public final class ThingCommandEnforcement
      * Report timeout of {@code ThingQueryCommand}.
      *
      * @param command the original command.
-     * @param askTimeoutException the timeout exception.
+     * @param askTimeout the timeout exception.
      */
     @Override
-    protected DittoRuntimeException reportTimeoutException(final ThingCommand<?> command,
-            final AskTimeoutException askTimeoutException) {
-        LOGGER.withCorrelationId(dittoHeaders()).error("Timeout before building JsonView", askTimeoutException);
+    protected DittoRuntimeException handleAskTimeoutForCommand(final ThingCommand<?> command,
+            final AskTimeoutException askTimeout) {
+        LOGGER.withCorrelationId(dittoHeaders()).error("Timeout before building JsonView", askTimeout);
         return ThingUnavailableException.newBuilder(command.getThingEntityId())
                 .dittoHeaders(command.getDittoHeaders())
                 .build();
@@ -510,7 +510,7 @@ public final class ThingCommandEnforcement
      * @param enforcer the enforcer.
      */
     @Override
-    protected ThingQueryCommandResponse reportJsonViewForQueryResponse(final ThingQueryCommandResponse commandResponse,
+    protected ThingQueryCommandResponse filterJsonView(final ThingQueryCommandResponse commandResponse,
             final Enforcer enforcer) {
         try {
             return buildJsonViewForThingQueryCommandResponse(commandResponse, enforcer);


### PR DESCRIPTION
* simplifies enforcement
* should fix timeouts for gathering metrics because exceptions were handled somewhere else than the default metric closing