### PR TITLE
fix regression about (expected) exceptions thrown in AmqpPublisherActor CompletionStage

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpMessageContext.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpMessageContext.java
@@ -23,5 +23,5 @@
  @FunctionalInterface
  interface AmqpMessageContext {
 
-     CompletionStage<?> onPublishMessage(final ExternalMessage message);
+     CompletionStage<?> onPublishMessage(ExternalMessage message);
  }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -145,6 +145,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
         final AmqpMessageContext context = messageToPublish.second();
         return CompletableFuture.supplyAsync(() -> context.onPublishMessage(message), jmsDispatcher)
                 .thenCompose(Function.identity())
+                .exceptionally(t -> null)
                 .thenApply(x -> x);
     }
 


### PR DESCRIPTION
backing the SourceQueue of AmqpPublisherActor

regression was introduced in #870 by not handling the "exceptionally" part which caused the queue to break