### PR TITLE
increase jms client version to 0.54.0

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -51,7 +51,7 @@
 
         <jjwt.version>0.10.7</jjwt.version>
         <asm.version>7.2</asm.version>
-        <qpid-jms-client.version>0.51.0</qpid-jms-client.version>
+        <qpid-jms-client.version>0.54.0</qpid-jms-client.version>
         <newmotion-akka-rabbitmq.version>5.1.2</newmotion-akka-rabbitmq.version>
         <amqp-client.version>5.7.3</amqp-client.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>


### PR DESCRIPTION
There were a few bugfixes in qpid jms client and this PR aims to take advantage of these fixes.