### PR TITLE
Speed up the container build

### DIFF
--- a/services/dockerfile-snapshot
+++ b/services/dockerfile-snapshot
@@ -13,8 +13,6 @@ EXPOSE 8080
 
 RUN mkdir -p $DITTO_HOME
 
-COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME
-
 RUN set -x \
     && apk upgrade --update-cache \
     && apk add --no-cache tini openssl \
@@ -30,3 +28,5 @@ USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/sbin/tini", "--"]
 CMD ["java", "-jar", "/opt/ditto/starter.jar"]
+
+COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME


### PR DESCRIPTION
Assuming the locally built artifacts changes more
frequent than the package dependencies, it makes more sense
to add the local artifacts as a last step to the container.

This will more often use cached build steps, and thus
speed up the container build process and, as image layers
can be re-use, requires less bytes to be transmitted when
pushing.

Signed-off-by: Jens Reimann <jreimann@redhat.com>