### PR TITLE
[#889]: Implement cloud events HTTP endpoint

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -56,6 +56,7 @@
         <amqp-client.version>5.7.3</amqp-client.version>
         <reactive-streams.version>1.0.3</reactive-streams.version>
         <netty.version>4.1.50.Final</netty.version>
+        <cloundevents.version>2.0.0.RC1</cloundevents.version>
 
         <slf4j.version>1.7.28</slf4j.version>
         <logback.version>1.2.3</logback.version>
@@ -324,6 +325,12 @@
                 <groupId>io.jsonwebtoken</groupId>
                 <artifactId>jjwt-impl</artifactId>
                 <version>${jjwt.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>io.cloudevents</groupId>
+                <artifactId>cloudevents-http-basic</artifactId>
+                <version>${cloundevents.version}</version>
             </dependency>
 
             <!-- ### Indirect "runtime" dependencies we want to pin to a common version -->

--- a/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
+++ b/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
@@ -251,6 +251,9 @@ entries:
           - title: WebSocket protocol binding
             url: /httpapi-protocol-bindings-websocket.html
             output: web
+          - title: Cloud Events HTTP protocol binding
+            url: /httpapi-protocol-bindings-cloudevents.html
+            output: web
           - title: Server sent events
             url: /httpapi-sse.html
             output: web

--- a/documentation/src/main/resources/pages/ditto/architecture-services-gateway.md
+++ b/documentation/src/main/resources/pages/ditto/architecture-services-gateway.md
@@ -27,5 +27,6 @@ The gateway service has no persistence by its own.
 * translate [Ditto Protocol](protocol-overview.html) messages incoming via the [WebSocket](httpapi-protocol-bindings-websocket.html)
   to [commands](basic-signals-command.html) and translates [command responses](basic-signals-commandresponse.html) back
   to [Ditto Protocol](protocol-overview.html) response messages
+* accepts [Ditto Protocol](protocol-overview.html) messages incoming via the [Cloud Events HTTP Binding](httpapi-protocol-bindings-cloudevents.html)
 * subscribe for [events](basic-signals-event.html) in Ditto cluster and emits [change notifications](basic-changenotifications.html)
   via connected [WebSocket](httpapi-protocol-bindings-websocket.html) clients or via [SSEs](httpapi-sse.html)

--- a/documentation/src/main/resources/pages/ditto/connectivity-overview.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-overview.md
@@ -24,3 +24,4 @@ The following connection types are supported:
 * [MQTT 5](connectivity-protocol-bindings-mqtt5.html)
 * [HTTP 1.1](connectivity-protocol-bindings-http.html)
 * [Kafka 2.x](connectivity-protocol-bindings-kafka2.html)
+

--- a/documentation/src/main/resources/pages/ditto/httpapi-protocol-bindings-cloudevents.md
+++ b/documentation/src/main/resources/pages/ditto/httpapi-protocol-bindings-cloudevents.md
@@ -1,0 +1,105 @@
+---
+title: Cloud Events HTTP protocol binding
+keywords: binding, protocol, http, cloudevents
+tags: [binding, protocol, http]
+permalink: httpapi-protocol-bindings-cloudevents.html
+---
+
+Implements the [HTTP Protocol Binding for CloudEvents - Version 1.0](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md).
+
+Unless mentioned otherwise, the endpoint following the Cloud Events specification for the HTTP binding in version 1.0.
+
+## Cloud Events features
+
+The Cloud Events endpoint provides an alternative to the other connectivity APIs to stream data into your instance.
+
+## Cloud Events endpoint
+
+The Cloud Events endpoint is accessible at these URLs (depending on which API version to use):
+
+```
+http://localhost:8080/api/1/cloudevents
+http://localhost:8080/api/2/cloudevents
+```
+
+### Authentication
+
+A user who connects to the Cloud Events endpoint can be authenticated by using
+
+* HTTP BASIC Authentication by providing a username and the password of a user managed within nginx or
+* a JSON Web Token (JWT) issued by an OpenID connect provider.
+
+See [Authenticate](basic-auth.html) for more details.
+
+## Cloud Events protocol format
+
+The source must be a Cloud Event, encoded in the format for the HTTP binding. It may be encoded in *binary content mode*
+or in *structural content mode*.
+
+The *data content type* of the event must be `application/json`.
+
+The *data schema* must start with `ditto:`, for example `ditto:some-schema`.
+
+The events *payload* must in the Ditto Protocol JSON format as defined in the
+[Protocol specification](protocol-specification.html).
+
+## Publishing events to the endpoint
+
+Publishing events to the endpoint can be done by directly sending HTTP requests, conforming to the Cloud Events
+HTTP binding specification. Or by using other technologies that have adopted Cloud Events.
+
+### Knative eventing
+
+The endpoint can directly be configured as a [Knative eventing](https://knative.dev/docs/eventing/) destination.
+
+In the following example, a Knative eventing flow is configured to normalize the payload with a Vorto converter
+and send the result to Ditto's cloud events endpoint:
+
+~~~yaml
+apiVersion: flows.knative.dev/v1
+kind: Sequence
+metadata:
+ name: digital-twin
+spec:
+  channelTemplate:
+    apiVersion: messaging.knative.dev/v1alpha1
+    kind: KafkaChannel
+    spec:
+      numPartitions: 1
+      replicationFactor: 1
+  steps:
+  - ref:
+      # Convert incoming payload to the Ditto format
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: vorto-converter
+      namespace: digital-twin
+  reply:
+    # Deliver to Ditto Cloud Events endpoint
+    uri: http://ditto:ditto@ditto-nginx.digital-twin.svc.cluster.local:8080/api/2/cloudevents
+~~~
+
+This sequence itself can again be the target of another operation.
+
+### Direct invocation
+
+Of course, it is also possible to directly access the Cloud Events endpoint through HTTP:
+
+An example HTTP request could look like this:
+
+~~~
+POST /api/2/cloudevents HTTP/1.1
+ce-specversion: 1.0
+ce-type: my.ditto.event
+ce-time: 2020-11-24T14:35:00Z
+ce-id: f7b197fe-2e59-11eb-a8f4-d45d6455d2cc
+ce-source: /my/source
+ce-dataschema: ditto:some-schema
+Content-Type: application/json; charset=utf-8
+
+{
+    ... Ditto Protocol JSON ...
+}
+~~~
+
+For more information, see [HTTP Protocol Binding for CloudEvents - Version 1.0](https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md).

--- a/json/src/main/java/org/eclipse/ditto/json/JsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonObject.java
@@ -39,6 +39,20 @@ public interface JsonObject extends JsonValue, JsonValueContainer<JsonField> {
     }
 
     /**
+     * Creates a {@code JsonObject} from the given byte array.
+     *
+     * @param jsonData the byte array that represents the JSON object.
+     * @return the JSON object that has been created from the data.
+     * @throws NullPointerException if {@code jsonData} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonData} is empty.
+     * @throws JsonParseException if {@code jsonData} does not represent a valid JSON object.
+     * @since 1.5.0
+     */
+    static JsonObject of(final byte[] jsonData) {
+        return JsonFactory.newObject(jsonData);
+    }
+
+    /**
      * Returns a new mutable builder with a fluent API for a {@code JsonObject}.
      *
      * @return the builder.

--- a/legal/NOTICE.md
+++ b/legal/NOTICE.md
@@ -28,6 +28,7 @@ SPDX-License-Identifier: EPL-2.0
 * Copyright 2019 Kiwigrid GmbH
 * Copyright 2020 Bosch.IO GmbH
 * Copyright 2020 DevBoost GmbH
+* Copyright 2020 Red Hat Inc
 
 All content is the property of the respective authors or their employers.
 For more information regarding authorship of content, please consult the

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventMissingPayloadException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventMissingPayloadException.java
@@ -1,0 +1,122 @@
+ /*
+  * Copyright (c) 2020 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.model.base.exceptions;
+
+ import java.net.URI;
+
+ import javax.annotation.Nullable;
+ import javax.annotation.concurrent.Immutable;
+ import javax.annotation.concurrent.NotThreadSafe;
+
+ import org.eclipse.ditto.json.JsonObject;
+ import org.eclipse.ditto.model.base.common.HttpStatusCode;
+ import org.eclipse.ditto.model.base.headers.DittoHeaders;
+ import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+ /**
+  * Thrown if a request with missing payload is being made.
+  *
+  * @since 1.5.0
+  */
+ @Immutable
+ @JsonParsableException(errorCode = CloudEventMissingPayloadException.ERROR_CODE)
+ public final class CloudEventMissingPayloadException extends DittoRuntimeException {
+
+     /**
+      * Error code of this exception.
+      */
+     public static final String ERROR_CODE = "cloudevents.payload.missing";
+
+     private static final String DEFAULT_MESSAGE = "The payload is missing.";
+     private static final String DEFAULT_DESCRIPTION = "The request is missing payload.";
+
+     private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
+
+     /**
+      * Constructs a new {@code MissingPayloadException} object.
+      *
+      * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+      * @param message the detail message for later retrieval with {@link #getMessage()}.
+      * @param description a description with further information about the exception.
+      * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+      * @param href a link to a resource which provides further information about the exception.
+      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+      */
+     private CloudEventMissingPayloadException(final DittoHeaders dittoHeaders,
+                                               @Nullable final String message,
+                                               @Nullable final String description,
+                                               @Nullable final Throwable cause,
+                                               @Nullable final URI href) {
+         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
+     }
+
+     /**
+      * A mutable builder for a {@code MissingPayloadException} where the message contains detailed information
+      * about the actual used data schema and the description information about data schemas are supported for the
+      * requested resource.
+      *
+      * @return the new MissingPayloadException.
+      */
+     public static DittoRuntimeExceptionBuilder<CloudEventMissingPayloadException> withDetailedInformationBuilder() {
+         return new Builder().message(DEFAULT_MESSAGE).description(DEFAULT_DESCRIPTION);
+     }
+
+     /**
+      * Constructs a new {@code MissingPayloadException} object with the exception message extracted from the
+      * given JSON object.
+      *
+      * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+      * @param dittoHeaders the headers of the command which resulted in this exception.
+      * @return the new MissingPayloadException.
+      * @throws NullPointerException if any argument is {@code null}.
+      * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+      * format.
+      */
+     public static CloudEventMissingPayloadException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+         return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+     }
+
+     @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+         return new Builder()
+                 .message(getMessage())
+                 .description(getDescription().orElse(null))
+                 .cause(getCause())
+                 .href(getHref().orElse(null))
+                 .dittoHeaders(dittoHeaders)
+                 .build();
+     }
+
+     /**
+      * A mutable builder with a fluent API for a {@link CloudEventMissingPayloadException}.
+      */
+     @NotThreadSafe
+     public static final class Builder extends DittoRuntimeExceptionBuilder<CloudEventMissingPayloadException> {
+
+         private Builder() {
+             message(DEFAULT_MESSAGE);
+         }
+
+         @Override
+         protected CloudEventMissingPayloadException doBuild(final DittoHeaders dittoHeaders,
+                                                             @Nullable final String message,
+                                                             @Nullable final String description,
+                                                             @Nullable final Throwable cause,
+                                                             @Nullable final URI href) {
+
+             return new CloudEventMissingPayloadException(dittoHeaders, message, description, cause, href);
+         }
+     }
+
+ }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventMissingPayloadException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventMissingPayloadException.java
@@ -24,7 +24,7 @@
  import org.eclipse.ditto.model.base.json.JsonParsableException;
 
  /**
-  * Thrown if a request with missing payload is being made.
+  * Thrown if a CloudEvent request with missing payload is being made.
   *
   * @since 1.5.0
   */
@@ -35,15 +35,15 @@
      /**
       * Error code of this exception.
       */
-     public static final String ERROR_CODE = "cloudevents.payload.missing";
+     public static final String ERROR_CODE = "cloudevent.payload.missing";
 
-     private static final String DEFAULT_MESSAGE = "The payload is missing.";
-     private static final String DEFAULT_DESCRIPTION = "The request is missing payload.";
+     private static final String DEFAULT_MESSAGE = "The cloud event's payload is missing.";
+     private static final String DEFAULT_DESCRIPTION = "Ensure to provide payload in the cloud event.";
 
      private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
 
      /**
-      * Constructs a new {@code MissingPayloadException} object.
+      * Constructs a new {@code CloudEventMissingPayloadException} object.
       *
       * @param dittoHeaders the headers with which this Exception should be reported back to the user.
       * @param message the detail message for later retrieval with {@link #getMessage()}.
@@ -53,42 +53,43 @@
       * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
       */
      private CloudEventMissingPayloadException(final DittoHeaders dittoHeaders,
-                                               @Nullable final String message,
-                                               @Nullable final String description,
-                                               @Nullable final Throwable cause,
-                                               @Nullable final URI href) {
+             @Nullable final String message,
+             @Nullable final String description,
+             @Nullable final Throwable cause,
+             @Nullable final URI href) {
          super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
      }
 
      /**
-      * A mutable builder for a {@code MissingPayloadException} where the message contains detailed information
+      * A mutable builder for a {@code CloudEventMissingPayloadException} where the message contains detailed information
       * about the actual used data schema and the description information about data schemas are supported for the
       * requested resource.
       *
-      * @return the new MissingPayloadException.
+      * @return the new CloudEventMissingPayloadException.
       */
      public static DittoRuntimeExceptionBuilder<CloudEventMissingPayloadException> withDetailedInformationBuilder() {
          return new Builder().message(DEFAULT_MESSAGE).description(DEFAULT_DESCRIPTION);
      }
 
      /**
-      * Constructs a new {@code MissingPayloadException} object with the exception message extracted from the
+      * Constructs a new {@code CloudEventMissingPayloadException} object with the exception message extracted from the
       * given JSON object.
       *
       * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
       * @param dittoHeaders the headers of the command which resulted in this exception.
-      * @return the new MissingPayloadException.
+      * @return the new CloudEventMissingPayloadException.
       * @throws NullPointerException if any argument is {@code null}.
       * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
       * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
       * format.
       */
-     public static CloudEventMissingPayloadException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+     public static CloudEventMissingPayloadException fromJson(final JsonObject jsonObject,
+             final DittoHeaders dittoHeaders) {
          return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
      }
 
      @Override
-    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+     public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
          return new Builder()
                  .message(getMessage())
                  .description(getDescription().orElse(null))
@@ -110,10 +111,10 @@
 
          @Override
          protected CloudEventMissingPayloadException doBuild(final DittoHeaders dittoHeaders,
-                                                             @Nullable final String message,
-                                                             @Nullable final String description,
-                                                             @Nullable final Throwable cause,
-                                                             @Nullable final URI href) {
+                 @Nullable final String message,
+                 @Nullable final String description,
+                 @Nullable final Throwable cause,
+                 @Nullable final URI href) {
 
              return new CloudEventMissingPayloadException(dittoHeaders, message, description, cause, href);
          }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventNotParsableException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventNotParsableException.java
@@ -1,0 +1,128 @@
+ /*
+  * Copyright (c) 2020 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.model.base.exceptions;
+
+ import java.net.URI;
+ import java.text.MessageFormat;
+
+ import javax.annotation.Nullable;
+ import javax.annotation.concurrent.Immutable;
+ import javax.annotation.concurrent.NotThreadSafe;
+
+ import org.eclipse.ditto.json.JsonObject;
+ import org.eclipse.ditto.model.base.common.HttpStatusCode;
+ import org.eclipse.ditto.model.base.headers.DittoHeaders;
+ import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+ /**
+  * Thrown if a request with an unparsable cloud event is made.
+  *
+  * @since 1.5.0
+  */
+ @Immutable
+ @JsonParsableException(errorCode = CloudEventNotParsableException.ERROR_CODE)
+ public final class CloudEventNotParsableException extends DittoRuntimeException {
+
+     /**
+      * Error code of this exception.
+      */
+     public static final String ERROR_CODE = "cloudevents.unparsable";
+
+     private static final String DEFAULT_MESSAGE = "The event could not be parsed.";
+     private static final String MESSAGE_PATTERN = "The system was unable to parse the event: {0}";
+     private static final String DESCRIPTION = "Ensure that the event is being transmitted according to the Cloud Events HTTP binding specification v1.0.";
+     private static final URI DEFAULT_URI = URI.create("https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md");
+
+     private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
+
+     /**
+      * Constructs a new {@code CloudEventNotParsableException} object.
+      *
+      * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+      * @param message the detail message for later retrieval with {@link #getMessage()}.
+      * @param description a description with further information about the exception.
+      * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+      * @param href a link to a resource which provides further information about the exception.
+      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+      */
+     private CloudEventNotParsableException(final DittoHeaders dittoHeaders,
+                                            @Nullable final String message,
+                                            @Nullable final String description,
+                                            @Nullable final Throwable cause,
+                                            @Nullable final URI href) {
+         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href == null ? DEFAULT_URI : href);
+     }
+
+     /**
+      * A mutable builder for a {@code CloudEventNotParsableException} where the message contains detailed information
+      * about the parse error.
+      *
+      * @param details the unsupported data schema used in the call.
+      * @return the new CloudEventNotParsableException.
+      */
+     public static DittoRuntimeExceptionBuilder<CloudEventNotParsableException> withDetailedInformationBuilder(
+             final String details) {
+
+         final String msgPattern = MessageFormat.format(MESSAGE_PATTERN, details);
+         return new Builder().message(msgPattern).description(DESCRIPTION);
+     }
+
+     /**
+      * Constructs a new {@code CloudEventNotParsableException} object with the exception message extracted from the
+      * given JSON object.
+      *
+      * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+      * @param dittoHeaders the headers of the command which resulted in this exception.
+      * @return the new CloudEventNotParsableException.
+      * @throws NullPointerException if any argument is {@code null}.
+      * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+      * format.
+      */
+     public static CloudEventNotParsableException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+         return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+     }
+
+     @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+         return new Builder()
+                 .message(getMessage())
+                 .description(getDescription().orElse(null))
+                 .cause(getCause())
+                 .href(getHref().orElse(null))
+                 .dittoHeaders(dittoHeaders)
+                 .build();
+     }
+
+     /**
+      * A mutable builder with a fluent API for a {@link CloudEventNotParsableException}.
+      */
+     @NotThreadSafe
+     public static final class Builder extends DittoRuntimeExceptionBuilder<CloudEventNotParsableException> {
+
+         private Builder() {
+             message(DEFAULT_MESSAGE);
+         }
+
+         @Override
+         protected CloudEventNotParsableException doBuild(final DittoHeaders dittoHeaders,
+                                                          @Nullable final String message,
+                                                          @Nullable final String description,
+                                                          @Nullable final Throwable cause,
+                                                          @Nullable final URI href) {
+
+             return new CloudEventNotParsableException(dittoHeaders, message, description, cause, href);
+         }
+     }
+
+ }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventNotParsableException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventNotParsableException.java
@@ -25,7 +25,7 @@
  import org.eclipse.ditto.model.base.json.JsonParsableException;
 
  /**
-  * Thrown if a request with an unparsable cloud event is made.
+  * Thrown if a request with an unparsable CloudEvent is made.
   *
   * @since 1.5.0
   */
@@ -36,12 +36,14 @@
      /**
       * Error code of this exception.
       */
-     public static final String ERROR_CODE = "cloudevents.unparsable";
+     public static final String ERROR_CODE = "cloudevent.unparsable";
 
      private static final String DEFAULT_MESSAGE = "The event could not be parsed.";
      private static final String MESSAGE_PATTERN = "The system was unable to parse the event: {0}";
-     private static final String DESCRIPTION = "Ensure that the event is being transmitted according to the Cloud Events HTTP binding specification v1.0.";
-     private static final URI DEFAULT_URI = URI.create("https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md");
+     private static final String DESCRIPTION =
+             "Ensure that the event is being transmitted according to the Cloud Events HTTP binding specification v1.0.";
+     private static final URI DEFAULT_URI =
+             URI.create("https://github.com/cloudevents/spec/blob/v1.0/http-protocol-binding.md");
 
      private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
 
@@ -56,10 +58,10 @@
       * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
       */
      private CloudEventNotParsableException(final DittoHeaders dittoHeaders,
-                                            @Nullable final String message,
-                                            @Nullable final String description,
-                                            @Nullable final Throwable cause,
-                                            @Nullable final URI href) {
+             @Nullable final String message,
+             @Nullable final String description,
+             @Nullable final Throwable cause,
+             @Nullable final URI href) {
          super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href == null ? DEFAULT_URI : href);
      }
 
@@ -67,7 +69,7 @@
       * A mutable builder for a {@code CloudEventNotParsableException} where the message contains detailed information
       * about the parse error.
       *
-      * @param details the unsupported data schema used in the call.
+      * @param details the details about why the CloudEvent could not be parsed.
       * @return the new CloudEventNotParsableException.
       */
      public static DittoRuntimeExceptionBuilder<CloudEventNotParsableException> withDetailedInformationBuilder(
@@ -89,12 +91,13 @@
       * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
       * format.
       */
-     public static CloudEventNotParsableException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+     public static CloudEventNotParsableException fromJson(final JsonObject jsonObject,
+             final DittoHeaders dittoHeaders) {
          return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
      }
 
      @Override
-    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+     public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
          return new Builder()
                  .message(getMessage())
                  .description(getDescription().orElse(null))
@@ -116,10 +119,10 @@
 
          @Override
          protected CloudEventNotParsableException doBuild(final DittoHeaders dittoHeaders,
-                                                          @Nullable final String message,
-                                                          @Nullable final String description,
-                                                          @Nullable final Throwable cause,
-                                                          @Nullable final URI href) {
+                 @Nullable final String message,
+                 @Nullable final String description,
+                 @Nullable final Throwable cause,
+                 @Nullable final URI href) {
 
              return new CloudEventNotParsableException(dittoHeaders, message, description, cause, href);
          }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventUnsupportedDataSchemaException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventUnsupportedDataSchemaException.java
@@ -1,0 +1,128 @@
+ /*
+  * Copyright (c) 2020 Contributors to the Eclipse Foundation
+  *
+  * See the NOTICE file(s) distributed with this work for additional
+  * information regarding copyright ownership.
+  *
+  * This program and the accompanying materials are made available under the
+  * terms of the Eclipse Public License 2.0 which is available at
+  * http://www.eclipse.org/legal/epl-2.0
+  *
+  * SPDX-License-Identifier: EPL-2.0
+  */
+ package org.eclipse.ditto.model.base.exceptions;
+
+ import java.net.URI;
+ import java.text.MessageFormat;
+
+ import javax.annotation.Nullable;
+ import javax.annotation.concurrent.Immutable;
+ import javax.annotation.concurrent.NotThreadSafe;
+
+ import org.eclipse.ditto.json.JsonObject;
+ import org.eclipse.ditto.model.base.common.HttpStatusCode;
+ import org.eclipse.ditto.model.base.headers.DittoHeaders;
+ import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+ /**
+  * Thrown if a request with an unsupported data schema is made.
+  *
+  * @since 1.5.0
+  */
+ @Immutable
+ @JsonParsableException(errorCode = CloudEventUnsupportedDataSchemaException.ERROR_CODE)
+ public final class CloudEventUnsupportedDataSchemaException extends DittoRuntimeException {
+
+     /**
+      * Error code of this exception.
+      */
+     public static final String ERROR_CODE = "cloudevents.dataschema.unsupported";
+
+     private static final String DEFAULT_MESSAGE = "The data schema is not supported.";
+     private static final String MESSAGE_PATTERN = "The data schema <{0}> is not supported for this Resource.";
+     private static final String DESCRIPTION = "Must start with 'ditto:'";
+
+     private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
+
+     /**
+      * Constructs a new {@code CloudEventUnsupportedDataSchemaException} object.
+      *
+      * @param dittoHeaders the headers with which this Exception should be reported back to the user.
+      * @param message the detail message for later retrieval with {@link #getMessage()}.
+      * @param description a description with further information about the exception.
+      * @param cause the cause of the exception for later retrieval with {@link #getCause()}.
+      * @param href a link to a resource which provides further information about the exception.
+      * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
+      */
+     private CloudEventUnsupportedDataSchemaException(final DittoHeaders dittoHeaders,
+                                                      @Nullable final String message,
+                                                      @Nullable final String description,
+                                                      @Nullable final Throwable cause,
+                                                      @Nullable final URI href) {
+         super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
+     }
+
+     /**
+      * A mutable builder for a {@code CloudEventUnsupportedDataSchemaException} where the message contains detailed information
+      * about the actual used data schema and the description information about data schemas are supported for the
+      * requested resource.
+      *
+      * @param callersDataSchema the unsupported data schema used in the call.
+      * @return the new CloudEventUnsupportedDataSchemaException.
+      */
+     public static DittoRuntimeExceptionBuilder<CloudEventUnsupportedDataSchemaException> withDetailedInformationBuilder(
+             final String callersDataSchema) {
+
+         final String msgPattern = MessageFormat.format(MESSAGE_PATTERN, callersDataSchema);
+         return new Builder().message(msgPattern).description(DESCRIPTION);
+     }
+
+     /**
+      * Constructs a new {@code UnsupportedDataSchemaException} object with the exception message extracted from the
+      * given JSON object.
+      *
+      * @param jsonObject the JSON to read the {@link org.eclipse.ditto.model.base.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+      * @param dittoHeaders the headers of the command which resulted in this exception.
+      * @return the new CloudEventUnsupportedDataSchemaException.
+      * @throws NullPointerException if any argument is {@code null}.
+      * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+      * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+      * format.
+      */
+     public static CloudEventUnsupportedDataSchemaException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+         return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+     }
+
+     @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+         return new Builder()
+                 .message(getMessage())
+                 .description(getDescription().orElse(null))
+                 .cause(getCause())
+                 .href(getHref().orElse(null))
+                 .dittoHeaders(dittoHeaders)
+                 .build();
+     }
+
+     /**
+      * A mutable builder with a fluent API for a {@link CloudEventUnsupportedDataSchemaException}.
+      */
+     @NotThreadSafe
+     public static final class Builder extends DittoRuntimeExceptionBuilder<CloudEventUnsupportedDataSchemaException> {
+
+         private Builder() {
+             message(DEFAULT_MESSAGE);
+         }
+
+         @Override
+         protected CloudEventUnsupportedDataSchemaException doBuild(final DittoHeaders dittoHeaders,
+                                                                    @Nullable final String message,
+                                                                    @Nullable final String description,
+                                                                    @Nullable final Throwable cause,
+                                                                    @Nullable final URI href) {
+
+             return new CloudEventUnsupportedDataSchemaException(dittoHeaders, message, description, cause, href);
+         }
+     }
+
+ }

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventUnsupportedDataSchemaException.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/exceptions/CloudEventUnsupportedDataSchemaException.java
@@ -25,7 +25,7 @@
  import org.eclipse.ditto.model.base.json.JsonParsableException;
 
  /**
-  * Thrown if a request with an unsupported data schema is made.
+  * Thrown if a CloudEvent request with an unsupported dataschema is made.
   *
   * @since 1.5.0
   */
@@ -36,11 +36,12 @@
      /**
       * Error code of this exception.
       */
-     public static final String ERROR_CODE = "cloudevents.dataschema.unsupported";
+     public static final String ERROR_CODE = "cloudevent.dataschema.unsupported";
 
      private static final String DEFAULT_MESSAGE = "The data schema is not supported.";
-     private static final String MESSAGE_PATTERN = "The data schema <{0}> is not supported for this Resource.";
-     private static final String DESCRIPTION = "Must start with 'ditto:'";
+     private static final String MESSAGE_PATTERN = "The data schema <{0}> is not supported for this resource.";
+     private static final String DESCRIPTION = "Ensure that the URI's scheme is 'ditto', so the complete dataschema " +
+             "starts with 'ditto:'";
 
      private static final HttpStatusCode STATUS_CODE = HttpStatusCode.BAD_REQUEST;
 
@@ -55,10 +56,10 @@
       * @throws NullPointerException if {@code dittoHeaders} is {@code null}.
       */
      private CloudEventUnsupportedDataSchemaException(final DittoHeaders dittoHeaders,
-                                                      @Nullable final String message,
-                                                      @Nullable final String description,
-                                                      @Nullable final Throwable cause,
-                                                      @Nullable final URI href) {
+             @Nullable final String message,
+             @Nullable final String description,
+             @Nullable final Throwable cause,
+             @Nullable final URI href) {
          super(ERROR_CODE, STATUS_CODE, dittoHeaders, message, description, cause, href);
      }
 
@@ -89,12 +90,13 @@
       * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
       * format.
       */
-     public static CloudEventUnsupportedDataSchemaException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+     public static CloudEventUnsupportedDataSchemaException fromJson(final JsonObject jsonObject,
+             final DittoHeaders dittoHeaders) {
          return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
      }
 
      @Override
-    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+     public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
          return new Builder()
                  .message(getMessage())
                  .description(getDescription().orElse(null))
@@ -116,10 +118,10 @@
 
          @Override
          protected CloudEventUnsupportedDataSchemaException doBuild(final DittoHeaders dittoHeaders,
-                                                                    @Nullable final String message,
-                                                                    @Nullable final String description,
-                                                                    @Nullable final Throwable cause,
-                                                                    @Nullable final URI href) {
+                 @Nullable final String message,
+                 @Nullable final String description,
+                 @Nullable final Throwable cause,
+                 @Nullable final URI href) {
 
              return new CloudEventUnsupportedDataSchemaException(dittoHeaders, message, description, cause, href);
          }

--- a/services/gateway/endpoints/pom.xml
+++ b/services/gateway/endpoints/pom.xml
@@ -145,6 +145,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.cloudevents</groupId>
+            <artifactId>cloudevents-http-basic</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
@@ -91,12 +91,12 @@ public abstract class AbstractRoute extends AllDirectives {
 
     protected final ActorRef proxyActor;
     protected final ActorSystem actorSystem;
+    protected final Set<String> mediaTypeJsonWithFallbacks;
 
     private final HttpConfig httpConfig;
     private final CommandConfig commandConfig;
     private final HeaderTranslator headerTranslator;
     private final HttpRequestActorPropsFactory httpRequestActorPropsFactory;
-    private final Set<String> mediaTypeJsonWithFallbacks;
     private final Attributes supervisionStrategy;
 
     /**

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRoute.java
@@ -38,6 +38,7 @@ import org.eclipse.ditto.services.gateway.endpoints.directives.HttpsEnsuringDire
 import org.eclipse.ditto.services.gateway.endpoints.directives.RequestResultLoggingDirective;
 import org.eclipse.ditto.services.gateway.endpoints.directives.RequestTimeoutHandlingDirective;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.GatewayAuthenticationDirective;
+import org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents.CloudEventsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.devops.DevOpsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.health.CachingHealthRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.policies.PoliciesRoute;
@@ -90,6 +91,7 @@ public final class RootRoute extends AllDirectives {
     private final WebSocketRouteBuilder websocketRouteBuilder;
     private final StatsRoute statsRoute;
     private final WhoamiRoute whoamiRoute;
+    private final CloudEventsRoute cloudEventsRoute;
 
     private final CustomApiRoutesProvider customApiRoutesProvider;
     private final GatewayAuthenticationDirective apiAuthenticationDirective;
@@ -118,6 +120,7 @@ public final class RootRoute extends AllDirectives {
         websocketRouteBuilder = builder.websocketRouteBuilder;
         statsRoute = builder.statsRoute;
         whoamiRoute = builder.whoamiRoute;
+        cloudEventsRoute = builder.cloudEventsRoute;
         customApiRoutesProvider = builder.customApiRoutesProvider;
         apiAuthenticationDirective = builder.httpAuthenticationDirective;
         wsAuthenticationDirective = builder.wsAuthenticationDirective;
@@ -275,7 +278,9 @@ public final class RootRoute extends AllDirectives {
                 // /api/{apiVersion}/search/things
                 thingSearchRoute.buildSearchRoute(ctx, dittoHeaders),
                 // /api/{apiVersion}/whoami
-                whoamiRoute.buildWhoamiRoute(ctx, dittoHeaders)
+                whoamiRoute.buildWhoamiRoute(ctx, dittoHeaders),
+                // /api/{apiVersion}/cloudevents
+                cloudEventsRoute.buildCloudEventsRoute(ctx, dittoHeaders)
         ).orElse(customApiSubRoutes);
     }
 
@@ -391,6 +396,7 @@ public final class RootRoute extends AllDirectives {
         private WebSocketRouteBuilder websocketRouteBuilder;
         private StatsRoute statsRoute;
         private WhoamiRoute whoamiRoute;
+        private CloudEventsRoute cloudEventsRoute;
 
         private CustomApiRoutesProvider customApiRoutesProvider;
         private GatewayAuthenticationDirective httpAuthenticationDirective;
@@ -471,6 +477,12 @@ public final class RootRoute extends AllDirectives {
         @Override
         public RootRouteBuilder whoamiRoute(final WhoamiRoute route) {
             whoamiRoute = route;
+            return this;
+        }
+
+        @Override
+        public RootRouteBuilder cloudEventsRoute(final CloudEventsRoute route) {
+            cloudEventsRoute = route;
             return this;
         }
 

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteBuilder.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteBuilder.java
@@ -18,6 +18,7 @@ import org.eclipse.ditto.model.base.headers.DittoHeadersSizeChecker;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.protocoladapter.HeaderTranslator;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.GatewayAuthenticationDirective;
+import org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents.CloudEventsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.devops.DevOpsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.health.CachingHealthRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.policies.PoliciesRoute;
@@ -128,6 +129,15 @@ public interface RootRouteBuilder {
      * @since 1.2.0
      */
     RootRouteBuilder whoamiRoute(WhoamiRoute route);
+
+    /**
+     * Sets the cloud events route.
+     *
+     * @param route the route to set.
+     * @return the Builder to allow method chaining.
+     * @since 1.5.0
+     */
+    RootRouteBuilder cloudEventsRoute(CloudEventsRoute route);
 
     /**
      * Sets the http authentication directive.

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/CloudEventsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/CloudEventsRoute.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents;
+
+import java.net.URI;
+import java.text.MessageFormat;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.exceptions.CloudEventNotParsableException;
+import org.eclipse.ditto.model.base.exceptions.CloudEventMissingPayloadException;
+import org.eclipse.ditto.model.base.exceptions.CloudEventUnsupportedDataSchemaException;
+import org.eclipse.ditto.model.base.exceptions.UnsupportedMediaTypeException;
+import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.protocoladapter.DittoProtocolAdapter;
+import org.eclipse.ditto.protocoladapter.HeaderTranslator;
+import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
+import org.eclipse.ditto.protocoladapter.ProtocolFactory;
+import org.eclipse.ditto.services.gateway.endpoints.actors.AbstractHttpRequestActor;
+import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.CommandConfig;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.HttpConfig;
+import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.services.utils.akka.logging.ThreadSafeDittoLogger;
+import org.eclipse.ditto.signals.base.Signal;
+import org.eclipse.ditto.signals.commands.base.CommandNotSupportedException;
+
+import com.eclipsesource.json.Json;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Status;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.model.HttpResponse;
+import akka.http.javadsl.server.RequestContext;
+import akka.http.javadsl.server.Route;
+import akka.stream.javadsl.Sink;
+import akka.util.ByteString;
+import io.cloudevents.CloudEvent;
+import io.cloudevents.CloudEventData;
+import io.cloudevents.core.message.MessageReader;
+import io.cloudevents.http.HttpMessageFactory;
+import io.cloudevents.rw.CloudEventRWException;
+
+/**
+ * Builder for creating Akka HTTP route for {@code /cloudevents}.
+ */
+public final class CloudEventsRoute extends AbstractRoute {
+
+    private static final ThreadSafeDittoLogger LOGGER =
+            DittoLoggerFactory.getThreadSafeLogger(CloudEventsRoute.class);
+
+    /**
+     * Public endpoint of cloud events.
+     */
+    public static final String PATH_CLOUDEVENTS = "cloudevents";
+
+    // use empty header translator to pass along the ditto-auth-context information
+    private static final DittoProtocolAdapter PROTOCOL_ADAPTER = DittoProtocolAdapter.of(HeaderTranslator.empty());
+
+    /**
+     * Constructs the cloud events route builder.
+     *
+     * @param proxyActor an actor selection of the actor handling delegating to persistence.
+     * @param actorSystem the ActorSystem to use.
+     * @param httpConfig the configuration settings of the Gateway service's HTTP endpoint.
+     * @param commandConfig the configuration settings for incoming commands (via HTTP requests) in the gateway.
+     * @param headerTranslator translates headers from external sources or to external sources.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    public CloudEventsRoute(
+            final ActorRef proxyActor,
+            final ActorSystem actorSystem,
+            final HttpConfig httpConfig,
+            final CommandConfig commandConfig,
+            final HeaderTranslator headerTranslator
+    ) {
+        super(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator);
+    }
+
+
+    /**
+     * Builds the {@code /cloudevents} route.
+     *
+     * @return the {@code /cloudevents} route.
+     */
+    public Route buildCloudEventsRoute(final RequestContext ctx, final DittoHeaders dittoHeaders) {
+        return path(PATH_CLOUDEVENTS, () -> // /cloudevents
+                post(() -> // POST
+                        acceptCloudEvent(ctx, dittoHeaders)
+                )
+        );
+    }
+
+    protected Route acceptCloudEvent(final RequestContext ctx, final DittoHeaders dittoHeaders) {
+
+        return extractDataBytes(payloadSource -> {
+
+            final CompletableFuture<HttpResponse> httpResponseFuture = new CompletableFuture<>();
+
+            runWithSupervisionStrategy(payloadSource
+                    // collect the binary payload
+                    .fold(ByteString.emptyByteString(), ByteString::concat)
+                    // map the payload to a cloud event
+                    .map(payload -> toCloudEvent(ctx, dittoHeaders, payload))
+                    // validate the cloud event
+                    .map(cloudEvent -> validateCloudEvent(cloudEvent, ctx, dittoHeaders))
+                    // process the event
+                    .map(cloudEvent -> {
+                        try {
+                            // DON'T replace this try-catch by .recover: The supervising strategy is called before recovery!
+                            final Optional<Signal<?>> optionalSignal = jsonToDittoSignal(cloudEvent.getData(), dittoHeaders);
+                            if (optionalSignal.isEmpty()) {
+                                return new Status.Failure(CloudEventMissingPayloadException
+                                        .withDetailedInformationBuilder()
+                                        .dittoHeaders(dittoHeaders)
+                                        .build());
+                            }
+
+                            final Signal<?> signal = optionalSignal.get();
+                            final JsonSchemaVersion schemaVersion = signal.getImplementedSchemaVersion();
+                            return signal.implementsSchemaVersion(schemaVersion) ? signal
+                                    : CommandNotSupportedException.newBuilder(schemaVersion.toInt())
+                                    .dittoHeaders(dittoHeaders)
+                                    .build();
+                        } catch (final Exception e) {
+                            return new Status.Failure(e);
+                        }
+                    })
+                    .to(Sink.actorRef(createHttpPerRequestActor(ctx, httpResponseFuture),
+                            AbstractHttpRequestActor.COMPLETE_MESSAGE))
+            );
+
+            // return with future
+
+            return completeWithFuture(httpResponseFuture);
+
+        });
+
+    }
+
+    /**
+     * Convert the request and payload to a cloud event.
+     *
+     * @param ctx The request context.
+     * @param payload The binary payload, this may contain the cloud event payload, or the fully encoded cloud
+     *         event structure.
+     * @return The cloud event
+     */
+    private CloudEvent toCloudEvent(final RequestContext ctx, final DittoHeaders dittoHeaders, final ByteString payload) {
+
+        if (LOGGER.isTraceEnabled()) {
+
+            final StringBuilder headers = new StringBuilder("Raw HTTP Headers:");
+            ctx.getRequest().getHeaders()
+                    .forEach(header -> headers
+                            .append("\n\t")
+                            .append(header.name())
+                            .append(" = ")
+                            .append(header.value()));
+
+            LOGGER
+                    .withCorrelationId(dittoHeaders)
+                    .trace(headers.toString());
+
+            LOGGER
+                    .withCorrelationId(dittoHeaders)
+                    .trace("Ditto: {}", dittoHeaders);
+        }
+
+        // create a reader for the message
+        final MessageReader reader = HttpMessageFactory.createReader(acceptor -> {
+
+            // NOTE: this acceptor may be run multiple times by the message reader
+
+            // record if we saw the content type header
+            final AtomicBoolean sawContentType = new AtomicBoolean();
+            // consume the HTTP request headers
+            ctx.getRequest().getHeaders().forEach(header -> {
+                if (header.lowercaseName().equals(DittoHeaderDefinition.CONTENT_TYPE.getKey())) {
+                    sawContentType.set(true);
+                }
+                acceptor.accept(header.name(), header.value());
+            });
+
+            if (!sawContentType.get()) {
+                // we didn't see the content type in the header, so extract it from akka's request
+                acceptor.accept(DittoHeaderDefinition.CONTENT_TYPE.getKey(), ctx.getRequest().entity().getContentType().mediaType().toString());
+            }
+        }, payload.toArray());
+
+        try {
+            return reader.toEvent();
+        } catch (final CloudEventRWException | IllegalStateException e) {
+            throw CloudEventNotParsableException.withDetailedInformationBuilder(e.getMessage())
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+    }
+
+    private CloudEvent validateCloudEvent(final CloudEvent cloudEvent, final RequestContext ctx, final DittoHeaders dittoHeaders) {
+
+        if (cloudEvent.getData() == null) {
+            throw CloudEventMissingPayloadException
+                    .withDetailedInformationBuilder()
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+
+        LOGGER
+                .withCorrelationId(dittoHeaders)
+                .debug("Cloud event: {}", cloudEvent);
+
+        ensureDataContentType(cloudEvent.getDataContentType(), ctx, dittoHeaders);
+        ensureDataSchema(cloudEvent.getDataSchema(), ctx, dittoHeaders);
+
+        return cloudEvent;
+    }
+
+    private Optional<Signal<?>> jsonToDittoSignal(@Nullable final CloudEventData data, final DittoHeaders dittoHeaders) {
+        if (data == null) {
+            return Optional.empty();
+        }
+        final byte[] payload = data.toBytes();
+        if (payload == null || payload.length == 0) {
+            return Optional.empty();
+        }
+
+        JsonObject jsonObject = JsonObject.of(payload);
+        LOGGER
+                .withCorrelationId(dittoHeaders)
+                .debug("JSON: {}", jsonObject);
+
+        final JsonObject headers = jsonObject.getField("headers")
+
+                // get value
+                .map(JsonField::getValue)
+
+                // convert to JsonObject, or "empty"
+                .flatMap(value -> {
+                    if (value.isObject()) {
+                        return Optional.of(value.asObject());
+                     } else {
+                        return Optional.empty();
+                    }
+                })
+
+                // get existing or new
+                .orElseGet(JsonObject::empty)
+
+                // never require a response
+                .setValue("response-required", false)
+                .setValue("requested-acks", JsonArray.newBuilder().add("twin-persisted").build());
+
+        jsonObject = jsonObject.setValue("headers", headers);
+
+        LOGGER
+                .withCorrelationId(dittoHeaders)
+                .debug("Updated JSON: {}", jsonObject);
+
+        final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
+        return Optional.of(PROTOCOL_ADAPTER
+                .fromAdaptable(jsonifiableAdaptable)
+                .setDittoHeaders(dittoHeaders));
+    }
+
+    private void ensureDataContentType(@Nullable final String dataContentType,
+                                       final RequestContext ctx,
+                                       final DittoHeaders dittoHeaders) {
+
+        if (dataContentType == null || !mediaTypeJsonWithFallbacks.contains(dataContentType)) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.withCorrelationId(dittoHeaders)
+                        .info("Request rejected: unsupported data-content-type: <{}>  request: <{}>", dataContentType,
+                                requestToLogString(ctx.getRequest()));
+            }
+            throw UnsupportedMediaTypeException
+                    .withDetailedInformationBuilder(dataContentType != null ? dataContentType : "<none>", mediaTypeJsonWithFallbacks)
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+    }
+
+    /**
+     * Ensure that the data schema starts with {@code ditto:}.
+     *
+     * @param dataSchema The schema to verify
+     * @param ctx The request context.
+     * @param dittoHeaders The ditto headers.
+     */
+    private void ensureDataSchema(@Nullable final URI dataSchema,
+                                  final RequestContext ctx,
+                                  final DittoHeaders dittoHeaders) {
+
+        if (dataSchema == null || !dataSchema.getScheme().equals("ditto")) {
+            if (LOGGER.isInfoEnabled()) {
+                LOGGER.withCorrelationId(dittoHeaders)
+                        .info("Request rejected: unsupported data-schema: <{}>  request: <{}>", dataSchema,
+                                requestToLogString(ctx.getRequest()));
+            }
+            throw CloudEventUnsupportedDataSchemaException
+                    .withDetailedInformationBuilder(dataSchema != null ? dataSchema.toString() : "<none>")
+                    .dittoHeaders(dittoHeaders)
+                    .build();
+        }
+    }
+
+    private static String requestToLogString(final HttpRequest request) {
+        return MessageFormat.format("{0} {1} {2}",
+                request.getUri().getHost().address(),
+                request.method().value(),
+                request.getUri().getPathString());
+    }
+
+}

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/CloudEventsRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/CloudEventsRoute.java
@@ -249,9 +249,10 @@ public final class CloudEventsRoute extends AbstractRoute {
                 .build();
 
         final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.jsonifiableAdaptableFromJson(jsonObject);
-        return Optional.of(PROTOCOL_ADAPTER
-                .fromAdaptable(jsonifiableAdaptable)
-                .setDittoHeaders(adjustedHeaders));
+        final Signal<?> signal = PROTOCOL_ADAPTER.fromAdaptable(jsonifiableAdaptable);
+        final Signal<?> signalWithAdjustedHeaders = signal.setDittoHeaders(
+                        signal.getDittoHeaders().toBuilder().putHeaders(adjustedHeaders).build());
+        return Optional.of(signalWithAdjustedHeaders);
     }
 
     private void ensureDataContentType(@Nullable final String dataContentType,

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/package-info.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/cloudevents/package-info.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+@org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault
+package org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents;

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -42,6 +42,7 @@ import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DevopsAuthen
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DevopsAuthenticationDirectiveFactory;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DittoGatewayAuthenticationDirectiveFactory;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.GatewayAuthenticationDirectiveFactory;
+import org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents.CloudEventsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.devops.DevOpsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.health.CachingHealthRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.policies.PoliciesRoute;
@@ -167,6 +168,7 @@ public final class RootRouteTest extends EndpointTestBase {
                 .thingSearchRoute(
                         new ThingSearchRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .whoamiRoute(new WhoamiRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
+                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .websocketRoute(WebSocketRoute.getInstance(proxyActor, streamingConfig, materializer))
                 .supportedSchemaVersions(httpConfig.getSupportedSchemaVersions())
                 .protocolAdapterProvider(protocolAdapterProvider)

--- a/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
+++ b/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
@@ -24,6 +24,7 @@ import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DevopsAuthen
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.DittoGatewayAuthenticationDirectiveFactory;
 import org.eclipse.ditto.services.gateway.endpoints.directives.auth.GatewayAuthenticationDirectiveFactory;
 import org.eclipse.ditto.services.gateway.endpoints.routes.RootRoute;
+import org.eclipse.ditto.services.gateway.endpoints.routes.cloudevents.CloudEventsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.devops.DevOpsRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.health.CachingHealthRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.policies.PoliciesRoute;
@@ -282,6 +283,7 @@ final class GatewayRootActor extends DittoRootActor {
                 .thingSearchRoute(
                         new ThingSearchRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .whoamiRoute(new WhoamiRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
+                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .websocketRoute(WebSocketRoute.getInstance(streamingActor, streamingConfig, materializer)
                         .withSignalEnrichmentProvider(signalEnrichmentProvider)
                         .withHeaderTranslator(headerTranslator))

--- a/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
+++ b/services/gateway/starter/src/test/java/org/eclipse/ditto/services/gateway/starter/GatewayServiceGlobalErrorRegistryTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.gateway.starter;
 
 import org.eclipse.ditto.model.base.acks.AcknowledgementLabelInvalidException;
 import org.eclipse.ditto.model.base.entity.id.NamespacedEntityIdInvalidException;
+import org.eclipse.ditto.model.base.exceptions.CloudEventNotParsableException;
 import org.eclipse.ditto.model.base.exceptions.DittoHeaderInvalidException;
 import org.eclipse.ditto.model.connectivity.ConnectionConfigurationInvalidException;
 import org.eclipse.ditto.model.jwt.JwtAudienceInvalidException;
@@ -25,6 +26,8 @@ import org.eclipse.ditto.model.policies.PolicyIdInvalidException;
 import org.eclipse.ditto.model.things.AclEntryInvalidException;
 import org.eclipse.ditto.model.things.ThingIdInvalidException;
 import org.eclipse.ditto.protocoladapter.UnknownCommandException;
+import org.eclipse.ditto.model.base.exceptions.CloudEventMissingPayloadException;
+import org.eclipse.ditto.model.base.exceptions.CloudEventUnsupportedDataSchemaException;
 import org.eclipse.ditto.services.gateway.security.authentication.jwt.PublicKeyProviderUnavailableException;
 import org.eclipse.ditto.services.utils.test.GlobalErrorRegistryTestCases;
 import org.eclipse.ditto.signals.acks.base.AcknowledgementCorrelationIdMissingException;
@@ -60,7 +63,11 @@ public final class GatewayServiceGlobalErrorRegistryTest extends GlobalErrorRegi
                 PolicyIdInvalidException.class,
                 PublicKeyProviderUnavailableException.class,
                 AcknowledgementLabelInvalidException.class,
-                AcknowledgementCorrelationIdMissingException.class);
+                AcknowledgementCorrelationIdMissingException.class,
+                CloudEventMissingPayloadException.class,
+                CloudEventUnsupportedDataSchemaException.class,
+                CloudEventNotParsableException.class
+        );
     }
 
 }

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/AbstractShardedPersistenceActor.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/AbstractShardedPersistenceActor.java
@@ -424,7 +424,7 @@ public abstract class AbstractShardedPersistenceActor<
 
     @Override
     public void onError(final DittoRuntimeException error, final Command errorCausingCommand) {
-        if (errorCausingCommand.getDittoHeaders().isResponseRequired()) {
+        if (shouldSendResponse(errorCausingCommand.getDittoHeaders())) {
             notifySender(error);
         }
     }


### PR DESCRIPTION
This change adds support for receiving cloud events through the HTTP
binding.

The event's payload must be in the Ditto Protocol JSON.

Signed-off-by: Jens Reimann <jreimann@redhat.com>