### PR TITLE
Add new cluster role "acks-aware" to cluster-status-roles-blocklist

### DIFF
--- a/services/utils/config/src/main/resources/ditto-cluster.conf
+++ b/services/utils/config/src/main/resources/ditto-cluster.conf
@@ -7,6 +7,7 @@ ditto.cluster {
     "dc-default",
     "blocked-namespaces-aware",
     "thing-event-aware",
-    "live-signal-aware"
+    "live-signal-aware",
+    "acks-aware"
   ]
 }


### PR DESCRIPTION
Was missing from that blocklist and thus "acks-aware" was included in Ditto's "status" and "health" resources.