### PR TITLE
Fix missing metrics for successfully published messages via HTTP connection

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -336,7 +336,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                     result = Acknowledgement.of(label, entityIdWithType, statusCode, dittoHeaders, body);
                 }
 
-                if (result != null && isMessageCommand) {
+                if (result instanceof MessageCommandResponse && isMessageCommand) {
                     // Do only return command response for live commands with a correct response.
                     validateLiveResponse(result, (MessageCommand<?, ?>) signal);
                 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/httppush/HttpPublisherActor.java
@@ -326,10 +326,10 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                         } else if (parsedResponse instanceof MessageCommandResponse) {
                             result = parsedResponse;
                         } else {
-                            result = null;
+                            result = Acknowledgement.of(NO_ACK_LABEL, entityIdWithType, statusCode, dittoHeaders, body);
                         }
                     } else {
-                        result = null;
+                        result = Acknowledgement.of(NO_ACK_LABEL, entityIdWithType, statusCode, dittoHeaders, body);
                     }
                 } else {
                     // There is an issued ack declared but its not live-response => handle response as acknowledgement.

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/SendingTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/SendingTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import org.assertj.core.api.SoftAssertions;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.acks.AcknowledgementLabel;
 import org.eclipse.ditto.model.base.acks.DittoAcknowledgementLabel;
@@ -168,7 +169,7 @@ public final class SendingTest {
     }
 
     @Test
-    public void monitorAcknowledgementSendFailureKeepOriginalResponse() {
+    public void monitorAcknowledgementSendSuccessInCaseOfHandledException() {
         final var acknowledgement = Mockito.mock(Acknowledgement.class);
         final var acknowledgementPayload = JsonObject.newBuilder().set("foo", "bar").build();
         final var acknowledgementStatusCode = HttpStatusCode.INTERNAL_SERVER_ERROR;
@@ -185,10 +186,51 @@ public final class SendingTest {
 
         final Optional<CompletionStage<CommandResponse>> result = underTest.monitorAndAcknowledge(exceptionConverter);
 
-        Mockito.verifyNoInteractions(publishedMonitor);
+        Mockito.verify(publishedMonitor).success(externalMessage);
         Mockito.verify(acknowledgedMonitor).failure(externalMessage, expectedException);
         assertThat(result)
                 .hasValueSatisfying(resultFuture -> assertThat(resultFuture).isCompletedWithValue(acknowledgement));
+    }
+
+    @Test
+    public void monitorAcknowledgementSendFailureInCaseOfUnhandledException() {
+        final var source = Mockito.mock(Signal.class);
+        final var thingId = ThingId.generateRandom();
+        Mockito.when(source.getEntityId()).thenReturn(thingId);
+        Mockito.when(source.getDittoHeaders()).thenReturn(dittoHeaders);
+        Mockito.when(mappedOutboundSignal.getSource()).thenReturn(source);
+        Mockito.when(autoAckTarget.getIssuedAcknowledgementLabel()).thenReturn(Optional.of(ACKNOWLEDGEMENT_LABEL));
+        final var thrownException = new IllegalStateException("Test");
+        final var acknowledgementPayload = JsonObject.newBuilder()
+                .set("message", "Encountered <IllegalStateException>.")
+                .set("description", "Test")
+                .build();
+        final var acknowledgementStatusCode = HttpStatusCode.INTERNAL_SERVER_ERROR;
+        final var expectedException = MessageSendingFailedException.newBuilder()
+                .statusCode(acknowledgementStatusCode)
+                .message("Received negative acknowledgement for label <" + ACKNOWLEDGEMENT_LABEL + ">.")
+                .description("Payload: " + acknowledgementPayload)
+                .build();
+        final CompletableFuture<CommandResponse<?>> failedFuture = new CompletableFuture<>();
+        failedFuture.completeExceptionally(thrownException);
+        final Sending underTest = new Sending(sendingContext, failedFuture, connectionIdResolver, logger);
+
+        final Optional<CompletionStage<CommandResponse>> result = underTest.monitorAndAcknowledge(exceptionConverter);
+
+        Mockito.verify(publishedMonitor).exception(externalMessage, thrownException);
+        Mockito.verify(acknowledgedMonitor).failure(externalMessage, expectedException);
+        assertThat(result).hasValueSatisfying(
+                resultFuture -> assertThat(resultFuture).isCompletedWithValueMatching(response -> {
+                    final SoftAssertions softly = new SoftAssertions();
+                    softly.assertThat(response).isInstanceOf(Acknowledgement.class);
+                    final Acknowledgement ack = (Acknowledgement) response;
+                    softly.assertThat(ack.getLabel().toString()).isEqualTo(ACKNOWLEDGEMENT_LABEL.toString());
+                    softly.assertThat(ack.getEntity()).contains(acknowledgementPayload);
+                    softly.assertThat(ack.getEntityId().toString()).isEqualTo(thingId.toString());
+                    softly.assertThat(ack.getStatusCode()).isEqualTo(acknowledgementStatusCode);
+                    softly.assertAll();
+                    return true;
+                }));
     }
 
     @Test


### PR DESCRIPTION
When publishing messages via a target of an HTTP connection without an issued acknowledgement configured, the metrics did not show successfully published messages.

Additionally I noticed that:
* live messages were not handled correctly in the metrics.
* it was not possible to issue an acknowledgement by the target of an HTTP connection for a live message that is not "live-response"
