### PR TITLE
[#903]: Make schema optional, allow alternate content type

### DIFF
--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/AbstractRoute.java
@@ -91,13 +91,13 @@ public abstract class AbstractRoute extends AllDirectives {
 
     protected final ActorRef proxyActor;
     protected final ActorSystem actorSystem;
-    protected final Set<String> mediaTypeJsonWithFallbacks;
 
     private final HttpConfig httpConfig;
     private final CommandConfig commandConfig;
     private final HeaderTranslator headerTranslator;
     private final HttpRequestActorPropsFactory httpRequestActorPropsFactory;
     private final Attributes supervisionStrategy;
+    private final Set<String> mediaTypeJsonWithFallbacks;
 
     /**
      * Constructs the abstract route builder.

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/EndpointTestBase.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/EndpointTestBase.java
@@ -38,8 +38,10 @@ import org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtAuthent
 import org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtAuthorizationSubjectsProviderFactory;
 import org.eclipse.ditto.services.gateway.security.utils.DefaultHttpClientFacade;
 import org.eclipse.ditto.services.gateway.security.utils.HttpClientFacade;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.CloudEventsConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.CommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultClaimMessageConfig;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultCloudEventsConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultCommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultMessageConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultPublicHealthConfig;
@@ -98,6 +100,7 @@ public abstract class EndpointTestBase extends JUnitRouteTest {
     protected static StreamingConfig streamingConfig;
     protected static PublicHealthConfig publicHealthConfig;
     protected static ProtocolConfig protocolConfig;
+    protected static CloudEventsConfig cloudEventsConfig;
     protected static JwtAuthenticationFactory jwtAuthenticationFactory;
     protected static HttpClientFacade httpClientFacade;
     protected static JwtAuthorizationSubjectsProviderFactory authorizationSubjectsProviderFactory;
@@ -117,6 +120,7 @@ public abstract class EndpointTestBase extends JUnitRouteTest {
         streamingConfig = DefaultStreamingConfig.of(gatewayScopedConfig);
         publicHealthConfig = DefaultPublicHealthConfig.of(gatewayScopedConfig);
         protocolConfig = DefaultProtocolConfig.of(dittoScopedConfig);
+        cloudEventsConfig = DefaultCloudEventsConfig.of(gatewayScopedConfig);
         httpClientFacade = DefaultHttpClientFacade.getInstance(ActorSystem.create(EndpointTestBase.class.getSimpleName()),
                 DefaultHttpProxyConfig.ofProxy(DefaultScopedConfig.empty("/")));
         authorizationSubjectsProviderFactory = DittoJwtAuthorizationSubjectsProvider::of;

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/RootRouteTest.java
@@ -168,7 +168,7 @@ public final class RootRouteTest extends EndpointTestBase {
                 .thingSearchRoute(
                         new ThingSearchRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .whoamiRoute(new WhoamiRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
-                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
+                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator, cloudEventsConfig))
                 .websocketRoute(WebSocketRoute.getInstance(proxyActor, streamingConfig, materializer))
                 .supportedSchemaVersions(httpConfig.getSupportedSchemaVersions())
                 .protocolAdapterProvider(protocolAdapterProvider)

--- a/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
+++ b/services/gateway/starter/src/main/java/org/eclipse/ditto/services/gateway/starter/GatewayRootActor.java
@@ -283,7 +283,8 @@ final class GatewayRootActor extends DittoRootActor {
                 .thingSearchRoute(
                         new ThingSearchRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
                 .whoamiRoute(new WhoamiRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
-                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig, headerTranslator))
+                .cloudEventsRoute(new CloudEventsRoute(proxyActor, actorSystem, httpConfig, commandConfig,
+                        headerTranslator, gatewayConfig.getCloudEventsConfig()))
                 .websocketRoute(WebSocketRoute.getInstance(streamingActor, streamingConfig, materializer)
                         .withSignalEnrichmentProvider(signalEnrichmentProvider)
                         .withHeaderTranslator(headerTranslator))

--- a/services/gateway/starter/src/main/resources/gateway.conf
+++ b/services/gateway/starter/src/main/resources/gateway.conf
@@ -255,6 +255,14 @@ ditto {
       cache-timeout = ${?GATEWAY_STATUS_HEALTH_EXTERNAL_TIMEOUT}
     }
 
+    cloud-events {
+      empty-schema-allowed = true
+      data-types = [
+        "application/json"
+        "application/vnd.eclipse.ditto+json"
+      ]
+    }
+
     cache {
       publickeys {
         maxentries = 32

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/DittoGatewayConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/DittoGatewayConfig.java
@@ -16,8 +16,10 @@ import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.services.base.config.DittoServiceConfig;
 import org.eclipse.ditto.services.base.config.limits.LimitsConfig;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.CloudEventsConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.CommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultClaimMessageConfig;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultCloudEventsConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultCommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultMessageConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.DefaultPublicHealthConfig;
@@ -59,6 +61,7 @@ public final class DittoGatewayConfig implements GatewayConfig, WithConfigPath {
     private final AuthenticationConfig authenticationConfig;
     private final StreamingConfig streamingConfig;
     private final PublicHealthConfig publicHealthConfig;
+    private final DefaultCloudEventsConfig cloudEventsConfig;
 
     private DittoGatewayConfig(final ScopedConfig dittoScopedConfig) {
 
@@ -73,6 +76,7 @@ public final class DittoGatewayConfig implements GatewayConfig, WithConfigPath {
         authenticationConfig = DefaultAuthenticationConfig.of(dittoServiceConfig);
         streamingConfig = DefaultStreamingConfig.of(dittoServiceConfig);
         publicHealthConfig = DefaultPublicHealthConfig.of(dittoServiceConfig);
+        cloudEventsConfig = DefaultCloudEventsConfig.of(dittoServiceConfig);
     }
 
     /**
@@ -150,6 +154,11 @@ public final class DittoGatewayConfig implements GatewayConfig, WithConfigPath {
     @Override
     public ProtocolConfig getProtocolConfig() {
         return protocolConfig;
+    }
+
+    @Override
+    public CloudEventsConfig getCloudEventsConfig() {
+        return cloudEventsConfig;
     }
 
     /**

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/GatewayConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/GatewayConfig.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.services.gateway.util.config;
 
 import org.eclipse.ditto.services.base.config.ServiceSpecificConfig;
+import org.eclipse.ditto.services.gateway.util.config.endpoints.CloudEventsConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.CommandConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.HttpConfig;
 import org.eclipse.ditto.services.gateway.util.config.endpoints.MessageConfig;
@@ -88,4 +89,10 @@ public interface GatewayConfig extends ServiceSpecificConfig, WithProtocolConfig
      */
     PublicHealthConfig getPublicHealthConfig();
 
+    /**
+     * Returns the configuration for the cloud events endpoint.
+     *
+     * @return the config.
+     */
+    CloudEventsConfig getCloudEventsConfig();
 }

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/CloudEventsConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/CloudEventsConfig.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.util.config.endpoints;
+
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import akka.http.javadsl.model.MediaTypes;
+import org.eclipse.ditto.model.base.common.DittoConstants;
+import org.eclipse.ditto.services.utils.config.KnownConfigValue;
+
+import static org.eclipse.ditto.model.base.common.DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE;
+
+/**
+ * Provides configuration settings for the cloud events endpoint of the Ditto Gateway service.
+ */
+@Immutable
+public interface CloudEventsConfig {
+
+    /**
+     * Returns if an empty data schema is allowed.
+     *
+     * @return {@code true} if an empty data schema is allowed {@code false} otherwise.
+     */
+    boolean isEmptySchemaAllowed();
+
+    /**
+     * Returns the allowed data types.
+     *
+     * @return The set of allowed data types.
+     */
+    Set<String> getDataTypes();
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values for
+     * {@code CloudEventsConfig}.
+     */
+    enum CloudEventsConfigValue implements KnownConfigValue {
+
+        /**
+         * Flag if an empty data schema is allowed.
+         */
+        EMPTY_SCHEMA_ALLOWED("empty-schema-allowed", true),
+
+        /**
+         * Set of allowed data types
+         */
+        DATA_TYPES("data-types", Set.of(MediaTypes.APPLICATION_JSON.toString(), DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE));
+
+        private final String path;
+        private final Object defaultValue;
+
+        private CloudEventsConfigValue(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+    }
+}

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/DefaultCloudEventsConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/DefaultCloudEventsConfig.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.util.config.endpoints;
+
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.services.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.services.utils.config.ScopedConfig;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class is the default implementation of the cloud events endpoint config.
+ */
+@Immutable
+public final class DefaultCloudEventsConfig implements CloudEventsConfig {
+
+    private static final String CONFIG_PATH = "cloud-events";
+
+    private final boolean emptySchemaAllowed;
+
+    private final Set<String> dataTypes;
+
+    private DefaultCloudEventsConfig(final ScopedConfig scopedConfig) {
+        emptySchemaAllowed = scopedConfig.getBoolean(CloudEventsConfig.CloudEventsConfigValue.EMPTY_SCHEMA_ALLOWED.getConfigPath());
+        dataTypes = Set.copyOf(scopedConfig.getStringList(CloudEventsConfigValue.DATA_TYPES.getConfigPath()));
+    }
+
+    /**
+     * Returns an instance of {@code DefaultCloudEventsConfig} based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the public health config at {@value #CONFIG_PATH}.
+     * @return the instance.
+     * @throws org.eclipse.ditto.services.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultCloudEventsConfig of(final Config config) {
+        return new DefaultCloudEventsConfig(
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, CloudEventsConfig.CloudEventsConfigValue.values()));
+    }
+
+    @Override
+    public boolean isEmptySchemaAllowed() {
+        return emptySchemaAllowed;
+    }
+
+    @Override
+    public Set<String> getDataTypes() {
+        return dataTypes;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultCloudEventsConfig that = (DefaultCloudEventsConfig) o;
+        return emptySchemaAllowed == that.emptySchemaAllowed && dataTypes.equals(that.dataTypes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(emptySchemaAllowed, dataTypes);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "emptySchemaAllowed=" + emptySchemaAllowed +
+                ", dataTypes=" + dataTypes +
+                "]";
+    }
+
+}


### PR DESCRIPTION
This change allows to make the schema optional and also allows to
configure the data content type.

Signed-off-by: Jens Reimann <jreimann@redhat.com>