### PR TITLE
Set failure-without-redelivery AMQP disposition to REJECTED 

### DIFF
--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
@@ -101,7 +101,7 @@ For Ditto acknowledgements with mixed successful/failed [status](protocol-specif
 * If some of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery (e.g. based on a timeout):
    * Negatively acknowledges the AMQP 1.0 message with `modified[delivery-failed]` outcome (see [AMQP 1.0 spec: 3.4.5 Modified](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified))
 * If none of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery:
-   * Negatively acknowledges the AMQP 1.0 message with `modified[undeliverable-here]` outcome (see [AMQP 1.0 spec: 3.4.5 Modified](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-modified)) preventing redelivery by the AMQP 1.0 endpoint
+   * Negatively acknowledges the AMQP 1.0 message with `rejected` outcome (see [AMQP 1.0 spec: 3.4.3 Rejected](http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-rejected)) preventing redelivery by the AMQP 1.0 endpoint
 
 ### Target format
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
@@ -14,7 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging.amqp;
 
 import static org.apache.qpid.jms.message.JmsMessageSupport.ACCEPTED;
 import static org.apache.qpid.jms.message.JmsMessageSupport.MODIFIED_FAILED;
-import static org.apache.qpid.jms.message.JmsMessageSupport.MODIFIED_FAILED_UNDELIVERABLE;
+import static org.apache.qpid.jms.message.JmsMessageSupport.REJECTED;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
 import java.nio.ByteBuffer;
@@ -366,7 +366,7 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
                 ackType = ACCEPTED;
                 ackTypeName = "accepted";
             } else {
-                ackType = redeliver ? MODIFIED_FAILED : MODIFIED_FAILED_UNDELIVERABLE;
+                ackType = redeliver ? MODIFIED_FAILED : REJECTED;
                 ackTypeName = redeliver ? "modified[delivery-failed]" : "modified[delivery-failed,undeliverable-here]";
             }
             log.withCorrelationId(correlationId)

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActor.java
@@ -367,7 +367,7 @@ final class AmqpConsumerActor extends BaseConsumerActor implements MessageListen
                 ackTypeName = "accepted";
             } else {
                 ackType = redeliver ? MODIFIED_FAILED : REJECTED;
-                ackTypeName = redeliver ? "modified[delivery-failed]" : "modified[delivery-failed,undeliverable-here]";
+                ackTypeName = redeliver ? "modified[delivery-failed]" : "rejected";
             }
             log.withCorrelationId(correlationId)
                     .info("Acking <{}> with original external message headers=<{}>, isSuccess=<{}>, ackType=<{} {}>",

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpConsumerActorTest.java
@@ -142,7 +142,7 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorTest<JmsMe
             assertThat(ackType).describedAs("Expect failure settlement without redelivery")
                     .isEqualTo(shouldRedeliver
                             ? JmsMessageSupport.MODIFIED_FAILED
-                            : JmsMessageSupport.MODIFIED_FAILED_UNDELIVERABLE
+                            : JmsMessageSupport.REJECTED
                     );
         }
     }


### PR DESCRIPTION
Instead of MODIFIED[undeliverableHere].

Reason: Incoming messages with client errors should not be delivered
to any other clients, including other client actors of the same
connection.