### PR TITLE
fix implicit thing creation with "If-None-Match: *" header

### DIFF
--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/ThingCommandEnforcement.java
@@ -714,7 +714,12 @@ public final class ThingCommandEnforcement
                 .map(referencePlaceholder -> {
                     l.debug("CreateThing command contains a reference placeholder for the policy it wants to copy: {}",
                             referencePlaceholder);
-                    return policyIdReferencePlaceholderResolver.resolve(referencePlaceholder, dittoHeaders());
+                    final DittoHeaders dittoHeadersWithoutPreconditionHeaders = dittoHeaders().toBuilder()
+                            .removePreconditionHeaders()
+                            .responseRequired(true)
+                            .build();
+                    return policyIdReferencePlaceholderResolver.resolve(referencePlaceholder,
+                            dittoHeadersWithoutPreconditionHeaders);
                 })
                 .orElseGet(() -> CompletableFuture.completedFuture(createThing.getPolicyIdOrPlaceholder().orElse(null)))
                 .thenCompose(policyId -> {
@@ -730,7 +735,8 @@ public final class ThingCommandEnforcement
     }
 
     private CompletionStage<Policy> retrievePolicyWithEnforcement(final PolicyId policyId) {
-        final DittoHeaders adjustedHeaders = DittoHeaders.newBuilder(dittoHeaders())
+        final DittoHeaders adjustedHeaders = dittoHeaders().toBuilder()
+                .removePreconditionHeaders()
                 .responseRequired(true)
                 .build();
 


### PR DESCRIPTION
caused that a referenced policy (via _copyPolicyFrom) kept the precondition headers
* this fails the "retrieve policy" as the condition most likely will not match