### PR TITLE
Fix pubsub incremental update and connectivity backoff

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -629,6 +629,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         logger.debug("Transition: {} -> {}", from, to);
         if (to == CONNECTED) {
             clientGauge.set(1L);
+            reconnectTimeoutStrategy.reset();
         }
         if (to == DISCONNECTED) {
             clientGauge.reset();

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -1756,21 +1756,6 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
          * Some form of recovery (reduction of backoff, timeout and retry counter) is necessary so that
          * connections that experience short downtime once every couple days do not fail permanently
          * after some time.
-         *
-         * Simply resetting the timeout strategy on connection success is not sufficient,
-         * because AMQP 1.0 connections can enter CONNECTED state and then fail immediately
-         * if source or target addresses are misconfigured--the broker would reject requests
-         * to create message consumers and publishers. If this strategy is reset on entering
-         * CONNECTED, then those misconfigured connections do not experience exponential
-         * backoff; reconnection would happen every minimum backoff duration forever.
-         *
-         * This recovery strategy is based on the duration D between timeouts, which are
-         * also caused by errors. If D is larger than a threshold, then the connection is considered
-         * stable and the timeout strategy is reset. Otherwise the connection is considered unstable
-         * and retry counter will count up until we give up for good.
-         *
-         * The recovery threshold is chosen to be 2*(maxTimeout + maxBackoff) so that after this much
-         * time, the connection has stayed open without errors for at least (maxTimeout + maxBackoff).
          */
         private void performRecovery(final Instant now) {
             // no point to perform linear recovery if this is the first timeout increase

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging.amqp;
 
 import java.net.URI;
 import java.text.MessageFormat;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +98,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
     private final Map<String, ActorRef> consumerByNamePrefix;
     private final boolean recoverSessionOnSessionClosed;
     private final boolean recoverSessionOnConnectionRestored;
+    private final Duration clientAskTimeout;
     private ActorRef amqpPublisherActor;
 
     /*
@@ -120,6 +122,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         consumerByNamePrefix = new HashMap<>();
         recoverSessionOnSessionClosed = isRecoverSessionOnSessionClosedEnabled(connection);
         recoverSessionOnConnectionRestored = isRecoverSessionOnConnectionRestoredEnabled(connection);
+        clientAskTimeout = connectionConfig.getClientActorAskTimeout();
     }
 
     /*
@@ -138,6 +141,7 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
         consumerByNamePrefix = new HashMap<>();
         recoverSessionOnSessionClosed = isRecoverSessionOnSessionClosedEnabled(connection);
         recoverSessionOnConnectionRestored = isRecoverSessionOnConnectionRestoredEnabled(connection);
+        clientAskTimeout = Duration.ofSeconds(10L);
     }
 
     /**
@@ -288,7 +292,16 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
                     AmqpPublisherActor.props(connection(), jmsSession, connectivityConfig.getConnectionConfig(),
                             getDefaultClientId());
             amqpPublisherActor = startChildActorConflictFree(AmqpPublisherActor.ACTOR_NAME_PREFIX, props);
-            future.complete(DONE);
+            Patterns.ask(amqpPublisherActor, AmqpPublisherActor.INITIALIZE, clientAskTimeout)
+                    .whenComplete((result, error) -> {
+                        if (error != null) {
+                            future.completeExceptionally(error);
+                        } else if (result instanceof Throwable) {
+                            future.completeExceptionally((Throwable) result);
+                        } else {
+                            future.complete(DONE);
+                        }
+                    });
         } else {
             future.completeExceptionally(ConnectionFailedException
                     .newBuilder(connectionId())

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActor.java
@@ -64,6 +64,7 @@ import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import akka.Done;
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.japi.Pair;
 import akka.japi.pf.PFBuilder;
 import akka.japi.pf.ReceiveBuilder;
@@ -87,6 +88,12 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
      * The name prefix of this Actor in the ActorSystem.
      */
     static final String ACTOR_NAME_PREFIX = "amqpPublisherActor";
+
+    /**
+     * Message to initialize the actor. The sender will receive the result of initialization.
+     * If initialization fails, this actor stops itself.
+     */
+    static final Object INITIALIZE = new Object();
 
     private static final Object START_PRODUCER = new Object();
 
@@ -118,8 +125,8 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
                         OverflowStrategy.dropNew())
                         .mapAsync(config.getPublisherParallelism(), msg -> triggerPublishAsync(msg, jmsDispatcher))
                         .recover(new PFBuilder<Throwable, Object>()
-                                .matchAny(
-                                        x -> Done.getInstance()) // the "Done" instance is not used, this just means to not fail the stream for any Throwables
+                                // the "Done" instance is not used, this just means to not fail the stream for any Throwables
+                                .matchAny(x -> Done.getInstance())
                                 .build()
                         )
                         .viaMat(KillSwitches.single(), Keep.both())
@@ -176,19 +183,20 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
     }
 
     @Override
-    public void preStart() throws Exception {
-        super.preStart();
-        // has to be done synchronously since there might already be messages in the actor's queue.
-        // we open producers for static addresses (no placeholders) on startup and try to reopen them when closed.
-        // producers for other addresses (with placeholders, reply-to) are opened on demand and may be closed to
-        // respect the cache size limit
-        handleStartProducer(START_PRODUCER);
-    }
-
-    @Override
     protected void preEnhancement(final ReceiveBuilder receiveBuilder) {
         receiveBuilder.match(ProducerClosedStatusReport.class, this::handleProducerClosedStatusReport)
-                .matchEquals(START_PRODUCER, this::handleStartProducer);
+                .matchEquals(START_PRODUCER, this::handleStartProducer)
+                .matchEquals(INITIALIZE, this::initialize);
+    }
+
+    private void initialize(final Object initialize) {
+        try {
+            createStaticTargetProducers();
+            getSender().tell(new Status.Success("publisher initialized"), getSelf());
+        } catch (final Exception e) {
+            getSender().tell(e, getSelf());
+            getContext().stop(getSelf());
+        }
     }
 
     private void handleProducerClosedStatusReport(final ProducerClosedStatusReport report) {
@@ -212,6 +220,14 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
         try {
             isInBackOffMode = false;
             createStaticTargetProducers();
+        } catch (final JMSException jmsException) {
+            // target producer not creatable; stop self and request restart by parent
+            final String errorMessage = "Failed to create target";
+            logger.error(jmsException, errorMessage);
+            final ConnectionFailure failure = new ImmutableConnectionFailure(getSelf(), jmsException, errorMessage);
+            final ActorContext context = getContext();
+            context.getParent().tell(failure, getSelf());
+            context.stop(getSelf());
         } catch (final Exception e) {
             logger.warning("Failed to create static target producers: {}", e.getMessage());
             getContext().getParent().tell(new ImmutableConnectionFailure(null, e,
@@ -220,7 +236,7 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
         }
     }
 
-    private void createStaticTargetProducers() {
+    private void createStaticTargetProducers() throws JMSException {
         final List<Target> targets = connection.getTargets();
 
         // using loop so that already created targets are closed on exception
@@ -238,19 +254,9 @@ public final class AmqpPublisherActor extends BasePublisherActor<AmqpTarget> {
     }
 
     // create a target producer. the previous incarnation, if any, must be closed.
-    private void createTargetProducer(final Destination destination) {
-        try {
-            staticTargets.put(destination, session.createProducer(destination));
-            logger.info("Target producer <{}> created", destination);
-        } catch (final JMSException jmsException) {
-            // target producer not creatable; stop self and request restart by parent
-            final String errorMessage = String.format("Failed to create target '%s'", destination);
-            logger.error(jmsException, errorMessage);
-            final ConnectionFailure failure = new ImmutableConnectionFailure(getSelf(), jmsException, errorMessage);
-            final ActorContext context = getContext();
-            context.getParent().tell(failure, getSelf());
-            context.stop(getSelf());
-        }
+    private void createTargetProducer(final Destination destination) throws JMSException {
+        staticTargets.put(destination, session.createProducer(destination));
+        logger.info("Target producer <{}> created", destination);
     }
 
     private static Stream<Map.Entry<Destination, MessageProducer>> findByValue(

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpPublisherActorTest.java
@@ -76,6 +76,7 @@ import org.slf4j.LoggerFactory;
 
 import akka.actor.ActorRef;
 import akka.actor.Props;
+import akka.actor.Status;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
@@ -264,6 +265,7 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
                     loadConnectionConfig(),
                     "clientId");
             final ActorRef publisherActor = actorSystem.actorOf(props);
+            publisherCreated(this, publisherActor);
 
             publisherActor.tell(mappedOutboundSignal, getRef());
             publisherActor.tell(mappedOutboundSignal, getRef());
@@ -397,8 +399,15 @@ public class AmqpPublisherActorTest extends AbstractPublisherActorTest {
         return target;
     }
 
+    @Override
     protected String getOutboundAddress() {
         return "outbound";
+    }
+
+    @Override
+    protected void publisherCreated(final TestKit kit, final ActorRef publisherActor) {
+        publisherActor.tell(AmqpPublisherActor.INITIALIZE, kit.getRef());
+        kit.expectMsgClass(Status.Success.class);
     }
 
     private static ConnectionConfig loadConnectionConfig() {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
@@ -217,6 +217,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
         } else if (subscriptions.isEmpty()) {
             snapshot = subscriptions.snapshot();
             ddataOp = topicsWriter.removeSubscriber(subscriber, writeConsistency);
+            previousUpdate = LiteralUpdate.empty();
             topicSizeMetric.set(0L);
         } else {
             // export before taking snapshot so that implementations may output incremental update.

--- a/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
+++ b/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
@@ -161,6 +161,12 @@ public final class PubSubFactoryTest {
             pub.publish(signal("hello"), publisher.ref());
             pub.publish(signal("hello-world"), publisher.ref());
             subscriber.expectNoMessage();
+
+            // WHEN: actor subscribes to the topic again
+            sub.subscribeWithFilterAndGroup(singleton("hello"), subscriber.ref(), null, null).toCompletableFuture().join();
+            // THEN: it receives published message again
+            pub.publish(signal("hello"), publisher.ref());
+            subscriber.expectMsg(signal("hello"));
         }};
     }
 


### PR DESCRIPTION
- Fix that re-subscription by the last subscriber did not trigger distributed data update.
- Reset backoff strategy whenever a client actor is connected.
- Prevent AmqpClientActor from entering CONNECTED state before message producers and consumers are created.