### PR TITLE
Add built-in acknowledgement label "search-persisted"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -88,7 +88,7 @@
         <!-- ### Testing dependencies versions -->
         <junit.version>4.13.1</junit.version>
         <assertj.version>3.12.0</assertj.version>
-        <mutability-detector.version>0.10.2</mutability-detector.version>
+        <mutability-detector.version>0.10.4</mutability-detector.version>
         <equals-verifier.version>3.1.10</equals-verifier.version>
         <mockito.version>3.1.0</mockito.version>
         <jsonassert.version>1.2.3</jsonassert.version>

--- a/documentation/src/main/resources/pages/ditto/basic-acknowledgements.md
+++ b/documentation/src/main/resources/pages/ditto/basic-acknowledgements.md
@@ -47,6 +47,9 @@ It is ignored for commands in the live channel.
 * **live-response**: For acknowledgement requests of live commands and live messages.
 It is fulfilled when a subscriber of the live command or message sends a corresponding response.
 It is ignored for commands in the twin channel.
+* **search-persisted**: For acknowledgement requests of twin modifying commands.
+It is fulfilled when a modifying command has successfully updated the search index of the digital twin.
+It is ignored for commands in the live channel.
 
 ### Custom acknowledgement labels
 In addition to the [built-in](#built-in-acknowledgement-labels) acknowledgement requests, 

--- a/documentation/src/main/resources/pages/ditto/basic-search.md
+++ b/documentation/src/main/resources/pages/ditto/basic-search.md
@@ -35,6 +35,10 @@ That means that when a thing is updated and the API (e.g. the HTTP endpoint) ret
 will not reflect that change in that instant. The change will most likely be reflected in the search index within
 1-2 seconds. In rare cases the duration until consistency is reached again might be higher.
 
+If it is important to know when a twin modification is reflected in the search index, request the
+[built-in acknowledgement](#built-in-acknowledgement-labels) `search-persisted` in the corresponding command.
+Search index update is successful if the status code of `search-persisted` in the command response is 204 "no content".
+Status codes at or above 400 indicate failed search index update due to client or server errors.
 
 ## Search queries
 

--- a/legal/3rd-party-dependencies/test.txt
+++ b/legal/3rd-party-dependencies/test.txt
@@ -23,7 +23,7 @@ org.hamcrest:hamcrest-library:jar:1.3:test
 org.json:json:jar:20090211:test
 org.json:json:jar:20180130:test
 org.mockito:mockito-core:jar:3.1.0:test
-org.mutabilitydetector:MutabilityDetector:jar:0.10.2:test
+org.mutabilitydetector:MutabilityDetector:jar:0.10.4:test
 org.objenesis:objenesis:jar:2.6:test
 org.openjdk.jmh:jmh-core:jar:1.21:test
 org.openjdk.jmh:jmh-generator-annprocess:jar:1.21:test

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AbstractCommandAckRequestSetter.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AbstractCommandAckRequestSetter.java
@@ -54,12 +54,31 @@ public abstract class AbstractCommandAckRequestSetter<C extends WithDittoHeaders
     private final AcknowledgementLabel implicitAcknowledgementLabel;
     private final Set<AcknowledgementLabel> negatedDittoAcknowledgementLabels;
 
+    /**
+     * Create a command acknowledgment request setter that sets one Ditto acknowledgement label implicitly and
+     * filters out other Ditto acknowledgment5 labels.
+     *
+     * @param implicitAcknowledgementLabel the label to set if the header 'requested-acks' is absent.
+     */
     protected AbstractCommandAckRequestSetter(final AcknowledgementLabel implicitAcknowledgementLabel) {
-        negatedDittoAcknowledgementLabels = Collections.unmodifiableSet(
-                Arrays.stream(DittoAcknowledgementLabel.values())
+        this(implicitAcknowledgementLabel,
+                Collections.unmodifiableSet(Arrays.stream(DittoAcknowledgementLabel.values())
                         .filter(v -> !implicitAcknowledgementLabel.equals(v))
-                        .collect(Collectors.toSet()));
+                        .collect(Collectors.toSet()))
+        );
+    }
+
+    /**
+     * Create a command acknowledgement request setter.
+     *
+     * @param implicitAcknowledgementLabel the label to set if the header 'requested-acks' is absent.
+     * @param negatedDittoAcknowledgementLabels the labels to filter out if present.
+     * @since 1.6.0
+     */
+    protected AbstractCommandAckRequestSetter(final AcknowledgementLabel implicitAcknowledgementLabel,
+            final Set<AcknowledgementLabel> negatedDittoAcknowledgementLabels) {
         this.implicitAcknowledgementLabel = implicitAcknowledgementLabel;
+        this.negatedDittoAcknowledgementLabels = negatedDittoAcknowledgementLabels;
     }
 
     @Override

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AbstractCommandAckRequestSetter.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/AbstractCommandAckRequestSetter.java
@@ -73,7 +73,7 @@ public abstract class AbstractCommandAckRequestSetter<C extends WithDittoHeaders
      *
      * @param implicitAcknowledgementLabel the label to set if the header 'requested-acks' is absent.
      * @param negatedDittoAcknowledgementLabels the labels to filter out if present.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected AbstractCommandAckRequestSetter(final AcknowledgementLabel implicitAcknowledgementLabel,
             final Set<AcknowledgementLabel> negatedDittoAcknowledgementLabels) {

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabel.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabel.java
@@ -44,7 +44,7 @@ public final class DittoAcknowledgementLabel implements AcknowledgementLabel {
      * Label for Acknowledgements indicating that a change to an entity (e. g. a thing) has successfully been reflected
      * in the search index.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static final DittoAcknowledgementLabel SEARCH_PERSISTED = new DittoAcknowledgementLabel("search-persisted");
 

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabel.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/acks/DittoAcknowledgementLabel.java
@@ -40,6 +40,14 @@ public final class DittoAcknowledgementLabel implements AcknowledgementLabel {
      */
     public static final DittoAcknowledgementLabel LIVE_RESPONSE = new DittoAcknowledgementLabel("live-response");
 
+    /**
+     * Label for Acknowledgements indicating that a change to an entity (e. g. a thing) has successfully been reflected
+     * in the search index.
+     *
+     * @since 1.6.0
+     */
+    public static final DittoAcknowledgementLabel SEARCH_PERSISTED = new DittoAcknowledgementLabel("search-persisted");
+
     private final AcknowledgementLabel delegate;
 
     private DittoAcknowledgementLabel(final CharSequence labelValue) {
@@ -52,7 +60,7 @@ public final class DittoAcknowledgementLabel implements AcknowledgementLabel {
      * @return an array containing the Ditto acknowledgement labels, in the order they're declared.
      */
     public static AcknowledgementLabel[] values() {
-        return new AcknowledgementLabel[]{TWIN_PERSISTED, LIVE_RESPONSE};
+        return new AcknowledgementLabel[]{TWIN_PERSISTED, LIVE_RESPONSE, SEARCH_PERSISTED};
     }
 
     /**

--- a/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementForwarderActorStarter.java
+++ b/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementForwarderActorStarter.java
@@ -212,7 +212,7 @@ final class AcknowledgementForwarderActorStarter implements Supplier<Optional<Ac
                 dittoRuntimeException.toJson());
     }
 
-    static boolean isNotBuiltIn(final AcknowledgementRequest request) {
+    static boolean isNotTwinPersistedOrLiveResponse(final AcknowledgementRequest request) {
         return isNotLiveResponse(request) && isNotTwinPersisted(request);
     }
 
@@ -231,7 +231,8 @@ final class AcknowledgementForwarderActorStarter implements Supplier<Optional<Ac
     static boolean hasEffectiveAckRequests(final Signal<?> signal, final Set<AcknowledgementRequest> ackRequests) {
         final boolean isLiveSignal = isLiveSignal(signal);
         if (signal instanceof ThingEvent && !isLiveSignal) {
-            return ackRequests.stream().anyMatch(AcknowledgementForwarderActorStarter::isNotBuiltIn);
+            return ackRequests.stream()
+                    .anyMatch(AcknowledgementForwarderActorStarter::isNotTwinPersistedOrLiveResponse);
         } else if (signal instanceof MessageCommand || (isLiveSignal && signal instanceof ThingCommand)) {
             return ackRequests.stream().anyMatch(AcknowledgementForwarderActorStarter::isNotTwinPersisted);
         } else {

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
@@ -43,10 +43,6 @@ public final class Metadata {
     @Nullable private final PolicyId policyId;
     @Nullable private final Long policyRevision;
     @Nullable final Instant modified;
-
-    /**
-     * Using Scala list to have immutability and constant-time prepend at the same time.
-     */
     private final List<ActorRef> senders;
 
     private Metadata(final ThingId thingId,
@@ -61,7 +57,7 @@ public final class Metadata {
         this.policyId = policyId;
         this.policyRevision = policyRevision;
         this.modified = modified;
-        this.senders = senders;
+        this.senders = senders; // does not need to be made unmodifiable as there is no getter returning that to the "outside world"
     }
 
     /**

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
@@ -13,15 +13,24 @@
 package org.eclipse.ditto.services.thingsearch.persistence.write.model;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.model.base.acks.DittoAcknowledgementLabel;
+import org.eclipse.ditto.model.base.common.HttpStatusCode;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.policies.PolicyId;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.models.thingsearch.commands.sudo.UpdateThingResponse;
+import org.eclipse.ditto.signals.acks.base.Acknowledgement;
+
+import akka.actor.ActorRef;
 
 /**
  * Data class holding information about a "thingEntities" database record.
@@ -35,17 +44,24 @@ public final class Metadata {
     @Nullable private final Long policyRevision;
     @Nullable final Instant modified;
 
+    /**
+     * Using Scala list to have immutability and constant-time prepend at the same time.
+     */
+    private final List<ActorRef> senders;
+
     private Metadata(final ThingId thingId,
             final long thingRevision,
             @Nullable final PolicyId policyId,
             @Nullable final Long policyRevision,
-            @Nullable final Instant modified) {
+            @Nullable final Instant modified,
+            final List<ActorRef> senders) {
 
         this.thingId = thingId;
         this.thingRevision = thingRevision;
         this.policyId = policyId;
         this.policyRevision = policyRevision;
         this.modified = modified;
+        this.senders = senders;
     }
 
     /**
@@ -62,7 +78,26 @@ public final class Metadata {
             @Nullable final PolicyId policyId,
             @Nullable final Long policyRevision) {
 
-        return new Metadata(thingId, thingRevision, policyId, policyRevision, null);
+        return new Metadata(thingId, thingRevision, policyId, policyRevision, null, List.of());
+    }
+
+    /**
+     * Create an Metadata object retaining the original sender of an event.
+     *
+     * @param thingId the Thing ID.
+     * @param thingRevision the Thing revision.
+     * @param policyId the Policy ID if the Thing has one.
+     * @param policyRevision the Policy revision if the Thing has a policy, or null if it does not.
+     * @param sender the sender
+     * @return the new Metadata object.
+     */
+    public static Metadata of(final ThingId thingId,
+            final long thingRevision,
+            @Nullable final PolicyId policyId,
+            @Nullable final Long policyRevision,
+            final ActorRef sender) {
+
+        return new Metadata(thingId, thingRevision, policyId, policyRevision, null, List.of(sender));
     }
 
     /**
@@ -81,7 +116,7 @@ public final class Metadata {
             @Nullable final Long policyRevision,
             @Nullable final Instant modified) {
 
-        return new Metadata(thingId, thingRevision, policyId, policyRevision, modified);
+        return new Metadata(thingId, thingRevision, policyId, policyRevision, modified, List.of());
     }
 
     /**
@@ -151,6 +186,39 @@ public final class Metadata {
         return Optional.ofNullable(modified);
     }
 
+    /**
+     * Prepend new senders to the senders stored in this object.
+     *
+     * @param newMetadata a previous metadata record.
+     * @return the new metadata with concatenated senders.
+     */
+    public Metadata prependSenders(final Metadata newMetadata) {
+        final List<ActorRef> newSenders =
+                Stream.concat(newMetadata.senders.stream(), senders.stream()).collect(Collectors.toList());
+        return new Metadata(newMetadata.thingId, newMetadata.thingRevision, newMetadata.policyId,
+                newMetadata.policyRevision, newMetadata.modified, newSenders);
+    }
+
+    /**
+     * Send negative acknowledgements to senders.
+     */
+    public void sendNAck() {
+        send(Acknowledgement.of(DittoAcknowledgementLabel.SEARCH_PERSISTED, thingId,
+                HttpStatusCode.INTERNAL_SERVER_ERROR, DittoHeaders.empty()));
+    }
+
+    /**
+     * Send positive acknowledgements to senders.
+     */
+    public void sendAck() {
+        send(Acknowledgement.of(DittoAcknowledgementLabel.SEARCH_PERSISTED, thingId, HttpStatusCode.NO_CONTENT,
+                DittoHeaders.empty()));
+    }
+
+    private void send(final Acknowledgement ack) {
+        senders.forEach(sender -> sender.tell(ack, ActorRef.noSender()));
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -164,12 +232,13 @@ public final class Metadata {
                 Objects.equals(policyRevision, that.policyRevision) &&
                 Objects.equals(thingId, that.thingId) &&
                 Objects.equals(policyId, that.policyId) &&
-                Objects.equals(modified, that.modified);
+                Objects.equals(modified, that.modified) &&
+                Objects.equals(senders, that.senders);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(thingId, thingRevision, policyId, policyRevision, modified);
+        return Objects.hash(thingId, thingRevision, policyId, policyRevision, modified, senders);
     }
 
     @Override
@@ -180,6 +249,7 @@ public final class Metadata {
                 ", policyId=" + policyId +
                 ", policyRevision=" + policyRevision +
                 ", modified=" + modified +
+                ", senders=" + senders +
                 "]";
     }
 

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/ChangeQueueActor.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/ChangeQueueActor.java
@@ -25,7 +25,7 @@ import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.japi.function.Function;
 import akka.japi.pf.ReceiveBuilder;
-import akka.pattern.PatternsCS;
+import akka.pattern.Patterns;
 import akka.stream.Attributes;
 import akka.stream.DelayOverflowStrategy;
 import akka.stream.javadsl.Source;
@@ -100,17 +100,16 @@ public final class ChangeQueueActor extends AbstractActor {
     }
 
     private static Function<Control, Source<Map<ThingId, Metadata>, NotUsed>> askSelf(final ActorRef self) {
-        return message ->
-                Source.fromSourceCompletionStage(
-                        PatternsCS.ask(self, message, ASK_SELF_TIMEOUT)
-                                .handle((result, error) -> {
-                                    if (result instanceof Map) {
-                                        return Source.single((Map<ThingId, Metadata>) result);
-                                    } else {
-                                        return Source.empty();
-                                    }
-                                }))
-                        .mapMaterializedValue(whatever -> NotUsed.getInstance());
+        return message -> Source.completionStageSource(
+                Patterns.ask(self, message, ASK_SELF_TIMEOUT)
+                        .handle((result, error) -> {
+                            if (result instanceof Map) {
+                                return Source.single((Map<ThingId, Metadata>) result);
+                            } else {
+                                return Source.empty();
+                            }
+                        }))
+                .mapMaterializedValue(whatever -> NotUsed.getInstance());
     }
 
     private enum Control {

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/ChangeQueueActor.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/ChangeQueueActor.java
@@ -74,7 +74,7 @@ public final class ChangeQueueActor extends AbstractActor {
      * @param metadata a description of the change.
      */
     private void enqueue(final Metadata metadata) {
-        cache.put(metadata.getThingId(), metadata);
+        cache.merge(metadata.getThingId(), metadata, Metadata::prependSenders);
     }
 
     /**

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
@@ -227,7 +227,8 @@ final class EnforcementFlow {
                             try {
                                 return EnforcedThingMapper.toWriteModel(thing, entry.getValueOrThrow(),
                                         entry.getRevision(),
-                                        maxArraySize);
+                                        maxArraySize,
+                                        metadata);
                             } catch (final JsonRuntimeException e) {
                                 log.error(e.getMessage(), e);
                                 return ThingDeleteModel.of(metadata);

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
@@ -199,7 +199,7 @@ final class EnforcementFlow {
                                 return Source.single((SudoRetrieveThingResponse) response);
                             } else {
                                 if (error != null) {
-                                    log.error("Failed " + command, error);
+                                    log.error("Failed command <{}>", command, error);
                                 } else if (!(response instanceof ThingNotAccessibleException)) {
                                     log.error("Unexpected response for <{}>: <{}>", command, response);
                                 }
@@ -207,7 +207,7 @@ final class EnforcementFlow {
                             }
                         });
 
-        return Source.fromSourceCompletionStage(responseFuture)
+        return Source.completionStageSource(responseFuture)
                 .viaMat(Flow.create(), Keep.none());
     }
 
@@ -267,7 +267,7 @@ final class EnforcementFlow {
     private Source<Entry<Enforcer>, NotUsed> readCachedEnforcer(final Metadata metadata,
             final EntityIdWithResourceType policyId, final int iteration) {
 
-        final Source<Entry<Enforcer>, ?> lazySource = Source.lazily(() -> {
+        final Source<Entry<Enforcer>, ?> lazySource = Source.lazySource(() -> {
             final CompletionStage<Source<Entry<Enforcer>, NotUsed>> enforcerFuture = policyEnforcerCache.get(policyId)
                     .thenApply(optionalEnforcerEntry -> {
                         if (shouldReloadCache(optionalEnforcerEntry.orElse(null), metadata, iteration)) {
@@ -285,7 +285,7 @@ final class EnforcementFlow {
                         return ENFORCER_NONEXISTENT;
                     });
 
-            return Source.fromSourceCompletionStage(enforcerFuture);
+            return Source.completionStageSource(enforcerFuture);
         });
 
         return lazySource.viaMat(Flow.create(), Keep.none());

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/TestSearchUpdaterStream.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/TestSearchUpdaterStream.java
@@ -71,7 +71,8 @@ public final class TestSearchUpdaterStream {
             final long policyRevision) {
 
         final JsonObject thingJson = thing.toJson(FieldType.all());
-        final AbstractWriteModel writeModel = EnforcedThingMapper.toWriteModel(thingJson, enforcer, policyRevision, -1);
+        final AbstractWriteModel writeModel = EnforcedThingMapper.toWriteModel(thingJson, enforcer, policyRevision, -1,
+                null);
 
         return Source.single(Source.single(writeModel))
                 .via(mongoSearchUpdaterFlow.start(1, 1, Duration.ZERO));

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/AbstractWithActorSystemTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/AbstractWithActorSystemTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.thingsearch.persistence.write.model;
+
+import javax.annotation.Nullable;
+
+import org.junit.After;
+
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * For tests that may create an actor system.
+ */
+abstract class AbstractWithActorSystemTest {
+
+    @Nullable protected ActorSystem system;
+
+    @After
+    public void shutdown() {
+        if (system != null) {
+            TestKit.shutdownActorSystem(system);
+        }
+    }
+}

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/MetadataTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/MetadataTest.java
@@ -12,32 +12,45 @@
  */
 package org.eclipse.ditto.services.thingsearch.persistence.write.model;
 
+import static org.mutabilitydetector.unittesting.AllowedReason.assumingFields;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import javax.annotation.Nullable;
+
 import org.eclipse.ditto.model.policies.PolicyId;
 import org.eclipse.ditto.model.things.ThingId;
+import org.junit.After;
 import org.junit.Test;
 
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Unit test for {@link Metadata}.
  */
-public final class MetadataTest {
+public final class MetadataTest extends AbstractWithActorSystemTest {
 
     @Test
     public void assertImmutability() {
         assertInstancesOf(Metadata.class,
                 areImmutable(),
-                provided(ThingId.class, PolicyId.class).isAlsoImmutable());
+                provided(ThingId.class, PolicyId.class).areAlsoImmutable(),
+                assumingFields("senders").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements());
     }
 
     @Test
     public void testHashCodeAndEquals() {
+        system = ActorSystem.create();
+        final TestProbe probe1 = TestProbe.apply(system);
+        final TestProbe probe2 = TestProbe.apply(system);
         EqualsVerifier.forClass(Metadata.class)
                 .usingGetClass()
+                .withPrefabValues(ActorRef.class, probe1.ref(), probe2.ref())
                 .verify();
     }
 

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/ThingDeleteModelTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/ThingDeleteModelTest.java
@@ -17,12 +17,15 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import org.junit.Test;
 
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.TestProbe;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Unit test for {@link ThingDeleteModel}.
  */
-public final class ThingDeleteModelTest {
+public final class ThingDeleteModelTest extends AbstractWithActorSystemTest {
 
     @Test
     public void assertImmutability() {
@@ -31,8 +34,12 @@ public final class ThingDeleteModelTest {
 
     @Test
     public void testHashCodeAndEquals() {
+        system = ActorSystem.create();
+        final TestProbe probe1 = TestProbe.apply(system);
+        final TestProbe probe2 = TestProbe.apply(system);
         EqualsVerifier.forClass(ThingDeleteModel.class)
                 .usingGetClass()
+                .withPrefabValues(ActorRef.class, probe1.ref(), probe2.ref())
                 .verify();
     }
 

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/ThingWriteModelTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/ThingWriteModelTest.java
@@ -14,17 +14,24 @@ package org.eclipse.ditto.services.thingsearch.persistence.write.model;
 
 import org.junit.Test;
 
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.TestProbe;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 /**
  * Unit test for {@link ThingWriteModel}.
  */
-public final class ThingWriteModelTest {
+public final class ThingWriteModelTest extends AbstractWithActorSystemTest {
 
     @Test
     public void testHashCodeAndEquals() {
+        system = ActorSystem.create();
+        final TestProbe probe1 = TestProbe.apply(system);
+        final TestProbe probe2 = TestProbe.apply(system);
         EqualsVerifier.forClass(ThingWriteModel.class)
                 .usingGetClass()
+                .withPrefabValues(ActorRef.class, probe1.ref(), probe2.ref())
                 .verify();
     }
 

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/NewEventForwarder.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/NewEventForwarder.java
@@ -133,7 +133,8 @@ final class NewEventForwarder extends AbstractActorWithTimers {
     private void processThingEvent(final ThingEvent<?> thingEvent) {
         log.withCorrelationId(thingEvent)
                 .debug("Forwarding incoming ThingEvent for thingId '{}'", thingEvent.getThingEntityId());
-        namespaceBlockingBehavior.block(thingEvent).thenAccept(m -> shardRegion.tell(m, getSelf()));
+        final ActorRef sender = getSender();
+        namespaceBlockingBehavior.block(thingEvent).thenAccept(m -> shardRegion.tell(m, sender()));
     }
 
     private static Collection<String> getActiveShardIds(final ShardRegion.ClusterShardingStats stats) {

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/NewEventForwarder.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/NewEventForwarder.java
@@ -36,7 +36,7 @@ import akka.actor.ActorRef;
 import akka.actor.Props;
 import akka.cluster.sharding.ShardRegion;
 import akka.japi.pf.ReceiveBuilder;
-import scala.concurrent.duration.FiniteDuration;
+import scala.concurrent.duration.Duration;
 
 /**
  * This Actor forwards thing events belonging to inactive shard regions.
@@ -74,7 +74,7 @@ final class NewEventForwarder extends AbstractActorWithTimers {
         namespaceBlockingBehavior = BlockNamespaceBehavior.of(blockedNamespaces);
 
         getClusterShardingStats = new ShardRegion.GetClusterShardingStats(
-                FiniteDuration.create(updaterConfig.getShardingStatePollInterval().toMillis(), TimeUnit.MILLISECONDS));
+                Duration.create(updaterConfig.getShardingStatePollInterval().toMillis(), TimeUnit.MILLISECONDS));
 
         shardRegionExtractor = ShardRegionExtractor.of(clusterConfig.getNumberOfShards(), getContext().getSystem());
 
@@ -134,7 +134,7 @@ final class NewEventForwarder extends AbstractActorWithTimers {
         log.withCorrelationId(thingEvent)
                 .debug("Forwarding incoming ThingEvent for thingId '{}'", thingEvent.getThingEntityId());
         final ActorRef sender = getSender();
-        namespaceBlockingBehavior.block(thingEvent).thenAccept(m -> shardRegion.tell(m, sender()));
+        namespaceBlockingBehavior.block(thingEvent).thenAccept(m -> shardRegion.tell(m, sender));
     }
 
     private static Collection<String> getActiveShardIds(final ShardRegion.ClusterShardingStats stats) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetter.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetter.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.signals.commands.things.acks;
 
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
+import java.util.Collections;
+
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.model.base.acks.AbstractCommandAckRequestSetter;
@@ -37,7 +39,8 @@ public final class ThingModifyCommandAckRequestSetter extends AbstractCommandAck
     private static final ThingModifyCommandAckRequestSetter INSTANCE = new ThingModifyCommandAckRequestSetter();
 
     private ThingModifyCommandAckRequestSetter() {
-        super(DittoAcknowledgementLabel.TWIN_PERSISTED);
+        // The Ditto acknowledgement label "search-persisted" is tolerated but not set by default.
+        super(DittoAcknowledgementLabel.TWIN_PERSISTED, Collections.singleton(DittoAcknowledgementLabel.LIVE_RESPONSE));
     }
 
     /**

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/acks/ThingLiveCommandAckRequestSetterTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/acks/ThingLiveCommandAckRequestSetterTest.java
@@ -87,7 +87,8 @@ public final class ThingLiveCommandAckRequestSetterTest {
         final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
                 .channel("live")
                 .acknowledgementRequest(AcknowledgementRequest.of(DittoAcknowledgementLabel.TWIN_PERSISTED),
-                        AcknowledgementRequest.of(DittoAcknowledgementLabel.LIVE_RESPONSE))
+                        AcknowledgementRequest.of(DittoAcknowledgementLabel.LIVE_RESPONSE),
+                        AcknowledgementRequest.of(DittoAcknowledgementLabel.SEARCH_PERSISTED))
                 .randomCorrelationId()
                 .build();
         final CreateThing command = CreateThing.of(Thing.newBuilder().build(), null, dittoHeaders);

--- a/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetterTest.java
+++ b/signals/commands/things/src/test/java/org/eclipse/ditto/signals/commands/things/acks/ThingModifyCommandAckRequestSetterTest.java
@@ -72,15 +72,17 @@ public final class ThingModifyCommandAckRequestSetterTest {
     }
 
     @Test
-    public void filterOutOtherBuiltInDittoAcknowledgementLabels() {
+    public void filterOutLiveResponseLabel() {
         final DittoHeaders dittoHeaders = DittoHeaders.newBuilder()
                 .acknowledgementRequest(AcknowledgementRequest.of(DittoAcknowledgementLabel.TWIN_PERSISTED),
-                        AcknowledgementRequest.of(DittoAcknowledgementLabel.LIVE_RESPONSE))
+                        AcknowledgementRequest.of(DittoAcknowledgementLabel.LIVE_RESPONSE),
+                        AcknowledgementRequest.of(DittoAcknowledgementLabel.SEARCH_PERSISTED))
                 .randomCorrelationId()
                 .build();
         final CreateThing command = CreateThing.of(Thing.newBuilder().build(), null, dittoHeaders);
         final DittoHeaders expectedHeaders = dittoHeaders.toBuilder()
-                .acknowledgementRequest(AcknowledgementRequest.of(DittoAcknowledgementLabel.TWIN_PERSISTED))
+                .acknowledgementRequest(AcknowledgementRequest.of(DittoAcknowledgementLabel.TWIN_PERSISTED),
+                        AcknowledgementRequest.of(DittoAcknowledgementLabel.SEARCH_PERSISTED))
                 .responseRequired(true)
                 .build();
         final CreateThing expected = CreateThing.of(Thing.newBuilder().build(), null, expectedHeaders);


### PR DESCRIPTION
Add an acknowledgement label `search-persisted` that when requested by any twin-modifying command, delays the response until the change is reflected in the search index.

Fix #914 