### PR TITLE
Enforce insertion and re-insertion order of Ditto headers.

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeaders.java
@@ -27,6 +27,10 @@ final class ImmutableDittoHeaders extends AbstractDittoHeaders implements DittoH
         super(headers);
     }
 
+    private ImmutableDittoHeaders(final Map<String, Header> headers, final boolean flag) {
+        super(headers, flag);
+    }
+
     /**
      * Returns an instance of {@code ImmutableDittoHeaders} which is based on the specified map.
      *
@@ -34,8 +38,12 @@ final class ImmutableDittoHeaders extends AbstractDittoHeaders implements DittoH
      * @return the instance.
      * @throws NullPointerException if {@code headers} is {@code null}.
      */
-    public static ImmutableDittoHeaders of(final Map<String, String> headers) {
+    static ImmutableDittoHeaders of(final Map<String, String> headers) {
         return new ImmutableDittoHeaders(headers);
+    }
+
+    static ImmutableDittoHeaders fromBuilder(final Map<String, Header> builderHeaders) {
+        return new ImmutableDittoHeaders(builderHeaders, true);
     }
 
     @Override

--- a/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
+++ b/model/base/src/test/java/org/eclipse/ditto/model/base/headers/ImmutableDittoHeadersTest.java
@@ -578,6 +578,32 @@ public final class ImmutableDittoHeadersTest {
         assertThat(deserialized.toJson()).isEqualTo(serialized);
     }
 
+    @Test
+    public void respectInsertionOrder() {
+        final Map<String, String> initialHeaders = new HashMap<>();
+        initialHeaders.put("Response-Required", "true");
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("response-required", "false");
+        assertThat(DittoHeaders.of(initialHeaders)
+                .toBuilder()
+                .responseRequired(false)
+                .build()
+                .asCaseSensitiveMap()).isEqualTo(expectedHeaders);
+    }
+
+    @Test
+    public void preserveCapitalizationOfCorrelationId() {
+        final Map<String, String> initialHeaders = new HashMap<>();
+        initialHeaders.put("Correlation-Id", "true");
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("Correlation-Id", "false");
+        assertThat(DittoHeaders.of(initialHeaders)
+                .toBuilder()
+                .correlationId("false")
+                .build()
+                .asCaseSensitiveMap()).isEqualTo(expectedHeaders);
+    }
+
     private static Map<String, String> createMapContainingAllKnownHeaders() {
         final Map<String, String> result = new HashMap<>();
         result.put(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey(),

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
@@ -22,6 +22,7 @@ import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -60,7 +61,8 @@ public final class ImmutableMessageHeadersTest {
                     AUTH_SUBJECTS_WITHOUT_DUPLICATES.stream()
                             .map(AuthorizationSubject::newInstance)
                             .collect(Collectors.toList()));
-    private static final Collection<String> AUTH_SUBJECTS = Arrays.asList("test:JohnOldman", "test:FrankGrimes", "JohnOldman", "FrankGrimes");
+    private static final Collection<String> AUTH_SUBJECTS =
+            Arrays.asList("test:JohnOldman", "test:FrankGrimes", "JohnOldman", "FrankGrimes");
     private static final AuthorizationContext AUTH_CONTEXT =
             AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
                     AUTH_SUBJECTS.stream()
@@ -261,9 +263,48 @@ public final class ImmutableMessageHeadersTest {
                 .withNoCause();
     }
 
+    @Test
+    public void respectInsertionOrder() {
+        final Map<String, String> initialHeaders = new LinkedHashMap<>();
+        initialHeaders.put("ditto-message-direction", "TO");
+        initialHeaders.put("ditto-message-thing-id", "thing:id");
+        initialHeaders.put("ditto-message-subject", "subject");
+        initialHeaders.put("Response-Required", "true");
+        final Map<String, String> expectedHeaders = new LinkedHashMap<>();
+        expectedHeaders.put("ditto-message-direction", "TO");
+        expectedHeaders.put("ditto-message-thing-id", "thing:id");
+        expectedHeaders.put("ditto-message-subject", "subject");
+        expectedHeaders.put("response-required", "false");
+        assertThat(MessageHeaders.of(initialHeaders)
+                .toBuilder()
+                .responseRequired(false)
+                .build()
+                .asCaseSensitiveMap()).isEqualTo(expectedHeaders);
+    }
+
+    @Test
+    public void preserveCapitalizationOfCorrelationId() {
+        final Map<String, String> initialHeaders = new HashMap<>();
+        initialHeaders.put("ditto-message-direction", "TO");
+        initialHeaders.put("ditto-message-thing-id", "thing:id");
+        initialHeaders.put("ditto-message-subject", "subject");
+        initialHeaders.put("Correlation-Id", "true");
+        final Map<String, String> expectedHeaders = new HashMap<>();
+        expectedHeaders.put("ditto-message-direction", "TO");
+        expectedHeaders.put("ditto-message-thing-id", "thing:id");
+        expectedHeaders.put("ditto-message-subject", "subject");
+        expectedHeaders.put("Correlation-Id", "false");
+        assertThat(MessageHeaders.of(initialHeaders)
+                .toBuilder()
+                .correlationId("false")
+                .build()
+                .asCaseSensitiveMap()).isEqualTo(expectedHeaders);
+    }
+
     private static Map<String, String> createMapContainingAllKnownHeaders() {
         final Map<String, String> result = new HashMap<>();
-        result.put(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey(), AUTH_CONTEXT_WITHOUT_DUPLICATES.toJsonString());
+        result.put(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey(),
+                AUTH_CONTEXT_WITHOUT_DUPLICATES.toJsonString());
         result.put(DittoHeaderDefinition.CORRELATION_ID.getKey(), "knownCorrelationId");
         result.put(DittoHeaderDefinition.SCHEMA_VERSION.getKey(), KNOWN_SCHEMA_VERSION.toString());
         result.put(DittoHeaderDefinition.CHANNEL.getKey(), KNOWN_CHANNEL);

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/HeaderTranslator.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/HeaderTranslator.java
@@ -17,7 +17,7 @@ import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -148,7 +148,7 @@ public final class HeaderTranslator {
     @Deprecated
     public HeaderTranslator forgetHeaderKeys(final Collection<String> headerKeys) {
         checkNotNull(headerKeys, "headerKeys");
-        final Map<String, HeaderDefinition> newHeaderDefinitions = new HashMap<>(headerDefinitions);
+        final Map<String, HeaderDefinition> newHeaderDefinitions = new LinkedHashMap<>(headerDefinitions);
         headerKeys.forEach(newHeaderDefinitions::remove);
         return new HeaderTranslator(newHeaderDefinitions);
     }
@@ -189,7 +189,7 @@ public final class HeaderTranslator {
     private static Map<String, String> filterHeadersMap(final Map<String, String> headersToFilter,
             final HeaderEntryFilter headerEntryFilter) {
 
-        final Map<String, String> result = new HashMap<>(headersToFilter.size());
+        final Map<String, String> result = new LinkedHashMap<>(headersToFilter.size());
         headersToFilter.forEach((originalKey, value) -> {
             final String lowercaseKey = originalKey.toLowerCase();
             final String filteredValue = headerEntryFilter.apply(lowercaseKey, value);


### PR DESCRIPTION
- Test insertion order of Ditto headers.
- Fix violations of insertion order.
- Add a special case for `correlation-id` so that the capitalization of the signal sender is visible to all signal receivers.