### PR TITLE
Fix irritating default content-type header mapping

### DIFF
--- a/documentation/src/main/resources/pages/ditto/release_notes_next.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_next.md
@@ -1,0 +1,56 @@
+---
+title: Release notes x.x.x
+tags: [release_notes]
+published: true
+keywords: release notes, announcements, changelog
+summary: "Version x.x.x of Eclipse Ditto, released on dd.MM.yyyy"
+permalink: release_notes_next.html
+---
+
+## Changelog
+
+
+### Changes
+
+#### [Removed content-type header mapping for connection targets](https://github.com/eclipse/ditto/pull/934)
+
+Removed the default header mapping of `content-type` for new connection targets. The header mapping led to irritating results,
+when payload mapping and header mapping disagreed on the actual `content-type`. Existing connections will still keep
+the "old" default and map the `content-type` header.
+
+### New features
+
+
+### Bugfixes
+
+
+## Migration notes
+
+### content-type header mapping in connection targets
+
+Due to the [removed default content-type header mapping for connection targets](https://github.com/eclipse/ditto/pull/934),
+it might be necessary to update the way connection targets are created in case you create connection targets without explicit
+`headerMapping` and rely on a specific content-type on the receiving side. The request to create connection targets
+can be updated to contain the "old" default in this case:
+```json
+{
+    "targetActorSelection": "/system/sharding/connection",
+    "headers": {
+        "aggregate": false
+    },
+    "piggybackCommand": {
+        "type": "connectivity.commands:createConnection",
+            "connection": {
+              "targets":[{
+                "headerMapping": {
+                  "content-type": "{%raw%}{{header:content-type}}{%endraw%}",
+                  "correlation-id": "{%raw%}{{header:correlation-id}}{%endraw%}",
+                  "reply-to": "{%raw%}{{header:reply-to}}{%endraw%}"
+                },
+                // ...
+              }]
+              // ...
+            }
+    }
+}
+```

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableSource.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableSource.java
@@ -54,16 +54,19 @@ final class ImmutableSource implements Source {
      */
     static final String DEFAULT_REPLY_TARGET_ADDRESS = "{{header:reply-to}}";
 
-    private static final String HEADER_CORRELATION_ID = "{{header:correlation-id}}";
-    private static final String HEADER_CONTENT_TYPE = "{{header:content-type}}";
+    /**
+     * Placeholder for getting the header 'correlation-id'
+     */
+    static final String PLACEHOLDER_HEADER_CORRELATION_ID = "{{header:correlation-id}}";
+    private static final String PLACEHOLDER_HEADER_CONTENT_TYPE = "{{header:content-type}}";
 
     /**
      * Default header mapping for legacy sources (i. e., no reply-target defined)
      */
     static final HeaderMapping DEFAULT_SOURCE_HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
-                    .set("correlation-id", HEADER_CORRELATION_ID)
-                    .set("content-type", HEADER_CONTENT_TYPE)
+                    .set("correlation-id", PLACEHOLDER_HEADER_CORRELATION_ID)
+                    .set("content-type", PLACEHOLDER_HEADER_CONTENT_TYPE)
                     .set("reply-to", DEFAULT_REPLY_TARGET_ADDRESS)
                     .build());
 
@@ -72,8 +75,8 @@ final class ImmutableSource implements Source {
      */
     static final HeaderMapping DEFAULT_REPLY_TARGET_HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
-                    .set("correlation-id", HEADER_CORRELATION_ID)
-                    .set("content-type", HEADER_CONTENT_TYPE)
+                    .set("correlation-id", PLACEHOLDER_HEADER_CORRELATION_ID)
+                    .set("content-type", PLACEHOLDER_HEADER_CONTENT_TYPE)
                     .build());
 
     private static final int DEFAULT_CONSUMER_COUNT = 1;

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableTarget.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableTarget.java
@@ -52,7 +52,11 @@ final class ImmutableTarget implements Target {
     /**
      * Default header mapping for legacy targets with no header mapping configured.
      */
-    static final HeaderMapping DEFAULT_HEADER_MAPPING = ImmutableSource.DEFAULT_SOURCE_HEADER_MAPPING;
+    static final HeaderMapping DEFAULT_HEADER_MAPPING =
+            ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
+                    .set("correlation-id", ImmutableSource.PLACEHOLDER_HEADER_CORRELATION_ID)
+                    .set("reply-to", ImmutableSource.DEFAULT_REPLY_TARGET_ADDRESS)
+                    .build());
 
     private final String address;
     private final Set<FilteredTopic> topics;

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableTargetTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableTargetTest.java
@@ -43,7 +43,7 @@ public final class ImmutableTargetTest {
     private static final String DITTO_MAPPING = "ditto-mapping";
     private static final AcknowledgementLabel ACKNOWLEDGEMENT_LABEL = AcknowledgementLabel.of("custom-ack");
 
-    private static final Target TARGET_WITH_AUTH_CONTEXT = ConnectivityModelFactory
+    private static final Target TARGET = ConnectivityModelFactory
             .newTargetBuilder()
             .address(ADDRESS)
             .authorizationContext(AUTHORIZATION_CONTEXT)
@@ -52,13 +52,9 @@ public final class ImmutableTargetTest {
             .payloadMapping(ConnectivityModelFactory.newPayloadMapping(DITTO_MAPPING, CUSTOM_MAPPING))
             .build();
 
-    private static final JsonObject TARGET_JSON_WITH_EMPTY_AUTH_CONTEXT = JsonObject
-            .newBuilder()
+    private static final JsonObject TARGET_JSON = JsonObject.newBuilder()
             .set(Target.JsonFields.TOPICS, JsonFactory.newArrayBuilder().add(TWIN_EVENTS.getName()).build())
             .set(Target.JsonFields.ADDRESS, ADDRESS)
-            .build();
-
-    private static final JsonObject TARGET_JSON_WITH_AUTH_CONTEXT = TARGET_JSON_WITH_EMPTY_AUTH_CONTEXT.toBuilder()
             .set(Target.JsonFields.AUTHORIZATION_CONTEXT, JsonFactory.newArrayBuilder().add("eclipse", "ditto").build())
             .set(Target.JsonFields.ISSUED_ACKNOWLEDGEMENT_LABEL, "custom-ack")
             .set(Target.JsonFields.PAYLOAD_MAPPING, JsonArray.of(DITTO_MAPPING, CUSTOM_MAPPING))
@@ -99,16 +95,16 @@ public final class ImmutableTargetTest {
 
     @Test
     public void toJsonReturnsExpected() {
-        final JsonObject actual = TARGET_WITH_AUTH_CONTEXT.toJson();
+        final JsonObject actual = TARGET.toJson();
 
-        assertThat(actual).isEqualTo(TARGET_JSON_WITH_AUTH_CONTEXT);
+        assertThat(actual).isEqualTo(TARGET_JSON);
     }
 
     @Test
     public void fromJsonReturnsExpected() {
-        final Target actual = ImmutableTarget.fromJson(TARGET_JSON_WITH_AUTH_CONTEXT);
+        final Target actual = ImmutableTarget.fromJson(TARGET_JSON);
 
-        assertThat(actual).isEqualTo(TARGET_WITH_AUTH_CONTEXT);
+        assertThat(actual).isEqualTo(TARGET);
     }
 
     @Test


### PR DESCRIPTION
The default mapping of content-type for connection targets led to irritating results when combined with payload mapping. The content-type set in a payload mapping wasn't used in the resulting message. A live message with `content-type: text/plain`, which is mapped to a Ditto protocol message, led to the device receiving also `content-type: text/plain` although `content-type: application/vnd.eclipse.ditto+json` was expected.

This PR removes the default mapping of content-type in connection targets. To not change the behavior of existing connections, the default mapping for "old" connections will still contain the content-type mapping. 