### PR TITLE
Fix non-thread-safe calls to actor-starting methods in client actors.

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpClientActor.java
@@ -546,9 +546,10 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
 
         jmsSession = sessionRecovered.getSession();
 
-        startPublisherActor()
-                .thenRun(() -> startCommandConsumers(sessionRecovered.getConsumerList(), jmsActor))
-                .thenRun(() -> connectionLogger.success("Session has been recovered successfully."))
+        final CompletionStage<Status.Status> publisherReady = startPublisherActor();
+        startCommandConsumers(sessionRecovered.getConsumerList(), jmsActor);
+
+        publisherReady.thenRun(() -> connectionLogger.success("Session has been recovered successfully."))
                 .exceptionally(t -> {
                     final ImmutableConnectionFailure failure = new ImmutableConnectionFailure(null, t,
                             "failed to recover session");


### PR DESCRIPTION
Moved method calls with potential actor creation to the client actor's message handling thread.