### PR TITLE
Fix live-response acknowledgement handling

### DIFF
--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageHeaderDefinition.java
@@ -37,7 +37,7 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * Key: {@code "ditto-message-direction"}, Java type: String.
      * </p>
      */
-    DIRECTION("ditto-message-direction", String.class, false, false, DittoMessageDirectionValueValidator.getInstance()),
+    DIRECTION("ditto-message-direction", String.class, false, true, DittoMessageDirectionValueValidator.getInstance()),
 
     /**
      * Header definitions for the subject of a message.
@@ -45,7 +45,7 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * Key: {@code "ditto-message-subject"}, Java type: String.
      * </p>
      */
-    SUBJECT("ditto-message-subject", String.class, false, false, DittoMessageSubjectValueValidator.getInstance()),
+    SUBJECT("ditto-message-subject", String.class, false, true, DittoMessageSubjectValueValidator.getInstance()),
 
     /**
      * Header definition for the Thing ID of a message.
@@ -53,7 +53,7 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * Key: {@code "ditto-message-thing-id"}, Java type: String.
      * </p>
      */
-    THING_ID("ditto-message-thing-id", String.class, false, false, DittoMessageThingIdValueValidator.getInstance()),
+    THING_ID("ditto-message-thing-id", String.class, false, true, DittoMessageThingIdValueValidator.getInstance()),
 
     /**
      * Header definition for the Feature ID of a message, if sent to a Feature.
@@ -61,7 +61,7 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * Key: {@code "ditto-message-feature-id"}, Java type: String.
      * </p>
      */
-    FEATURE_ID("ditto-message-feature-id", String.class, false, false, HeaderValueValidators.getNoOpValidator()),
+    FEATURE_ID("ditto-message-feature-id", String.class, false, true, HeaderValueValidators.getNoOpValidator()),
 
     /**
      * Header definition for the timeout in seconds of a message.
@@ -88,7 +88,7 @@ public enum MessageHeaderDefinition implements HeaderDefinition {
      * Key: {@code "status"}, Java type: {@code int}.
      * </p>
      */
-    STATUS_CODE("status", int.class, true, false, HttpStatusCodeValueValidator.getInstance());
+    STATUS_CODE("status", int.class, true, true, HttpStatusCodeValueValidator.getInstance());
 
     /**
      * Map to speed up lookup of header definition by key.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ResponseCollectorActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ResponseCollectorActor.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandResponse;
 import org.eclipse.ditto.signals.commands.things.ThingCommand;
+import org.eclipse.ditto.signals.commands.things.ThingCommandResponse;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -162,15 +163,6 @@ public final class ResponseCollectorActor extends AbstractActor {
                     .collect(Collectors.toList());
         }
 
-        /**
-         * @return list of successful responses.
-         */
-        public List<CommandResponse<?>> getSuccessfulResponses() {
-            return commandResponses.stream()
-                    .filter(response -> !isFailedResponse(response))
-                    .collect(Collectors.toList());
-        }
-
         @Override
         public String toString() {
             return getClass().getSimpleName() +
@@ -192,9 +184,9 @@ public final class ResponseCollectorActor extends AbstractActor {
             }
         }
 
-        private static boolean isLiveResponse(final Signal<? extends CommandResponse<?>> response) {
+        private static boolean isLiveResponse(final CommandResponse<?> response) {
             return response instanceof MessageCommandResponse ||
-                    response instanceof ThingCommand && ProtocolAdapter.isLiveSignal(response);
+                    response instanceof ThingCommandResponse && ProtocolAdapter.isLiveSignal(response);
         }
     }
 

--- a/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementAggregator.java
+++ b/services/models/acks/src/main/java/org/eclipse/ditto/services/models/acks/AcknowledgementAggregator.java
@@ -184,7 +184,7 @@ public final class AcknowledgementAggregator {
     }
 
     private DittoHeaders filterHeaders(final DittoHeaders dittoHeaders) {
-        return DittoHeaders.of(headerTranslator.toExternalAndRetainKnownHeaders(dittoHeaders));
+        return DittoHeaders.of(headerTranslator.toExternalHeaders(dittoHeaders));
     }
 
     /**

--- a/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgement.java
+++ b/signals/acks/base/src/main/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgement.java
@@ -27,7 +27,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.acks.AcknowledgementLabel;
-import org.eclipse.ditto.model.base.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.model.base.common.HttpStatus;
 import org.eclipse.ditto.model.base.entity.id.EntityIdWithType;
 import org.eclipse.ditto.model.base.entity.type.EntityType;
@@ -106,13 +105,6 @@ final class ImmutableAcknowledgement<T extends EntityIdWithType> implements Ackn
 
     @Override
     public boolean isSuccess() {
-        if (DittoAcknowledgementLabel.LIVE_RESPONSE.equals(label)) {
-            /*
-             * Consider live responses only as failed acknowledgement when the response timed out.
-             * Otherwise it would not be possible to respond with an error status code to live messages.
-             */
-            return !isTimeout();
-        }
         return httpStatus.isSuccess();
     }
 

--- a/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementTest.java
+++ b/signals/acks/base/src/test/java/org/eclipse/ditto/signals/acks/base/ImmutableAcknowledgementTest.java
@@ -199,26 +199,6 @@ public final class ImmutableAcknowledgementTest {
     }
 
     @Test
-    public void liveResponseAcknowledgementWithNonTimeoutIsSuccess() {
-        final HttpStatus httpStatus = HttpStatus.NOT_FOUND;
-        final ImmutableAcknowledgement<ThingId> underTest =
-                ImmutableAcknowledgement.of(DittoAcknowledgementLabel.LIVE_RESPONSE, KNOWN_ENTITY_ID, httpStatus,
-                        dittoHeaders, KNOWN_PAYLOAD);
-
-        assertThat(underTest.isSuccess()).isTrue();
-    }
-
-    @Test
-    public void liveResponseAcknowledgementWithTimeoutIsFailed() {
-        final HttpStatus httpStatus = HttpStatus.REQUEST_TIMEOUT;
-        final ImmutableAcknowledgement<ThingId> underTest =
-                ImmutableAcknowledgement.of(DittoAcknowledgementLabel.LIVE_RESPONSE, KNOWN_ENTITY_ID, httpStatus,
-                        dittoHeaders, KNOWN_PAYLOAD);
-
-        assertThat(underTest.isSuccess()).isFalse();
-    }
-
-    @Test
     public void acknowledgementWithHttpStatusOkIsNotTimeout() {
         final HttpStatus httpStatus = HttpStatus.OK;
         final ImmutableAcknowledgement<ThingId> underTest =

--- a/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessagePayloadSerializer.java
+++ b/signals/commands/messages/src/main/java/org/eclipse/ditto/signals/commands/messages/MessagePayloadSerializer.java
@@ -32,7 +32,7 @@ import org.eclipse.ditto.model.messages.MessageHeaders;
 /**
  * (De-)Serializes message payloads of {@code MessageCommand}s and {@code MessageCommandResponse}s.
  */
-class MessagePayloadSerializer {
+public class MessagePayloadSerializer {
 
     private static final Base64.Encoder BASE64_ENCODER = Base64.getEncoder();
     private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
@@ -94,7 +94,7 @@ class MessagePayloadSerializer {
     }
 
     // also validate message size
-    static void deserialize(@Nullable final JsonValue payload, final MessageBuilder<Object> messageBuilder,
+    public static void deserialize(@Nullable final JsonValue payload, final MessageBuilder<Object> messageBuilder,
             final MessageHeaders messageHeaders) {
 
         final ContentType contentType = messageHeaders.getDittoContentType().orElse(ContentType.of(""));


### PR DESCRIPTION
This PR 

* removes the special handling of live-response acknowledgements to decide if an acknowledgement was successful or not
* Unwraps the Message for a live-response acknowledgement so the value of the live-response acknowledgement is now the payload of the message instead of the JSON representation of a message