### PR TITLE
Fix MongoDB health checker to use fixed read- and writeConcerns

### DIFF
--- a/services/utils/config/src/main/resources/ditto-mongo.conf
+++ b/services/utils/config/src/main/resources/ditto-mongo.conf
@@ -51,9 +51,6 @@ ditto.mongodb {
     maxSize = 100
     maxSize = ${?MONGO_DB_CONNECTION_POOL_SIZE}
 
-    maxWaitQueueSize = 100
-    maxWaitQueueSize = ${?MONGO_DB_CONNECTION_POOL_QUEUE_SIZE}
-
     maxWaitTime = 30s
     maxWaitTime = ${?MONGO_DB_CONNECTION_POOL_WAIT_TIME}
   }

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
@@ -417,13 +417,11 @@ public final class MongoClientWrapper implements DittoMongoClient {
                         .eventLoopGroup(eventLoopGroup).build())
                         .applyToSslSettings(builder -> builder
                                 .context(tryToCreateAndInitSslContext())
-                                .enabled(true)
-                                .build());
+                                .enabled(true));
             } else if (null != connectionString) {
                 eventLoopGroup = null;
                 mongoClientSettingsBuilder.applyToSslSettings(builder -> builder
-                        .applyConnectionString(connectionString)
-                        .build());
+                        .applyConnectionString(connectionString));
             }
         }
 


### PR DESCRIPTION
In order to not use the configured ones from the mongo settings.
This could fail e.g. when "writeConcern" is "acknowledged" and "readConcern" is "majority".