### PR TITLE
AmqpSpecificConfig: support double-encoding of credentials

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
@@ -14,11 +14,13 @@ package org.eclipse.ditto.services.connectivity.messaging.amqp;
 
 import static org.apache.qpid.jms.provider.failover.FailoverProviderFactory.FAILOVER_OPTION_PREFIX;
 
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.time.Duration;
-import java.util.HashMap;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -49,8 +51,8 @@ public final class AmqpSpecificConfig {
 
     private AmqpSpecificConfig(final Map<String, String> amqpParameters, final Map<String, String> jmsParameters,
             final boolean failoverEnabled) {
-        this.amqpParameters = Map.copyOf(amqpParameters);
-        this.jmsParameters = Map.copyOf(jmsParameters);
+        this.amqpParameters = Collections.unmodifiableMap(new LinkedHashMap<>(amqpParameters));
+        this.jmsParameters = Collections.unmodifiableMap(new LinkedHashMap<>(jmsParameters));
         this.failoverEnabled = failoverEnabled;
     }
 
@@ -64,15 +66,15 @@ public final class AmqpSpecificConfig {
      */
     public static AmqpSpecificConfig withDefault(final String clientId, final Connection connection,
             final Map<String, String> defaultConfig) {
-        final var amqpParameters = new HashMap<>(filterForAmqpParameters(defaultConfig));
+        final var amqpParameters = new LinkedHashMap<>(filterForAmqpParameters(defaultConfig));
         addSaslMechanisms(amqpParameters, connection);
         addTransportParameters(amqpParameters, connection);
         addSpecificConfigParameters(amqpParameters, connection, AmqpSpecificConfig::isPermittedAmqpConfig);
 
-        final var jmsParameters = new HashMap<>(filterForJmsParameters(defaultConfig));
+        final var jmsParameters = new LinkedHashMap<>(filterForJmsParameters(defaultConfig));
         addParameter(jmsParameters, CLIENT_ID, clientId);
         addCredentials(jmsParameters, connection);
-        addFailoverParameters(jmsParameters);
+        addFailoverParameters(jmsParameters, connection);
         addSpecificConfigParameters(jmsParameters, connection, AmqpSpecificConfig::isPermittedJmsConfig);
 
         return new AmqpSpecificConfig(amqpParameters, jmsParameters, connection.isFailoverEnabled());
@@ -85,7 +87,7 @@ public final class AmqpSpecificConfig {
      * @return the relevant config values.
      */
     public static Map<String, String> toDefaultConfig(final Amqp10Config config) {
-        final HashMap<String, String> defaultConfig = new HashMap<>();
+        final LinkedHashMap<String, String> defaultConfig = new LinkedHashMap<>();
         addParameter(defaultConfig, CONNECT_TIMEOUT, config.getGlobalConnectTimeout().toMillis());
         addParameter(defaultConfig, SEND_TIMEOUT, config.getGlobalSendTimeout().toMillis());
         addParameter(defaultConfig, REQUEST_TIMEOUT, config.getGlobalRequestTimeout().toMillis());
@@ -124,7 +126,7 @@ public final class AmqpSpecificConfig {
         return key.startsWith("amqp") || key.startsWith("transport");
     }
 
-    private static void addSpecificConfigParameters(final HashMap<String, String> parameters,
+    private static void addSpecificConfigParameters(final LinkedHashMap<String, String> parameters,
             final Connection connection, final Predicate<String> keyFilter) {
         connection.getSpecificConfig().forEach((key, value) -> {
             if (keyFilter.test(key)) {
@@ -133,7 +135,7 @@ public final class AmqpSpecificConfig {
         });
     }
 
-    private static void addSaslMechanisms(final HashMap<String, String> parameters, final Connection connection) {
+    private static void addSaslMechanisms(final LinkedHashMap<String, String> parameters, final Connection connection) {
         if (connection.getUsername().isPresent() && connection.getPassword().isPresent()) {
             addParameter(parameters, SASL_MECHANISMS, "PLAIN");
         } else {
@@ -141,16 +143,18 @@ public final class AmqpSpecificConfig {
         }
     }
 
-    private static void addCredentials(final HashMap<String, String> parameters, final Connection connection) {
+    private static void addCredentials(final LinkedHashMap<String, String> parameters, final Connection connection) {
         final var username = connection.getUsername();
         final var password = connection.getPassword();
         if (username.isPresent() && password.isPresent()) {
-            addParameter(parameters, USERNAME, username.get());
-            addParameter(parameters, PASSWORD, password.get());
+            // URL-decode the username and password to preserve previous behavior (no apparent encoding of parameters)
+            addParameter(parameters, USERNAME, tryDecode(username.get()));
+            addParameter(parameters, PASSWORD, tryDecode(password.get()));
         }
     }
 
-    private static void addTransportParameters(final HashMap<String, String> parameters, final Connection connection) {
+    private static void addTransportParameters(final LinkedHashMap<String, String> parameters,
+            final Connection connection) {
         if (isSecuredConnection(connection) && !connection.isValidateCertificates()) {
             // these setting can only be applied for amqps connections:
             addParameter(parameters, TRUST_ALL, true);
@@ -158,7 +162,8 @@ public final class AmqpSpecificConfig {
         }
     }
 
-    private static void addParameter(final HashMap<String, String> parameters, final String key, final Object value) {
+    private static void addParameter(final LinkedHashMap<String, String> parameters, final String key,
+            final Object value) {
         parameters.put(key, String.valueOf(value));
     }
 
@@ -166,26 +171,37 @@ public final class AmqpSpecificConfig {
         return URLEncoder.encode(string, StandardCharsets.UTF_8);
     }
 
+    private static String tryDecode(final String string) {
+        try {
+            return URLDecoder.decode(string, StandardCharsets.UTF_8);
+        } catch (final IllegalArgumentException e) {
+            return string;
+        }
+    }
+
     private static boolean isSecuredConnection(final Connection connection) {
         return ConnectionBasedJmsConnectionFactory.isSecuredConnection(connection);
     }
 
-    private static void addFailoverParameters(final HashMap<String, String> parameters) {
-        final long fifteenMinutes = Duration.ofMinutes(15L).toMillis();
+    private static void addFailoverParameters(final LinkedHashMap<String, String> parameters,
+            final Connection connection) {
 
-        // Important: we cannot interrupt connection initiation.
-        // These failover parameters ensure qpid client gives up after at most
-        // 128 + 256 + 512 + 1024 + 2048 + 4096 = 8064 ms < 10_000 ms = 10 s
-        // at the first attempt. The client will retry endlessly after the connection
-        // is established with reasonable max reconnect delay until the user terminates
-        // the connection manually.
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "startupMaxReconnectAttempts", 5);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "maxReconnectAttempts", -1);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "initialReconnectDelay", 128);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "reconnectDelay", 128);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "maxReconnectDelay", fifteenMinutes);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "reconnectBackOffMultiplier", 2);
-        addParameter(parameters, FAILOVER_OPTION_PREFIX + "useReconnectBackOff", true);
+        if (connection.isFailoverEnabled()) {
+            final long fifteenMinutes = Duration.ofMinutes(15L).toMillis();
+            // Important: we cannot interrupt connection initiation.
+            // These failover parameters ensure qpid client gives up after at most
+            // 128 + 256 + 512 + 1024 + 2048 + 4096 = 8064 ms < 10_000 ms = 10 s
+            // at the first attempt. The client will retry endlessly after the connection
+            // is established with reasonable max reconnect delay until the user terminates
+            // the connection manually.
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "startupMaxReconnectAttempts", 5);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "maxReconnectAttempts", -1);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "initialReconnectDelay", 128);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "reconnectDelay", 128);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "maxReconnectDelay", fifteenMinutes);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "reconnectBackOffMultiplier", 2);
+            addParameter(parameters, FAILOVER_OPTION_PREFIX + "useReconnectBackOff", true);
+        }
     }
 
     private static Map<String, String> filterForAmqpParameters(final Map<String, String> defaultConfig) {

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfigTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfigTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.connectivity.messaging.amqp;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.ditto.services.connectivity.config.DefaultAmqp10Config;
+import org.eclipse.ditto.services.connectivity.messaging.TestConstants;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Tests {@link AmqpSpecificConfig}.
+ */
+public final class AmqpSpecificConfigTest {
+
+    @Test
+    public void decodeDoublyEncodedUsernameAndPassword() {
+        final var uri = "amqps://%2525u%2525s%2525e%2525r:%2525p%2525a%2525s%2525s@localhost:1234/";
+        final var connection = TestConstants.createConnection()
+                .toBuilder()
+                .uri(uri)
+                .build();
+
+        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of());
+
+        assertThat(underTest.render("amqps://localhost:1234/"))
+                .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
+                        "?jms.clientID=CID&jms.username=%25u%25s%25e%25r&jms.password=%25p%25a%25s%25s" +
+                        "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
+                        "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
+                        "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
+                        "&failover.useReconnectBackOff=true");
+    }
+
+    @Test
+    public void decodeSinglyEncodedUsernameAndPassword() {
+        final var uri = "amqps://%25u%25s%25e%25r:%25p%25a%25s%25s@localhost:1234/";
+        final var connection = TestConstants.createConnection()
+                .toBuilder()
+                .uri(uri)
+                .build();
+
+        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of());
+
+        assertThat(underTest.render("amqps://localhost:1234/"))
+                .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
+                        "?jms.clientID=CID&jms.username=%25u%25s%25e%25r&jms.password=%25p%25a%25s%25s" +
+                        "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
+                        "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
+                        "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
+                        "&failover.useReconnectBackOff=true");
+    }
+
+    @Test
+    public void appendDefaultParameters() {
+        final var connection = TestConstants.createConnection();
+        final var amqp10Config = DefaultAmqp10Config.of(ConfigFactory.empty());
+        final var defaultConfig = AmqpSpecificConfig.toDefaultConfig(amqp10Config);
+
+        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, defaultConfig);
+
+        assertThat(underTest.render("amqps://localhost:1234/"))
+                .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
+                        "?jms.sendTimeout=60000&jms.prefetchPolicy.all=10&jms.connectTimeout=15000" +
+                        "&jms.requestTimeout=5000&jms.clientID=CID" +
+                        "&jms.username=username&jms.password=password" +
+                        "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
+                        "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
+                        "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
+                        "&failover.useReconnectBackOff=true");
+    }
+
+    @Test
+    public void withoutFailover() {
+        final var connection = TestConstants.createConnection().toBuilder().failoverEnabled(false).build();
+        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of());
+        assertThat(underTest.render("amqps://localhost:1234/"))
+                .isEqualTo("amqps://localhost:1234/?amqp.saslMechanisms=PLAIN&jms.clientID=CID" +
+                        "&jms.username=username&jms.password=password");
+    }
+}


### PR DESCRIPTION
Add support for double-encoded credentials, which was the only way to use special characters in passwords of AMQP connections previously.