### PR TITLE
fixed priority of MongoDB setting "sslEnabled"

### DIFF
--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapper.java
@@ -413,15 +413,16 @@ public final class MongoClientWrapper implements DittoMongoClient {
         private void buildAndApplySslSettings() {
             if (sslEnabled) {
                 eventLoopGroup = new NioEventLoopGroup();
-                mongoClientSettingsBuilder.streamFactoryFactory(NettyStreamFactoryFactory.builder()
-                        .eventLoopGroup(eventLoopGroup).build())
+                mongoClientSettingsBuilder
+                        .streamFactoryFactory(NettyStreamFactoryFactory.builder().eventLoopGroup(eventLoopGroup).build())
                         .applyToSslSettings(builder -> builder
                                 .context(tryToCreateAndInitSslContext())
-                                .enabled(true));
+                                .enabled(sslEnabled));
             } else if (null != connectionString) {
                 eventLoopGroup = null;
-                mongoClientSettingsBuilder.applyToSslSettings(builder -> builder
-                        .applyConnectionString(connectionString));
+                mongoClientSettingsBuilder
+                        .applyToSslSettings(builder -> builder
+                                .enabled(sslEnabled));
             }
         }
 

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapperTest.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/MongoClientWrapperTest.java
@@ -131,7 +131,8 @@ public final class MongoClientWrapperTest {
         final MongoClientWrapper underTest = MongoClientWrapper.newInstance(mongoDbConfig);
 
         // verify
-        assertWithExpected(underTest, true, true);
+        // sslEnabled=false because the default config of MongoDbConfig.OptionsConfig.isSslEnabled() is "false":
+        assertWithExpected(underTest, false, true);
     }
 
     @Test
@@ -148,6 +149,22 @@ public final class MongoClientWrapperTest {
 
         // verify
         assertWithExpected(underTest, true, true);
+    }
+
+    @Test
+    public void createWithSslEnabledInUriAndOverwriteToDisabled() {
+        // prepare
+        final String uriWithSslEnabled = createUri(true, APPLICATION_NAME);
+
+        final Config config = CONFIG.withValue(MONGO_URI_CONFIG_KEY, ConfigValueFactory.fromAnyRef(uriWithSslEnabled))
+                .withValue(MONGO_SSL_CONFIG_KEY, ConfigValueFactory.fromAnyRef(false));
+        final DefaultMongoDbConfig mongoDbConfig = DefaultMongoDbConfig.of(config);
+
+        // test
+        final MongoClientWrapper underTest = MongoClientWrapper.newInstance(mongoDbConfig);
+
+        // verify
+        assertWithExpected(underTest, false, true);
     }
 
     @Test


### PR DESCRIPTION
* the configured value must have priority above the one configured via the MongoDB "uri"