### PR TITLE
fixed that the "ssl" option in ditto-mongo.conf was not applied

### DIFF
--- a/services/utils/config/src/main/resources/ditto-mongo.conf
+++ b/services/utils/config/src/main/resources/ditto-mongo.conf
@@ -50,7 +50,11 @@ ditto.mongodb {
     // that way any available URI option may be added, even if not explicitly specified in Ditto's mongo config
     extra-uri-options {
       // e.g.:
+      // ssl=true
       // sslInvalidHostNameAllowed=true
+      // minPoolSize=0
+      // maxPoolSize=100
+      // ...
     }
   }
 

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfig.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfig.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.services.utils.persistence.mongo.config;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -44,7 +45,17 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
         maxQueryTime = config.getDuration(MongoDbConfigValue.MAX_QUERY_TIME.getConfigPath());
         optionsConfig = DefaultOptionsConfig.of(config);
         final String configuredUri = config.getString(MongoDbConfigValue.URI.getConfigPath());
-        mongoDbUri = determineMongoDbUri(configuredUri, optionsConfig.extraUriOptions());
+        final Map<String, Object> configuredExtraUriOptions = optionsConfig.extraUriOptions();
+
+        final String sslKey = OptionsConfig.OptionsConfigValue.SSL_ENABLED.getConfigPath();
+        final Map<String, Object> extraUriOptions;
+        if (configuredExtraUriOptions.containsKey(sslKey)) {
+            extraUriOptions = configuredExtraUriOptions;
+        } else {
+            extraUriOptions = new HashMap<>(configuredExtraUriOptions);
+            extraUriOptions.put(sslKey, optionsConfig.isSslEnabled());
+        }
+        mongoDbUri = determineMongoDbUri(configuredUri, extraUriOptions);
         connectionPoolConfig = DefaultConnectionPoolConfig.of(config);
         circuitBreakerConfig = DefaultCircuitBreakerConfig.of(config);
         monitoringConfig = DefaultMonitoringConfig.of(config);

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbConfig.java
@@ -146,6 +146,11 @@ public interface MongoDbConfig {
          */
         boolean isRetryWrites();
 
+        /**
+         * Gets the extra options to add to the configured MongoDB {@code uri}.
+         *
+         * @return the extra options.
+         */
         Map<String, Object> extraUriOptions();
 
         /**

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbUriSupplier.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/config/MongoDbUriSupplier.java
@@ -45,9 +45,6 @@ final class MongoDbUriSupplier implements Supplier<String> {
      */
     static final String URI_CONFIG_PATH = "uri";
 
-    static final String EXTRA_URI_OPTIONS_PATH = DefaultOptionsConfig.CONFIG_PATH + "." +
-            MongoDbConfig.OptionsConfig.OptionsConfigValue.EXTRA_URI_OPTIONS.getConfigPath();
-
     private final URI mongoDbSourceUri;
     private final Map<String, Object> extraUriOptions;
 

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/config/DefaultMongoDbConfigTest.java
@@ -81,8 +81,9 @@ public final class DefaultMongoDbConfigTest {
 
         softly.assertThat(underTest.getMaxQueryTime()).isEqualTo(Duration.ofSeconds(10));
         // query options from the configured Mongo URI in "mongodb_test.conf" must be preserved
+        // exception is the "ssl" option where the configured value in the config has priority
         softly.assertThat(underTest.getMongoDbUri())
-                .isEqualTo("mongodb://foo:bar@mongodb:27017/test?w=1&ssl=true&sslInvalidHostNameAllowed=true");
+                .isEqualTo("mongodb://foo:bar@mongodb:27017/test?w=1&ssl=false&sslInvalidHostNameAllowed=true");
         softly.assertThat(underTest.getOptionsConfig()).satisfies(optionsConfig -> {
             softly.assertThat(optionsConfig.isSslEnabled()).isFalse();
         });
@@ -114,7 +115,7 @@ public final class DefaultMongoDbConfigTest {
         final DefaultMongoDbConfig underTest = DefaultMongoDbConfig.of(originalMongoDbConfig);
 
         softly.assertThat(underTest.getMaxQueryTime()).as("maxQueryTime").isEqualTo(Duration.ofMinutes(1));
-        softly.assertThat(underTest.getMongoDbUri()).as("mongoDbUri").isEqualTo("mongodb://foo:bar@mongodb:27017/test");
+        softly.assertThat(underTest.getMongoDbUri()).as("mongoDbUri").isEqualTo("mongodb://foo:bar@mongodb:27017/test?ssl=false");
         softly.assertThat(underTest.getOptionsConfig()).satisfies(optionsConfig -> {
             softly.assertThat(optionsConfig.isSslEnabled()).as("ssl").isFalse();
             softly.assertThat(optionsConfig.readPreference())


### PR DESCRIPTION
... for MongoDB connections using Akka Persistence

* the configured "ssl" option is now added to the "extra-uri-options" if not configured explicitly there resulting in an adjustment of the used MongoDB uri string