### PR TITLE
Use content-type to describe payload of ditto protocol message

### DIFF
--- a/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
+++ b/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
@@ -24,7 +24,7 @@ entries:
         output: web
         folderitems:
           - title: 2.0.0
-            url: /release_notes_200.html
+            url: /release_notes_next.html
             output: web
           - title: 1.5.1
             url: /release_notes_151.html

--- a/documentation/src/main/resources/_posts/2021-02-04-merge-feature.md
+++ b/documentation/src/main/resources/_posts/2021-02-04-merge-feature.md
@@ -163,7 +163,7 @@ Applying the following Ditto merge command to the existing thing will lead to th
 {
   "topic": "com.acme/coffeebrewer/things/twin/commands/merge",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/merge-patch+json"
   },
   "path": "/",
   "value": {
@@ -191,7 +191,7 @@ Another Ditto protocol example to merge a feature property:
 {
   "topic": "com.acme/coffeebrewer/things/twin/commands/merge",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/merge-patch+json"
   },
   "path": "/features/coffee-brewer/properties/brewed-coffees",
   "value": 42

--- a/documentation/src/main/resources/jsonschema/protocol-envelope.json
+++ b/documentation/src/main/resources/jsonschema/protocol-envelope.json
@@ -14,7 +14,7 @@
       "properties": {
         "content-type": {
           "type": "string",
-          "description": "The content-type of the message, for Ditto Protocol messages: `application/vnd.eclipse.ditto+json`."
+          "description": "The content-type which describes the value of Ditto Protocol messages."
         },
         "correlation-id": {
           "type": "string",

--- a/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
@@ -101,7 +101,7 @@ Events are mapped to a nested sparse JSON.
 ```json
 {
   "topic": "thing/id/things/twin/events/modified",
-  "headers": { "content-type": "application/vnd.eclipse.ditto+json" },
+  "headers": { "content-type": "application/json" },
   "path": "/features/sensors/properties/temperature/indoor/value",
   "value": 42
 }
@@ -127,7 +127,7 @@ would result in the following normalized JSON representation:
     "topic": "thing/id/things/twin/events/modified",
     "path": "/features/sensors/properties/temperature/indoor/value",
     "headers": {
-      "content-type": "application/vnd.eclipse.ditto+json"
+      "content-type": "application/json"
     }
   }
 }

--- a/documentation/src/main/resources/pages/ditto/protocol-specification.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification.md
@@ -79,7 +79,7 @@ There are some pre-defined headers, which have a special meaning for Ditto:
 
 | Header Key | Description                    | Possible values           |
 |------------|--------------------------------|---------------------------|
-| `content-type` | The content-type which describes the [value](#Value) of Ditto Protocol messages. | `String` |
+| `content-type` | The content-type which describes the [value](#value) of Ditto Protocol messages. | `String` |
 | `correlation-id` | Used for correlating protocol messages (e.g. a **command** would have the same correlation-id as the sent back **response** message. | `String` |
 | `ditto-originator` | Contains the first authorization subject of the command that caused the sending of this message. Set by Ditto. | `String` |
 | `if-match` | Has the same semantics as defined for the [HTTP API](httpapi-concepts.html#conditional-requests). | `String` |

--- a/documentation/src/main/resources/pages/ditto/protocol-specification.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification.md
@@ -79,7 +79,7 @@ There are some pre-defined headers, which have a special meaning for Ditto:
 
 | Header Key | Description                    | Possible values           |
 |------------|--------------------------------|---------------------------|
-| `content-type` | The content-type of the message, for Ditto Protocol messages: `application/vnd.eclipse.ditto+json` | `String` |
+| `content-type` | The content-type which describes the [value](#Value) of Ditto Protocol messages. | `String` |
 | `correlation-id` | Used for correlating protocol messages (e.g. a **command** would have the same correlation-id as the sent back **response** message. | `String` |
 | `ditto-originator` | Contains the first authorization subject of the command that caused the sending of this message. Set by Ditto. | `String` |
 | `if-match` | Has the same semantics as defined for the [HTTP API](httpapi-concepts.html#conditional-requests). | `String` |

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/createpolicy.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/createpolicy.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/create",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/createpolicyresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/createpolicyresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/create",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicy.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicy.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyentry.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyentry.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyentryresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyentryresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletepolicyresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deleteresource.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deleteresource.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deleteresourceresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deleteresourceresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletesubject.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletesubject.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletesubjectresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/deletesubjectresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/delete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicy.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicy.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentries.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentries.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentriesresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentriesresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentry.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentry.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentryresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentryresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentryresponsecreated.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyentryresponsecreated.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyresponsecreated.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifypolicyresponsecreated.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresource.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresource.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourceresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourceresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourceresponsecreated.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourceresponsecreated.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresources.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresources.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourcesresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifyresourcesresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubject.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubject.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectresponsecreated.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectresponsecreated.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjects.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjects.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectsresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/modify/modifysubjectsresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/modify",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects",
   "status": 204

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicy.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicy.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentries.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentries.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentriesresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentriesresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentry.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentry.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentryresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyentryresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicyresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresource.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresource.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresourceresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresourceresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources/thing:/the_resource_path",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresources.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresources.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresourcesresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrieveresourcesresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/resources",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubject.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubject.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjectresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjectresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects/google:the_subjectid",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjects.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjects.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects"
 }

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjectsresponse.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievesubjectsresponse.md
@@ -4,7 +4,7 @@
 {
   "topic": "com.acme/the_policy_id/policies/commands/retrieve",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/entries/the_label/subjects",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_invalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_modificationinvalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_modificationinvalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_entry_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_id_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_id_invalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_conflict.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_conflict.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_modificationinvalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_modificationinvalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_toomanymodifyingrequests.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_toomanymodifyingrequests.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_unavailable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_policy_unavailable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resource_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resource_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resource_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resource_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resources_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resources_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resources_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_resources_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subject_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subject_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subject_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subject_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjectid_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjectid_invalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjects_notfound.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjects_notfound.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjects_notmodifiable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/exceptions/policies_subjects_notmodifiable.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/policies/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/cancel-subscription-command.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/cancel-subscription-command.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/cancel",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/create-subscription-command.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/create-subscription-command.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/subscribe",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json",
+    "content-type": "application/json",
     "correlation-id": "444dae7e-bacf-312b-bc97-8f393dadf1bd"
   },
   "path": "/",

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/request-subscription-command.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/commands/request-subscription-command.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/request",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-complete-event.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-complete-event.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/complete",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-created-event.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-created-event.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/created",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json",
+    "content-type": "application/json",
     "correlation-id": "444dae7e-bacf-312b-bc97-8f393dadf1bd"
   },
   "path": "/",

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-failed-event.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-failed-event.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/failed",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-has-next-event.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/events/subscription-has-next-event.md
@@ -4,7 +4,7 @@
 {
   "topic": "_/_/things/twin/search/next",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/exceptions/thing-search_search_option_invalid.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/search/generated/exceptions/thing-search_search_option_invalid.md
@@ -4,7 +4,7 @@
 {
   "topic": "unknown/unknown/things/twin/errors",
   "headers": {
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/exceptions/things_id_notdeletable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/exceptions/things_id_notdeletable.md
@@ -5,7 +5,7 @@
   "topic": "unknown/unknown/things/twin/errors",
   "headers": {
     "response-required": false,
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/exceptions/things_policyId_notdeletable.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/things/generated/exceptions/things_policyId_notdeletable.md
@@ -5,7 +5,7 @@
   "topic": "unknown/unknown/things/twin/errors",
   "headers": {
     "response-required": false,
-    "content-type": "application/vnd.eclipse.ditto+json"
+    "content-type": "application/json"
   },
   "path": "/",
   "value": {

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractErrorResponseAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/AbstractErrorResponseAdapter.java
@@ -47,7 +47,6 @@ public abstract class AbstractErrorResponseAdapter<T extends ErrorResponse<T>> i
      * @param dittoHeaders Headers of the error.
      * @param errorRegistry The error registry.
      * @return The parsed {@code DittoRuntimeException}.
-     *
      * @since 1.1.0
      */
     public static DittoRuntimeException parseWithErrorRegistry(final JsonObject errorJson,
@@ -101,7 +100,7 @@ public abstract class AbstractErrorResponseAdapter<T extends ErrorResponse<T>> i
         }
 
         final DittoHeaders responseHeaders =
-                ProtocolFactory.newHeadersWithDittoContentType(errorResponse.getDittoHeaders());
+                ProtocolFactory.newHeadersWithJsonContentType(errorResponse.getDittoHeaders());
 
         return Adaptable.newBuilder(topicPathBuildable.build())
                 .withPayload(payload)

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ProtocolFactory.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/ProtocolFactory.java
@@ -311,6 +311,19 @@ public final class ProtocolFactory {
     }
 
     /**
+     * Returns new {@code Headers} for the specified {@code headers} map with having
+     * {@link ContentType#APPLICATION_JSON} set for the content-type header.
+     *
+     * @param headers the headers map.
+     * @return the headers.
+     */
+    public static DittoHeaders newHeadersWithJsonContentType(final Map<String, String> headers) {
+        return DittoHeaders.newBuilder(headers)
+                .contentType(ContentType.APPLICATION_JSON)
+                .build();
+    }
+
+    /**
      * Returns new {@code Headers} for the specified {@code headers} map with Json merge patch content-type.
      *
      * @param headers the headers map.

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementAdapter.java
@@ -101,7 +101,7 @@ final class AcknowledgementAdapter implements Adapter<Acknowledgement> {
         final TopicPath topicPath = adaptable.getTopicPath();
         return topicPath.getSubject()
                 .map(AcknowledgementLabel::of)
-                .map(ackLabel ->  {
+                .map(ackLabel -> {
                     if (DittoAcknowledgementLabel.contains(ackLabel)) {
                         throw new DittoAcknowledgementLabelExternalUseForbiddenException(ackLabel);
                     }
@@ -175,10 +175,7 @@ final class AcknowledgementAdapter implements Adapter<Acknowledgement> {
 
     private DittoHeaders getExternalHeaders(final DittoHeaders acknowledgementHeaders) {
         final Map<String, String> externalHeaders = headerTranslator.toExternalHeaders(acknowledgementHeaders);
-        if (externalHeaders.containsKey(DittoHeaderDefinition.CONTENT_TYPE.getKey())) {
-            return DittoHeaders.of(externalHeaders);
-        }
-        return ProtocolFactory.newHeadersWithDittoContentType(externalHeaders);
+        return DittoHeaders.of(externalHeaders);
     }
 
 }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementsAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/acknowledgements/AcknowledgementsAdapter.java
@@ -29,7 +29,6 @@ import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.common.HttpStatus;
-import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.things.ThingConstants;
 import org.eclipse.ditto.model.things.ThingId;
@@ -180,10 +179,7 @@ final class AcknowledgementsAdapter implements Adapter<Acknowledgements> {
 
     private DittoHeaders getExternalHeaders(final DittoHeaders acknowledgementHeaders) {
         final Map<String, String> externalHeaders = headerTranslator.toExternalHeaders(acknowledgementHeaders);
-        if (externalHeaders.containsKey(DittoHeaderDefinition.CONTENT_TYPE.getKey())) {
-            return DittoHeaders.of(externalHeaders);
-        }
-        return ProtocolFactory.newHeadersWithDittoContentType(externalHeaders);
+        return ProtocolFactory.newHeadersWithJsonContentType(externalHeaders);
     }
 
 }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/signals/AbstractSignalMapper.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/signals/AbstractSignalMapper.java
@@ -84,7 +84,7 @@ abstract class AbstractSignalMapper<T extends Signal<?>> implements SignalMapper
      * @param signal the {@code signal} that is processed
      */
     DittoHeaders enhanceHeaders(final T signal) {
-        return ProtocolFactory.newHeadersWithDittoContentType(signal.getDittoHeaders());
+        return ProtocolFactory.newHeadersWithJsonContentType(signal.getDittoHeaders());
     }
 
 }

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/SubscriptionEventAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/SubscriptionEventAdapter.java
@@ -104,7 +104,7 @@ final class SubscriptionEventAdapter extends AbstractThingAdapter<SubscriptionEv
 
         return Adaptable.newBuilder(topicPath)
                 .withPayload(payloadBuilder.withValue(payloadContentBuilder.build()).build())
-                .withHeaders(ProtocolFactory.newHeadersWithDittoContentType(event.getDittoHeaders()))
+                .withHeaders(ProtocolFactory.newHeadersWithJsonContentType(event.getDittoHeaders()))
                 .build();
     }
 

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/ThingEventAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/ThingEventAdapter.java
@@ -18,6 +18,7 @@ import java.util.Optional;
 
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.protocoladapter.AbstractAdapter;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.EventAdapter;
@@ -75,9 +76,16 @@ final class ThingEventAdapter extends AbstractThingAdapter<ThingEvent<?>> implem
                 event.getEntity(event.getDittoHeaders().getSchemaVersion().orElse(event.getLatestSchemaVersion()));
         value.ifPresent(payloadBuilder::withValue);
 
+        final DittoHeaders headers;
+        if (value.isPresent()) {
+            headers = ProtocolFactory.newHeadersWithJsonContentType(event.getDittoHeaders());
+        } else {
+            headers = event.getDittoHeaders();
+        }
+
         return Adaptable.newBuilder(eventsTopicPathBuilder.build())
                 .withPayload(payloadBuilder.build())
-                .withHeaders(ProtocolFactory.newHeadersWithJsonContentType(event.getDittoHeaders()))
+                .withHeaders(headers)
                 .build();
     }
 

--- a/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/ThingEventAdapter.java
+++ b/protocol-adapter/src/main/java/org/eclipse/ditto/protocoladapter/things/ThingEventAdapter.java
@@ -77,7 +77,7 @@ final class ThingEventAdapter extends AbstractThingAdapter<ThingEvent<?>> implem
 
         return Adaptable.newBuilder(eventsTopicPathBuilder.build())
                 .withPayload(payloadBuilder.build())
-                .withHeaders(ProtocolFactory.newHeadersWithDittoContentType(event.getDittoHeaders()))
+                .withHeaders(ProtocolFactory.newHeadersWithJsonContentType(event.getDittoHeaders()))
                 .build();
     }
 

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/DittoProtocolAdapterTest.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.model.base.common.HttpStatus;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.headers.contenttype.ContentType;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
 import org.eclipse.ditto.model.things.ThingId;
@@ -504,7 +505,7 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
                 "    \"the-ack-label\": { \"status\": 508,\"headers\":{\"response-required\":false} }\n" +
                 "  },\n" +
                 "  \"status\": 424,\n" +
-                "  \"headers\": { \"content-type\": \"" + DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE +
+                "  \"headers\": { \"content-type\": \"" + ContentType.APPLICATION_JSON.getValue() +
                 "\",\"response-required\":false }\n" +
                 "}"));
 
@@ -517,7 +518,7 @@ public final class DittoProtocolAdapterTest implements ProtocolAdapterTest {
                                 HttpStatus.LOOP_DETECTED, DittoHeaders.empty())
                 ),
                 DittoHeaders.newBuilder()
-                        .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE)
+                        .contentType(ContentType.APPLICATION_JSON)
                         .build()
         ));
 

--- a/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/TestConstants.java
+++ b/protocol-adapter/src/test/java/org/eclipse/ditto/protocoladapter/TestConstants.java
@@ -183,28 +183,25 @@ public final class TestConstants {
     public static final DittoHeaders DITTO_HEADERS_V_1 = DittoHeaders.newBuilder()
             .correlationId(CORRELATION_ID)
             .schemaVersion(JsonSchemaVersion.V_1)
-            .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE)
             .build();
 
     public static final DittoHeaders DITTO_HEADERS_V_2 = DittoHeaders.newBuilder()
             .correlationId(CORRELATION_ID)
             .schemaVersion(JsonSchemaVersion.V_2)
-            .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE)
             .putHeader(MessageHeaderDefinition.STATUS_CODE.getKey(), "200")
             .build();
 
     public static final DittoHeaders DITTO_HEADERS_V_2_NO_STATUS = DittoHeaders.newBuilder()
             .correlationId(CORRELATION_ID)
             .schemaVersion(JsonSchemaVersion.V_2)
-            .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE)
             .build();
 
-    public static final DittoHeaders HEADERS_V_1 = ProtocolFactory.newHeadersWithDittoContentType(DITTO_HEADERS_V_1);
+    public static final DittoHeaders HEADERS_V_1 = ProtocolFactory.newHeadersWithJsonContentType(DITTO_HEADERS_V_1);
 
     public static final DittoHeaders HEADERS_V_1_FOR_MERGE_COMMANDS =
             ProtocolFactory.newHeadersWithJsonMergePatchContentType(DITTO_HEADERS_V_1);
 
-    public static final DittoHeaders HEADERS_V_2 = ProtocolFactory.newHeadersWithDittoContentType(DITTO_HEADERS_V_2);
+    public static final DittoHeaders HEADERS_V_2 = ProtocolFactory.newHeadersWithJsonContentType(DITTO_HEADERS_V_2);
 
     public static final DittoHeaders HEADERS_V_2_FOR_MERGE_COMMANDS =
             ProtocolFactory.newHeadersWithJsonMergePatchContentType(DITTO_HEADERS_V_2);

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapper.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapper.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.ditto.services.connectivity.mapping;
 
-import static org.eclipse.ditto.model.base.common.DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE;
 import static org.eclipse.ditto.model.base.exceptions.DittoJsonException.wrapJsonRuntimeException;
 
 import java.util.Collections;
@@ -196,7 +195,6 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         final JsonObject inlinePolicyJson = createInlinePolicyJson(thingJson);
         final String copyPolicyFrom = getCopyPolicyFrom(thingJson);
         final DittoHeaders dittoHeaders = message.getInternalHeaders().toBuilder()
-                .contentType(DITTO_PROTOCOL_CONTENT_TYPE)
                 .putHeaders(commandHeaders)
                 .build();
         return CreateThing.of(newThing, inlinePolicyJson, copyPolicyFrom, dittoHeaders);

--- a/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
+++ b/services/connectivity/mapping/src/main/java/org/eclipse/ditto/services/connectivity/mapping/javascript/DefaultOutgoingMapping.java
@@ -12,10 +12,11 @@
  */
 package org.eclipse.ditto.services.connectivity.mapping.javascript;
 
+import static org.eclipse.ditto.model.base.common.DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE;
+
 import java.util.Collections;
 import java.util.List;
 
-import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.protocoladapter.Adaptable;
 import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
 import org.eclipse.ditto.protocoladapter.ProtocolFactory;
@@ -40,11 +41,10 @@ public class DefaultOutgoingMapping implements MappingFunction<Adaptable, List<E
     @Override
     public List<ExternalMessage> apply(final Adaptable adaptable) {
         final JsonifiableAdaptable jsonifiableAdaptable = ProtocolFactory.wrapAsJsonifiableAdaptable(adaptable);
-        final ExternalMessageBuilder messageBuilder = ExternalMessageFactory.newExternalMessageBuilder(
-                adaptable.getDittoHeaders())
-                        .withTopicPath(adaptable.getTopicPath());
-        messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER,
-                DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);
+        final ExternalMessageBuilder messageBuilder = ExternalMessageFactory
+                .newExternalMessageBuilder(adaptable.getDittoHeaders())
+                .withTopicPath(adaptable.getTopicPath());
+        messageBuilder.withAdditionalHeaders(ExternalMessage.CONTENT_TYPE_HEADER, DITTO_PROTOCOL_CONTENT_TYPE);
         messageBuilder.withText(jsonifiableAdaptable.toJsonString());
         return Collections.singletonList(messageBuilder.build());
     }

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapperTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/DittoMessageMapperTest.java
@@ -91,7 +91,6 @@ public final class DittoMessageMapperTest {
     private static Map.Entry<ExternalMessage, List<Adaptable>> valid1() {
         final Map<String, String> headers = new HashMap<>();
         headers.put("header-key", "header-value");
-        headers.put(ExternalMessage.CONTENT_TYPE_HEADER, DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE);
         final ThingId thingId = ThingId.of("org.eclipse.ditto:thing1");
         final JsonifiableAdaptable adaptable =
                 ProtocolFactory.wrapAsJsonifiableAdaptable(ProtocolFactory.newAdaptableBuilder
@@ -105,7 +104,8 @@ public final class DittoMessageMapperTest {
 
         // by default, the DittoMessageMapper should not automatically use all headers from the ExternalMessage
         //  those would have to be mapped by an explicit header mapping
-        final ExternalMessage message = ExternalMessageFactory.newExternalMessageBuilder(Collections.emptyMap())
+        final ExternalMessage message = ExternalMessageFactory.newExternalMessageBuilder(
+                Map.of(ExternalMessage.CONTENT_TYPE_HEADER, DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE))
                 .withTopicPath(adaptable.getTopicPath())
                 .withText(adaptable.toJsonString())
                 .build();
@@ -165,8 +165,9 @@ public final class DittoMessageMapperTest {
                 .contentType(DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE)
                 .correlationId(correlationId)
                 .build();
-        final DittoHeaders adaptableHeaders = expectedMessageHeaders.toBuilder()
+        final DittoHeaders adaptableHeaders = DittoHeaders.newBuilder()
                 .putHeader("header-key", "header-value")
+                .correlationId(correlationId)
                 .build();
 
 

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapperTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/ImplicitThingCreationMessageMapperTest.java
@@ -16,7 +16,6 @@ package org.eclipse.ditto.services.connectivity.mapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
-import static org.eclipse.ditto.model.base.common.DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE;
 import static org.eclipse.ditto.services.models.things.Permission.READ;
 import static org.eclipse.ditto.services.models.things.Permission.WRITE;
 
@@ -139,7 +138,6 @@ public final class ImplicitThingCreationMessageMapperTest {
         assertThat(createThing.getThing().getAttributes()).isEqualTo(expectedThing.getAttributes());
         assertThat(createThing.getDittoHeaders().get("other-test-header")).isEqualTo(GATEWAY_ID);
         assertThat(createThing.getDittoHeaders().get("test-header")).isEqualTo("this-is-a-test-header");
-        assertThat(createThing.getDittoHeaders().getContentType()).contains(DITTO_PROTOCOL_CONTENT_TYPE);
         assertThat(createThing.getDittoHeaders().isAllowPolicyLockout()).isTrue();
         assertThat(createThing.getDittoHeaders().getIfNoneMatch()).contains(EntityTagMatchers.fromStrings("*"));
         assertThat(createThing.getPolicyIdOrPlaceholder()).contains(GATEWAY_ID);
@@ -161,7 +159,6 @@ public final class ImplicitThingCreationMessageMapperTest {
         assertThat(createThing.getThing().getEntityId()).isEqualTo(expectedThing.getEntityId());
         assertThat(createThing.getThing().getPolicyEntityId()).isEmpty();
         assertThat(createThing.getThing().getAttributes()).isEqualTo(expectedThing.getAttributes());
-        assertThat(createThing.getDittoHeaders().getContentType()).contains(DITTO_PROTOCOL_CONTENT_TYPE);
         assertThat(createThing.getPolicyIdOrPlaceholder()).contains(GATEWAY_ID);
         assertThat(createThing.getDittoHeaders().isAllowPolicyLockout()).isTrue();
         assertThat(createThing.getDittoHeaders().getIfNoneMatch()).contains(EntityTagMatchers.fromStrings("*"));

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapperTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/NormalizedMessageMapperTest.java
@@ -105,7 +105,7 @@ public final class NormalizedMessageMapperTest {
                         "    \"path\": \"/\",\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
-                        "      \"content-type\": \"application/vnd.eclipse.ditto+json\"\n" +
+                        "      \"content-type\": \"application/json\"\n" +
                         "    }\n" +
                         "  }\n" +
                         "}"));
@@ -140,7 +140,7 @@ public final class NormalizedMessageMapperTest {
                         "    \"path\": \"/features/featureId/properties/the/quick/brown/fox/jumps/over/the/lazy/dog\",\n" +
                         "    \"headers\": {\n" +
                         "      \"response-required\": \"false\",\n" +
-                        "      \"content-type\": \"application/vnd.eclipse.ditto+json\"\n" +
+                        "      \"content-type\": \"application/json\"\n" +
                         "    }\n" +
                         "  }\n" +
                         "}"));
@@ -186,7 +186,7 @@ public final class NormalizedMessageMapperTest {
                         "  \"_context\": {\n" +
                         "    \"topic\": \"thing/id/things/twin/events/modified\",\n" +
                         "    \"headers\": {\n" +
-                        "      \"content-type\": \"application/vnd.eclipse.ditto+json\"\n" +
+                        "      \"content-type\": \"application/json\"\n" +
                         "    }\n" +
                         "  }\n" +
                         "}"));

--- a/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhinoTest.java
+++ b/services/connectivity/mapping/src/test/java/org/eclipse/ditto/services/connectivity/mapping/javascript/JavaScriptMessageMapperRhinoTest.java
@@ -436,7 +436,8 @@ public final class JavaScriptMessageMapperRhinoTest {
                         .build()
         );
 
-        javaScriptRhinoMapperPlainWithStatusAndExtra = JavaScriptMessageMapperFactory.createJavaScriptMessageMapperRhino();
+        javaScriptRhinoMapperPlainWithStatusAndExtra =
+                JavaScriptMessageMapperFactory.createJavaScriptMessageMapperRhino();
         javaScriptRhinoMapperPlainWithStatusAndExtra.configure(MAPPING_CONFIG,
                 JavaScriptMessageMapperFactory
                         .createJavaScriptMessageMapperConfigurationBuilder("plainStatus", Collections.emptyMap())
@@ -554,7 +555,7 @@ public final class JavaScriptMessageMapperRhinoTest {
                                 "{{topic:action-subject}}").build());
 
 
-        System.out.println("HEADERS: " + ProtocolFactory.newHeadersWithDittoContentType(createThing.getDittoHeaders()));
+        System.out.println("HEADERS: " + ProtocolFactory.newHeadersWithJsonContentType(createThing.getDittoHeaders()));
 
         System.out.println("CREATE THING :" + createThing);
 
@@ -599,7 +600,7 @@ public final class JavaScriptMessageMapperRhinoTest {
 
 
         System.out.println(
-                "HEADERS: " + ProtocolFactory.newHeadersWithDittoContentType(createThingResponse.getDittoHeaders()));
+                "HEADERS: " + ProtocolFactory.newHeadersWithJsonContentType(createThingResponse.getDittoHeaders()));
 
         System.out.println("CREATE THING RESPONSE :" + createThingResponse);
 
@@ -684,7 +685,8 @@ public final class JavaScriptMessageMapperRhinoTest {
         assertThat(adaptable.getTopicPath().getNamespace()).isEqualTo(MAPPING_INCOMING_NAMESPACE);
         assertThat(adaptable.getTopicPath().getId()).isEqualTo(MAPPING_INCOMING_ID);
         assertThat(adaptable.getPayload().getPath().toString()).isEqualTo(MAPPING_INCOMING_PATH);
-        assertThat(adaptable.getPayload().getValue()).map(JsonValue::asString).contains(modifyThingResponse.toJsonString());
+        assertThat(adaptable.getPayload().getValue()).map(JsonValue::asString)
+                .contains(modifyThingResponse.toJsonString());
         assertThat(adaptable.getPayload().getHttpStatus()).contains(HttpStatus.NO_CONTENT);
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtil.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtil.java
@@ -300,7 +300,6 @@ final class ConnectionMigrationUtil {
 
         private static final JsonObject LEGACY_DEFAULT_TARGET_HEADER_MAPPING = JsonObject.newBuilder()
                 .set("correlation-id", "{{header:correlation-id}}")
-                .set("content-type", "{{header:content-type}}")
                 .set("reply-to", "{{header:reply-to}}")
                 .build();
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/AbstractPublisherActorTest.java
@@ -14,12 +14,14 @@ package org.eclipse.ditto.services.connectivity.messaging;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.acks.AcknowledgementLabel;
+import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.DittoHeadersBuilder;

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/TestConstants.java
@@ -204,7 +204,6 @@ public final class TestConstants {
         map.put("suffixed_thing_id", "{{ header:device_id }}.some.suffix");
         map.put("subject", "{{ topic:action-subject }}");
         map.put("correlation-id", "{{ header:correlation-id }}");
-        map.put("content-type", "{{ header:content-type }}");
         map.put("reply-to", "{{ header:reply-to }}");
         map.put("ditto-connection-id", "hallo");
         HEADER_MAPPING = ConnectivityModelFactory.newHeaderMapping(map);

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/HiveMqtt5PublisherActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/HiveMqtt5PublisherActorTest.java
@@ -85,7 +85,7 @@ public class HiveMqtt5PublisherActorTest extends AbstractPublisherActorTest {
                         prop.getValue().toString().equals("ditto"))).isTrue();
         assertThat(ByteBufferUtils.toUtf8String(mqttMessage.getCorrelationData().get())).isEqualTo(
                 TestConstants.CORRELATION_ID);
-        assertThat(mqttMessage.getContentType().get().toString()).isEqualTo("application/vnd.eclipse.ditto+json");
+        assertThat(mqttMessage.getContentType()).isEmpty();
     }
 
     @Override

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtilTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtilTest.java
@@ -147,7 +147,6 @@ public class ConnectionMigrationUtilTest {
             .build();
     private static final HeaderMapping LEGACY_TARGET_HEADER_MAPPING =
             ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
-                    .set("content-type", "{{header:content-type}}")
                     .set("correlation-id", "{{header:correlation-id}}")
                     .set("reply-to", "{{header:reply-to}}")
                     .build());

--- a/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/CloudEventsConfig.java
+++ b/services/gateway/util/src/main/java/org/eclipse/ditto/services/gateway/util/config/endpoints/CloudEventsConfig.java
@@ -16,11 +16,10 @@ import java.util.Set;
 
 import javax.annotation.concurrent.Immutable;
 
-import akka.http.javadsl.model.MediaTypes;
 import org.eclipse.ditto.model.base.common.DittoConstants;
 import org.eclipse.ditto.services.utils.config.KnownConfigValue;
 
-import static org.eclipse.ditto.model.base.common.DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE;
+import akka.http.javadsl.model.MediaTypes;
 
 /**
  * Provides configuration settings for the cloud events endpoint of the Ditto Gateway service.
@@ -56,7 +55,8 @@ public interface CloudEventsConfig {
         /**
          * Set of allowed data types
          */
-        DATA_TYPES("data-types", Set.of(MediaTypes.APPLICATION_JSON.toString(), DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE));
+        DATA_TYPES("data-types",
+                Set.of(MediaTypes.APPLICATION_JSON.toString(), DittoConstants.DITTO_PROTOCOL_CONTENT_TYPE));
 
         private final String path;
         private final Object defaultValue;


### PR DESCRIPTION
This PR corrects the handling of the content-type header in ditto protocol messages.
It now should consequently describe the payload of the ditto protocol message.