### PR TITLE
Bugfix for accidentally applied default header mappings

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectivityModelFactory.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectivityModelFactory.java
@@ -48,6 +48,9 @@ public final class ConnectivityModelFactory {
      */
     public static final String SOURCE_ADDRESS_ENFORCEMENT = "{{ source:address }}";
 
+    private static final HeaderMapping EMPTY_HEADER_MAPPING =
+            ConnectivityModelFactory.newHeaderMapping(new HashMap<>());
+
     private ConnectivityModelFactory() {
         throw new AssertionError();
     }
@@ -380,7 +383,6 @@ public final class ConnectivityModelFactory {
      * @param options the mapping options required to instantiate a mapper.
      * @return the created MappingContext.
      * @throws NullPointerException if any argument is {@code null}.
-     *
      * @since 1.3.0
      */
     public static MappingContextBuilder newMappingContextBuilder(final String mappingEngine,
@@ -925,6 +927,15 @@ public final class ConnectivityModelFactory {
      */
     public static Enforcement newEnforcement(final Enforcement enforcement) {
         return ImmutableEnforcement.of(enforcement.getInput(), enforcement.getFilters());
+    }
+
+    /**
+     * Returns singleton of a header mapping without any mappings defined
+     *
+     * @return the empty header mapping
+     */
+    public static HeaderMapping emptyHeaderMapping() {
+        return EMPTY_HEADER_MAPPING;
     }
 
     /**

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableSource.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableSource.java
@@ -90,7 +90,7 @@ final class ImmutableSource implements Source {
     private final AuthorizationContext authorizationContext;
     @Nullable private final Enforcement enforcement;
     @Nullable private final FilteredAcknowledgementRequest acknowledgementRequests;
-    @Nullable private final HeaderMapping headerMapping;
+    private final HeaderMapping headerMapping;
     private final PayloadMapping payloadMapping;
     private final boolean replyTargetEnabled;
     @Nullable private final ReplyTarget replyTarget;
@@ -149,7 +149,7 @@ final class ImmutableSource implements Source {
 
     @Override
     public Optional<HeaderMapping> getHeaderMapping() {
-        return Optional.ofNullable(headerMapping);
+        return Optional.of(headerMapping);
     }
 
     @Override
@@ -202,10 +202,8 @@ final class ImmutableSource implements Source {
                     acknowledgementRequests.toJson(schemaVersion, thePredicate), predicate);
         }
 
-        if (headerMapping != null) {
-            jsonObjectBuilder.set(JsonFields.HEADER_MAPPING, headerMapping.toJson(schemaVersion, thePredicate),
+        jsonObjectBuilder.set(JsonFields.HEADER_MAPPING, headerMapping.toJson(schemaVersion, thePredicate),
                     predicate);
-        }
 
         if (!payloadMapping.isEmpty()) {
             jsonObjectBuilder.set(JsonFields.PAYLOAD_MAPPING, payloadMapping.toJson(), predicate);
@@ -405,7 +403,7 @@ final class ImmutableSource implements Source {
 
         // optional:
         @Nullable private Enforcement enforcement;
-        @Nullable private HeaderMapping headerMapping;
+        private HeaderMapping headerMapping = ConnectivityModelFactory.emptyHeaderMapping();
         @Nullable private Integer qos = null;
         @Nullable private FilteredAcknowledgementRequest acknowledgementRequests;
         private boolean replyTargetEnabled = DEFAULT_REPLY_TARGET_ENABLED;
@@ -486,7 +484,7 @@ final class ImmutableSource implements Source {
 
         @Override
         public Builder headerMapping(@Nullable final HeaderMapping headerMapping) {
-            this.headerMapping = headerMapping;
+            this.headerMapping = headerMapping == null ? ConnectivityModelFactory.emptyHeaderMapping() : headerMapping;
             return this;
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableTarget.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableTarget.java
@@ -64,7 +64,7 @@ final class ImmutableTarget implements Target {
     private final AuthorizationContext authorizationContext;
     private final String originalAddress;
     @Nullable private final AcknowledgementLabel issuedAcknowledgementLabel;
-    @Nullable private final HeaderMapping headerMapping;
+    private final HeaderMapping headerMapping;
     private final PayloadMapping payloadMapping;
 
     private ImmutableTarget(final ImmutableTarget.Builder builder) {
@@ -116,7 +116,7 @@ final class ImmutableTarget implements Target {
 
     @Override
     public Optional<HeaderMapping> getHeaderMapping() {
-        return Optional.ofNullable(headerMapping);
+        return Optional.of(headerMapping);
     }
 
     @Override
@@ -150,10 +150,8 @@ final class ImmutableTarget implements Target {
                     predicate);
         }
 
-        if (headerMapping != null) {
-            jsonObjectBuilder.set(JsonFields.HEADER_MAPPING, headerMapping.toJson(schemaVersion, thePredicate),
-                    predicate);
-        }
+        jsonObjectBuilder.set(JsonFields.HEADER_MAPPING, headerMapping.toJson(schemaVersion, thePredicate),
+                predicate);
 
         if (!payloadMapping.isEmpty()) {
             jsonObjectBuilder.set(Target.JsonFields.PAYLOAD_MAPPING, payloadMapping.toJson(), predicate);
@@ -265,7 +263,7 @@ final class ImmutableTarget implements Target {
         @Nullable private Integer qos;
         @Nullable private AuthorizationContext authorizationContext;
         @Nullable private AcknowledgementLabel issuedAcknowledgementLabel;
-        @Nullable private HeaderMapping headerMapping;
+        private HeaderMapping headerMapping = ConnectivityModelFactory.emptyHeaderMapping();
 
         Builder() {
         }
@@ -341,7 +339,7 @@ final class ImmutableTarget implements Target {
 
         @Override
         public TargetBuilder headerMapping(@Nullable final HeaderMapping headerMapping) {
-            this.headerMapping = headerMapping;
+            this.headerMapping = headerMapping == null ? ConnectivityModelFactory.emptyHeaderMapping() : headerMapping;
             return this;
         }
 

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Source.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Source.java
@@ -81,7 +81,7 @@ public interface Source extends Jsonifiable.WithFieldSelectorAndPredicate<JsonFi
      * Defines an optional header mapping e.g. rename, combine etc. headers for inbound message. Mapping is
      * applied after payload mapping is applied. The mapping may contain {@code thing:*} and {@code header:*}
      * placeholders.
-     *
+     * TODO: make this non-optional.
      * @return the optional header mappings
      */
     Optional<HeaderMapping> getHeaderMapping();

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Target.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/Target.java
@@ -86,6 +86,7 @@ public interface Target extends Jsonifiable.WithFieldSelectorAndPredicate<JsonFi
      * Defines an optional header mapping e.g. to rename, combine etc. headers for outbound message. Mapping is
      * applied after payload mapping is applied. The mapping may contain {@code thing:*} and {@code header:*}
      * placeholders.
+     * TODO: make this non-optional.
      *
      * @return the optional header mapping
      */

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
@@ -124,7 +124,7 @@ public final class ImmutableConnectionTest {
                     .map(o -> o.asObject().toBuilder()
                             .set(Target.JsonFields.HEADER_MAPPING, o.asObject()
                                     .getValue(Target.JsonFields.HEADER_MAPPING)
-                                    .orElseGet(ImmutableTarget.DEFAULT_HEADER_MAPPING::toJson))
+                                    .orElseGet(ConnectivityModelFactory.emptyHeaderMapping()::toJson))
                             .build())
                     .collect(JsonCollectors.valuesToArray());
 
@@ -207,12 +207,6 @@ public final class ImmutableConnectionTest {
 
     private static final JsonObject KNOWN_LEGACY_JSON = KNOWN_JSON
             .set(Connection.JsonFields.MAPPING_CONTEXT, KNOWN_MAPPING_CONTEXT.toJson());
-
-    private static final HeaderMapping DEFAULT_TARGET_HEADER_MAPPING =
-            ConnectivityModelFactory.newHeaderMapping(JsonObject.newBuilder()
-                    .set("correlation-id", "{{header:correlation-id}}")
-                    .set("reply-to", "{{header:reply-to}}")
-                    .build());
 
     @Test
     public void testHashCodeAndEquals() {
@@ -492,7 +486,8 @@ public final class ImmutableConnectionTest {
                         .build();
 
         connectionWithoutHeaderMappingForTarget.getTargets()
-                .forEach(target -> assertThat(target.getHeaderMapping()).contains(DEFAULT_TARGET_HEADER_MAPPING));
+                .forEach(target -> assertThat(target.getHeaderMapping())
+                        .contains(ConnectivityModelFactory.emptyHeaderMapping()));
     }
 
     @Test
@@ -505,7 +500,8 @@ public final class ImmutableConnectionTest {
                 ImmutableConnection.fromJson(connectionJsonWithoutHeaderMappingForTarget);
 
         connectionWithoutHeaderMappingForTarget.getTargets()
-                .forEach(target -> assertThat(target.getHeaderMapping()).contains(DEFAULT_TARGET_HEADER_MAPPING));
+                .forEach(target -> assertThat(target.getHeaderMapping())
+                        .contains(ConnectivityModelFactory.emptyHeaderMapping()));
     }
 
     private List<Source> addSourceMapping(final List<Source> sources, final String... mapping) {

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableSourceTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableSourceTest.java
@@ -153,6 +153,7 @@ public final class ImmutableSourceTest {
                             .set(FilteredAcknowledgementRequest.JsonFields.FILTER,
                                     FILTERED_ACKNOWLEDGEMENT_REQUEST.getFilter().orElse(null))
                             .build())
+            .set(Source.JsonFields.HEADER_MAPPING, JsonObject.empty())
             .build();
 
 

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableTargetTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableTargetTest.java
@@ -57,6 +57,7 @@ public final class ImmutableTargetTest {
             .set(Target.JsonFields.ADDRESS, ADDRESS)
             .set(Target.JsonFields.AUTHORIZATION_CONTEXT, JsonFactory.newArrayBuilder().add("eclipse", "ditto").build())
             .set(Target.JsonFields.ISSUED_ACKNOWLEDGEMENT_LABEL, "custom-ack")
+            .set(Target.JsonFields.HEADER_MAPPING, JsonObject.empty())
             .set(Target.JsonFields.PAYLOAD_MAPPING, JsonArray.of(DITTO_MAPPING, CUSTOM_MAPPING))
             .build();
 
@@ -74,6 +75,7 @@ public final class ImmutableTargetTest {
             .set(Target.JsonFields.ADDRESS, MQTT_ADDRESS)
             .set(Target.JsonFields.QOS, 1)
             .set(Target.JsonFields.AUTHORIZATION_CONTEXT, JsonFactory.newArrayBuilder().add("eclipse", "ditto").build())
+            .set(Target.JsonFields.HEADER_MAPPING, JsonObject.empty())
             .build();
 
     @Test

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
@@ -185,17 +185,15 @@ abstract class AbstractMqttConsumerActor<P> extends BaseConsumerActor {
             headers = extractHeadersMapFromMqttMessage(message);
 
             final Map<String, String> headerMappingMap = new HashMap<>();
+            final Map<String, String> mqttMappings = Map.of(
+                    MQTT_TOPIC_HEADER, getHeaderPlaceholder(MQTT_TOPIC_HEADER),
+                    MQTT_QOS_HEADER, getHeaderPlaceholder(MQTT_QOS_HEADER),
+                    MQTT_RETAIN_HEADER, getHeaderPlaceholder(MQTT_RETAIN_HEADER)
+            );
 
             final Optional<HeaderMapping> sourceHeaderMapping = source.getHeaderMapping();
-            if (sourceHeaderMapping.isPresent()) {
-                headerMappingMap.putAll(sourceHeaderMapping.get().getMapping());
-            } else {
-                // apply fallback header mapping when headerMapping was "null"/not present in order to stay backwards
-                //  compatible:
-                headerMappingMap.put(MQTT_TOPIC_HEADER, getHeaderPlaceholder(MQTT_TOPIC_HEADER));
-                headerMappingMap.put(MQTT_QOS_HEADER, getHeaderPlaceholder(MQTT_QOS_HEADER));
-                headerMappingMap.put(MQTT_RETAIN_HEADER, getHeaderPlaceholder(MQTT_RETAIN_HEADER));
-            }
+            sourceHeaderMapping.ifPresent(headerMapping -> headerMappingMap.putAll(headerMapping.getMapping()));
+            headerMappingMap.putAll(mqttMappings);
 
             final HeaderMapping mqttTopicHeaderMapping = ConnectivityModelFactory.newHeaderMapping(headerMappingMap);
             final ExternalMessage externalMessage = ExternalMessageFactory

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtil.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionMigrationUtil.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.connectivity.Connection;
+import org.eclipse.ditto.model.connectivity.ConnectionType;
 import org.eclipse.ditto.model.connectivity.ConnectivityModelFactory;
 import org.eclipse.ditto.model.connectivity.Enforcement;
 import org.eclipse.ditto.model.connectivity.Source;
@@ -306,7 +307,11 @@ final class ConnectionMigrationUtil {
 
         @Override
         public JsonObject apply(final JsonObject connectionJsonObject) {
-            if (containsTargets(connectionJsonObject)) {
+            final boolean shouldSkipMigration = connectionJsonObject.getValue(Connection.JsonFields.CONNECTION_TYPE)
+                    .flatMap(ConnectionType::forName)
+                    .filter(ConnectionType.MQTT::equals)
+                    .isPresent();
+            if (!shouldSkipMigration && containsTargets(connectionJsonObject)) {
                 final JsonArray migratedTargets = connectionJsonObject.getValue(Connection.JsonFields.TARGETS)
                         .map(MigrateTargetHeaderMappings::migrateTargets)
                         .orElse(null);


### PR DESCRIPTION
We applied a default target header mapping for all types of connections (including mqtt, which should not support them at all).
This PR does check for the connection type before migrating a target.
Additionally this PR makes headerMapping of sources and targets non-nullable so new connections are not affected from this live migration.