### PR TITLE
Bugfix/password decoding

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableConnection.java
@@ -15,8 +15,10 @@ package org.eclipse.ditto.model.connectivity;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkArgument;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -786,8 +788,8 @@ final class ImmutableConnection implements Connection {
             final String userInfo = uri.getUserInfo();
             if (userInfo != null && userInfo.contains(USERNAME_PASSWORD_SEPARATOR)) {
                 final int separatorIndex = userInfo.indexOf(USERNAME_PASSWORD_SEPARATOR);
-                userName = userInfo.substring(0, separatorIndex);
-                password = userInfo.substring(separatorIndex + 1);
+                userName = tryDecodeUriComponent(userInfo.substring(0, separatorIndex));
+                password = tryDecodeUriComponent(userInfo.substring(separatorIndex + 1));
             } else {
                 userName = null;
                 password = null;
@@ -795,6 +797,15 @@ final class ImmutableConnection implements Connection {
 
             // must be initialized after all else
             uriStringWithMaskedPassword = createUriStringWithMaskedPassword();
+        }
+
+        private static String tryDecodeUriComponent(final String string) {
+            try {
+                final String withoutPlus = string.replace("+", "%2B");
+                return URLDecoder.decode(withoutPlus, "UTF-8");
+            } catch (final IllegalArgumentException|UnsupportedEncodingException e) {
+                return string;
+            }
         }
 
         private String createUriStringWithMaskedPassword() {

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableConnectionTest.java
@@ -416,6 +416,24 @@ public final class ImmutableConnectionTest {
     }
 
     @Test
+    public void parsePasswordWithPlusSign() {
+        final ConnectionUri underTest = ConnectionUri.of("amqps://foo:bar+baz@hono.eclipse.org:5671/vhost");
+        assertThat(underTest.getPassword()).contains("bar+baz");
+    }
+
+    @Test
+    public void parsePasswordWithPlusSignEncoded() {
+        final ConnectionUri underTest = ConnectionUri.of("amqps://foo:bar%2Bbaz@hono.eclipse.org:5671/vhost");
+        assertThat(underTest.getPassword()).contains("bar+baz");
+    }
+
+    @Test
+    public void parsePasswordWithPlusSignDoubleEncoded() {
+        final ConnectionUri underTest = ConnectionUri.of("amqps://foo:bar%252Bbaz@hono.eclipse.org:5671/vhost");
+        assertThat(underTest.getPassword()).contains("bar+baz");
+    }
+
+    @Test
     public void parseUriWithoutCredentials() {
         final ConnectionUri underTest = ConnectionUri.of("amqps://hono.eclipse.org:5671");
 

--- a/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
+++ b/model/messages/src/main/java/org/eclipse/ditto/model/messages/MessageSendNotAllowedException.java
@@ -43,7 +43,8 @@ public final class MessageSendNotAllowedException extends DittoRuntimeException 
             "You are not allowed to send messages for the Thing with id ''{0}''!";
 
     private static final String DEFAULT_DESCRIPTION =
-            "Please make sure that the Thing exists and that you have a WRITE permission on the Thing.";
+            "Please make sure that the Thing exists and that you have WRITE permissions on the message resource in " +
+                    "the policy of the Thing.";
 
     private static final long serialVersionUID = -7767643705375184154L;
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
@@ -147,7 +147,6 @@ public final class AmqpSpecificConfig {
         final var username = connection.getUsername();
         final var password = connection.getPassword();
         if (username.isPresent() && password.isPresent()) {
-            // URL-decode the username and password to preserve previous behavior (no apparent encoding of parameters)
             addParameter(parameters, USERNAME, username.get());
             addParameter(parameters, PASSWORD, password.get());
         }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/amqp/AmqpSpecificConfig.java
@@ -148,8 +148,8 @@ public final class AmqpSpecificConfig {
         final var password = connection.getPassword();
         if (username.isPresent() && password.isPresent()) {
             // URL-decode the username and password to preserve previous behavior (no apparent encoding of parameters)
-            addParameter(parameters, USERNAME, tryDecode(username.get()));
-            addParameter(parameters, PASSWORD, tryDecode(password.get()));
+            addParameter(parameters, USERNAME, username.get());
+            addParameter(parameters, PASSWORD, password.get());
         }
     }
 
@@ -169,14 +169,6 @@ public final class AmqpSpecificConfig {
 
     private static String encode(final String string) {
         return URLEncoder.encode(string, StandardCharsets.UTF_8);
-    }
-
-    private static String tryDecode(final String string) {
-        try {
-            return URLDecoder.decode(string, StandardCharsets.UTF_8);
-        } catch (final IllegalArgumentException e) {
-            return string;
-        }
     }
 
     private static boolean isSecuredConnection(final Connection connection) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/exceptions/EventSendNotAllowedException.java
@@ -44,7 +44,8 @@ public final class EventSendNotAllowedException extends DittoRuntimeException im
             "You are not allowed to send events for the Thing with id ''{0}''!";
 
     private static final String DEFAULT_DESCRIPTION =
-            "Please make sure that the Thing exists and that you have a WRITE permission on the Thing.";
+            "Please make sure that the Thing exists and that you have WRITE permissions on the message resource in " +
+                    "the policy of the Thing.";
 
     private static final long serialVersionUID = 9055307625270596757L;
 


### PR DESCRIPTION
This PR fixes an issue in AMQP password decoding.
Previously the decoding was made by using `java.net.URLDecoder` which is meant to be used on `x-www-form-urlencoded` payload.
This decodes the `+` character to a space.

In this PR all `+` characters are replaced by their encoded representation `%2B` before calling the `java.net.URLDecoder`

Additionally I've made an improvement of the error description for failure when sending messages to or from a thing.