### PR TITLE
Add test for policy revision update in search index; fix timer duplication.

### DIFF
--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/mapping/EnforcedThingMapper.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/mapping/EnforcedThingMapper.java
@@ -126,8 +126,7 @@ public final class EnforcedThingMapper {
                         .append(FIELD_SORTING, thingCopyForSorting)
                         .append(FIELD_INTERNAL, flattenedValues);
 
-        final Metadata metadataToRetain = oldMetadata == null ? metadata : oldMetadata.prependTimersAndSenders(metadata);
-        return ThingWriteModel.of(metadataToRetain, thingDocument);
+        return ThingWriteModel.of(metadata, thingDocument);
     }
 
     private static BsonArray getGlobalRead(final Enforcer enforcer) {

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/model/Metadata.java
@@ -53,7 +53,8 @@ public final class Metadata {
             @Nullable final Long policyRevision,
             @Nullable final Instant modified,
             final Collection<StartedTimer> timers,
-            final Collection<ActorRef> senders, final boolean invalidateCache) {
+            final Collection<ActorRef> senders,
+            final boolean invalidateCache) {
 
         this.thingId = thingId;
         this.thingRevision = thingRevision;
@@ -279,7 +280,7 @@ public final class Metadata {
                 Stream.concat(newMetadata.senders.stream(), senders.stream()).collect(Collectors.toList());
         return new Metadata(newMetadata.thingId, newMetadata.thingRevision, newMetadata.policyId,
                 newMetadata.policyRevision, newMetadata.modified, newTimers, newSenders,
-                invalidateCache | newMetadata.invalidateCache);
+                invalidateCache || newMetadata.invalidateCache);
     }
 
     /**

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlow.java
@@ -144,7 +144,7 @@ final class EnforcementFlow {
             final int iteration) {
 
         if (iteration <= 0) {
-            return entry == null || !entry.exists() ||
+            return metadata.shouldInvalidateCache() || entry == null || !entry.exists() ||
                     entry.getRevision() < metadata.getPolicyRevision().orElse(Long.MAX_VALUE);
         } else {
             // never attempt to reload cache more than once

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
@@ -73,6 +73,7 @@ public final class EnforcementFlowTest {
     @Test
     public void updateThingAndPolicyRevisions() {
         new TestKit(system) {{
+            // GIVEN: enqueued metadata is out of date
             final long thingRev1 = 1L;
             final long thingRev2 = 99L;
             final long policyRev1 = 2L;
@@ -99,6 +100,7 @@ public final class EnforcementFlowTest {
             sourceProbe.sendNext(inputMap);
             sourceProbe.sendComplete();
 
+            // WHEN: thing and policy are retrieved with up-to-date revisions
             thingsProbe.expectMsgClass(SudoRetrieveThing.class);
             final var thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).setRevision(thingRev2).build();
             final var thingJson = thing.toJson(FieldType.regularOrSpecial());
@@ -109,6 +111,7 @@ public final class EnforcementFlowTest {
             final var policy = Policy.newBuilder(policyId).setRevision(policyRev2).build();
             policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy, DittoHeaders.empty()));
 
+            // THEN: the write model contains up-to-date revisions
             final AbstractWriteModel writeModel = sinkProbe.expectNext();
             sinkProbe.expectComplete();
             assertThat(writeModel).isInstanceOf(ThingWriteModel.class);
@@ -118,6 +121,69 @@ public final class EnforcementFlowTest {
             assertThat(document.getValue("_revision")).contains(JsonValue.of(thingRev2));
             assertThat(document.getValue("__policyRev")).contains(JsonValue.of(policyRev2));
         }};
+    }
+
+    @Test
+    public void ignoreCacheWhenRequestedToUpdate() {
+        // GIVEN: the enqueued metadata is out-of-date
+        final long thingRev1 = 1L;
+        final long thingRev2 = 99L;
+        final long policyRev1 = 2L;
+        final long policyRev2 = 98L;
+        final ThingId thingId = ThingId.of("thing:id");
+        final PolicyId policyId = PolicyId.of("policy:id");
+        final Metadata metadata1 = Metadata.of(thingId, thingRev1, policyId, policyRev1, null);
+
+        final TestProbe thingsProbe = TestProbe.apply(system);
+        final TestProbe policiesProbe = TestProbe.apply(system);
+
+        final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+        final EnforcementFlow underTest =
+                EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                        system.dispatchers().defaultGlobalDispatcher());
+
+        materializeTestProbes(underTest.create(false, 1));
+
+        sinkProbe.ensureSubscription();
+        sourceProbe.ensureSubscription();
+        sinkProbe.request(2);
+        sourceProbe.sendNext(Map.of(thingId, metadata1));
+
+        thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+        final var thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).setRevision(thingRev2).build();
+        final var thingJson = thing.toJson(FieldType.regularOrSpecial());
+        thingsProbe.reply(SudoRetrieveThingResponse.of(thingJson, DittoHeaders.empty()));
+
+        // GIVEN: enforcer cache is loaded with out-of-date policy
+        policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+        final var policy1 = Policy.newBuilder(policyId).setRevision(policyRev1).build();
+        policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy1, DittoHeaders.empty()));
+
+        final AbstractWriteModel writeModel1 = sinkProbe.expectNext();
+        assertThat(writeModel1).isInstanceOf(ThingWriteModel.class);
+        final var document1 = JsonObject.of(((ThingWriteModel) writeModel1).getThingDocument().toJson());
+        assertThat(document1.getValue("_revision")).contains(JsonValue.of(thingRev2));
+        assertThat(document1.getValue("__policyRev")).contains(JsonValue.of(policyRev1));
+
+        // WHEN: a metadata with 'invalidateCache' flag is enqueued
+        final Metadata metadata2 = metadata1.invalidateCache();
+        sourceProbe.sendNext(Map.of(thingId, metadata2));
+        sourceProbe.sendComplete();
+        thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+        thingsProbe.reply(SudoRetrieveThingResponse.of(thingJson, DittoHeaders.empty()));
+
+        // THEN: policy cache is reloaded
+        policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+        final var policy2 = Policy.newBuilder(policyId).setRevision(policyRev2).build();
+        policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy2, DittoHeaders.empty()));
+
+        // THEN: write model contains up-to-date policy revisions.
+        final AbstractWriteModel writeModel2 = sinkProbe.expectNext();
+        sinkProbe.expectComplete();
+        assertThat(writeModel2).isInstanceOf(ThingWriteModel.class);
+        final var document2 = JsonObject.of(((ThingWriteModel) writeModel2).getThingDocument().toJson());
+        assertThat(document2.getValue("_revision")).contains(JsonValue.of(thingRev2));
+        assertThat(document2.getValue("__policyRev")).contains(JsonValue.of(policyRev2));
     }
 
     private void materializeTestProbes(

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.thingsearch.persistence.write.streaming;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.util.Map;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.FieldType;
+import org.eclipse.ditto.model.policies.Policy;
+import org.eclipse.ditto.model.policies.PolicyId;
+import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingId;
+import org.eclipse.ditto.services.models.policies.commands.sudo.SudoRetrievePolicy;
+import org.eclipse.ditto.services.models.policies.commands.sudo.SudoRetrievePolicyResponse;
+import org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThing;
+import org.eclipse.ditto.services.models.things.commands.sudo.SudoRetrieveThingResponse;
+import org.eclipse.ditto.services.thingsearch.common.config.DefaultStreamConfig;
+import org.eclipse.ditto.services.thingsearch.common.config.StreamConfig;
+import org.eclipse.ditto.services.thingsearch.persistence.write.model.AbstractWriteModel;
+import org.eclipse.ditto.services.thingsearch.persistence.write.model.Metadata;
+import org.eclipse.ditto.services.thingsearch.persistence.write.model.ThingWriteModel;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
+import akka.stream.javadsl.Flow;
+import akka.stream.javadsl.Keep;
+import akka.stream.javadsl.Source;
+import akka.stream.testkit.TestPublisher;
+import akka.stream.testkit.TestSubscriber;
+import akka.stream.testkit.javadsl.TestSink;
+import akka.stream.testkit.javadsl.TestSource;
+import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
+
+public final class EnforcementFlowTest {
+
+    private static ActorSystem system;
+
+    private TestPublisher.Probe<Map<ThingId, Metadata>> sourceProbe;
+    private TestSubscriber.Probe<AbstractWriteModel> sinkProbe;
+
+    @BeforeClass
+    public static void init() {
+        system = ActorSystem.create();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        if (system != null) {
+            TestKit.shutdownActorSystem(system);
+        }
+    }
+
+    @Test
+    public void updateThingAndPolicyRevisions() {
+        new TestKit(system) {{
+            final long thingRev1 = 1L;
+            final long thingRev2 = 99L;
+            final long policyRev1 = 2L;
+            final long policyRev2 = 98L;
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Metadata metadata = Metadata.of(thingId, thingRev1, policyId, policyRev1, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+            final var thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).setRevision(thingRev2).build();
+            final var thingJson = thing.toJson(FieldType.regularOrSpecial());
+            assertThat(thingJson.getValue(Thing.JsonFields.REVISION)).contains(thingRev2);
+            thingsProbe.reply(SudoRetrieveThingResponse.of(thingJson, DittoHeaders.empty()));
+
+            policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+            final var policy = Policy.newBuilder(policyId).setRevision(policyRev2).build();
+            policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy, DittoHeaders.empty()));
+
+            final AbstractWriteModel writeModel = sinkProbe.expectNext();
+            sinkProbe.expectComplete();
+            assertThat(writeModel).isInstanceOf(ThingWriteModel.class);
+            final var document = JsonObject.of(((ThingWriteModel) writeModel).getThingDocument().toJson());
+            assertThat(document.getValue("_id")).contains(JsonValue.of(thingId));
+            assertThat(document.getValue("policyId")).contains(JsonValue.of(policyId));
+            assertThat(document.getValue("_revision")).contains(JsonValue.of(thingRev2));
+            assertThat(document.getValue("__policyRev")).contains(JsonValue.of(policyRev2));
+        }};
+    }
+
+    private void materializeTestProbes(
+            final Flow<Map<ThingId, Metadata>, Source<AbstractWriteModel, NotUsed>, NotUsed> enforcementFlow) {
+        final var source = TestSource.<Map<ThingId, Metadata>>probe(system);
+        final var sink = TestSink.<AbstractWriteModel>probe(system);
+        final var runnableGraph =
+                source.viaMat(enforcementFlow, Keep.left()).flatMapConcat(x -> x).toMat(sink, Keep.both());
+        final var materializedValue = runnableGraph.run(() -> system);
+        sourceProbe = materializedValue.first();
+        sinkProbe = materializedValue.second();
+    }
+
+}

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/write/streaming/EnforcementFlowTest.java
@@ -51,6 +51,9 @@ import akka.stream.testkit.javadsl.TestSource;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
+/**
+ * Unit tests for {@link EnforcementFlow}.
+ */
 public final class EnforcementFlowTest {
 
     private static ActorSystem system;

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/ThingUpdater.java
@@ -161,7 +161,7 @@ final class ThingUpdater extends AbstractActor {
     private void updateThing(final UpdateThing updateThing) {
         log.withCorrelationId(updateThing)
                 .info("Requested to update search index <{}> by <{}>", updateThing, getSender());
-        enqueueMetadata();
+        enqueueMetadata(exportMetadata(null).invalidateCache());
     }
 
     private void processUpdateThingResponse(final UpdateThingResponse response) {
@@ -211,8 +211,7 @@ final class ThingUpdater extends AbstractActor {
             final StartedTimer timer = DittoMetrics.timer(ConsistencyLag.TIMER_NAME)
                     .tag(ConsistencyLag.TAG_SHOULD_ACK, Boolean.toString(shouldAcknowledge))
                     .onExpiration(startedTimer ->
-                            l.warning("Timer measuring consistency lag timed out for event <{}>",
-                            thingEvent))
+                            l.warning("Timer measuring consistency lag timed out for event <{}>", thingEvent))
                     .start();
             ConsistencyLag.startS0InUpdater(timer);
             enqueueMetadata(exportMetadataWithSender(shouldAcknowledge, getSender(), timer));


### PR DESCRIPTION
- Add `EnforcementFlowTest` to test that thing and policy revisions are updated correctly in the search index.
- Remove duplicate timers in  `EnforcedThingMapper`.
- Force cache reload when requested for search index update.