### PR TITLE
Parse the search criteria before validating it.

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonPointer.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonPointer.java
@@ -67,6 +67,7 @@ final class ImmutableJsonPointer implements JsonPointer {
      * @return a new JSON pointer consisting of the JSON keys which were extracted from {@code
      * slashDelimitedCharSequence}.
      * @throws NullPointerException if {@code slashDelimitedCharSequence} is {@code null}.
+     * @throws JsonPointerInvalidException if the passed {@code slashDelimitedCharSequence} contained double slashes.
      */
     public static JsonPointer ofParsed(final CharSequence slashDelimitedCharSequence) {
         requireNonNull(slashDelimitedCharSequence, "The JSON pointer character sequence must not be null!");

--- a/json/src/main/java/org/eclipse/ditto/json/JsonFactory.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonFactory.java
@@ -548,6 +548,7 @@ public final class JsonFactory {
      * @return a new JSON pointer consisting of the JSON keys which were extracted from {@code
      * slashDelimitedCharSequence}.
      * @throws NullPointerException if {@code slashDelimitedCharSequence} is {@code null}.
+     * @throws JsonPointerInvalidException if the passed {@code slashDelimitedCharSequence} contained double slashes.
      */
     public static JsonPointer newPointer(final CharSequence slashDelimitedCharSequence) {
         return ImmutableJsonPointer.ofParsed(slashDelimitedCharSequence);
@@ -656,6 +657,7 @@ public final class JsonFactory {
      * @param furtherPointerStrings additional JSON pointers to form the field selector to be created by this method.
      * @return a new JSON field selector.
      * @throws NullPointerException if any argument is {@code null}.
+     * @throws JsonPointerInvalidException if any passed {@code pointerString} contained double slashes.
      */
     public static JsonFieldSelector newFieldSelector(final CharSequence pointerString,
             final CharSequence... furtherPointerStrings) {
@@ -907,6 +909,7 @@ public final class JsonFactory {
      * @return the pointer.
      * @throws NullPointerException if {@code keyOrPointer} is {@code null}.
      * @throws IllegalArgumentException if {@code keyOrPointer} would lead to an empty JsonPointer.
+     * @throws JsonPointerInvalidException if the passed {@code keyOrPointer} contained double slashes.
      */
     static JsonPointer getNonEmptyPointer(final CharSequence keyOrPointer) {
         requireNonNull(keyOrPointer, "The key or pointer char sequence must not be null!");

--- a/json/src/main/java/org/eclipse/ditto/json/JsonPointer.java
+++ b/json/src/main/java/org/eclipse/ditto/json/JsonPointer.java
@@ -69,6 +69,7 @@ public interface JsonPointer extends CharSequence, Iterable<JsonKey> {
      * @return a new JSON pointer consisting of the JSON keys which were extracted from
      * {@code slashDelimitedCharSequence}.
      * @throws NullPointerException if {@code slashDelimitedCharSequence} is {@code null}.
+     * @throws JsonPointerInvalidException if the passed {@code slashDelimitedCharSequence} contained double slashes.
      */
     static JsonPointer of(final CharSequence slashDelimitedCharSequence) {
         return JsonFactory.newPointer(slashDelimitedCharSequence);

--- a/services/base/src/main/java/org/eclipse/ditto/services/base/DittoService.java
+++ b/services/base/src/main/java/org/eclipse/ditto/services/base/DittoService.java
@@ -42,7 +42,7 @@ import org.eclipse.ditto.services.utils.metrics.config.MetricsConfig;
 import org.eclipse.ditto.services.utils.metrics.prometheus.PrometheusReporterRoute;
 import org.eclipse.ditto.services.utils.persistence.mongo.config.MongoDbConfig;
 import org.eclipse.ditto.services.utils.persistence.mongo.config.WithMongoDbConfig;
-import org.eclipse.ditto.signals.base.MergeToggle;
+import org.eclipse.ditto.signals.base.FeatureToggle;
 import org.eclipse.ditto.signals.commands.messages.MessageCommandSizeValidator;
 import org.eclipse.ditto.signals.commands.policies.PolicyCommandSizeValidator;
 import org.eclipse.ditto.signals.commands.things.ThingCommandSizeValidator;
@@ -431,8 +431,8 @@ public abstract class DittoService<C extends ServiceSpecificConfig> {
                 Long.toString(limitsConfig.getPoliciesMaxSize()));
         System.setProperty(MessageCommandSizeValidator.DITTO_LIMITS_MESSAGES_MAX_SIZE_BYTES,
                 Long.toString(limitsConfig.getMessagesMaxSize()));
-        System.setProperty(MergeToggle.MERGE_THINGS_ENABLED,
-                Boolean.toString(rawConfig.getBoolean(MergeToggle.MERGE_THINGS_ENABLED)));
+        System.setProperty(FeatureToggle.MERGE_THINGS_ENABLED,
+                Boolean.toString(rawConfig.getBoolean(FeatureToggle.MERGE_THINGS_ENABLED)));
     }
 
     private static ActorRef getDistributedPubSubMediatorActor(final ActorSystem actorSystem) {

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryParser.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryParser.java
@@ -79,8 +79,8 @@ public final class QueryParser {
      * @return the query.
      */
     public Query parse(final ThingSearchQueryCommand<?> command) {
-        queryCriteriaValidator.validateCommand(command);
         final Criteria criteria = parseCriteria(command);
+        queryCriteriaValidator.validateCommand(command);
         if (command instanceof QueryThings) {
             final QueryThings queryThings = (QueryThings) command;
             final QueryBuilder queryBuilder = queryBuilderFactory.newBuilder(criteria);

--- a/signals/base/src/main/java/org/eclipse/ditto/signals/base/FeatureToggle.java
+++ b/signals/base/src/main/java/org/eclipse/ditto/signals/base/FeatureToggle.java
@@ -15,11 +15,12 @@ package org.eclipse.ditto.signals.base;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 
 /**
- * Decides based on the system property {@value MERGE_THINGS_ENABLED} whether the merge thing feature
- * is enabled and throws an {@link org.eclipse.ditto.signals.base.UnsupportedSignalException} if the property is set
- * to {@code false}.
+ * Decides based on system properties whether certain features of Ditto are enabled or throws an
+ * {@link UnsupportedSignalException} if a feature is disabled.
+ *
+ * @since 2.0.0
  */
-public final class MergeToggle {
+public final class FeatureToggle {
 
     /**
      * System property name of the property defining whether the merge feature is enabled.
@@ -29,14 +30,16 @@ public final class MergeToggle {
     /**
      * Resolves the system property {@value MERGE_THINGS_ENABLED}.
      */
-    private static final boolean IS_MERGE_THINGS_ENABLED = resolveProperty();
+    private static final boolean IS_MERGE_THINGS_ENABLED = resolveProperty(MERGE_THINGS_ENABLED);
 
-    private static boolean resolveProperty() {
-        final String propertyValue = System.getProperty(MERGE_THINGS_ENABLED, Boolean.TRUE.toString());
+    private static boolean resolveProperty(final String propertyName) {
+        final String propertyValue = System.getProperty(propertyName, Boolean.TRUE.toString());
         return !Boolean.FALSE.toString().equalsIgnoreCase(propertyValue);
     }
 
-    private MergeToggle() {}
+    private FeatureToggle() {
+        throw new AssertionError();
+    }
 
     /**
      * Checks if the merge feature is enabled based on the system property {@value MERGE_THINGS_ENABLED}.
@@ -44,7 +47,7 @@ public final class MergeToggle {
      * @param signal the name of the signal that was supposed to be processed
      * @param dittoHeaders headers used to build exception
      * @return the unmodified headers parameters
-     * @throws org.eclipse.ditto.signals.base.UnsupportedSignalException if the system property
+     * @throws UnsupportedSignalException if the system property
      * {@value MERGE_THINGS_ENABLED} resolves to {@code false}
      */
     public static DittoHeaders checkMergeFeatureEnabled(final String signal, final DittoHeaders dittoHeaders) {

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/MergeThing.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/MergeThing.java
@@ -44,7 +44,7 @@ import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingDefinition;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.model.things.ThingsModelFactory;
-import org.eclipse.ditto.signals.base.MergeToggle;
+import org.eclipse.ditto.signals.base.FeatureToggle;
 import org.eclipse.ditto.signals.base.UnsupportedSchemaVersionException;
 import org.eclipse.ditto.signals.commands.base.AbstractCommand;
 import org.eclipse.ditto.signals.commands.base.CommandJsonDeserializer;
@@ -82,7 +82,7 @@ public final class MergeThing extends AbstractCommand<MergeThing> implements Thi
 
     private MergeThing(final ThingId thingId, final JsonPointer path, final JsonValue value,
             final DittoHeaders dittoHeaders) {
-        super(TYPE, MergeToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders));
+        super(TYPE, FeatureToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders));
         this.thingId = checkNotNull(thingId, "thingId");
         this.path = checkNotNull(path, "path");
         this.value = checkJsonSize(checkNotNull(value, "value"), dittoHeaders);

--- a/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/MergeThingResponse.java
+++ b/signals/commands/things/src/main/java/org/eclipse/ditto/signals/commands/things/modify/MergeThingResponse.java
@@ -31,7 +31,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
-import org.eclipse.ditto.signals.base.MergeToggle;
+import org.eclipse.ditto.signals.base.FeatureToggle;
 import org.eclipse.ditto.signals.base.UnsupportedSchemaVersionException;
 import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
 import org.eclipse.ditto.signals.commands.base.CommandResponseJsonDeserializer;
@@ -56,7 +56,7 @@ public final class MergeThingResponse extends AbstractCommandResponse<MergeThing
     private final JsonPointer path;
 
     private MergeThingResponse(final ThingId thingId, final JsonPointer path, final DittoHeaders dittoHeaders) {
-        super(TYPE, HttpStatus.NO_CONTENT, MergeToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders));
+        super(TYPE, HttpStatus.NO_CONTENT, FeatureToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders));
         this.thingId = checkNotNull(thingId, "thingId");
         this.path = checkNotNull(path, "path");
         checkSchemaVersion();

--- a/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingMerged.java
+++ b/signals/events/things/src/main/java/org/eclipse/ditto/signals/events/things/ThingMerged.java
@@ -34,7 +34,7 @@ import org.eclipse.ditto.model.base.json.FieldType;
 import org.eclipse.ditto.model.base.json.JsonParsableEvent;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 import org.eclipse.ditto.model.things.ThingId;
-import org.eclipse.ditto.signals.base.MergeToggle;
+import org.eclipse.ditto.signals.base.FeatureToggle;
 import org.eclipse.ditto.signals.base.UnsupportedSchemaVersionException;
 import org.eclipse.ditto.signals.events.base.EventJsonDeserializer;
 
@@ -68,7 +68,7 @@ public final class ThingMerged extends AbstractThingEvent<ThingMerged> implement
             @Nullable final Instant timestamp,
             final DittoHeaders dittoHeaders,
             @Nullable final Metadata metadata) {
-        super(TYPE, thingId, revision, timestamp, MergeToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders), metadata);
+        super(TYPE, thingId, revision, timestamp, FeatureToggle.checkMergeFeatureEnabled(TYPE, dittoHeaders), metadata);
         this.thingId = checkNotNull(thingId, "thingId");
         this.path = checkNotNull(path, "path");
         this.value = checkNotNull(value, "value");


### PR DESCRIPTION
This will ensure that a rql.expression.invalid exception is thrown if e.g. a field named 'a' is
used in the filter