### PR TITLE
Fix search inconsistency health warning not clearing after healthy again

### DIFF
--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActor.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActor.java
@@ -159,13 +159,10 @@ public final class BackgroundSyncActor
         int terminationCount = 0;
         for (final var pair : events) {
             final var event = pair.second();
-            if (event instanceof StreamTerminated) {
-                if (++terminationCount > 1) {
-                    break;
-                }
-            } else {
-                final var eventLevel = event.level();
-                level = level.compareTo(eventLevel) >= 0 ? level : eventLevel;
+            final var eventLevel = event.level();
+            level = level.compareTo(eventLevel) >= 0 ? level : eventLevel;
+            if (event instanceof StreamTerminated && ++terminationCount > 1) {
+                break;
             }
         }
         return level;
@@ -283,10 +280,6 @@ public final class BackgroundSyncActor
             this.thingId = thingId;
             this.thingRevision = thingRevision;
             this.level = level;
-        }
-
-        private Event setLevelInfo() {
-            return new SyncEvent(description, thingId, thingRevision, StatusDetailMessage.Level.INFO);
         }
 
         private static Event inconsistency(final Metadata metadata) {

--- a/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActor.java
+++ b/services/thingsearch/updater-actors/src/main/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActor.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.services.thingsearch.updater.actors;
 
 import java.time.Instant;
+import java.util.Deque;
 import java.util.List;
 import java.util.function.Function;
 
@@ -108,12 +109,12 @@ public final class BackgroundSyncActor
     protected void preEnhanceSleepingBehavior(final ReceiveBuilder sleepingReceiveBuilder) {
         sleepingReceiveBuilder.matchEquals(Control.BOOKMARK_THING_ID,
                 trigger ->
-                    // ignore scheduled bookmark messages when sleeping
-                    log.debug("Ignoring: <{}>", trigger)
-                )
+                        // ignore scheduled bookmark messages when sleeping
+                        log.debug("Ignoring: <{}>", trigger)
+        )
                 .match(ThingId.class, thingId ->
-                    // got outdated progress update message after actor resumes sleeping; ignore it.
-                    log.debug("Ignoring: <{}>", thingId)
+                        // got outdated progress update message after actor resumes sleeping; ignore it.
+                        log.debug("Ignoring: <{}>", thingId)
                 );
     }
 
@@ -150,6 +151,26 @@ public final class BackgroundSyncActor
                 .wireTap(this::handleInconsistency);
     }
 
+    @Override
+    protected StatusDetailMessage.Level getMostSevereLevelFromEvents(final Deque<Pair<Instant, Event>> events) {
+        // ignore status detail message after the second "StreamTerminated" so that only the ongoing sync and
+        // the last completed sync count
+        StatusDetailMessage.Level level = StatusDetailMessage.Level.DEFAULT;
+        int terminationCount = 0;
+        for (final var pair : events) {
+            final var event = pair.second();
+            if (event instanceof StreamTerminated) {
+                if (++terminationCount > 1) {
+                    break;
+                }
+            } else {
+                final var eventLevel = event.level();
+                level = level.compareTo(eventLevel) >= 0 ? level : eventLevel;
+            }
+        }
+        return level;
+    }
+
     private Source<Metadata, NotUsed> streamMetadataFromLowerBound(final ThingId lowerBound) {
         final Source<Metadata, NotUsed> persistedMetadata =
                 getPersistedMetadataSourceWithProgressReporting(lowerBound);
@@ -183,7 +204,7 @@ public final class BackgroundSyncActor
     private void handleInconsistency(final Metadata metadata) {
         final ThingId thingId = metadata.getThingId();
         thingsUpdater.tell(UpdateThing.of(thingId, DittoHeaders.empty()), ActorRef.noSender());
-        if(isInconsistentAgain(metadata)) {
+        if (isInconsistentAgain(metadata)) {
             getSelf().tell(SyncEvent.inconsistencyAgain(metadata), ActorRef.noSender());
         } else {
             getSelf().tell(SyncEvent.inconsistency(metadata), ActorRef.noSender());
@@ -192,10 +213,15 @@ public final class BackgroundSyncActor
 
     private boolean isInconsistentAgain(final Metadata metadata) {
         // check if the previous events already contain a SyncEvent for the same thing with the same revision
-        return this.getEventStream().map(Pair::second)
+        return this.getEventStream()
+                .map(Pair::second)
+                // only consider events in the previous run
+                .dropWhile(event -> !(event instanceof StreamTerminated))
+                .takeWhile(event -> !(event instanceof WokeUp))
                 .filter(event -> SyncEvent.class.isAssignableFrom(event.getClass()))
                 .map(event -> (SyncEvent) event)
-                .anyMatch(event -> metadata.getThingId().equals(event.thingId) && metadata.getThingRevision() == event.thingRevision);
+                .anyMatch(event -> metadata.getThingId().equals(event.thingId) &&
+                        metadata.getThingRevision() == event.thingRevision);
     }
 
     private Source<ThingId, NotUsed> getLowerBoundSource() {
@@ -251,19 +277,26 @@ public final class BackgroundSyncActor
         private final long thingRevision;
         private final StatusDetailMessage.Level level;
 
-        private SyncEvent(final String description, final ThingId thingId, final long thingRevision, final StatusDetailMessage.Level level) {
+        private SyncEvent(final String description, final ThingId thingId, final long thingRevision,
+                final StatusDetailMessage.Level level) {
             this.description = description;
             this.thingId = thingId;
             this.thingRevision = thingRevision;
             this.level = level;
         }
 
+        private Event setLevelInfo() {
+            return new SyncEvent(description, thingId, thingRevision, StatusDetailMessage.Level.INFO);
+        }
+
         private static Event inconsistency(final Metadata metadata) {
-            return new SyncEvent("Inconsistent: " + metadata, metadata.getThingId(), metadata.getThingRevision(), StatusDetailMessage.Level.DEFAULT);
+            return new SyncEvent("Inconsistent: " + metadata, metadata.getThingId(), metadata.getThingRevision(),
+                    StatusDetailMessage.Level.DEFAULT);
         }
 
         private static Event inconsistencyAgain(final Metadata metadata) {
-            return new SyncEvent("Inconsistent again: " + metadata, metadata.getThingId(), metadata.getThingRevision(), StatusDetailMessage.Level.WARN);
+            return new SyncEvent("Inconsistent again: " + metadata, metadata.getThingId(), metadata.getThingRevision(),
+                    StatusDetailMessage.Level.WARN);
         }
 
         @Override

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
@@ -144,9 +144,8 @@ public final class BackgroundSyncActorTest {
         }};
     }
 
-    // TODO: test failing
     @Test
-    public void providesHealthWarningWhenSyncStreamFails() throws Exception {
+    public void providesHealthWarningWhenSyncStreamFails() {
 
         new TestKit(actorSystem) {{
             whenSearchPersistenceHasIndexedThings();

--- a/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
+++ b/services/thingsearch/updater-actors/src/test/java/org/eclipse/ditto/services/thingsearch/updater/actors/BackgroundSyncActorTest.java
@@ -33,6 +33,7 @@ import javax.annotation.Nullable;
 
 import org.awaitility.Awaitility;
 import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.model.base.common.HttpStatus;
 import org.eclipse.ditto.model.base.entity.id.DefaultNamespacedEntityId;
 import org.eclipse.ditto.model.base.entity.id.EntityId;
 import org.eclipse.ditto.model.base.entity.id.NamespacedEntityId;
@@ -52,6 +53,8 @@ import org.eclipse.ditto.services.thingsearch.common.model.ResultList;
 import org.eclipse.ditto.services.thingsearch.persistence.read.ThingsSearchPersistence;
 import org.eclipse.ditto.services.thingsearch.persistence.write.model.Metadata;
 import org.eclipse.ditto.services.utils.akka.streaming.TimestampPersistence;
+import org.eclipse.ditto.services.utils.health.ResetHealthEvents;
+import org.eclipse.ditto.services.utils.health.ResetHealthEventsResponse;
 import org.eclipse.ditto.services.utils.health.RetrieveHealth;
 import org.eclipse.ditto.services.utils.health.RetrieveHealthResponse;
 import org.eclipse.ditto.services.utils.health.StatusDetailMessage;
@@ -158,6 +161,32 @@ public final class BackgroundSyncActorTest {
             thenRespondWithFailingPersistedThingsStream(pubSub);
 
             expectSyncActorToBeUpWithWarning(underTest, this);
+        }};
+
+    }
+
+    @Test
+    public void resettingHealthEventsAfterSyncStreamFailureClearsErrors() {
+        final Metadata indexedThingMetadata = Metadata.of(THING_ID, 2, null, null, null);
+        final long persistedRevision = indexedThingMetadata.getThingRevision() + 1;
+
+        new TestKit(actorSystem) {{
+            whenSearchPersistenceHasIndexedThings(List.of(indexedThingMetadata));
+            whenTimestampPersistenceProvidesTaggedTimestamp();
+
+            final ActorRef underTest = thenCreateBackgroundSyncActor(this);
+
+            expectSyncActorToStartStreaming(pubSub);
+            thenRespondWithPersistedThingsStream(pubSub, List.of(createStreamedSnapshot(THING_ID, persistedRevision + 1)));
+            expectSyncActorToRequestThingUpdatesInSearch(thingsUpdater, List.of(THING_ID));
+
+            expectSyncActorToBeUpWithWarning(underTest, this);
+
+            underTest.tell(ResetHealthEvents.newInstance(), getRef());
+            final ResetHealthEventsResponse response = expectMsgClass(ResetHealthEventsResponse.class);
+            assertThat(response.getHttpStatus()).isEqualTo(HttpStatus.NO_CONTENT);
+
+            expectSyncActorToBeUpAndHealthy(underTest, this);
         }};
 
     }

--- a/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
+++ b/services/thingsearch/updater-actors/src/test/resources/background-sync-test.conf
@@ -2,7 +2,7 @@ enabled = true
 quiet-period = 0s
 idle-timeout = 500ms
 keep {
-  events = 10
+  events = 200
 }
 throttle {
   throughput = 100

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
@@ -304,10 +304,23 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
     private StatusInfo renderStatusInfo() {
         return StatusInfo.fromStatus(StatusInfo.Status.UP,
-                Collections.singletonList(StatusDetailMessage.of(getMostSevereLevelFromEvents(), render())));
+                Collections.singletonList(StatusDetailMessage.of(getMostSevereLevelFromEvents(events), render())));
     }
 
-    private StatusDetailMessage.Level getMostSevereLevelFromEvents() {
+    private JsonObject render() {
+        final JsonObjectBuilder statusReportBuilder = JsonObject.newBuilder()
+                .set(JsonFields.ENABLED, config.isEnabled())
+                .set(JsonFields.EVENTS, renderEvents(events));
+        postEnhanceStatusReport(statusReportBuilder);
+        return statusReportBuilder.build();
+    }
+
+    /**
+     * Get the most severe log level from evennts.
+     *
+     * @return The most severe log level to report.
+     */
+    protected StatusDetailMessage.Level getMostSevereLevelFromEvents(final Deque<Pair<Instant, Event>> events) {
         return events.stream()
                 .map(Pair::second)
                 .map(Event::level)
@@ -315,17 +328,25 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
                 .orElse(StatusDetailMessage.Level.DEFAULT);
     }
 
-    private JsonObject render() {
-        final JsonObjectBuilder statusReportBuilder = JsonObject.newBuilder()
-                .set(JsonFields.ENABLED, config.isEnabled())
-                .set(JsonFields.EVENTS, events.stream()
-                        .map(AbstractBackgroundStreamingActorWithConfigWithStatusReport::renderEvent)
-                        .collect(JsonCollectors.valuesToArray()));
-        postEnhanceStatusReport(statusReportBuilder);
-        return statusReportBuilder.build();
+    /**
+     * Render known events as a JSON array.
+     *
+     * @param events events to render.
+     * @return the rendered events.
+     */
+    protected JsonArray renderEvents(final Deque<Pair<Instant, Event>> events) {
+        return events.stream()
+                .map(this::renderEvent)
+                .collect(JsonCollectors.valuesToArray());
     }
 
-    private static JsonObject renderEvent(final Pair<Instant, Event> element) {
+    /**
+     * Render a single event as JSON for health reporting.
+     *
+     * @param element the event together with its timestamp.
+     * @return the rendered JSON object.
+     */
+    protected JsonObject renderEvent(final Pair<Instant, Event> element) {
         return JsonObject.newBuilder()
                 .set(element.first().toString(), element.second().name())
                 .build();
@@ -344,7 +365,10 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
     }
 
-    private static final class WokeUp implements Event {
+    /**
+     * Event for when a stream started.
+     */
+    protected static final class WokeUp implements Event {
 
         private static final WokeUp ENABLED = new WokeUp(true);
 
@@ -365,7 +389,10 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
     }
 
-    private static final class StreamTerminated implements Event {
+    /**
+     * Event for when a stream terminated.
+     */
+    protected static final class StreamTerminated implements Event {
 
         private static final StatusDetailMessage.Level STREAM_ERROR_STATUS_LEVEL = StatusDetailMessage.Level.WARN;
         private final String whatHappened;

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEvents.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEvents.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.health;
+
+import java.util.function.Predicate;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableCommand;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.signals.base.WithIdButActuallyNot;
+import org.eclipse.ditto.signals.commands.base.AbstractCommand;
+
+/**
+ * Internal command to reset the health events of underlying systems.
+ */
+@Immutable
+@JsonParsableCommand(typePrefix = ResetHealthEvents.TYPE_PREFIX, name = ResetHealthEvents.NAME)
+public final class ResetHealthEvents extends AbstractCommand<ResetHealthEvents> implements WithIdButActuallyNot {
+
+    /**
+     * Type prefix of this command.
+     */
+    public static final String TYPE_PREFIX = "status." + TYPE_QUALIFIER + ":";
+
+    /**
+     * Name of this command.
+     */
+    public static final String NAME = "resetHealthEvents";
+
+    /**
+     * Type of this command.
+     */
+    public static final String TYPE = TYPE_PREFIX + NAME;
+
+    private ResetHealthEvents(final DittoHeaders headers) {
+        super(TYPE, headers);
+    }
+
+    /**
+     * Returns a new {@code RetrieveHealth} instance.
+     *
+     * @return the new RetrieveHealth instance.
+     */
+    public static ResetHealthEvents newInstance() {
+        return new ResetHealthEvents(DittoHeaders.empty());
+    }
+
+    /**
+     * Creates a new {@code RetrieveHealth} command from the given JSON object.
+     *
+     * @param jsonObject the JSON object of which the Cleanup is to be created.
+     * @param dittoHeaders the headers.
+     * @return the command.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
+    public static ResetHealthEvents fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        // Json object is ignored -- this command has no payload.
+        return new ResetHealthEvents(dittoHeaders);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> predicate) {
+        // there is no payload.
+    }
+
+    @Override
+    public String getTypePrefix() {
+        return TYPE_PREFIX;
+    }
+
+    @Override
+    public Category getCategory() {
+        return Category.QUERY;
+    }
+
+    @Override
+    public ResetHealthEvents setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new ResetHealthEvents(dittoHeaders);
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        return JsonPointer.empty();
+    }
+
+    @Override
+    public String getResourceType() {
+        // no resource type
+        return "";
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() + "]";
+    }
+
+}

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponse.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponse.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.health;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.model.base.common.HttpStatus;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableCommandResponse;
+import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
+import org.eclipse.ditto.signals.base.WithIdButActuallyNot;
+import org.eclipse.ditto.signals.commands.base.AbstractCommandResponse;
+
+/**
+ * Response of {@link org.eclipse.ditto.services.utils.health.ResetHealthEvents}.
+ */
+@Immutable
+@JsonParsableCommandResponse(type = ResetHealthEventsResponse.TYPE)
+public final class ResetHealthEventsResponse extends AbstractCommandResponse<ResetHealthEventsResponse> implements
+        WithIdButActuallyNot {
+
+    /**
+     * Type of this response.
+     */
+    public static final String TYPE = "status." + TYPE_QUALIFIER + ":" + ResetHealthEvents.NAME;
+
+    private ResetHealthEventsResponse(final DittoHeaders headers) {
+        super(TYPE, HttpStatus.NO_CONTENT, headers);
+    }
+
+    /**
+     * Create a ResetHealthEventsResponse.
+     *
+     * @param statusInfo the status info.
+     * @param dittoHeaders the Ditto headers.
+     * @return the ResetHealthEventsResponse.
+     */
+    public static ResetHealthEventsResponse of(final DittoHeaders dittoHeaders) {
+        return new ResetHealthEventsResponse(dittoHeaders);
+    }
+
+    /**
+     * Create a ResetHealthEventsResponse from its JSON representation.
+     *
+     * @param jsonObject JSON of the response.
+     * @param dittoHeaders headers of the response.
+     * @return the response.
+     */
+    public static ResetHealthEventsResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return of(dittoHeaders);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> predicate) {
+        // nothing to append
+    }
+
+    @Override
+    public ResetHealthEventsResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new ResetHealthEventsResponse(dittoHeaders);
+    }
+
+    @Override
+    public JsonPointer getResourcePath() {
+        return JsonPointer.empty();
+    }
+
+    @Override
+    public String getResourceType() {
+        // no resource type
+        return "";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o instanceof ResetHealthEventsResponse) {
+            return super.equals(o);
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() + "]";
+    }
+
+}

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponse.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponse.java
@@ -48,7 +48,6 @@ public final class ResetHealthEventsResponse extends AbstractCommandResponse<Res
     /**
      * Create a ResetHealthEventsResponse.
      *
-     * @param statusInfo the status info.
      * @param dittoHeaders the Ditto headers.
      * @return the ResetHealthEventsResponse.
      */
@@ -64,6 +63,7 @@ public final class ResetHealthEventsResponse extends AbstractCommandResponse<Res
      * @return the response.
      */
     public static ResetHealthEventsResponse fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        // Json object is ignored -- this command response has no payload.
         return of(dittoHeaders);
     }
 

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/StatusDetailMessage.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/StatusDetailMessage.java
@@ -30,6 +30,12 @@ import org.eclipse.ditto.model.base.json.Jsonifiable;
  */
 public final class StatusDetailMessage implements Jsonifiable<JsonObject> {
 
+    /**
+     * The available levels of a StatusDetailMessage.
+     * <p>
+     * Order of Level entries is important - as {@code compareTo} of Enum uses defined order - first entry < second
+     * entry.
+     */
     public enum Level {
         INFO, WARN, ERROR;
 

--- a/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/StatusDetailMessage.java
+++ b/services/utils/health/src/main/java/org/eclipse/ditto/services/utils/health/StatusDetailMessage.java
@@ -33,8 +33,8 @@ public final class StatusDetailMessage implements Jsonifiable<JsonObject> {
     /**
      * The available levels of a StatusDetailMessage.
      * <p>
-     * Order of Level entries is important - as {@code compareTo} of Enum uses defined order - first entry < second
-     * entry.
+     * Order of Level entries is important - as {@code compareTo} of Enum uses defined order - first entry is less than
+     * second entry.
      */
     public enum Level {
         INFO, WARN, ERROR;

--- a/services/utils/health/src/test/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponseTest.java
+++ b/services/utils/health/src/test/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsResponseTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.health;
+
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.junit.Test;
+import org.mutabilitydetector.unittesting.MutabilityAssert;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit tests for {@link ResetHealthEventsResponse}.
+ */
+public final class ResetHealthEventsResponseTest {
+
+    @Test
+    public void assertImmutability() {
+        MutabilityAssert.assertInstancesOf(ResetHealthEventsResponse.class, areImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(ResetHealthEventsResponse.class)
+                .usingGetClass()
+                .withRedefinedSuperclass()
+                .verify();
+    }
+
+}

--- a/services/utils/health/src/test/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsTest.java
+++ b/services/utils/health/src/test/java/org/eclipse/ditto/services/utils/health/ResetHealthEventsTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.utils.health;
+
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.junit.Test;
+import org.mutabilitydetector.unittesting.MutabilityAssert;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit tests for {@link ResetHealthEvents}.
+ */
+public final class ResetHealthEventsTest {
+
+    @Test
+    public void assertImmutability() {
+        MutabilityAssert.assertInstancesOf(ResetHealthEvents.class, areImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(ResetHealthEvents.class)
+                .usingGetClass()
+                .withRedefinedSuperclass()
+                .verify();
+    }
+
+}


### PR DESCRIPTION
The search background sync consistency health mechanism did not recover quickly to "healthy" again after consistency was regained.
This PR fixes this.

In addition, a new "ResetHealthEvents" command was added which can be triggered via piggyback/devops command in order to manually reset the events causing the background sync health to report "WARNING".