### PR TITLE
Add SonarQube stage in multibranch pipeline

### DIFF
--- a/Jenkinsfile_multibranch_pipeline
+++ b/Jenkinsfile_multibranch_pipeline
@@ -67,7 +67,7 @@ pipeline {
             }
             when {
                 expression {
-                    return params.SKIP_SONAR_SCAN
+                    return !params.SKIP_SONAR_SCAN
                 }
             }
             steps {

--- a/Jenkinsfile_multibranch_pipeline
+++ b/Jenkinsfile_multibranch_pipeline
@@ -56,6 +56,26 @@ pipeline {
                 }
             }
         }
+        stage('SonarQube Scan') {
+            agent {
+                docker {
+                    args "$DITTO_DOCKER_ARGUMENTS"
+                    image "$DITTO_DOCKER_IMAGE_MAVEN_JDK_11"
+                    reuseNode true
+                }
+            }
+            steps {
+                configFileProvider([configFile(fileId: 'mvn-bdc-settings', variable: 'MVN_SETTINGS')]) {
+                    echo 'Sonar Scan'
+                    withSonarQubeEnv(installationName: "${env.SONAR_QUBE_ENV}", credentialsId: 'sonarqube') {
+                        sh "mvn -s $MVN_SETTINGS --batch-mode --errors $SONAR_MAVEN_GOAL " +
+                                "-Dsonar.host.url=$SONAR_HOST_URL " +
+                                "-Dsonar.projectKey=org.eclipse.ditto:${theBranch} " +
+                                "-Drevision=${theVersion}"
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/Jenkinsfile_multibranch_pipeline
+++ b/Jenkinsfile_multibranch_pipeline
@@ -5,6 +5,7 @@ pipeline {
     }
     parameters {
         string(name: 'EXTRA_MAVEN_ARGS', defaultValue: '', description: 'Additional maven arguments.')
+        booleanParam(name: 'SKIP_SONAR_SCAN', defaultValue: false, description: 'Set to true to skip Sonarqube Scan.')
     }
     environment {
         // Need to replace the '%2F' used by Jenkins to deal with / in the path (e.g. story/...)
@@ -64,14 +65,19 @@ pipeline {
                     reuseNode true
                 }
             }
+            when {
+                expression {
+                    return params.SKIP_SONAR_SCAN
+                }
+            }
             steps {
                 configFileProvider([configFile(fileId: 'mvn-bdc-settings', variable: 'MVN_SETTINGS')]) {
                     echo 'Sonar Scan'
                     withSonarQubeEnv(installationName: "${env.SONAR_QUBE_ENV}", credentialsId: 'sonarqube') {
                         sh "mvn -s $MVN_SETTINGS --batch-mode --errors $SONAR_MAVEN_GOAL " +
-                                "-Dsonar.host.url=$SONAR_HOST_URL " +
-                                "-Dsonar.projectKey=org.eclipse.ditto:${theBranch} " +
-                                "-Drevision=${theVersion}"
+                                   "-Dsonar.host.url=$SONAR_HOST_URL " +
+                                   "-Dsonar.projectKey=org.eclipse.ditto:${theBranch} " +
+                                   "-Drevision=${theVersion}"
                     }
                 }
             }


### PR DESCRIPTION
The multibranch pipeline is used to build feature branches. This PR adds a SonarQube stage, so that feature branches will also be scanned. The feature branch name is used as part of the sonar project key, to distinguish between the different scans from different branches.

Signed-off-by: Joel Bartelheimer <joel.bartelheimer@bosch.io>