### PR TITLE
Validate extra field selection for connection topics

### DIFF
--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/FilteredTopicBuilder.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/FilteredTopicBuilder.java
@@ -13,10 +13,12 @@
 package org.eclipse.ditto.model.connectivity;
 
 import java.util.Collection;
+
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 
 /**
  * A mutable builder with a fluent API for creating a {@link FilteredTopic}.
@@ -46,8 +48,22 @@ public interface FilteredTopicBuilder {
      *
      * @param extraFields the extra fields.
      * @return this builder instance to allow method chaining.
+     * @deprecated Use {@link #withExtraFields(ThingFieldSelector)} instead.
      */
-    FilteredTopicBuilder withExtraFields(@Nullable JsonFieldSelector extraFields);
+    @Deprecated
+    default FilteredTopicBuilder withExtraFields(@Nullable JsonFieldSelector extraFields) {
+        return extraFields == null ?
+                withExtraFields(null) :
+                withExtraFields(ThingFieldSelector.fromJsonFieldSelector(extraFields));
+    }
+
+    /**
+     * Sets the selector for the extra fields and their values to enrich outgoing signals of the topic to be built with.
+     *
+     * @param extraFields the extra fields.
+     * @return this builder instance to allow method chaining.
+     */
+    FilteredTopicBuilder withExtraFields(@Nullable ThingFieldSelector extraFields);
 
     /**
      * Builds a filtered topic with the current properties of this builder instance.

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopic.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopic.java
@@ -31,9 +31,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
-import org.eclipse.ditto.json.JsonParseOptions;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 
 /**
  * Immutable implementation of {@link FilteredTopic}.
@@ -48,14 +47,12 @@ final class ImmutableFilteredTopic implements FilteredTopic {
     private static final String FILTER_ARG = "filter";
     private static final String NAMESPACES_ARG = "namespaces";
     private static final String EXTRA_FIELDS_ARG = "extraFields";
-    private static final JsonParseOptions JSON_PARSE_OPTIONS = JsonParseOptions.newBuilder()
-            .withoutUrlDecoding()
-            .build();
+
 
     private final Topic topic;
     private final List<String> namespaces;
     @Nullable private final String filterString;
-    @Nullable private final JsonFieldSelector extraFields;
+    @Nullable private final ThingFieldSelector extraFields;
 
     private ImmutableFilteredTopic(final ImmutableFilteredTopicBuilder builder) {
         topic = builder.topic;
@@ -188,7 +185,7 @@ final class ImmutableFilteredTopic implements FilteredTopic {
         private final Topic topic;
         @Nullable private Collection<String> namespaces;
         @Nullable private CharSequence filter;
-        @Nullable private JsonFieldSelector extraFields;
+        @Nullable private ThingFieldSelector extraFields;
 
         private ImmutableFilteredTopicBuilder(final Topic topic) {
             this.topic = checkNotNull(topic, "topic");
@@ -213,7 +210,7 @@ final class ImmutableFilteredTopic implements FilteredTopic {
         }
 
         @Override
-        public ImmutableFilteredTopicBuilder withExtraFields(@Nullable final JsonFieldSelector extraFields) {
+        public ImmutableFilteredTopicBuilder withExtraFields(@Nullable final ThingFieldSelector extraFields) {
             // policy announcements do not support extra fields.
             if (topic != Topic.POLICY_ANNOUNCEMENTS) {
                 this.extraFields = extraFields;
@@ -286,9 +283,9 @@ final class ImmutableFilteredTopic implements FilteredTopic {
         }
 
         @Nullable
-        private static JsonFieldSelector parseExtraFields(@Nullable final String extraFieldsString) {
+        private static ThingFieldSelector parseExtraFields(@Nullable final String extraFieldsString) {
             if (null != extraFieldsString && !extraFieldsString.isEmpty()) {
-                return JsonFactory.newFieldSelector(extraFieldsString, JSON_PARSE_OPTIONS);
+                return ThingFieldSelector.fromString(extraFieldsString);
             }
             return null;
         }

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopic.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopic.java
@@ -81,6 +81,8 @@ final class ImmutableFilteredTopic implements FilteredTopic {
      * @param filteredTopicString the string representation of a FilteredTopic.
      * @return instance.
      * @throws NullPointerException if {@code filteredTopicString} is {@code null}.
+     * @throws org.eclipse.ditto.model.things.InvalidThingFieldSelectionException when the given
+     * {@code filteredTopicString} contained a field selector with invalid fields.
      */
     public static ImmutableFilteredTopic fromString(final String filteredTopicString) {
         checkNotNull(filteredTopicString, "filteredTopicString");

--- a/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopicTest.java
+++ b/model/connectivity/src/test/java/org/eclipse/ditto/model/connectivity/ImmutableFilteredTopicTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import org.assertj.core.util.Lists;
 import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -36,8 +37,8 @@ public final class ImmutableFilteredTopicTest {
     private static final List<String> NAMESPACES =
             Collections.unmodifiableList(Lists.list("this.is.a.namespace", "eat.that", "foo.bar"));
     private static final String FILTER_EXAMPLE = "gt(attributes/a,42)";
-    private static final JsonFieldSelector EXTRA_FIELDS =
-            JsonFieldSelector.newInstance("attributes", "features/location");
+    private static final ThingFieldSelector EXTRA_FIELDS =
+            ThingFieldSelector.fromJsonFieldSelector(JsonFieldSelector.newInstance("attributes", "features/location"));
 
     @Test
     public void testHashCodeAndEquals() {
@@ -50,7 +51,7 @@ public final class ImmutableFilteredTopicTest {
     public void assertImmutability() {
         assertInstancesOf(ImmutableFilteredTopic.class,
                 areImmutable(),
-                provided(Topic.class, JsonFieldSelector.class).areAlsoImmutable(),
+                provided(Topic.class, ThingFieldSelector.class).areAlsoImmutable(),
                 assumingFields("namespaces").areSafelyCopiedUnmodifiableCollectionsWithImmutableElements());
     }
 

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/InvalidThingFieldSelectionException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/InvalidThingFieldSelectionException.java
@@ -25,6 +25,11 @@ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonParsableException;
 
+/**
+ * Thrown when a {@link ThingFieldSelector} was not valid.
+ *
+ * @since 2.0.0
+ */
 @JsonParsableException(errorCode = InvalidThingFieldSelectionException.ERROR_CODE)
 public final class InvalidThingFieldSelectionException extends DittoRuntimeException implements ThingException {
 

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/InvalidThingFieldSelectionException.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/InvalidThingFieldSelectionException.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.things;
+
+import java.net.URI;
+import java.text.MessageFormat;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.model.base.common.HttpStatus;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.base.json.JsonParsableException;
+
+@JsonParsableException(errorCode = InvalidThingFieldSelectionException.ERROR_CODE)
+public final class InvalidThingFieldSelectionException extends DittoRuntimeException implements ThingException {
+
+    private static final String DEFAULT_MESSAGE_TEMPLATE = "Thing field selection <{0}> was not valid.";
+    private static final String DEFAULT_DESCRIPTION = "Please provide a comma separated List of valid Thing fields." +
+            "Make sure that you did not use a space after a comma. Valid Fields are: " +
+            ThingFieldSelector.SELECTABLE_FIELDS.toString();
+
+    static final String ERROR_CODE = ERROR_CODE_PREFIX + "field.selection.invalid";
+
+    private InvalidThingFieldSelectionException(
+            final DittoHeaders dittoHeaders,
+            @Nullable final String message, @Nullable final String description,
+            @Nullable final Throwable cause, @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatus.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    static InvalidThingFieldSelectionException forExtraFieldSelectionString(final String extraFieldString) {
+        return new Builder(MessageFormat.format(DEFAULT_MESSAGE_TEMPLATE, extraFieldString)).build();
+    }
+
+    /**
+     * Constructs a new {@code InvalidThingFieldSelectionException} object with the exception message extracted
+     * from the given JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new FeatureDefinitionEmptyException.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static InvalidThingFieldSelectionException fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromJson(jsonObject, dittoHeaders,
+                new InvalidThingFieldSelectionException.Builder());
+    }
+
+    @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .message(getMessage())
+                .description(getDescription().orElse(null))
+                .cause(getCause())
+                .href(getHref().orElse(null))
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for an immutable {@code FeatureDefinitionEmptyException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends
+            DittoRuntimeExceptionBuilder<InvalidThingFieldSelectionException> {
+
+        private Builder() {
+            description(DEFAULT_DESCRIPTION);
+        }
+
+        private Builder(final String message) {
+            description(DEFAULT_DESCRIPTION);
+            message(message);
+        }
+
+        @Override
+        protected InvalidThingFieldSelectionException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new InvalidThingFieldSelectionException(dittoHeaders, message, description, cause, href);
+        }
+
+    }
+}

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingFieldSelector.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingFieldSelector.java
@@ -27,6 +27,8 @@ import org.eclipse.ditto.json.JsonPointer;
 /**
  * A Json field selector which validates that only valid fields of a thing can be selected.
  * Commas in keys are not supported by this selector.
+ *
+ * @since 2.0.0
  */
 public final class ThingFieldSelector implements JsonFieldSelector {
 
@@ -43,7 +45,9 @@ public final class ThingFieldSelector implements JsonFieldSelector {
     private final JsonFieldSelector jsonFieldSelector;
 
 
-    private ThingFieldSelector(final JsonFieldSelector jsonFieldSelector) {this.jsonFieldSelector = jsonFieldSelector;}
+    private ThingFieldSelector(final JsonFieldSelector jsonFieldSelector) {
+        this.jsonFieldSelector = jsonFieldSelector;
+    }
 
     /**
      * Creates a thing field selector based on the more generic json field selector. Selected fields are validated.
@@ -52,7 +56,8 @@ public final class ThingFieldSelector implements JsonFieldSelector {
      *
      * @param jsonFieldSelector the generic json field selector.
      * @return the ThingFieldSelector.
-     * @throws InvalidThingFieldSelectionException when the given json field selector is null or contains invalid fields.
+     * @throws InvalidThingFieldSelectionException when the given json field selector is {@code null} or contains
+     * invalid fields.
      */
     public static ThingFieldSelector fromJsonFieldSelector(final JsonFieldSelector jsonFieldSelector) {
         if (jsonFieldSelector instanceof ThingFieldSelector) {
@@ -72,7 +77,7 @@ public final class ThingFieldSelector implements JsonFieldSelector {
      *
      * @param selectionString the string representation of a json field selector.
      * @return the ThingFieldSelector.
-     * @throws InvalidThingFieldSelectionException when the given string is null or contains invalid fields.
+     * @throws InvalidThingFieldSelectionException when the given string is {@code null} or contains invalid fields.
      */
     public static ThingFieldSelector fromString(final String selectionString) {
         if (selectionString == null) {
@@ -83,6 +88,11 @@ public final class ThingFieldSelector implements JsonFieldSelector {
         throw InvalidThingFieldSelectionException.forExtraFieldSelectionString(selectionString);
     }
 
+    /**
+     * Returns the underlying JsonFieldSelector.
+     *
+     * @return the underlying JsonFieldSelector.
+     */
     public JsonFieldSelector getJsonFieldSelector() {
         return jsonFieldSelector;
     }

--- a/model/things/src/main/java/org/eclipse/ditto/model/things/ThingFieldSelector.java
+++ b/model/things/src/main/java/org/eclipse/ditto/model/things/ThingFieldSelector.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.things;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonParseOptions;
+import org.eclipse.ditto.json.JsonPointer;
+
+/**
+ * A Json field selector which validates that only valid fields of a thing can be selected.
+ * Commas in keys are not supported by this selector.
+ */
+public final class ThingFieldSelector implements JsonFieldSelector {
+
+    private static final JsonParseOptions JSON_PARSE_OPTIONS = JsonParseOptions.newBuilder()
+            .withoutUrlDecoding()
+            .build();
+    static final List<String> SELECTABLE_FIELDS = Arrays.asList("thingId", "policyId", "definition",
+            "_namespace", "_revision", "_created", "_modified", "_metadata", "_policy", "features(/[^,]+)?",
+            "attributes(/[^,]+)?");
+    private static final String KNOWN_FIELDS_REGEX = "/?(" + String.join("|", SELECTABLE_FIELDS) + ")";
+    private static final String FIELD_SELECTION_REGEX = "^" + KNOWN_FIELDS_REGEX + "(," + KNOWN_FIELDS_REGEX + ")*$";
+    private static final Pattern FIELD_SELECTION_PATTERN = Pattern.compile(FIELD_SELECTION_REGEX);
+
+    private final JsonFieldSelector jsonFieldSelector;
+
+
+    private ThingFieldSelector(final JsonFieldSelector jsonFieldSelector) {this.jsonFieldSelector = jsonFieldSelector;}
+
+    /**
+     * Creates a thing field selector based on the more generic json field selector. Selected fields are validated.
+     * If the given json field selector is already an instance of {@link ThingFieldSelector} the same
+     * instance will be returned.
+     *
+     * @param jsonFieldSelector the generic json field selector.
+     * @return the ThingFieldSelector.
+     * @throws InvalidThingFieldSelectionException when the given json field selector is null or contains invalid fields.
+     */
+    public static ThingFieldSelector fromJsonFieldSelector(final JsonFieldSelector jsonFieldSelector) {
+        if (jsonFieldSelector instanceof ThingFieldSelector) {
+            return (ThingFieldSelector) jsonFieldSelector;
+        } else if (jsonFieldSelector == null) {
+            throw InvalidThingFieldSelectionException.forExtraFieldSelectionString(null);
+        } else if (FIELD_SELECTION_PATTERN.matcher(jsonFieldSelector.toString()).matches()) {
+            return new ThingFieldSelector(jsonFieldSelector);
+        } else {
+            throw InvalidThingFieldSelectionException.forExtraFieldSelectionString(jsonFieldSelector.toString());
+        }
+    }
+
+    /**
+     * Creates a thing field selector based on the given string representation of a json field selector.
+     * Selected fields are validated.
+     *
+     * @param selectionString the string representation of a json field selector.
+     * @return the ThingFieldSelector.
+     * @throws InvalidThingFieldSelectionException when the given string is null or contains invalid fields.
+     */
+    public static ThingFieldSelector fromString(final String selectionString) {
+        if (selectionString == null) {
+            throw InvalidThingFieldSelectionException.forExtraFieldSelectionString(null);
+        } else if (FIELD_SELECTION_PATTERN.matcher(selectionString).matches()) {
+            return new ThingFieldSelector(JsonFactory.newFieldSelector(selectionString, JSON_PARSE_OPTIONS));
+        }
+        throw InvalidThingFieldSelectionException.forExtraFieldSelectionString(selectionString);
+    }
+
+    public JsonFieldSelector getJsonFieldSelector() {
+        return jsonFieldSelector;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ThingFieldSelector that = (ThingFieldSelector) o;
+        return Objects.equals(jsonFieldSelector, that.jsonFieldSelector);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(jsonFieldSelector);
+    }
+
+    @Override
+    public Set<JsonPointer> getPointers() {
+        return jsonFieldSelector.getPointers();
+    }
+
+    @Override
+    public int getSize() {
+        return jsonFieldSelector.getSize();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return jsonFieldSelector.isEmpty();
+    }
+
+    @Override
+    public String toString() {
+        return jsonFieldSelector.toString();
+    }
+
+    @Override
+    public Iterator<JsonPointer> iterator() {
+        return jsonFieldSelector.iterator();
+    }
+
+}

--- a/model/things/src/test/java/org/eclipse/ditto/model/things/ThingFieldSelectorTest.java
+++ b/model/things/src/test/java/org/eclipse/ditto/model/things/ThingFieldSelectorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.things;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.in;
+
+import org.eclipse.ditto.json.JsonFieldSelector;
+import org.junit.Test;
+
+public final class ThingFieldSelectorTest {
+
+    @Test
+    public void fromNullStringThrows() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromString(null))
+                .withMessage("Thing field selection <null> was not valid.");
+    }
+
+    @Test
+    public void fromNullSelectorThrows() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromJsonFieldSelector(null))
+                .withMessage("Thing field selection <null> was not valid.");
+    }
+
+    @Test
+    public void fromStringWithInvalidFieldThrows() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromString("faetures"))
+                .withMessage("Thing field selection <faetures> was not valid.");
+    }
+
+    @Test
+    public void fromJsonFieldSelectorWithInvalidFieldThrows() {
+        final JsonFieldSelector invalidFieldSelector = JsonFieldSelector.newInstance("faetures");
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromJsonFieldSelector(invalidFieldSelector))
+                .withMessage("Thing field selection </faetures> was not valid.");
+    }
+
+    @Test
+    public void leadingSlashIsAllowed() {
+        assertThatCode(() -> ThingFieldSelector.fromString("/thingId"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void leadingSlashIsOptional() {
+        assertThatCode(() -> ThingFieldSelector.fromString("thingId"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void fromValidFieldSelector() {
+        assertThatCode(() -> ThingFieldSelector.fromJsonFieldSelector(JsonFieldSelector.newInstance("thingId")))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void trailingSlashForFeaturesIsNotAllowed() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromString("features/"));
+    }
+
+    @Test
+    public void multipleValidFieldsAreAllowed() {
+        assertThatCode(() -> ThingFieldSelector.fromString("thingId,features"))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    public void secondFieldInvalidThrows() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromString("features,thingd"));
+    }
+
+    @Test
+    public void commaInFeatureNameIsNotSupported() {
+        assertThatExceptionOfType(InvalidThingFieldSelectionException.class)
+                .isThrownBy(() -> ThingFieldSelector.fromString("features/name,withcomma,thingd"));
+    }
+
+    @Test
+    public void fromJsonFieldSelectorWithThingFieldSelectorReturnsSameInstance() {
+        final ThingFieldSelector initial = ThingFieldSelector.fromString("thingId");
+        final ThingFieldSelector result = ThingFieldSelector.fromJsonFieldSelector(initial);
+        assertThat(result).isSameAs(initial);
+    }
+
+}

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/MessageMappingProcessorActorTest.java
@@ -54,6 +54,7 @@ import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.model.connectivity.Topic;
 import org.eclipse.ditto.model.placeholders.UnresolvedPlaceholderException;
 import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.protocoladapter.JsonifiableAdaptable;
 import org.eclipse.ditto.protocoladapter.ProtocolFactory;
@@ -147,7 +148,8 @@ public final class MessageMappingProcessorActorTest extends AbstractMessageMappi
             final ActorRef outboundMappingProcessorActor = createOutboundMappingProcessorActor(this);
 
             // WHEN: a signal is received with 2 targets, one with enrichment and one without
-            final JsonFieldSelector extraFields = JsonFieldSelector.newInstance("attributes/x", "attributes/y");
+            final ThingFieldSelector extraFields = ThingFieldSelector.fromJsonFieldSelector(
+                    JsonFieldSelector.newInstance("attributes/x", "attributes/y"));
             final AuthorizationSubject targetAuthSubject = AuthorizationSubject.newInstance("target:auth-subject");
             final AuthorizationSubject targetAuthSubjectWithoutIssuer =
                     AuthorizationSubject.newInstance("auth-subject");

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -46,6 +46,7 @@ import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
 import org.eclipse.ditto.model.query.things.ModelBasedThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.gateway.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.services.gateway.endpoints.routes.things.ThingsParameter;
@@ -240,8 +241,8 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
         @Nullable final String filterString = parameters.get(PARAM_FILTER);
         final List<String> namespaces = getNamespaces(parameters.get(PARAM_NAMESPACES));
         final List<ThingId> targetThingIds = getThingIds(parameters.get(ThingsParameter.IDS.toString()));
-        @Nullable final JsonFieldSelector fields = getFieldSelector(parameters.get(ThingsParameter.FIELDS.toString()));
-        @Nullable final JsonFieldSelector extraFields = getFieldSelector(parameters.get(PARAM_EXTRA_FIELDS));
+        @Nullable final ThingFieldSelector fields = getFieldSelector(parameters.get(ThingsParameter.FIELDS.toString()));
+        @Nullable final ThingFieldSelector extraFields = getFieldSelector(parameters.get(PARAM_EXTRA_FIELDS));
         final SignalEnrichmentFacade facade =
                 signalEnrichmentProvider == null ? null : signalEnrichmentProvider.getFacade(ctx.getRequest());
 
@@ -424,11 +425,8 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
     }
 
     @Nullable
-    private static JsonFieldSelector getFieldSelector(@Nullable final String fieldsString) {
-        if (null != fieldsString) {
-            return JsonFactory.newFieldSelector(fieldsString, AbstractRoute.JSON_FIELD_SELECTOR_PARSE_OPTIONS);
-        }
-        return null;
+    private static ThingFieldSelector getFieldSelector(@Nullable final String fieldsString) {
+        return fieldsString == null ? null : ThingFieldSelector.fromString(fieldsString);
     }
 
     private static String namespaceFromId(final ThingEvent<?> thingEvent) {

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractor.java
@@ -26,11 +26,9 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonFieldSelector;
-import org.eclipse.ditto.json.JsonParseOptions;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.services.gateway.streaming.Jwt;
 import org.eclipse.ditto.services.gateway.streaming.StartStreaming;
 import org.eclipse.ditto.services.gateway.streaming.StopStreaming;
@@ -49,9 +47,6 @@ final class ProtocolMessageExtractor implements Function<String, Optional<Stream
     private static final String PARAM_NAMESPACES = "namespaces";
     private static final String PARAM_JWT = "jwtToken";
     private static final String PARAM_EXTRA_FIELDS = "extraFields";
-    private static final JsonParseOptions JSON_PARSE_OPTIONS = JsonParseOptions.newBuilder()
-            .withoutUrlDecoding()
-            .build();
 
     private final AuthorizationContext connectionAuthContext;
     private final CharSequence connectionCorrelationId;
@@ -150,9 +145,9 @@ final class ProtocolMessageExtractor implements Function<String, Optional<Stream
     }
 
     @Nullable
-    private static JsonFieldSelector getExtraFields(@Nullable final String extraFieldsParam) {
+    private static ThingFieldSelector getExtraFields(@Nullable final String extraFieldsParam) {
         if (null != extraFieldsParam && !extraFieldsParam.isEmpty()) {
-            return JsonFactory.newFieldSelector(extraFieldsParam, JSON_PARSE_OPTIONS);
+            return ThingFieldSelector.fromString(extraFieldsParam);
         }
         return null;
     }

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.model.base.auth.AuthorizationModelFactory;
 import org.eclipse.ditto.model.base.auth.DittoAuthorizationContextType;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.gateway.endpoints.EndpointTestBase;
 import org.eclipse.ditto.services.gateway.streaming.Connect;
@@ -241,7 +242,8 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
 
     @Test
     public void getWithAcceptHeaderAndExtraFieldsParameterOpensSseConnection() {
-        final JsonFieldSelector extraFields = JsonFieldSelector.newInstance("attributes", "features/location");
+        final ThingFieldSelector extraFields = ThingFieldSelector.fromJsonFieldSelector(
+                JsonFieldSelector.newInstance("attributes", "features/location"));
 
         final String requestUrl = THINGS_ROUTE + "?extraFields=" + extraFields;
 

--- a/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractorTest.java
+++ b/services/gateway/endpoints/src/test/java/org/eclipse/ditto/services/gateway/endpoints/routes/websocket/ProtocolMessageExtractorTest.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
 import org.eclipse.ditto.model.base.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.services.gateway.streaming.Jwt;
 import org.eclipse.ditto.services.gateway.streaming.StartStreaming;
 import org.eclipse.ditto.services.gateway.streaming.StopStreaming;
@@ -116,7 +117,7 @@ public final class ProtocolMessageExtractorTest {
         private ProtocolMessageExtractor underTest;
 
         @Parameterized.Parameters(name = "{0}")
-        public static List<ProtocolMessageType> startSendingProtocolMessageTypes( ) {
+        public static List<ProtocolMessageType> startSendingProtocolMessageTypes() {
             return Arrays.stream(ProtocolMessageType.values())
                     .filter(ProtocolMessageType::isStartSending)
                     .collect(Collectors.toList());
@@ -181,7 +182,8 @@ public final class ProtocolMessageExtractorTest {
 
         @Test
         public void startSendingWithExtraFields() {
-            final JsonFieldSelector extraFields = JsonFieldSelector.newInstance("attributes", "features/location");
+            final ThingFieldSelector extraFields = ThingFieldSelector.fromJsonFieldSelector(
+                    JsonFieldSelector.newInstance("attributes", "features/location"));
             final StartStreaming expected = StartStreaming.getBuilder(streamingType, correlationId, authContext)
                     .withExtraFields(extraFields)
                     .build();
@@ -203,7 +205,8 @@ public final class ProtocolMessageExtractorTest {
         public void startSendingWithNamespacesFilterAndExtraFields() {
             final Collection<String> namespaces = Arrays.asList("eclipse", "ditto", "is", "awesome");
             final String filter = "eq(foo,1)";
-            final JsonFieldSelector extraFields = JsonFieldSelector.newInstance("attributes", "features/location");
+            final ThingFieldSelector extraFields = ThingFieldSelector.fromJsonFieldSelector(
+                    JsonFieldSelector.newInstance("attributes", "features/location"));
             final StartStreaming expected = StartStreaming.getBuilder(streamingType, correlationId, authContext)
                     .withNamespaces(namespaces)
                     .withFilter(filter)
@@ -242,7 +245,7 @@ public final class ProtocolMessageExtractorTest {
         public void startSendingWithUnknownParameters() {
             final StartStreaming expected =
                     StartStreaming.getBuilder(streamingType, correlationId, authContext).build();
-            
+
             final Optional<StreamControlMessage> extracted = underTest.apply(protocolMessageType + "?eclipse=ditto");
 
             assertThat(extracted).contains(expected);
@@ -257,7 +260,7 @@ public final class ProtocolMessageExtractorTest {
         public ProtocolMessageType protocolMessageType;
 
         @Parameterized.Parameters(name = "{0}")
-        public static List<ProtocolMessageType> startSendingProtocolMessageTypes( ) {
+        public static List<ProtocolMessageType> startSendingProtocolMessageTypes() {
             return Arrays.stream(ProtocolMessageType.values())
                     .filter(protocolMessage -> protocolMessage.getIdentifier().startsWith("STOP"))
                     .collect(Collectors.toList());

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StartStreaming.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/StartStreaming.java
@@ -23,8 +23,8 @@ import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.services.utils.pubsub.StreamingType;
 
 /**
@@ -37,7 +37,7 @@ public final class StartStreaming implements StreamControlMessage {
     private final AuthorizationContext authorizationContext;
     private final List<String> namespaces;
     @Nullable private final String filter;
-    @Nullable private final JsonFieldSelector extraFields;
+    @Nullable private final ThingFieldSelector extraFields;
     @Nullable private final CharSequence correlationId;
 
     private StartStreaming(final StartStreamingBuilder builder) {
@@ -105,7 +105,7 @@ public final class StartStreaming implements StreamControlMessage {
      *
      * @return the selector or an empty Optional if signals should not be enriched.
      */
-    public Optional<JsonFieldSelector> getExtraFields() {
+    public Optional<ThingFieldSelector> getExtraFields() {
         return Optional.ofNullable(extraFields);
     }
 
@@ -156,7 +156,7 @@ public final class StartStreaming implements StreamControlMessage {
 
         @Nullable private Collection<String> namespaces;
         @Nullable private CharSequence filter;
-        @Nullable private JsonFieldSelector extraFields;
+        @Nullable private ThingFieldSelector extraFields;
         @Nullable private CharSequence correlationId;
 
         private StartStreamingBuilder(final StreamingType streamingType, final CharSequence connectionCorrelationId,
@@ -203,7 +203,7 @@ public final class StartStreaming implements StreamControlMessage {
          * @param extraFields selector for the extra fields or {@code null} if outgoing signals should not be enriched.
          * @return this builder instance to allow method chaining.
          */
-        public StartStreamingBuilder withExtraFields(@Nullable final JsonFieldSelector extraFields) {
+        public StartStreamingBuilder withExtraFields(@Nullable final ThingFieldSelector extraFields) {
             // policy announcements do not support extra fields.
             if (streamingType != StreamingType.POLICY_ANNOUNCEMENTS) {
                 this.extraFields = extraFields;

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/SessionedSignal.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/SessionedSignal.java
@@ -20,12 +20,12 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.entity.id.EntityId;
 import org.eclipse.ditto.model.base.exceptions.SignalEnrichmentFailedException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.Jsonifiable;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.models.signalenrichment.SignalEnrichmentFacade;
 import org.eclipse.ditto.signals.base.Signal;
@@ -59,7 +59,7 @@ final class SessionedSignal implements SessionedJsonifiable {
     @Override
     public CompletionStage<JsonObject> retrieveExtraFields(@Nullable final SignalEnrichmentFacade facade) {
         final EntityId entityId = signal.getEntityId();
-        final Optional<JsonFieldSelector> extraFields = session.getExtraFields();
+        final Optional<ThingFieldSelector> extraFields = session.getExtraFields();
         if (extraFields.isPresent() && (facade == null || !(entityId instanceof ThingId))) {
             final CompletableFuture<JsonObject> future = new CompletableFuture<>();
             future.completeExceptionally(SignalEnrichmentFailedException.newBuilder()

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSession.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSession.java
@@ -18,11 +18,11 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.things.ThingPredicateVisitor;
 import org.eclipse.ditto.model.things.Thing;
+import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.events.things.ThingEventToThingConverter;
 
@@ -35,11 +35,11 @@ public final class StreamingSession {
 
     private final List<String> namespaces;
     private final Predicate<Thing> thingPredicate;
-    @Nullable private final JsonFieldSelector extraFields;
+    @Nullable private final ThingFieldSelector extraFields;
     private final ActorRef streamingSessionActor;
 
     private StreamingSession(final List<String> namespaces, @Nullable final Criteria eventFilterCriteria,
-            @Nullable final JsonFieldSelector extraFields, final ActorRef streamingSessionActor) {
+            @Nullable final ThingFieldSelector extraFields, final ActorRef streamingSessionActor) {
         this.namespaces = namespaces;
         thingPredicate = eventFilterCriteria == null
                 ? thing -> true
@@ -49,7 +49,7 @@ public final class StreamingSession {
     }
 
     static StreamingSession of(final List<String> namespaces, @Nullable final Criteria eventFilterCriteria,
-            @Nullable final JsonFieldSelector extraFields, final ActorRef streamingSessionActor) {
+            @Nullable final ThingFieldSelector extraFields, final ActorRef streamingSessionActor) {
 
         return new StreamingSession(namespaces, eventFilterCriteria, extraFields, streamingSessionActor);
     }
@@ -64,7 +64,7 @@ public final class StreamingSession {
     /**
      * @return extra fields of the session if any is given.
      */
-    public Optional<JsonFieldSelector> getExtraFields() {
+    public Optional<ThingFieldSelector> getExtraFields() {
         return Optional.ofNullable(extraFields);
     }
 


### PR DESCRIPTION
This PR validates the extra field selection of connection topics.
This should improve the management of connections as it indicates very early, what's wrong with the connection configuration.