### PR TITLE
Fixed bug that iterator in EventSnapshotCleanupCoordinator was not cleaned up

### DIFF
--- a/services/concierge/actors/src/main/java/org/eclipse/ditto/services/concierge/actors/cleanup/EventSnapshotCleanupCoordinator.java
+++ b/services/concierge/actors/src/main/java/org/eclipse/ditto/services/concierge/actors/cleanup/EventSnapshotCleanupCoordinator.java
@@ -199,6 +199,7 @@ public final class EventSnapshotCleanupCoordinator
         while (creditForRequests > 0 && iterator.hasNext()) {
             --creditForRequests;
             cleanUpThingByRequest(iterator.next());
+            iterator.remove();
         }
     }
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BasePublisherActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BasePublisherActor.java
@@ -282,8 +282,7 @@ public abstract class BasePublisherActor<T extends PublishTarget> extends Abstra
         final List<Target> outboundTargets = outbound.getTargets();
 
         final ThreadSafeDittoLoggingAdapter l = logger.withCorrelationId(correlationId);
-        l.debug("Publishing mapped message of type <{}> to targets <{}>: {}", outboundSource.getType(), outboundTargets,
-                message);
+        l.info("Publishing mapped message of type <{}> to targets <{}>", outboundSource.getType(), outboundTargets);
 
         final Optional<SendingContext> replyTargetSendingContext = getSendingContext(outbound);
 
@@ -411,6 +410,7 @@ public abstract class BasePublisherActor<T extends PublishTarget> extends Abstra
         final SendingOrDropped result;
         if (publishTargetOptional.isPresent()) {
             final Signal<?> outboundSource = outbound.getSource();
+            logger.info("Publishing mapped message of type <{}> to address <{}>", outboundSource.getType());
             logger.debug("Publishing mapped message of type <{}> to address <{}>: {}", outboundSource.getType(),
                     address, sendingContext.getExternalMessage());
             final T publishTarget = publishTargetOptional.get();


### PR DESCRIPTION
* this caused the mechamism for "active" things to not work (clean up) at all
* also adjusted logging in BasePublisherActor to "info" in order to find out what was published on a connection