### PR TITLE
Get connectivity config via DittoHeaders

### DIFF
--- a/services/connectivity/common/src/main/java/org/eclipse/ditto/services/connectivity/config/ConnectivityConfigProvider.java
+++ b/services/connectivity/common/src/main/java/org/eclipse/ditto/services/connectivity/config/ConnectivityConfigProvider.java
@@ -16,6 +16,7 @@ package org.eclipse.ditto.services.connectivity.config;
 import java.util.Optional;
 
 import org.atteo.classindex.IndexSubclasses;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.ConnectionId;
 import org.eclipse.ditto.signals.events.base.Event;
 
@@ -31,9 +32,20 @@ public interface ConnectivityConfigProvider {
      * Loads a {@link ConnectivityConfig} by a connection ID.
      *
      * @param connectionId the connection id for which to load the {@link ConnectivityConfig}
+     * @param dittoHeaders the ditto headers for which to load the {@link ConnectivityConfig}
      * @return the connectivity config
      */
-    ConnectivityConfig getConnectivityConfig(ConnectionId connectionId);
+    ConnectivityConfig getConnectivityConfig(ConnectionId connectionId, DittoHeaders dittoHeaders);
+
+    /**
+     * Loads a {@link ConnectivityConfig} by a connection ID.
+     *
+     * @param connectionId the connection id for which to load the {@link ConnectivityConfig}
+     * @return the connectivity config
+     */
+    default ConnectivityConfig getConnectivityConfig(ConnectionId connectionId) {
+        return getConnectivityConfig(connectionId, DittoHeaders.empty());
+    }
 
     /**
      * Register the given {@code subscriber} for changes to the {@link ConnectivityConfig} of the given {@code

--- a/services/connectivity/common/src/main/java/org/eclipse/ditto/services/connectivity/config/DittoConnectivityConfigProvider.java
+++ b/services/connectivity/common/src/main/java/org/eclipse/ditto/services/connectivity/config/DittoConnectivityConfigProvider.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.connectivity.config;
 
 import java.util.Optional;
 
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.ConnectionId;
 import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.signals.events.base.Event;
@@ -35,7 +36,7 @@ public class DittoConnectivityConfigProvider implements ConnectivityConfigProvid
     }
 
     @Override
-    public ConnectivityConfig getConnectivityConfig(final ConnectionId connectionId) {
+    public ConnectivityConfig getConnectivityConfig(final ConnectionId connectionId, final DittoHeaders dittoHeaders) {
         return connectivityConfig;
     }
 

--- a/services/connectivity/config/src/main/resources/connectivity-dev.conf
+++ b/services/connectivity/config/src/main/resources/connectivity-dev.conf
@@ -11,6 +11,7 @@ ditto {
   connectivity {
     connection {
       blocked-hostnames = "" // for development, allow "localhost" which would normally be on that block-list
+      blocked-hostnames = ${?CONNECTIVITY_CONNECTION_BLOCKED_HOSTNAMES}
     }
   }
 }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidator.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidator.java
@@ -188,7 +188,7 @@ public final class ConnectionValidator {
      */
     void validate(final Connection connection, final DittoHeaders dittoHeaders, final ActorSystem actorSystem) {
         final ConnectivityConfig connectivityConfig =
-                connectivityConfigProvider.getConnectivityConfig(connection.getId());
+                connectivityConfigProvider.getConnectivityConfig(connection.getId(), dittoHeaders);
 
         // validate sources and targets
         validateSourcesAndTargets(connection, dittoHeaders, connectivityConfig);

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
@@ -58,8 +58,8 @@ final class HostValidator {
      */
     HostValidator(final ConnectivityConfig connectivityConfig, final LoggingAdapter loggingAdapter,
             final AddressResolver resolver) {
-        this.allowedHostnames = connectivityConfig.getConnectionConfig().getAllowedHostnames();
         this.resolver = resolver;
+        this.allowedHostnames = connectivityConfig.getConnectionConfig().getAllowedHostnames();
         final Collection<String> blockedHostnames = connectivityConfig.getConnectionConfig().getBlockedHostnames();
         this.blockedAddresses = calculateBlockedAddresses(blockedHostnames, loggingAdapter);
     }
@@ -67,10 +67,10 @@ final class HostValidator {
     /**
      * Validate if connections to a host are allowed by checking (in this order):
      * <ul>
-     *     <li>blocklist is empty? this completely disables validation, every host is allowed</li>
-     *     <li>host is contained in allowlist? host is allowed</li>
+     *     <li>blocklist is empty this completely disables validation, every host is allowed</li>
+     *     <li>host is contained in allowlist host is allowed</li>
      *     <li>host is resolved to a blocked ip (loopback, site-local, multicast, wildcard ip)? host is blocked</li>
-     *     <li>host is contained in the blocklist? host is blocked</li>
+     *     <li>host is contained in the blocklist host is blocked</li>
      *  </ul>
      * Loopback, private, multicast and wildcard addresses are allowed only if the blocklist is empty or explicitly
      * contained in allowlist.
@@ -120,6 +120,7 @@ final class HostValidator {
      */
     private Collection<InetAddress> calculateBlockedAddresses(final Collection<String> blockedHostnames,
             final LoggingAdapter log) {
+
         return blockedHostnames.stream()
                 .filter(host -> !host.isEmpty())
                 .flatMap(host -> {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
@@ -69,8 +69,8 @@ final class HostValidator {
      * <ul>
      *     <li>if the blocklist is empty, this completely disables validation, every host is allowed</li>
      *     <li>if the host is contained in the allowlist, the host is allowed</li>
-     *     <li>host is resolved to a blocked ip (loopback, site-local, multicast, wildcard ip)? host is blocked</li>
-     *     <li>host is contained in the blocklist host is blocked</li>
+     *     <li>if the host is resolved to a blocked ip (loopback, site-local, multicast, wildcard ip), the host is blocked</li>
+     *     <li>if the host is contained in the blocklist, the host is blocked</li>
      *  </ul>
      * Loopback, private, multicast and wildcard addresses are allowed only if the blocklist is empty or explicitly
      * contained in allowlist.

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/HostValidator.java
@@ -67,8 +67,8 @@ final class HostValidator {
     /**
      * Validate if connections to a host are allowed by checking (in this order):
      * <ul>
-     *     <li>blocklist is empty this completely disables validation, every host is allowed</li>
-     *     <li>host is contained in allowlist host is allowed</li>
+     *     <li>if the blocklist is empty, this completely disables validation, every host is allowed</li>
+     *     <li>if the host is contained in the allowlist, the host is allowed</li>
      *     <li>host is resolved to a blocked ip (loopback, site-local, multicast, wildcard ip)? host is blocked</li>
      *     <li>host is contained in the blocklist host is blocked</li>
      *  </ul>

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidatorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidatorTest.java
@@ -109,7 +109,7 @@ public class ConnectionValidatorTest {
     @Before
     public void before() {
         connectivityConfigProvider = Mockito.mock(ConnectivityConfigProvider.class);
-        Mockito.when(connectivityConfigProvider.getConnectivityConfig(CONNECTION_ID))
+        Mockito.when(connectivityConfigProvider.getConnectivityConfig(CONNECTION_ID, DittoHeaders.empty()))
                 .thenReturn(CONNECTIVITY_CONFIG_WITH_ENABLED_BLOCKLIST);
     }
 


### PR DESCRIPTION
Extend the ConnectivityConfigProvider interface with an additional method to retrieve the connectivity config via DittoHeaders.