### PR TITLE
Establish ddata sharding for Ditto pub/sub

### DIFF
--- a/documentation/src/main/resources/_data/authors.yml
+++ b/documentation/src/main/resources/_data/authors.yml
@@ -52,3 +52,8 @@ stefan_maute:
     name: Stefan Maute
     email: stefan.mautek@bosch.io
     web: https://github.com/stmaute
+
+vadim_guenther:
+    name: Vadim Günther
+    email: vadim.guenther@bosch.io
+    web: https://github.com/VadimGue

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/BaseClientActor.java
@@ -198,6 +198,10 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
 
         this.connection = checkNotNull(connection, "connection");
         this.connectionActor = connectionActor;
+        // this is retrieve via the extension for each baseClientActor in order to not pass it as constructor arg
+        //  as all constructor arguments need to be serializable as the BaseClientActor is started behind a cluster
+        //  router
+        this.dittoProtocolSub = DittoProtocolSub.get(getContext().getSystem());
         actorUUID = UUID.randomUUID().toString();
 
         final ConnectionId connectionId = connection.getId();
@@ -246,7 +250,6 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         supervisorStrategy = createSupervisorStrategy(getSelf());
         clientActorRefs = ClientActorRefs.empty();
         clientActorRefsNotificationDelay = randomize(clientConfig.getClientActorRefsNotificationDelay());
-        dittoProtocolSub = DittoProtocolSub.get(getContext().getSystem());
         subscriptionIdPrefixLength =
                 ConnectionPersistenceActor.getSubscriptionPrefixLength(connection.getClientCount());
 

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/InboundDispatchingActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/InboundDispatchingActor.java
@@ -296,9 +296,13 @@ public final class InboundDispatchingActor extends AbstractActor
                                 e.getMessage());
                 mappedHeaders = applyInboundHeaderMapping(errorResponse, message, authorizationContext,
                         message.getTopicPath().orElse(null), message.getInternalHeaders());
-                logger.withCorrelationId(mappedHeaders)
-                        .info("Resolved mapped headers of {} : with HeaderMapping {} : and external headers {}",
-                                mappedHeaders, message.getHeaderMapping(), message.getHeaders());
+                final DittoDiagnosticLoggingAdapter l = logger.withCorrelationId(mappedHeaders);
+                l.info("Got exception <{}> when processing external message with mapper <{}>: <{}>",
+                        dittoRuntimeException.getErrorCode(),
+                        mapperId,
+                        e.getMessage());
+                l.info("Resolved mapped headers of {} : with HeaderMapping {} : and external headers {}",
+                        mappedHeaders, message.getHeaderMapping(), message.getHeaders());
             } else {
                 mappedHeaders = dittoRuntimeException.getDittoHeaders();
             }
@@ -310,7 +314,8 @@ public final class InboundDispatchingActor extends AbstractActor
             logger.withCorrelationId(Optional.ofNullable(message)
                     .map(ExternalMessage::getInternalHeaders)
                     .orElseGet(DittoHeaders::empty)
-            ).warning("Got <{}> when message was processed: <{}>", e.getClass().getSimpleName(), e.getMessage());
+            ).warning("Got unknown exception <{}> when processing external message with mapper <{}>: <{}>",
+                    e.getClass().getSimpleName(), mapperId, e.getMessage());
         }
         return Optional.empty();
     }

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/InboundDispatchingActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/InboundDispatchingActor.java
@@ -307,12 +307,10 @@ public final class InboundDispatchingActor extends AbstractActor
         } else if (e != null) {
             responseMappedMonitor.getLogger()
                     .failure("Got unknown exception when processing external message: {0}", e.getMessage());
-            if (message != null) {
-                logger.setCorrelationId(message.getInternalHeaders());
-            }
-            logger.warning("Got <{}> when message was processed: <{}>", e.getClass().getSimpleName(),
-                    e.getMessage());
-            logger.discardCorrelationId();
+            logger.withCorrelationId(Optional.ofNullable(message)
+                    .map(ExternalMessage::getInternalHeaders)
+                    .orElseGet(DittoHeaders::empty)
+            ).warning("Got <{}> when message was processed: <{}>", e.getClass().getSimpleName(), e.getMessage());
         }
         return Optional.empty();
     }

--- a/services/connectivity/starter/src/main/java/org/eclipse/ditto/services/connectivity/ConnectivityRootActor.java
+++ b/services/connectivity/starter/src/main/java/org/eclipse/ditto/services/connectivity/ConnectivityRootActor.java
@@ -41,6 +41,7 @@ import org.eclipse.ditto.services.utils.health.config.PersistenceConfig;
 import org.eclipse.ditto.services.utils.persistence.mongo.MongoHealthChecker;
 import org.eclipse.ditto.services.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.services.utils.persistentactors.PersistencePingActor;
+import org.eclipse.ditto.services.utils.pubsub.DittoProtocolSub;
 import org.eclipse.ditto.signals.base.Signal;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityCommandInterceptor;
 
@@ -92,6 +93,12 @@ public final class ConnectivityRootActor extends DittoRootActor {
                 startChildActor(ConnectionPersistenceStreamingActorCreator.ACTOR_NAME,
                         ConnectionPersistenceStreamingActorCreator.props(0));
         pubSubMediator.tell(DistPubSubAccess.put(persistenceStreamingActor), getSelf());
+
+        // start DittoProtocolSub extension, even if not passed to connections via reference
+        //  because of serialization issues the single BaseClientActors "get" the extension themselves
+        //  it must however be started here in order to already participate in Ditto pub/sub, even if no connection is
+        //  available!
+        DittoProtocolSub.get(actorSystem);
 
         startClusterSingletonActor(
                 PersistencePingActor.props(

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/actors/AbstractHttpRequestActor.java
@@ -469,15 +469,15 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
     private HttpResponse enhanceResponseWithExternalDittoHeaders(final HttpResponse response,
             final DittoHeaders allDittoHeaders) {
 
-        logger.setCorrelationId(allDittoHeaders);
+        final DittoDiagnosticLoggingAdapter l = logger.withCorrelationId(allDittoHeaders);
         final Map<String, String> externalHeaders = getExternalHeaders(allDittoHeaders);
 
         if (externalHeaders.isEmpty()) {
-            logger.debug("No external headers for enhancing the response, returning it as-is.");
+            l.debug("No external headers for enhancing the response, returning it as-is.");
             return response;
         }
 
-        logger.debug("Enhancing response with external headers <{}>.", externalHeaders);
+        l.debug("Enhancing response with external headers <{}>.", externalHeaders);
         final List<HttpHeader> externalHttpHeaders = externalHeaders
                 .entrySet()
                 .stream()
@@ -488,7 +488,6 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
                 .filter(entry -> !entry.getKey().equalsIgnoreCase(DittoHeaderDefinition.CONTENT_TYPE.getKey()))
                 .map(entry -> RawHeader.create(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
-        logger.discardCorrelationId();
 
         return response.withHeaders(externalHttpHeaders);
     }

--- a/services/utils/config/src/main/resources/ditto-akka-config.conf
+++ b/services/utils/config/src/main/resources/ditto-akka-config.conf
@@ -152,27 +152,6 @@ akka {
   remote {
     log-remote-lifecycle-events = on
 
-    netty.tcp {
-      # InetAddress.getLocalHost.getHostAddress is used if empty
-      hostname = ""
-      hostname = ${?REMOTE_HOSTNAME}
-      port = 2551
-      port = ${?REMOTE_PORT}
-
-      bind-hostname = ${?BIND_HOSTNAME}
-      bind-port = ${?BIND_TCP_PORT}
-
-      # maximum-frame-size = 128000b # this is the default
-      maximum-frame-size = 256000b # 256 KiB
-      maximum-frame-size = ${?REMOTE_MAX_FRAMESIZE}
-      # send-buffer-size = 256000b # this is the default
-      send-buffer-size = 320000b # 320 KiB
-      send-buffer-size = ${?REMOTE_SEND_BUFFERSIZE}
-      # receive-buffer-size = 256000b # this is the default
-      receive-buffer-size = 320000b # 320 KiB
-      receive-buffer-size = ${?REMOTE_RECEIVE_BUFFERSIZE}
-    }
-
     artery {
       enabled = on
       enabled = ${?ARTERY_ENABLED}

--- a/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DefaultDistributedDataConfig.java
+++ b/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DefaultDistributedDataConfig.java
@@ -33,34 +33,32 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
     private final Replicator.WriteConsistency subscriptionWriteConsistency;
     private final Duration subscriptionDelay;
     private final AkkaReplicatorConfig akkaReplicatorConfig;
+    private final int numberOfShards;
 
     private DefaultDistributedDataConfig(final Config configWithFallback) {
         readTimeout = configWithFallback.getDuration(DistributedDataConfigValue.READ_TIMEOUT.getConfigPath());
-        final Duration writeTimeout =
-                configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath());
-        this.writeTimeout = writeTimeout;
+        writeTimeout = configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath());
         akkaReplicatorConfig = DefaultAkkaReplicatorConfig.of(configWithFallback);
         subscriptionWriteConsistency = toWriteConsistency(configWithFallback.getString(
                 DistributedDataConfigValue.SUBSCRIPTION_WRITE_CONSISTENCY.getConfigPath()),
                 writeTimeout);
         subscriptionDelay =
                 configWithFallback.getDuration(DistributedDataConfigValue.SUBSCRIPTION_DELAY.getConfigPath());
+        numberOfShards = configWithFallback.getInt(DistributedDataConfigValue.NUMBER_OF_SHARDS.getConfigPath());
     }
 
     private DefaultDistributedDataConfig(final Config configWithFallback,
             final CharSequence replicatorName,
             final CharSequence replicatorRole) {
         readTimeout = configWithFallback.getDuration(DistributedDataConfigValue.READ_TIMEOUT.getConfigPath());
-        final Duration writeTimeout =
-                configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath());
-        this.writeTimeout = writeTimeout;
-        akkaReplicatorConfig = DefaultAkkaReplicatorConfig.of(configWithFallback, replicatorName,
-                replicatorRole);
+        writeTimeout = configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath());
+        akkaReplicatorConfig = DefaultAkkaReplicatorConfig.of(configWithFallback, replicatorName, replicatorRole);
         subscriptionWriteConsistency = toWriteConsistency(configWithFallback.getString(
                 DistributedDataConfigValue.SUBSCRIPTION_WRITE_CONSISTENCY.getConfigPath()),
                 writeTimeout);
         subscriptionDelay =
                 configWithFallback.getDuration(DistributedDataConfigValue.SUBSCRIPTION_DELAY.getConfigPath());
+        numberOfShards = configWithFallback.getInt(DistributedDataConfigValue.NUMBER_OF_SHARDS.getConfigPath());
     }
 
     /**
@@ -120,6 +118,11 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
     }
 
     @Override
+    public int getNumberOfShards() {
+        return numberOfShards;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -132,13 +135,14 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
                 Objects.equals(writeTimeout, that.writeTimeout) &&
                 Objects.equals(subscriptionWriteConsistency, that.subscriptionWriteConsistency) &&
                 Objects.equals(subscriptionDelay, that.subscriptionDelay) &&
-                Objects.equals(akkaReplicatorConfig, that.akkaReplicatorConfig);
+                Objects.equals(akkaReplicatorConfig, that.akkaReplicatorConfig) &&
+                numberOfShards == that.numberOfShards;
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(readTimeout, writeTimeout, akkaReplicatorConfig, subscriptionWriteConsistency,
-                subscriptionDelay);
+                subscriptionDelay, numberOfShards);
     }
 
     @Override
@@ -149,6 +153,7 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
                 ", subscriptionWriteConsistency=" + subscriptionWriteConsistency +
                 ", subscriptionDelay" + subscriptionDelay +
                 ", akkaReplicatorConfig=" + akkaReplicatorConfig +
+                ", numberOfShards=" + numberOfShards +
                 "]";
     }
 

--- a/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DefaultDistributedDataConfig.java
+++ b/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DefaultDistributedDataConfig.java
@@ -41,7 +41,7 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
         akkaReplicatorConfig = DefaultAkkaReplicatorConfig.of(configWithFallback);
         subscriptionWriteConsistency = toWriteConsistency(configWithFallback.getString(
                 DistributedDataConfigValue.SUBSCRIPTION_WRITE_CONSISTENCY.getConfigPath()),
-                writeTimeout);
+                configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath()));
         subscriptionDelay =
                 configWithFallback.getDuration(DistributedDataConfigValue.SUBSCRIPTION_DELAY.getConfigPath());
         numberOfShards = configWithFallback.getInt(DistributedDataConfigValue.NUMBER_OF_SHARDS.getConfigPath());
@@ -55,7 +55,7 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
         akkaReplicatorConfig = DefaultAkkaReplicatorConfig.of(configWithFallback, replicatorName, replicatorRole);
         subscriptionWriteConsistency = toWriteConsistency(configWithFallback.getString(
                 DistributedDataConfigValue.SUBSCRIPTION_WRITE_CONSISTENCY.getConfigPath()),
-                writeTimeout);
+                configWithFallback.getDuration(DistributedDataConfigValue.WRITE_TIMEOUT.getConfigPath()));
         subscriptionDelay =
                 configWithFallback.getDuration(DistributedDataConfigValue.SUBSCRIPTION_DELAY.getConfigPath());
         numberOfShards = configWithFallback.getInt(DistributedDataConfigValue.NUMBER_OF_SHARDS.getConfigPath());
@@ -131,12 +131,11 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
             return false;
         }
         final DefaultDistributedDataConfig that = (DefaultDistributedDataConfig) o;
-        return Objects.equals(readTimeout, that.readTimeout) &&
+        return numberOfShards == that.numberOfShards && Objects.equals(readTimeout, that.readTimeout) &&
                 Objects.equals(writeTimeout, that.writeTimeout) &&
                 Objects.equals(subscriptionWriteConsistency, that.subscriptionWriteConsistency) &&
                 Objects.equals(subscriptionDelay, that.subscriptionDelay) &&
-                Objects.equals(akkaReplicatorConfig, that.akkaReplicatorConfig) &&
-                numberOfShards == that.numberOfShards;
+                Objects.equals(akkaReplicatorConfig, that.akkaReplicatorConfig);
     }
 
     @Override

--- a/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedData.java
+++ b/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedData.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
+import java.util.stream.IntStream;
 
 import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
 
@@ -60,6 +61,8 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
      */
     protected final ActorRef replicator;
 
+    protected final int numberOfShards;
+
     private final Executor ddataExecutor;
 
     /**
@@ -76,6 +79,7 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
         this.ddataExecutor = ddataExecutor;
         readTimeout = config.getReadTimeout();
         writeTimeout = config.getWriteTimeout();
+        numberOfShards = config.getNumberOfShards();
     }
 
     /**
@@ -108,9 +112,12 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
     }
 
     /**
+     * Creates/gets a key for the passed {@code shardNumber}.
+     *
+     * @param shardNumber the number of the shard to append to the key.
      * @return key of the distributed collection. Should be unique among collections of the same type.
      */
-    protected abstract Key<R> getKey();
+    protected abstract Key<R> getKey(int shardNumber);
 
     /**
      * @return initial value of the distributed data.
@@ -120,11 +127,12 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
     /**
      * Asynchronously retrieves the replicated data.
      *
+     * @param key the key to get the replicated data for.
      * @param readConsistency how many replicas to consult.
      * @return future of the replicated data that completes exceptionally on error.
      */
-    public CompletionStage<Optional<R>> get(final Replicator.ReadConsistency readConsistency) {
-        final Replicator.Get<R> replicatorGet = new Replicator.Get<>(getKey(), readConsistency);
+    public CompletionStage<Optional<R>> get(final Key<R> key, final Replicator.ReadConsistency readConsistency) {
+        final Replicator.Get<R> replicatorGet = new Replicator.Get<>(key, readConsistency);
         return Patterns.ask(replicator, replicatorGet, getAskTimeout(readConsistency.timeout(), readTimeout))
                 .thenApplyAsync(this::handleGetResponse, ddataExecutor);
     }
@@ -132,15 +140,16 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
     /**
      * Modify the replicated data.
      *
+     * @param key the key to update.
      * @param writeConsistency how many replicas to update.
      * @param updateFunction what to do to the replicas.
      * @return future that completes when the update completes, exceptionally when any error is encountered.
      */
-    public CompletionStage<Void> update(final Replicator.WriteConsistency writeConsistency,
+    public CompletionStage<Void> update(final Key<R> key, final Replicator.WriteConsistency writeConsistency,
             final Function<R, R> updateFunction) {
 
         final Replicator.Update<R> replicatorUpdate =
-                new Replicator.Update<>(getKey(), getInitialValue(), writeConsistency, updateFunction);
+                new Replicator.Update<>(key, getInitialValue(), writeConsistency, updateFunction);
         return Patterns.ask(replicator, replicatorUpdate, getAskTimeout(writeConsistency.timeout(), writeTimeout))
                 .thenApplyAsync(this::handleUpdateResponse, ddataExecutor);
     }
@@ -151,7 +160,8 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
      * @param subscriber whom to notify of changes.
      */
     public void subscribeForChanges(final ActorRef subscriber) {
-        replicator.tell(new Replicator.Subscribe<>(getKey(), subscriber), ActorRef.noSender());
+        IntStream.range(0, numberOfShards)
+                .forEach(i -> replicator.tell(new Replicator.Subscribe<>(getKey(i), subscriber), ActorRef.noSender()));
     }
 
     /**
@@ -167,7 +177,7 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
         } else {
             final String errorMessage =
                     MessageFormat.format("Expect Replicator.UpdateSuccess for key ''{2}'' from ''{1}'', Got: ''{0}''",
-                            reply, replicator, getKey());
+                            reply, replicator, getKey(0));
             throw new IllegalArgumentException(errorMessage);
         }
     }
@@ -182,7 +192,7 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
         } else {
             final String errorMessage =
                     MessageFormat.format("Expect Replicator.GetResponse for key ''{2}'' from ''{1}'', Got: ''{0}''",
-                            reply, replicator, getKey());
+                            reply, replicator, getKey(0));
             throw new IllegalArgumentException(errorMessage);
         }
     }
@@ -215,7 +225,8 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
         /**
          * Constructor available for subclasses only.
          */
-        protected AbstractDDataProvider() {}
+        protected AbstractDDataProvider() {
+        }
 
         @Override
         public abstract T createExtension(ExtendedActorSystem system);

--- a/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedDataConfig.java
+++ b/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedDataConfig.java
@@ -62,6 +62,13 @@ public interface DistributedDataConfig {
     AkkaReplicatorConfig getAkkaReplicatorConfig();
 
     /**
+     * The number of shards Ditto's ddata extension applies for Map keys.
+     *
+     * @return the number of shards to apply.
+     */
+    int getNumberOfShards();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code DistributedDataConfig}.
      */
@@ -85,7 +92,12 @@ public interface DistributedDataConfig {
         /**
          * Local delay for topic subscription to account for replication and notification delay.
          */
-        SUBSCRIPTION_DELAY("subscription-delay", Duration.ofSeconds(2L));
+        SUBSCRIPTION_DELAY("subscription-delay", Duration.ofSeconds(2L)),
+
+        /**
+         * The number of shards Ditto's ddata extension applies for Map keys.
+         */
+        NUMBER_OF_SHARDS("number-of-shards", 1);
 
         private final String path;
         private final Object defaultValue;

--- a/services/utils/ddata/src/main/resources/reference.conf
+++ b/services/utils/ddata/src/main/resources/reference.conf
@@ -6,6 +6,36 @@ ditto {
     akka-distributed-data = ${akka.cluster.distributed-data}
     akka-distributed-data {
       // specific overrides come here
+
+      # How often the Replicator should send out gossip information.
+      #  Next chunk will be transferred in next round of gossip.
+      #  default: 2s
+      gossip-interval = 2s
+      gossip-interval = ${?DITTO_DDATA_GOSSIP_INTERVAL}
+
+
+      # from which data size to start logging INFO messages about the ddata size of a *single ddata key* in
+      #  akka.cluster.ddata.PayloadSizeAggregator (using logger "akka.cluster.ddata.Replicator):
+      #  default: 10 KiB
+      log-data-size-exceeding = 100 B
+      log-data-size-exceeding = ${?DITTO_DDATA_LOG_DATA_SIZE_EXCEEDING}
+
+      # reduce max amount of ddata map keys to send per gossip-interval, postpone others to next interval
+      #  default: 500
+      #  as we apply sharding on the map keys for Ditto pub/sub, "1" configures to use minimal remoting size, whereas
+      #  values "> 1" reduce networking interactions
+      max-delta-elements = 1
+      max-delta-elements = ${?DITTO_DDATA_MAX_DELTA_ELEMENTS}
+
+      # increase max size to transfer in a delta update
+      #  default: 50
+      #  If this is too low, full syncs of the ddata map will be triggered which may be larger than the configured
+      #  `max-frame-size` of the cluster,
+      #  then we will see: Failed to serialize oversized message [akka.cluster.ddata.Replicator$Internal$Gossip].
+      #  If this is configured too high,
+      #       we will see: Failed to serialize oversized message [ActorSelectionMessage(akka.cluster.ddata.Replicator$Internal$DeltaPropagation)]
+      delta-crdt.max-delta-size = 50
+      delta-crdt.max-delta-size = ${?DITTO_DDATA_DELTA_MAX_DELTA_SIZE}
     }
 
     read-timeout = 5s
@@ -16,8 +46,15 @@ ditto {
     subscription-write-consistency = ${?DITTO_DDATA_SUBSCRIPTION_WRITE_CONSISTENCY}
 
     # Local delay for topic subscription to account for replication and notification delay.
-    # Set to 0s to disable.
+    #  Set to 0s to disable.
     subscription-delay = 2s
     subscription-delay = ${?DITTO_DDATA_SUBSCRIPTION_DELAY}
+
+    # The number of shards Ditto's ddata extension applies for Map keys:
+    #  - when configured to "1", there will be exactly 1 map key containing all ddata values in its value
+    #  - increase to higher values in order to apply sharding
+    #  The sharding is done based on a hash of the Address or ActorRef of the Subscriber of a service instance.
+    number-of-shards = 1
+    number-of-shards = ${?DITTO_DDATA_NUMBER_OF_SHARDS}
   }
 }

--- a/services/utils/ddata/src/test/java/org/eclipse/ditto/services/utils/ddata/DefaultAkkaReplicatorConfigTest.java
+++ b/services/utils/ddata/src/test/java/org/eclipse/ditto/services/utils/ddata/DefaultAkkaReplicatorConfigTest.java
@@ -79,6 +79,9 @@ public final class DefaultAkkaReplicatorConfigTest {
         softly.assertThat(underTest.getRole())
                 .as(AkkaReplicatorConfig.AkkaReplicatorConfigValue.ROLE.getConfigPath())
                 .isEqualTo("a-role");
+        softly.assertThat(underTest.getGossipInterval())
+                .as(AkkaReplicatorConfig.AkkaReplicatorConfigValue.GOSSIP_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofMillis(1337));
         softly.assertThat(underTest.getNotifySubscribersInterval())
                 .as(AkkaReplicatorConfig.AkkaReplicatorConfigValue.NOTIFY_SUBSCRIBERS_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(1));
@@ -100,7 +103,7 @@ public final class DefaultAkkaReplicatorConfigTest {
 
         // test that akka default config values are copied
         final Config completeConfig = underTest.getCompleteConfig();
-        assertThat(completeConfig.getDuration("gossip-interval")).isEqualTo(Duration.ofSeconds(2L));
+        assertThat(completeConfig.getDuration("gossip-interval")).isEqualTo(Duration.ofMillis(1337L));
         assertThat(completeConfig.getBoolean("delta-crdt.enabled")).isEqualTo(true);
     }
 

--- a/services/utils/ddata/src/test/resources/akka-replicator-ddata-test.conf
+++ b/services/utils/ddata/src/test/resources/akka-replicator-ddata-test.conf
@@ -2,5 +2,6 @@ akka-distributed-data = ${akka.cluster.distributed-data}
 akka-distributed-data {
   name = "the-name"
   role = "a-role"
+  gossip-interval = 1337ms
   notify-subscribers-interval = 1 s
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/AckUpdater.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/AckUpdater.java
@@ -51,6 +51,7 @@ import akka.actor.ActorRef;
 import akka.actor.Address;
 import akka.actor.Props;
 import akka.actor.Terminated;
+import akka.cluster.ddata.ORMultiMap;
 import akka.cluster.ddata.Replicator;
 import akka.event.LoggingAdapter;
 import akka.japi.pf.ReceiveBuilder;
@@ -192,8 +193,8 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
     }
 
     private void onChanged(final Replicator.Changed<?> event) {
-        final Map<Address, List<Grouped<String>>> mmap =
-                Grouped.deserializeORMultiMap(event.get(ackDData.getReader().getKey()), JsonValue::asString);
+        final Map<Address, List<Grouped<String>>> mmap = Grouped.deserializeORMultiMap(
+                ((ORMultiMap<Address, String>) event.dataValue()), JsonValue::asString);
         final List<Grouped<String>> remoteGroupedAckLabels = getRemoteGroupedAckLabelsOrderByAddress(mmap);
         remoteGroups = getRemoteGroups(remoteGroupedAckLabels);
         remoteAckLabels = getRemoteAckLabels(remoteGroupedAckLabels);

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/SubUpdater.java
@@ -237,7 +237,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
      * @param failure the update failure.
      */
     private void updateFailure(final Status.Failure failure) {
-        log.error(failure.cause(), "updateFailure");
+        log.error(failure.cause(), "Failure updating Ditto pub/sub subscription - trying again next clock tick");
         // try again next clock tick
         localSubscriptionsChanged = true;
     }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.services.utils.pubsub.ddata;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -86,7 +85,9 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
             final SubscriberData subscriberData = SubscriberData.of(topics, filter, group);
             subscriberDataMap.merge(subscriber, subscriberData, (oldData, newData) -> {
                 changed[0] = !oldData.getFilter().equals(newData.getFilter());
-                return newData.withTopics(unionSet(oldData.getTopics(), newData.getTopics()));
+                final Set<String> unionTopics = unionSet(oldData.getTopics(), newData.getTopics());
+                changed[0] |= !unionTopics.equals(oldData.getTopics());
+                return newData.withTopics(unionTopics);
             });
 
             // add subscriber for each new topic; detect whether there is any change.
@@ -162,12 +163,6 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
                 .stream()
                 .map(entry -> Pair.create(entry.getKey(), entry.getValue().export()))
                 .collect(Collectors.toMap(Pair::first, Pair::second));
-    }
-
-    private Map<String, Set<ActorRef>> exportTopicData() {
-        return Collections.unmodifiableMap(topicDataMap.entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().exportSubscribers())));
     }
 
     private boolean removeSubscriberForTopics(final ActorRef subscriber, final Collection<String> topics) {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/DDataReader.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/DDataReader.java
@@ -12,14 +12,9 @@
  */
 package org.eclipse.ditto.services.utils.pubsub.ddata;
 
-import java.util.Map;
-import java.util.concurrent.CompletionStage;
-
 import akka.actor.ActorRef;
 import akka.cluster.ddata.Key;
 import akka.cluster.ddata.ORMultiMap;
-import akka.cluster.ddata.Replicator;
-import scala.collection.immutable.Set;
 
 /**
  * Reader of distributed Bloom filters of subscribed topics.
@@ -27,22 +22,6 @@ import scala.collection.immutable.Set;
  * @param <T> type of topic approximations.
  */
 public interface DDataReader<K, T> {
-
-    /**
-     * Read a low-level map from the local replicator.
-     *
-     * @return the low-level map.
-     */
-    default CompletionStage<Map<K, Set<T>>> read() {
-        return read((Replicator.ReadConsistency) Replicator.readLocal());
-    }
-
-    /**
-     * Read a low-level map from the local replicator.
-     *
-     * @return the low-level map.
-     */
-    CompletionStage<Map<K, Set<T>>> read(Replicator.ReadConsistency readConsistency);
 
     /**
      * Map a topic to a key with which to read distributed data.
@@ -61,7 +40,17 @@ public interface DDataReader<K, T> {
     void receiveChanges(ActorRef recipient);
 
     /**
+     * Returns the number of shards Ditto's ddata extension applies for Map keys.
+     *
+     * @return the number of shards Ditto's ddata extension applies for Map keys
+     */
+    int getNumberOfShards();
+
+    /**
+     * Creates/gets a key for the passed {@code shardNumber}.
+     *
+     * @param shardNumber the number of the shard to append to the key.
      * @return Key of the distributed data.
      */
-    Key<ORMultiMap<K, T>> getKey();
+    Key<ORMultiMap<K, T>> getKey(int shardNumber);
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/SubscriberData.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/SubscriberData.java
@@ -119,4 +119,13 @@ public final class SubscriberData {
     public int hashCode() {
         return Objects.hash(topics, filter, group);
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "topics=" + topics +
+                ", filter=" + filter +
+                ", group=" + group +
+                "]";
+    }
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/compressed/CompressedDDataHandler.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/compressed/CompressedDDataHandler.java
@@ -86,7 +86,8 @@ public final class CompressedDDataHandler extends AbstractDDataHandler<ActorRef,
     @Override
     public CompletionStage<Void> removeAddress(final Address address,
             final Replicator.WriteConsistency writeConsistency) {
-        return update(writeConsistency, mmap -> {
+        final int shardNumber = Math.abs(address.hashCode() % numberOfShards);
+        return update(getKey(shardNumber), writeConsistency, mmap -> {
             ORMultiMap<ActorRef, String> result = mmap;
             for (final ActorRef subscriber : mmap.getEntries().keySet()) {
                 if (subscriber.path().address().equals(address)) {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/literal/LiteralDDataHandler.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/literal/LiteralDDataHandler.java
@@ -60,6 +60,7 @@ public final class LiteralDDataHandler extends AbstractDDataHandler<Address, Str
     @Override
     public CompletionStage<Void> removeAddress(final Address address,
             final Replicator.WriteConsistency writeConsistency) {
-        return update(writeConsistency, mmap -> mmap.remove(selfUniqueAddress, address));
+        final int shardNumber = Math.abs(address.hashCode() % numberOfShards);
+        return update(getKey(shardNumber), writeConsistency, mmap -> mmap.remove(selfUniqueAddress, address));
     }
 }

--- a/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
+++ b/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
@@ -226,7 +226,7 @@ public final class PubSubFactoryTest {
 
             // THEN: the subscriber is removed
             Awaitility.await().untilAsserted(() ->
-                    assertThat(factory1.getSubscribers().toCompletableFuture().join())
+                    assertThat(factory1.getSubscribers())
                             .describedAs("subscriber should be removed from ddata after termination")
                             .isEmpty()
             );
@@ -256,9 +256,10 @@ public final class PubSubFactoryTest {
 
             // THEN: the subscriber is removed
             Awaitility.await().untilAsserted(() ->
-                    assertThat(factory1.getSubscribers().toCompletableFuture().join())
+                    assertThat(factory1.getSubscribers())
                             .describedAs("subscriber should be removed from ddata")
-                            .isEmpty());
+                            .isEmpty()
+                            );
         }};
     }
 


### PR DESCRIPTION
Currently, maps managed in Ditto pub/sub (via Akka `ddata`) always contain only a single map "key", e.g.: `"thing-event-aware"`.
When this single map entry gets too big (e.g. if too many subscribers, for example WebSocket sessions, for "thing events" are managed), the configured `maximum-frame-size` with which Ditto is configured will prevent that the "distributed data" can be replicated in the cluster (via `Gossip`) messages.

As a result, the following error is logged:
```
Failed to serialize oversized message [akka.cluster.ddata.Replicator$Internal$Gossip]
```

This can and should be prevented by applying a "sharding" approach on the maps replicated via Akka `ddata` (containing a number suffix).

This PR:
* adds the configuration: `ditto.ddata.number-of-shards` (by default `1` in order to keep the same behavior as currently)
* configures `ditto.ddata.akka-distributed-data.max-data-elements` to `1` (default is 500)
   * this value determines how many map entries are sent across the Ditto cluster "at once" - so only by setting this to "1", the applied sharding will be of use
* applies the sharding based on the hash of the `Subscriber` or `Address` which subscribes for messages via Ditto pub/sub