### PR TITLE
Improves the priority ordering in MongoReadJournal

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/ConnectionPersistenceActor.java
@@ -77,6 +77,7 @@ import org.eclipse.ditto.services.utils.akka.logging.DittoDiagnosticLoggingAdapt
 import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
 import org.eclipse.ditto.services.utils.config.InstanceIdentifierSupplier;
 import org.eclipse.ditto.services.utils.persistence.mongo.config.ActivityCheckConfig;
+import org.eclipse.ditto.services.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.services.utils.persistentactors.AbstractShardedPersistenceActor;
 import org.eclipse.ditto.services.utils.persistentactors.EmptyEvent;
 import org.eclipse.ditto.services.utils.persistentactors.commands.CommandStrategy;
@@ -405,7 +406,7 @@ public final class ConnectionPersistenceActor
 
     private Set<String> journalTags() {
         return Set.of(JOURNAL_TAG_ALWAYS_ALIVE,
-                JOURNAL_TAG_ALWAYS_ALIVE + "-" + Optional.ofNullable(priority).orElse(0));
+                MongoReadJournal.PRIORITY_TAG_PREFIX + Optional.ofNullable(priority).orElse(0));
     }
 
     @Override

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournalIT.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournalIT.java
@@ -275,7 +275,7 @@ public final class MongoReadJournalIT {
                 .append("to", 2L));
 
         final List<String> pids =
-                readJournal.getJournalPidsWithTagOrderedByTags("always-alive", Duration.ZERO)
+                readJournal.getJournalPidsWithTagOrderedByPriorityTag("always-alive", Duration.ZERO)
                         .runWith(Sink.seq(), materializer)
                         .toCompletableFuture().join();
 
@@ -306,7 +306,7 @@ public final class MongoReadJournalIT {
                 .append("to", 2L));
 
         final List<String> pids =
-                readJournal.getJournalPidsWithTagOrderedByTags("always-alive", Duration.ZERO)
+                readJournal.getJournalPidsWithTagOrderedByPriorityTag("always-alive", Duration.ZERO)
                         .runWith(Sink.seq(), materializer)
                         .toCompletableFuture().join();
 
@@ -333,11 +333,38 @@ public final class MongoReadJournalIT {
                 .append("to", 2L));
 
         final List<String> pids =
-                readJournal.getJournalPidsWithTagOrderedByTags("always-alive", Duration.ZERO)
+                readJournal.getJournalPidsWithTagOrderedByPriorityTag("always-alive", Duration.ZERO)
                         .runWith(Sink.seq(), materializer)
                         .toCompletableFuture().join();
 
         assertThat(pids).containsExactly("pid1", "pid4", "pid3", "pid2");
+    }
+
+    @Test
+    public void extractJournalPidsWithTagOrderedByPriorityTagWhenPriorityTagMissing() {
+        insert("test_journal", new Document()
+                .append("pid", "pid1")
+                .append("_tg", Set.of("always-alive"))
+                .append("to", 1L));
+        insert("test_journal", new Document()
+                .append("pid", "pid2")
+                .append("_tg", Set.of("always-alive"))
+                .append("to", 1L));
+        insert("test_journal", new Document()
+                .append("pid", "pid3")
+                .append("_tg", Set.of("always-alive"))
+                .append("to", 2L));
+        insert("test_journal", new Document()
+                .append("pid", "pid4")
+                .append("_tg", Set.of("always-alive"))
+                .append("to", 2L));
+
+        final List<String> pids =
+                readJournal.getJournalPidsWithTagOrderedByPriorityTag("always-alive", Duration.ZERO)
+                        .runWith(Sink.seq(), materializer)
+                        .toCompletableFuture().join();
+
+        assertThat(pids).containsExactlyInAnyOrder("pid1", "pid2", "pid3", "pid4");
     }
 
     @Test

--- a/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournalIT.java
+++ b/services/utils/persistence/src/test/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournalIT.java
@@ -259,19 +259,19 @@ public final class MongoReadJournalIT {
     public void extractJournalPidsInOrderOfTags() {
         insert("test_journal", new Document()
                 .append("pid", "pid1")
-                .append("_tg", Set.of("always-alive", "always-alive-10"))
+                .append("_tg", Set.of("always-alive", "priority-10"))
                 .append("to", 1L));
         insert("test_journal", new Document()
                 .append("pid", "pid2")
-                .append("_tg", Set.of("always-alive", "always-alive-2"))
+                .append("_tg", Set.of("always-alive", "priority-2"))
                 .append("to", 1L));
         insert("test_journal", new Document()
                 .append("pid", "pid3")
-                .append("_tg", Set.of("always-alive", "always-alive-3"))
+                .append("_tg", Set.of("always-alive", "priority-3"))
                 .append("to", 2L));
         insert("test_journal", new Document()
                 .append("pid", "pid4")
-                .append("_tg", Set.of("always-alive", "always-alive-4"))
+                .append("_tg", Set.of("always-alive", "priority-4"))
                 .append("to", 2L));
 
         final List<String> pids =
@@ -286,23 +286,23 @@ public final class MongoReadJournalIT {
     public void extractJournalPidsInOrderOfTagsOfNewestEvent() {
         insert("test_journal", new Document()
                 .append("pid", "pid1")
-                .append("_tg", Set.of("always-alive", "always-alive-99"))
+                .append("_tg", Set.of("always-alive", "priority-99"))
                 .append("to", 1L));
         insert("test_journal", new Document()
                 .append("pid", "pid1")
-                .append("_tg", Set.of("always-alive", "always-alive-1"))
+                .append("_tg", Set.of("always-alive", "priority-1"))
                 .append("to", 2L));
         insert("test_journal", new Document()
                 .append("pid", "pid2")
-                .append("_tg", Set.of("always-alive", "always-alive-2"))
+                .append("_tg", Set.of("always-alive", "priority-2"))
                 .append("to", 1L));
         insert("test_journal", new Document()
                 .append("pid", "pid3")
-                .append("_tg", Set.of("always-alive", "always-alive-3"))
+                .append("_tg", Set.of("always-alive", "priority-3"))
                 .append("to", 2L));
         insert("test_journal", new Document()
                 .append("pid", "pid4")
-                .append("_tg", Set.of("always-alive", "always-alive-4"))
+                .append("_tg", Set.of("always-alive", "priority-4"))
                 .append("to", 2L));
 
         final List<String> pids =
@@ -311,6 +311,33 @@ public final class MongoReadJournalIT {
                         .toCompletableFuture().join();
 
         assertThat(pids).containsExactly("pid4", "pid3", "pid2", "pid1");
+    }
+
+    @Test
+    public void extractJournalPidsInOrderOfTagsIgnoresOtherTags() {
+        insert("test_journal", new Document()
+                .append("pid", "pid1")
+                .append("_tg", Set.of("always-alive", "priority-99"))
+                .append("to", 1L));
+        insert("test_journal", new Document()
+                .append("pid", "pid2")
+                .append("_tg", Set.of("always-alive", "priority-2"))
+                .append("to", 1L));
+        insert("test_journal", new Document()
+                .append("pid", "pid3")
+                .append("_tg", Set.of("always-alive", "z-tag", "priority-3"))
+                .append("to", 2L));
+        insert("test_journal", new Document()
+                .append("pid", "pid4")
+                .append("_tg", Set.of("always-alive", "priority-4"))
+                .append("to", 2L));
+
+        final List<String> pids =
+                readJournal.getJournalPidsWithTagOrderedByTags("always-alive", Duration.ZERO)
+                        .runWith(Sink.seq(), materializer)
+                        .toCompletableFuture().join();
+
+        assertThat(pids).containsExactly("pid1", "pid4", "pid3", "pid2");
     }
 
     @Test

--- a/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/PersistencePingActor.java
+++ b/services/utils/persistent-actors/src/main/java/org/eclipse/ditto/services/utils/persistentactors/PersistencePingActor.java
@@ -85,7 +85,7 @@ public final class PersistencePingActor extends AbstractActor {
         switch (streamingOrder) {
             case TAGS:
                 persistenceIdsSourceSupplier = () ->
-                        readJournal.getJournalPidsWithTagOrderedByTags(pingConfig.getJournalTag(),
+                        readJournal.getJournalPidsWithTagOrderedByPriorityTag(pingConfig.getJournalTag(),
                                 pingConfig.getInterval());
                 break;
             case ID:


### PR DESCRIPTION
* Defines a prefix 'priority-'
* removes irrelevant sorting step
* adds projection step to remove all other tags than 'priority-.*' to avoid that other tags can have impact on the sorting of events