### PR TITLE
Validate JWT signature also in default validator

### DIFF
--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtValidator.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtValidator.java
@@ -82,7 +82,7 @@ public final class DefaultJwtValidator implements JwtValidator {
         jwtParserBuilder.deserializeJsonWith(JjwtDeserializer.getInstance())
                 .setSigningKey(publicKey)
                 .build()
-                .parse(jsonWebToken.getToken());
+                .parseClaimsJws(jsonWebToken.getToken());
 
         return BinaryValidationResult.valid();
     }

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtTestConstants.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtTestConstants.java
@@ -30,6 +30,7 @@ import io.jsonwebtoken.SignatureAlgorithm;
 final class JwtTestConstants {
 
     static final String VALID_JWT_TOKEN;
+    static final String UNSIGNED_JWT_TOKEN;
     static final String EXPIRED_JWT_TOKEN;
     static final PublicKey PUBLIC_KEY_2;
 
@@ -52,6 +53,7 @@ final class JwtTestConstants {
             PUBLIC_KEY_2 = keyPair2.getPublic();
 
             VALID_JWT_TOKEN = createJwt();
+            UNSIGNED_JWT_TOKEN = createUnsignedJwt();
             EXPIRED_JWT_TOKEN = createExpiredJwt();
         } catch (final Exception e) {
             throw new IllegalStateException(e);
@@ -63,6 +65,13 @@ final class JwtTestConstants {
                 .setHeaderParam("kid", KEY_ID)
                 .setIssuer(ISSUER)
                 .signWith(PRIVATE_KEY, SignatureAlgorithm.RS256)
+                .compact();
+    }
+
+    private static String createUnsignedJwt() {
+        return Jwts.builder()
+                .setHeaderParam("kid", KEY_ID)
+                .setIssuer(ISSUER)
                 .compact();
     }
 

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtValidatorTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtValidatorTest.java
@@ -15,11 +15,18 @@ package org.eclipse.ditto.services.gateway.security.authentication.jwt;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.model.base.common.BinaryValidationResult;
+import org.eclipse.ditto.model.jwt.Audience;
 import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
 import org.eclipse.ditto.model.jwt.JsonWebToken;
 import org.junit.Test;
@@ -28,6 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 
 /**
  * Unit test for {@link DefaultJwtValidator}.
@@ -36,10 +44,14 @@ import io.jsonwebtoken.ExpiredJwtException;
 public final class JwtValidatorTest {
 
     private static final JsonWebToken VALID_JSON_WEB_TOKEN =
-            ImmutableJsonWebToken.fromAuthorization("Bearer " + JwtTestConstants.VALID_JWT_TOKEN);
+            ImmutableJsonWebToken.fromToken(JwtTestConstants.VALID_JWT_TOKEN);
+
+    private static final JsonWebToken VALID_JSON_WEB_TOKEN_WITHOUT_SIGNATURE =
+            // Can't use ImmutableJsonWebToken as it already verifies that the token contains a signature
+            new JsonWebTokenWithoutSignature(JwtTestConstants.UNSIGNED_JWT_TOKEN);
 
     private static final JsonWebToken INVALID_JSON_WEB_TOKEN =
-            ImmutableJsonWebToken.fromAuthorization("Bearer " + JwtTestConstants.EXPIRED_JWT_TOKEN);
+            ImmutableJsonWebToken.fromToken(JwtTestConstants.EXPIRED_JWT_TOKEN);
 
     @Mock
     private PublicKeyProvider publicKeyProvider;
@@ -57,6 +69,20 @@ public final class JwtValidatorTest {
     }
 
     @Test
+    public void validateFailsIfSignatureIsMissing() throws ExecutionException, InterruptedException {
+        when(publicKeyProvider.getPublicKey(JwtTestConstants.ISSUER, JwtTestConstants.KEY_ID)).thenReturn(
+                CompletableFuture.completedFuture(Optional.of(JwtTestConstants.PUBLIC_KEY)));
+
+        final JwtValidator underTest = DefaultJwtValidator.of(publicKeyProvider);
+
+        final BinaryValidationResult jwtValidationResult =
+                underTest.validate(VALID_JSON_WEB_TOKEN_WITHOUT_SIGNATURE).get();
+
+        assertThat(jwtValidationResult.isValid()).isFalse();
+        assertThat(jwtValidationResult.getReasonForInvalidity()).isInstanceOf(UnsupportedJwtException.class);
+    }
+
+    @Test
     public void validateFails() throws ExecutionException, InterruptedException {
         when(publicKeyProvider.getPublicKey(JwtTestConstants.ISSUER, JwtTestConstants.KEY_ID))
                 .thenReturn(CompletableFuture.completedFuture(Optional.of(JwtTestConstants.PUBLIC_KEY)));
@@ -67,6 +93,86 @@ public final class JwtValidatorTest {
 
         assertThat(jwtValidationResult.isValid()).isFalse();
         assertThat(jwtValidationResult.getReasonForInvalidity()).isInstanceOf(ExpiredJwtException.class);
+    }
+
+    private static final class JsonWebTokenWithoutSignature implements JsonWebToken {
+
+        private final String token;
+        private final JsonObject header;
+        private final JsonObject body;
+
+        private JsonWebTokenWithoutSignature(final String token) {
+            this.token = token;
+            final String[] tokenParts = this.token.split("\\.");
+            header = decodeJwtPart(tokenParts[0]);
+            body = decodeJwtPart(tokenParts[1]);
+        }
+
+        private static JsonObject decodeJwtPart(final String jwtPart) {
+            final Base64.Decoder decoder = Base64.getDecoder();
+            return JsonFactory.newObject(new String(decoder.decode(jwtPart), StandardCharsets.UTF_8));
+        }
+
+        @Override
+        public String getToken() {
+            return token;
+        }
+
+        @Override
+        public JsonObject getHeader() {
+            return header;
+        }
+
+        @Override
+        public JsonObject getBody() {
+            return body;
+        }
+
+        @Override
+        public String getKeyId() {
+            return header.getValueOrThrow(JsonFields.KID);
+        }
+
+        @Override
+        public String getIssuer() {
+            return body.getValueOrThrow(JsonFields.ISS);
+        }
+
+        @Override
+        public String getSignature() {
+            return "";
+        }
+
+        @Override
+        public List<String> getSubjects() {
+            return List.of();
+        }
+
+        @Override
+        public Audience getAudience() {
+            return Audience.empty();
+        }
+
+        @Override
+        public String getAuthorizedParty() {
+            return "";
+        }
+
+        @Override
+        public List<String> getScopes() {
+            return List.of();
+        }
+
+        @Override
+        public Instant getExpirationTime() {
+            return Instant.ofEpochSecond(body.getValueOrThrow(JsonFields.EXP));
+        }
+
+        @Override
+        public boolean isExpired() {
+            return Instant.now().isAfter(getExpirationTime());
+        }
+
     }
 
 }


### PR DESCRIPTION
We're validating for an existing signature in JWTs in our default implementation `ImmutableJsonWebToken`, which will then be validated in `DefaultJwtValidator#validateWithPublicKey:85`.
However, the used [`io.jsonwebtoken.JwtParser#parse(String)`](https://github.com/jwtk/jjwt/blob/a4130dd1ec5d4bef4b1835927a2a1d966a519109/api/src/main/java/io/jsonwebtoken/JwtParser.java#L428) basically also would work for unsigned tokens. Therefore changed to [`io.jsonwebtoken.JwtParse#parseClaimsJws(String)`](https://github.com/jwtk/jjwt/blob/a4130dd1ec5d4bef4b1835927a2a1d966a519109/api/src/main/java/io/jsonwebtoken/JwtParser.java#L594) which will throw an exception if the JWT isn't signed.