### PR TITLE
Fix ddata sharding message duplication

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
           - mongodb
     command: mongod --storageEngine wiredTiger --noscripting
     user: mongodb
+    ports:
+      - 27017:27017
     environment:
        TZ: Europe/Berlin
 

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ErrorHandlingActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ErrorHandlingActorTest.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.services.connectivity.messaging;
 
 import static org.eclipse.ditto.services.connectivity.messaging.FaultyClientActor.faultyClientActorPropsFactory;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
@@ -72,7 +73,7 @@ public class ErrorHandlingActorTest extends WithMockServers {
             watch(underTest);
 
             // create connection
-            final ConnectivityModifyCommand command = CreateConnection.of(connection, DittoHeaders.empty());
+            final ConnectivityModifyCommand<?> command = CreateConnection.of(connection, DittoHeaders.empty());
             underTest.tell(command, getRef());
             expectMsg(CreateConnectionResponse.of(connection, DittoHeaders.empty()));
         }};
@@ -106,9 +107,9 @@ public class ErrorHandlingActorTest extends WithMockServers {
             expectMsg(createConnectionResponse);
 
             // delete connection
-            final ConnectivityModifyCommand command = DeleteConnection.of(connectionId, DittoHeaders.empty());
+            final ConnectivityModifyCommand<?> command = DeleteConnection.of(connectionId, DittoHeaders.empty());
             underTest.tell(command, getRef());
-            expectMsg(DeleteConnectionResponse.of(connectionId, DittoHeaders.empty()));
+            expectMsg(dilated(Duration.ofSeconds(5)), DeleteConnectionResponse.of(connectionId, DittoHeaders.empty()));
         }};
     }
 
@@ -129,7 +130,7 @@ public class ErrorHandlingActorTest extends WithMockServers {
             expectMsg(createConnectionResponse);
 
             // modify connection
-            final ConnectivityModifyCommand command;
+            final ConnectivityModifyCommand<?> command;
             switch (action) {
                 case "open":
                     command = OpenConnection.of(connectionId, DittoHeaders.empty());

--- a/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedDataConfig.java
+++ b/services/utils/ddata/src/main/java/org/eclipse/ditto/services/utils/ddata/DistributedDataConfig.java
@@ -97,7 +97,7 @@ public interface DistributedDataConfig {
         /**
          * The number of shards Ditto's ddata extension applies for Map keys.
          */
-        NUMBER_OF_SHARDS("number-of-shards", 1);
+        NUMBER_OF_SHARDS("number-of-shards", 5);
 
         private final String path;
         private final Object defaultValue;

--- a/services/utils/ddata/src/main/resources/reference.conf
+++ b/services/utils/ddata/src/main/resources/reference.conf
@@ -24,7 +24,7 @@ ditto {
       #  default: 500
       #  as we apply sharding on the map keys for Ditto pub/sub, "1" configures to use minimal remoting size, whereas
       #  values "> 1" reduce networking interactions
-      max-delta-elements = 1
+      max-delta-elements = ${ditto.ddata.number-of-shards}
       max-delta-elements = ${?DITTO_DDATA_MAX_DELTA_ELEMENTS}
 
       # increase max size to transfer in a delta update
@@ -54,7 +54,7 @@ ditto {
     #  - when configured to "1", there will be exactly 1 map key containing all ddata values in its value
     #  - increase to higher values in order to apply sharding
     #  The sharding is done based on a hash of the Address or ActorRef of the Subscriber of a service instance.
-    number-of-shards = 1
+    number-of-shards = 5
     number-of-shards = ${?DITTO_DDATA_NUMBER_OF_SHARDS}
   }
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
@@ -13,7 +13,6 @@
 package org.eclipse.ditto.services.utils.pubsub.actors;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +40,6 @@ import org.eclipse.ditto.signals.base.Signal;
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
 import akka.actor.Props;
-import akka.cluster.ddata.Key;
 import akka.cluster.ddata.ORMultiMap;
 import akka.cluster.ddata.Replicator;
 import akka.japi.Pair;
@@ -65,7 +63,7 @@ public final class Publisher extends AbstractActor {
     private final Counter messageCounter = DittoMetrics.counter("pubsub-published-messages");
     private final Counter topicCounter = DittoMetrics.counter("pubsub-published-topics");
 
-    private final Map<Key<?>, PublisherIndex<Long>> publisherIndex = new HashMap<>();
+    private PublisherIndex<Long> publisherIndex = PublisherIndex.empty();
 
     private RemoteAcksChanged remoteAcks = RemoteAcksChanged.of(Map.of());
 
@@ -165,10 +163,8 @@ public final class Publisher extends AbstractActor {
         final List<Long> hashes = topics.stream().map(ddataReader::approximate).collect(Collectors.toList());
         final ActorRef sender = getSender();
 
-        final List<Pair<ActorRef, PublishSignal>> subscribers = publisherIndex.values().stream()
-                .map(index -> index.assignGroupsToSubscribers(signal, hashes))
-                .flatMap(List::stream)
-                .collect(Collectors.toList());
+        final List<Pair<ActorRef, PublishSignal>> subscribers =
+                publisherIndex.assignGroupsToSubscribers(signal, hashes);
         subscribers.forEach(pair -> pair.first().tell(pair.second(), sender));
         return subscribers;
     }
@@ -184,7 +180,7 @@ public final class Publisher extends AbstractActor {
                 .stream()
                 .map(entry -> Pair.create(entry.getKey(), deserializeGroupedHashes(entry.getValue())))
                 .collect(Collectors.toMap(Pair::first, Pair::second));
-        publisherIndex.put(event.key(), PublisherIndex.fromDeserializedMMap(deserializedMMap));
+        publisherIndex = PublisherIndex.mergeExistingWithDeserializedMMap(publisherIndex, deserializedMMap);
     }
 
     private void logUnhandled(final Object message) {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
@@ -56,13 +56,14 @@ final class PublisherIndex<T> {
         return new PublisherIndex<>(Map.of(), Map.of());
     }
 
-    static PublisherIndex<Long> fromDeserializedMMap(final Map<ActorRef, List<Grouped<Long>>> mmap) {
-        final Map<Long, Map<ActorRef, Set<String>>> index = new HashMap<>();
+    static PublisherIndex<Long> mergeExistingWithDeserializedMMap(final PublisherIndex<Long> publisherIndex,
+            final Map<ActorRef, List<Grouped<Long>>> mmap) {
+        final Map<Long, Map<ActorRef, Set<String>>> index = new HashMap<>(publisherIndex.index);
         mmap.forEach((subscriber, groupedList) ->
                 groupedList.forEach(grouped -> grouped.getValues()
                         .forEach(computeIndex(index, subscriber, grouped.getGroup().orElse("")))
                 ));
-        return new PublisherIndex<>(index, Map.of());
+        return new PublisherIndex<>(index, publisherIndex.filterMap);
     }
 
     static PublisherIndex<String> fromSubscriptionsReader(final SubscriptionsReader reader) {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractDDataHandler.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractDDataHandler.java
@@ -63,8 +63,7 @@ public abstract class AbstractDDataHandler<K, S, T extends DDataUpdate<S>>
         if (update.isEmpty()) {
             return CompletableFuture.completedFuture(null);
         } else {
-            final int shardNumber = Math.abs(ownSubscriber.hashCode() % numberOfShards);
-            return update(getKey(shardNumber), writeConsistency, initialMMap -> {
+            return update(getKey(selfUniqueAddress.uniqueAddress().address()), writeConsistency, initialMMap -> {
                 ORMultiMap<K, S> mmap = initialMMap;
                 for (final S delete : update.getDeletes()) {
                     mmap = mmap.removeBinding(selfUniqueAddress, ownSubscriber, delete);
@@ -80,8 +79,7 @@ public abstract class AbstractDDataHandler<K, S, T extends DDataUpdate<S>>
     @Override
     public CompletionStage<Void> removeSubscriber(final K subscriber,
             final Replicator.WriteConsistency writeConsistency) {
-        final int shardNumber = Math.abs(subscriber.hashCode() % numberOfShards);
-        return update(getKey(shardNumber), writeConsistency, mmap -> mmap.remove(selfUniqueAddress, subscriber));
+        return update(getKey(selfUniqueAddress.uniqueAddress().address()), writeConsistency, mmap -> mmap.remove(selfUniqueAddress, subscriber));
     }
 
     @Override

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/DDataReader.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/DDataReader.java
@@ -13,12 +13,14 @@
 package org.eclipse.ditto.services.utils.pubsub.ddata;
 
 import akka.actor.ActorRef;
+import akka.actor.Address;
 import akka.cluster.ddata.Key;
 import akka.cluster.ddata.ORMultiMap;
 
 /**
  * Reader of distributed Bloom filters of subscribed topics.
  *
+ * @param <K> type of keys of the multimap.
  * @param <T> type of topic approximations.
  */
 public interface DDataReader<K, T> {
@@ -47,7 +49,19 @@ public interface DDataReader<K, T> {
     int getNumberOfShards();
 
     /**
+     * Creates/gets a key for the passed {@code hashProvider} object.
+     *
+     * @param hashProvider the key used to calculate the number of the shard to append to the key.
+     * @return Key of the distributed data.
+     */
+    default Key<ORMultiMap<K, T>> getKey(final Address hashProvider) {
+        final int shardNumber = Math.abs(hashProvider.hashCode() % getNumberOfShards());
+        return getKey(shardNumber);
+    }
+
+    /**
      * Creates/gets a key for the passed {@code shardNumber}.
+     * Should only be directly called in order to iterate over all existing keys.
      *
      * @param shardNumber the number of the shard to append to the key.
      * @return Key of the distributed data.

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/SubscriptionsReader.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/SubscriptionsReader.java
@@ -83,4 +83,11 @@ public final class SubscriptionsReader {
     public int hashCode() {
         return subscriberDataMap.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "subscriberDataMap=" + subscriberDataMap +
+                "]";
+    }
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/compressed/CompressedDDataHandler.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/compressed/CompressedDDataHandler.java
@@ -86,8 +86,7 @@ public final class CompressedDDataHandler extends AbstractDDataHandler<ActorRef,
     @Override
     public CompletionStage<Void> removeAddress(final Address address,
             final Replicator.WriteConsistency writeConsistency) {
-        final int shardNumber = Math.abs(address.hashCode() % numberOfShards);
-        return update(getKey(shardNumber), writeConsistency, mmap -> {
+        return update(getKey(address), writeConsistency, mmap -> {
             ORMultiMap<ActorRef, String> result = mmap;
             for (final ActorRef subscriber : mmap.getEntries().keySet()) {
                 if (subscriber.path().address().equals(address)) {

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/literal/LiteralDDataHandler.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/literal/LiteralDDataHandler.java
@@ -60,7 +60,6 @@ public final class LiteralDDataHandler extends AbstractDDataHandler<Address, Str
     @Override
     public CompletionStage<Void> removeAddress(final Address address,
             final Replicator.WriteConsistency writeConsistency) {
-        final int shardNumber = Math.abs(address.hashCode() % numberOfShards);
-        return update(getKey(shardNumber), writeConsistency, mmap -> mmap.remove(selfUniqueAddress, address));
+        return update(getKey(address), writeConsistency, mmap -> mmap.remove(selfUniqueAddress, address));
     }
 }

--- a/services/utils/pubsub/src/test/resources/pubsub-factory-test.conf
+++ b/services/utils/pubsub/src/test/resources/pubsub-factory-test.conf
@@ -42,6 +42,10 @@ ditto {
     update-interval = 100ms // increase this value to simulate slow systems
     seed = "dummy-seed"
   }
+
+  ddata {
+    number-of-shards = 5
+  }
 }
 akka.cluster.distributed-data {
   gossip-interval = 100ms


### PR DESCRIPTION
When sharding was introduced into Ditto pub/sub in milestone 2.0.0-M2, a bug was introduced that when using "groups" the messages/events were duplicated if > 1 shard count was configured.

This PR fixes this bug and configures the default sharding count to 5 (instead of defaulting to 1).