### PR TITLE
Don't return IDs of deleted Connections in RetrieveAllConnectionIdsResponse

### DIFF
--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionIdsRetrievalActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionIdsRetrievalActor.java
@@ -24,15 +24,14 @@ import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.headers.WithDittoHeaders;
 import org.eclipse.ditto.model.connectivity.ConnectivityInternalErrorException;
 import org.eclipse.ditto.services.connectivity.config.ConnectionIdsRetrievalConfig;
-import org.eclipse.ditto.services.connectivity.config.DittoConnectivityConfig;
 import org.eclipse.ditto.services.connectivity.messaging.persistence.ConnectionPersistenceActor;
 import org.eclipse.ditto.services.utils.akka.logging.DittoLoggerFactory;
-import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.services.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.signals.commands.base.CommandResponse;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityErrorResponse;
 import org.eclipse.ditto.signals.commands.connectivity.query.RetrieveAllConnectionIds;
 import org.eclipse.ditto.signals.commands.connectivity.query.RetrieveAllConnectionIdsResponse;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionDeleted;
 
 import akka.NotUsed;
 import akka.actor.AbstractActor;
@@ -58,31 +57,16 @@ public final class ConnectionIdsRetrievalActor extends AbstractActor {
 
     private final DiagnosticLoggingAdapter log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
 
-    private final Supplier<Source<String, NotUsed>> persistenceIdsFromJournalSourceSupplier;
+    private final Supplier<Source<Document, NotUsed>> persistenceIdsFromJournalSourceSupplier;
     private final Supplier<Source<Document, NotUsed>> persistenceIdsFromSnapshotSourceSupplier;
     private final Materializer materializer;
-    private final ConnectionIdsRetrievalConfig connectionIdsRetrievalConfig;
 
     @SuppressWarnings("unused")
-    private ConnectionIdsRetrievalActor(
-            final Supplier<Source<String, NotUsed>> persistenceIdsFromJournalSourceSupplier,
-            final Supplier<Source<Document, NotUsed>> persistenceIdsFromSnapshotSourceSupplier) {
-        this.persistenceIdsFromJournalSourceSupplier = persistenceIdsFromJournalSourceSupplier;
-        this.persistenceIdsFromSnapshotSourceSupplier = persistenceIdsFromSnapshotSourceSupplier;
+    private ConnectionIdsRetrievalActor(final MongoReadJournal readJournal,
+            final ConnectionIdsRetrievalConfig connectionIdsRetrievalConfig) {
         materializer = Materializer.createMaterializer(this::getContext);
-        connectionIdsRetrievalConfig =
-                DittoConnectivityConfig.of(DefaultScopedConfig.dittoScoped(getContext().system().settings().config()))
-                        .getConnectionIdsRetrievalConfig();
-    }
-
-    @SuppressWarnings("unused")
-    private ConnectionIdsRetrievalActor(final MongoReadJournal readJournal) {
-        materializer = Materializer.createMaterializer(this::getContext);
-        connectionIdsRetrievalConfig =
-                DittoConnectivityConfig.of(DefaultScopedConfig.dittoScoped(getContext().system().settings().config()))
-                        .getConnectionIdsRetrievalConfig();
         persistenceIdsFromJournalSourceSupplier =
-                () -> readJournal.getJournalPids(connectionIdsRetrievalConfig.getReadJournalBatchSize(),
+                () -> readJournal.getLatestJournalEntries(connectionIdsRetrievalConfig.getReadJournalBatchSize(),
                         Duration.ofSeconds(1), materializer);
         persistenceIdsFromSnapshotSourceSupplier =
                 () -> readJournal.getNewestSnapshotsAbove("", connectionIdsRetrievalConfig.getReadSnapshotBatchSize(),
@@ -93,24 +77,24 @@ public final class ConnectionIdsRetrievalActor extends AbstractActor {
      * Creates Akka configuration object Props for this Actor.
      *
      * @param readJournal readJournal to extract current PIDs from.
+     * @param connectionIdsRetrievalConfig the config to build the pid suppliers from.
      * @return the Akka configuration Props object.
      */
-    public static Props props(final MongoReadJournal readJournal) {
-        return Props.create(ConnectionIdsRetrievalActor.class, readJournal);
+    public static Props props(final MongoReadJournal readJournal,
+            final ConnectionIdsRetrievalConfig connectionIdsRetrievalConfig) {
+        return Props.create(ConnectionIdsRetrievalActor.class, readJournal, connectionIdsRetrievalConfig);
     }
 
-    /**
-     * Creates Akka configuration object Props for this Actor.
-     *
-     * @param persistenceIdsFromJournalSourceSupplier supplier of persistence ids source from journal
-     * @param persistenceIdsFromSnapshotSourceSupplier supplier of persistence ids source from snapshot
-     * @return the Akka configuration Props object.
-     */
-    static Props props(
-            final Supplier<Source<String, NotUsed>> persistenceIdsFromJournalSourceSupplier,
-            final Supplier<Source<Document, NotUsed>> persistenceIdsFromSnapshotSourceSupplier) {
-        return Props.create(ConnectionIdsRetrievalActor.class, persistenceIdsFromJournalSourceSupplier,
-                persistenceIdsFromSnapshotSourceSupplier);
+    private static boolean isDeleted(final Document document) {
+        return Optional.ofNullable(document.getString(MongoReadJournal.J_EVENT_MANIFEST))
+                .map(ConnectionDeleted.TYPE::equals)
+                .orElse(true);
+    }
+
+    private static boolean isNotDeleted(final Document document) {
+        return Optional.ofNullable(document.getString(MongoReadJournal.J_EVENT_MANIFEST))
+                .map(manifest -> !ConnectionDeleted.TYPE.equals(manifest))
+                .orElse(false);
     }
 
     @Override
@@ -126,12 +110,21 @@ public final class ConnectionIdsRetrievalActor extends AbstractActor {
     private void getAllConnectionIDs(final WithDittoHeaders<RetrieveAllConnectionIds> cmd) {
         try {
             final Source<String, NotUsed> idsFromSnapshots = getIdsFromSnapshotsSource();
-            final Source<String, NotUsed> idsFromJournal = persistenceIdsFromJournalSourceSupplier.get();
+            final Source<String, NotUsed> idsFromJournal = persistenceIdsFromJournalSourceSupplier.get()
+                    .filter(ConnectionIdsRetrievalActor::isNotDeleted)
+                    .map(document -> document.getString(MongoReadJournal.J_EVENT_PID));
+
             final CompletionStage<CommandResponse> retrieveAllConnectionIdsResponse =
-                    idsFromSnapshots.concat(idsFromJournal)
-                            .filter(pid -> pid.startsWith(ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX))
-                            .map(pid -> pid.substring(ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX.length()))
+                    persistenceIdsFromJournalSourceSupplier.get()
+                            .filter(ConnectionIdsRetrievalActor::isDeleted)
+                            .map(document -> document.getString(MongoReadJournal.J_EVENT_PID))
                             .runWith(Sink.seq(), materializer)
+                            .thenCompose(deletedIdsFromJournal -> idsFromSnapshots.concat(idsFromJournal)
+                                    .filter(pid -> !deletedIdsFromJournal.contains(pid))
+                                    .filter(pid -> pid.startsWith(ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX))
+                                    .map(pid -> pid.substring(
+                                            ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX.length()))
+                                    .runWith(Sink.seq(), materializer))
                             .thenApply(HashSet::new)
                             .thenApply(ids -> buildResponse(cmd, ids))
                             .exceptionally(throwable -> buildErrorResponse(throwable, cmd.getDittoHeaders()));

--- a/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionIdsRetrievalActorTest.java
+++ b/services/connectivity/messaging/src/test/java/org/eclipse/ditto/services/connectivity/messaging/ConnectionIdsRetrievalActorTest.java
@@ -13,20 +13,32 @@
 package org.eclipse.ditto.services.connectivity.messaging;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
 import org.bson.Document;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.connectivity.ConnectivityInternalErrorException;
+import org.eclipse.ditto.services.connectivity.config.ConnectionIdsRetrievalConfig;
 import org.eclipse.ditto.services.connectivity.messaging.persistence.ConnectionPersistenceActor;
+import org.eclipse.ditto.services.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.signals.commands.connectivity.ConnectivityErrorResponse;
 import org.eclipse.ditto.signals.commands.connectivity.query.RetrieveAllConnectionIds;
 import org.eclipse.ditto.signals.commands.connectivity.query.RetrieveAllConnectionIdsResponse;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionCreated;
+import org.eclipse.ditto.signals.events.connectivity.ConnectionDeleted;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -41,17 +53,23 @@ import akka.testkit.javadsl.TestKit;
  */
 public final class ConnectionIdsRetrievalActorTest {
 
-    private static final List<String> JOURNAL_IDS =
-            List.of(pid("connection-1"), pid("connection-2"), pid("connection-3"));
+    private static final List<Document> JOURNAL_ENTRIES =
+            List.of(document(pid("connection-1"), ConnectionCreated.TYPE),
+                    document(pid("connection-2"), ConnectionCreated.TYPE),
+                    document(pid("connection-3"), ConnectionDeleted.TYPE),
+                    document(pid("connection-4"), ConnectionCreated.TYPE));
 
     private static final List<Document> SNAPSHOT_IDS =
-            // connection-3 is a duplicate by intention
+            // connection-3 and connection-4 is a duplicate by intention
             List.of(doc("connection-3"), doc("connection-4"), doc("connection-5"));
 
     private static final DittoHeaders DITTO_HEADERS =
             DittoHeaders.newBuilder().correlationId(UUID.randomUUID().toString()).build();
 
     private static ActorSystem actorSystem;
+    private static final int BATCH_SIZE = 10;
+    private MongoReadJournal mongoReadJournal;
+    private ConnectionIdsRetrievalConfig connectionIdsRetrievalConfig;
 
     @BeforeClass
     public static void setUp() {
@@ -63,26 +81,42 @@ public final class ConnectionIdsRetrievalActorTest {
         TestKit.shutdownActorSystem(actorSystem, scala.concurrent.duration.Duration.apply(5, TimeUnit.SECONDS), false);
     }
 
+    @Before
+    public void setup() {
+        mongoReadJournal = mock(MongoReadJournal.class);
+        connectionIdsRetrievalConfig = mock(ConnectionIdsRetrievalConfig.class);
+        when(connectionIdsRetrievalConfig.getReadJournalBatchSize()).thenReturn(BATCH_SIZE);
+        when(connectionIdsRetrievalConfig.getReadSnapshotBatchSize()).thenReturn(BATCH_SIZE);
+    }
+
     @Test
     public void testRetrieveAllConnectionIds() {
         new TestKit(actorSystem) {{
+            when(mongoReadJournal.getLatestJournalEntries(eq(BATCH_SIZE), any(), any()))
+                    .thenReturn(Source.from(JOURNAL_ENTRIES));
+            when(mongoReadJournal.getNewestSnapshotsAbove(any(), eq(BATCH_SIZE), any()))
+                    .thenReturn(Source.from(SNAPSHOT_IDS));
             final Props props =
-                    ConnectionIdsRetrievalActor.props(() -> Source.from(JOURNAL_IDS), () -> Source.from(SNAPSHOT_IDS));
+                    ConnectionIdsRetrievalActor.props(mongoReadJournal, connectionIdsRetrievalConfig);
 
             final ActorRef reconnectActor = actorSystem.actorOf(props);
             reconnectActor.tell(RetrieveAllConnectionIds.of(DITTO_HEADERS), getRef());
 
             final RetrieveAllConnectionIdsResponse response = expectMsgClass(RetrieveAllConnectionIdsResponse.class);
             assertThat(response.getAllConnectionIds()).isEqualTo(
-                    Set.of("connection-1", "connection-2", "connection-3", "connection-4", "connection-5"));
+                    Set.of("connection-1", "connection-2", "connection-4", "connection-5"));
         }};
     }
 
     @Test
-    public void testNullExpectErrorResponse() {
+    public void internalErrorShouldResultInErrorResponse() {
         new TestKit(actorSystem) {{
+            when(mongoReadJournal.getLatestJournalEntries(eq(BATCH_SIZE), any(), any()))
+                    .thenThrow(new NullPointerException("expected"));
+            when(mongoReadJournal.getNewestSnapshotsAbove(any(), eq(BATCH_SIZE), any()))
+                    .thenThrow(new NullPointerException("expected"));
             final Props props =
-                    ConnectionIdsRetrievalActor.props(() -> Source.single(null), () -> Source.single(null));
+                    ConnectionIdsRetrievalActor.props(mongoReadJournal, connectionIdsRetrievalConfig);
 
             final ActorRef reconnectActor = actorSystem.actorOf(props);
             reconnectActor.tell(RetrieveAllConnectionIds.of(DITTO_HEADERS), getRef());
@@ -99,4 +133,11 @@ public final class ConnectionIdsRetrievalActorTest {
     private static String pid(final String id) {
         return ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX + id;
     }
+
+    private static Document document(final String pid, final String manifest) {
+        return new Document()
+                .append("pid", pid)
+                .append("manifest", manifest);
+    }
+
 }

--- a/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/services/utils/persistence/src/main/java/org/eclipse/ditto/services/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -23,7 +23,11 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonString;
+import org.bson.BsonValue;
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.services.utils.config.DefaultScopedConfig;
@@ -99,12 +103,18 @@ public class MongoReadJournal {
     private static final String SNAPS_COLLECTION_NAME_KEY = "overrides.snaps-collection";
 
     private static final String J_PROCESSOR_ID = JournallingFieldNames$.MODULE$.PROCESSOR_ID();
+    private static final String J_TO = JournallingFieldNames$.MODULE$.TO();
     private static final String J_TAGS = JournallingFieldNames$.MODULE$.TAGS();
     private static final String S_SN = SnapshottingFieldNames$.MODULE$.SEQUENCE_NUMBER();
 
     // Not working: SnapshottingFieldNames.V2$.MODULE$.SERIALIZED()
     private static final String S_SERIALIZED_SNAPSHOT = "s2";
     private static final String LIFECYCLE = "__lifecycle";
+
+    private static final String J_EVENT = JournallingFieldNames$.MODULE$.EVENTS();
+    public static final String J_EVENT_PID = JournallingFieldNames$.MODULE$.PROCESSOR_ID();
+    public static final String J_EVENT_MANIFEST = JournallingFieldNames$.MODULE$.MANIFEST();
+    public static final String J_EVENT_SN = JournallingFieldNames$.MODULE$.SEQUENCE_NUMBER();
 
     private static final Duration MAX_BACK_OFF_DURATION = Duration.ofSeconds(128L);
 
@@ -185,6 +195,44 @@ public class MongoReadJournal {
                         listPidsInJournal(journal, "", "", batchSize, mat, MAX_BACK_OFF_DURATION, maxRestarts)
                 )
                 .mapConcat(pids -> pids);
+    }
+
+    /**
+     * Retrieve latest journal entries for each distinct PID.
+     * Does its best not to create long-living cursors on the database by reading {@code batchSize} events per query.
+     *
+     * @param batchSize how many events to read in one query.
+     * @param maxIdleTime how long the stream is allowed to idle without sending any element. Bounds the number of
+     * retries with exponential back-off.
+     * @param mat the actor materializer to run the query streams.
+     * @return Source of all latest journal entries per pid such that each element contains the persistence IDs in
+     * {@code batchSize} events that do not occur in prior buckets.
+     */
+    public Source<Document, NotUsed> getLatestJournalEntries(final int batchSize, final Duration maxIdleTime,
+            final Materializer mat) {
+
+        final int maxRestarts = computeMaxRestarts(maxIdleTime);
+        return getJournal().withAttributes(Attributes.inputBuffer(1, 1))
+                .flatMapConcat(
+                        journal -> listLatestJournalEntries(journal, "", "", batchSize, MAX_BACK_OFF_DURATION, mat,
+                                maxRestarts, J_EVENT_PID, J_EVENT_SN, J_EVENT_MANIFEST))
+                .mapConcat(pids -> pids);
+    }
+
+    private Source<List<Document>, NotUsed> listLatestJournalEntries(final MongoCollection<Document> journal,
+            final String lowerBoundPid,
+            final String tag,
+            final int batchSize,
+            final Duration maxBackoff,
+            final Materializer mat,
+            final int maxRestarts,
+            final String... journalFields) {
+
+        return this.unfoldBatchedSource(lowerBoundPid,
+                mat,
+                document -> document.getString(J_ID),
+                actualStartPid -> listLatestJournalEntries(journal, actualStartPid, tag, batchSize, maxBackoff,
+                        maxRestarts, journalFields));
     }
 
     /**
@@ -307,6 +355,20 @@ public class MongoReadJournal {
         );
     }
 
+    private Source<String, NotUsed> listJournalPidsAbove(final MongoCollection<Document> journal, final String startPid,
+            final String tag, final int batchSize, final Duration maxBackOff, final int maxRestarts) {
+
+        return listLatestJournalEntries(journal, startPid, tag, batchSize, maxBackOff, maxRestarts, J_EVENT_PID)
+                .flatMapConcat(document -> {
+                    final Object pid = document.get(J_EVENT_PID);
+                    if (pid instanceof CharSequence) {
+                        return Source.single(pid.toString());
+                    } else {
+                        return Source.empty();
+                    }
+                });
+    }
+
     private Source<List<Document>, NotUsed> listNewestSnapshots(final MongoCollection<Document> snapshotStore,
             final String lowerBoundPid,
             final int batchSize,
@@ -359,19 +421,19 @@ public class MongoReadJournal {
         // Filter irrelevant tags for priority ordering.
         final BsonDocument arrayFilter = BsonDocument.parse(
                 "{\n" +
-                "    $filter: {\n" +
-                "        input: \"$" + J_TAGS + "\",\n" +
-                "        as: \"tags\",\n" +
-                "        cond: {\n" +
-                "            $eq: [\n" +
-                "                {\n" +
-                "                    $substrCP: [\"$$tags\", 0, " + PRIORITY_TAG_PREFIX.length() + "]\n" +
-                "                }\n," +
-                "                \"" + PRIORITY_TAG_PREFIX + "\"\n" +
-                "            ]\n" +
-                "        }\n" +
-                "    }\n" +
-                "}"
+                        "    $filter: {\n" +
+                        "        input: \"$" + J_TAGS + "\",\n" +
+                        "        as: \"tags\",\n" +
+                        "        cond: {\n" +
+                        "            $eq: [\n" +
+                        "                {\n" +
+                        "                    $substrCP: [\"$$tags\", 0, " + PRIORITY_TAG_PREFIX.length() + "]\n" +
+                        "                }\n," +
+                        "                \"" + PRIORITY_TAG_PREFIX + "\"\n" +
+                        "            ]\n" +
+                        "        }\n" +
+                        "    }\n" +
+                        "}"
         );
         pipeline.add(Aggregates.project(Projections.computed(J_TAGS, arrayFilter)));
 
@@ -397,8 +459,9 @@ public class MongoReadJournal {
         );
     }
 
-    private Source<String, NotUsed> listJournalPidsAbove(final MongoCollection<Document> journal, final String startPid,
-            final String tag, final int batchSize, final Duration maxBackOff, final int maxRestarts) {
+    private Source<Document, NotUsed> listLatestJournalEntries(final MongoCollection<Document> journal,
+            final String startPid, final String tag, final int batchSize, final Duration maxBackOff,
+            final int maxRestarts, final String... fieldNames) {
 
         final List<Bson> pipeline = new ArrayList<>(6);
         // optional match stages: consecutive match stages are optimized together ($match + $match coalescence)
@@ -410,13 +473,13 @@ public class MongoReadJournal {
         }
 
         // sort stage
-        pipeline.add(Aggregates.sort(Sorts.ascending(J_PROCESSOR_ID)));
+        pipeline.add(Aggregates.sort(Sorts.orderBy(Sorts.ascending(J_PROCESSOR_ID), Sorts.descending(J_TO))));
 
         // limit stage. It should come before group stage or MongoDB would scan the entire journal collection.
         pipeline.add(Aggregates.limit(batchSize));
 
         // group stage
-        pipeline.add(Aggregates.group("$" + J_PROCESSOR_ID));
+        pipeline.add(Aggregates.group("$" + J_PROCESSOR_ID, toFirstJournalEntryFields(fieldNames)));
 
         // sort stage 2 -- order after group stage is not defined
         pipeline.add(Aggregates.sort(Sorts.ascending(J_ID)));
@@ -428,15 +491,18 @@ public class MongoReadJournal {
                 .withMaxRestarts(maxRestarts, minBackOff);
         return RestartSource.onFailuresWithBackoff(restartSettings, () ->
                 Source.fromPublisher(journal.aggregate(pipeline))
-                        .flatMapConcat(document -> {
-                            final Object pid = document.get(J_ID);
-                            if (pid instanceof CharSequence) {
-                                return Source.single(pid.toString());
-                            } else {
-                                return Source.empty();
-                            }
-                        })
         );
+    }
+
+    private List<BsonField> toFirstJournalEntryFields(final String... journalFields) {
+        return Arrays.stream(journalFields)
+                .map(fieldName -> {
+                    final String serializedFieldName = String.format("$%s.%s", J_EVENT, fieldName);
+                    final BsonArray bsonArray =
+                            new BsonArray(List.of(new BsonString(serializedFieldName), new BsonInt32(0)));
+                    return Accumulators.first(fieldName, new BsonDocument().append("$arrayElemAt", bsonArray));
+                })
+                .collect(Collectors.toList());
     }
 
     private int computeMaxRestarts(final Duration maxDuration) {


### PR DESCRIPTION
Stream journal entries instead of just the pid string

* This allows to distinguish between deleted or other events in
  ConnectionIdsRetrievalActor
* Skip PIDs of connections of which the last event ist a deleted event
  in ConnectionIdsRetrievalActor