### PR TITLE
Simplified ditto-model-query dependencies + API

### DIFF
--- a/model/query/pom.xml
+++ b/model/query/pom.xml
@@ -26,6 +26,7 @@
     <name>Eclipse Ditto :: Model :: Query</name>
 
     <dependencies>
+        <!-- ### Compile ### -->
         <dependency>
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-model-things</artifactId>
@@ -34,9 +35,12 @@
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-model-rql</artifactId>
         </dependency>
+
+        <!-- ### Testing ### -->
         <dependency>
             <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-model-rql-parser</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/AndCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/AndCriteriaImpl.java
@@ -23,7 +23,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.CriteriaVisitor;
 /**
  * Criteria which performs a logical AND of arbitrary criterias.
  */
-public class AndCriteriaImpl implements Criteria {
+final class AndCriteriaImpl implements Criteria {
 
     private final List<Criteria> criterias;
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/AnyCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/AnyCriteriaImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.CriteriaVisitor;
 /**
  * This Criteria matches any document.
  */
-public class AnyCriteriaImpl implements Criteria {
+final class AnyCriteriaImpl implements Criteria {
 
     private static final AnyCriteriaImpl INSTANCE = new AnyCriteriaImpl();
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/Criteria.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/Criteria.java
@@ -27,5 +27,5 @@ public interface Criteria {
      * @param visitor The visitor that performs the evaluation.
      * @return Result of the evaluation.
      */
-    <T> T accept(final CriteriaVisitor<T> visitor);
+    <T> T accept(CriteriaVisitor<T> visitor);
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/CriteriaFactory.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/CriteriaFactory.java
@@ -26,6 +26,15 @@ import org.eclipse.ditto.model.query.expression.FilterFieldExpression;
 public interface CriteriaFactory {
 
     /**
+     * Returns the CriteriaFactory instance.
+     *
+     * @return the CriteriaFactory instance.
+     */
+    static CriteriaFactory getInstance() {
+        return CriteriaFactoryImpl.getInstance();
+    }
+
+    /**
      * Creates a Criteria which matches any document.
      *
      * @return the criteria.

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/CriteriaFactoryImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/CriteriaFactoryImpl.java
@@ -23,7 +23,22 @@ import org.eclipse.ditto.model.query.expression.FilterFieldExpression;
 /**
  * Class for creating queries.
  */
-public final class CriteriaFactoryImpl implements CriteriaFactory {
+final class CriteriaFactoryImpl implements CriteriaFactory {
+
+    private static final CriteriaFactoryImpl INSTANCE = new CriteriaFactoryImpl();
+
+    private CriteriaFactoryImpl() {
+        // private
+    }
+
+    /**
+     * Returns the CriteriaFactoryImpl instance.
+     *
+     * @return the CriteriaFactoryImpl instance.
+     */
+    static CriteriaFactoryImpl getInstance() {
+       return INSTANCE;
+    }
 
     @Override
     public Criteria any() {

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/EqPredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/EqPredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Equals predicate.
  */
-public class EqPredicateImpl extends AbstractSinglePredicate {
+final class EqPredicateImpl extends AbstractSinglePredicate {
 
     /**
      * Constructor.

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/ExistsCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/ExistsCriteriaImpl.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.model.query.expression.ExistsFieldExpression;
 /**
  * Criteria implementation which can handle arbitrary field existence filters.
  */
-public class ExistsCriteriaImpl implements Criteria {
+final class ExistsCriteriaImpl implements Criteria {
 
     private final ExistsFieldExpression fieldExpression;
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/FieldCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/FieldCriteriaImpl.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.model.query.expression.FilterFieldExpression;
 /**
  * Criteria implementation which can handle arbitrary field expressions and predicates.
  */
-public class FieldCriteriaImpl implements Criteria {
+final class FieldCriteriaImpl implements Criteria {
 
     private final FilterFieldExpression fieldExpression;
     private final Predicate predicate;

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/GePredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/GePredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Greater than or equals predicate.
  */
-public class GePredicateImpl extends AbstractSinglePredicate {
+final class GePredicateImpl extends AbstractSinglePredicate {
 
     public GePredicateImpl(final Object value) {
         super(value);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/GtPredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/GtPredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Greater than predicate.
  */
-public class GtPredicateImpl extends AbstractSinglePredicate {
+final class GtPredicateImpl extends AbstractSinglePredicate {
 
     public GtPredicateImpl(final Object value) {
         super(value);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/InPredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/InPredicateImpl.java
@@ -19,7 +19,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * In predicate.
  */
-public class InPredicateImpl extends AbstractMultiPredicate {
+final class InPredicateImpl extends AbstractMultiPredicate {
 
     public InPredicateImpl(final List<?> values) {
         super(values);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LePredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LePredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Lower than or equals predicate.
  */
-public class LePredicateImpl extends AbstractSinglePredicate {
+final class LePredicateImpl extends AbstractSinglePredicate {
 
     public LePredicateImpl(final Object value) {
         super(value);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LikePredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LikePredicateImpl.java
@@ -20,7 +20,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Like predicate.
  */
-public class LikePredicateImpl extends AbstractSinglePredicate {
+final class LikePredicateImpl extends AbstractSinglePredicate {
 
     private static final String LEADING_WILDCARD = "\\Q\\E.*";
     private static final String TRAILING_WILDCARD = ".*\\Q\\E";

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LtPredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/LtPredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Lower than predicate.
  */
-public class LtPredicateImpl extends AbstractSinglePredicate {
+final class LtPredicateImpl extends AbstractSinglePredicate {
 
     public LtPredicateImpl(final Object value) {
         super(value);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/NePredicateImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/NePredicateImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.ditto.model.query.criteria.visitors.PredicateVisitor;
 /**
  * Not equals predicate.
  */
-public class NePredicateImpl extends AbstractSinglePredicate {
+final class NePredicateImpl extends AbstractSinglePredicate {
 
     public NePredicateImpl(final Object value) {
         super(value);

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/NorCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/NorCriteriaImpl.java
@@ -20,11 +20,10 @@ import java.util.stream.Collectors;
 
 import org.eclipse.ditto.model.query.criteria.visitors.CriteriaVisitor;
 
-
 /**
  * Criteria which performs a logical NOR of arbitrary criterias.
  */
-public class NorCriteriaImpl implements Criteria {
+final class NorCriteriaImpl implements Criteria {
 
     private final List<Criteria> criterias;
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/OrCriteriaImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/OrCriteriaImpl.java
@@ -20,11 +20,10 @@ import java.util.stream.Collectors;
 
 import org.eclipse.ditto.model.query.criteria.visitors.CriteriaVisitor;
 
-
 /**
  * Criteria which performs a logical OR of arbitrary criterias.
  */
-public class OrCriteriaImpl implements Criteria {
+final class OrCriteriaImpl implements Criteria {
 
     private final List<Criteria> criterias;
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/Predicate.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/criteria/Predicate.java
@@ -26,5 +26,5 @@ public interface Predicate {
      * @param <T> The result type.
      * @return The result of evaluation.
      */
-    <T> T accept(final PredicateVisitor<T> visitor);
+    <T> T accept(PredicateVisitor<T> visitor);
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/AttributeExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/AttributeExpression.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Expression for an attribute.
+ *
+ * @since 2.0.0
+ */
+public interface AttributeExpression extends FilterFieldExpression, SortFieldExpression, ExistsFieldExpression {
+
+    /**
+     * Creates an expression for an attribute.
+     *
+     * @param key the attribute key.
+     * @return the created AttributeExpression
+     * @throws NullPointerException if {@code key} is {@code null}.
+     */
+    static AttributeExpression of(final String key) {
+        return new AttributeExpressionImpl(key);
+    }
+
+    /**
+     * Returns the attribute key.
+     *
+     * @return the attribute key
+     */
+    String getKey();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/AttributeExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/AttributeExpressionImpl.java
@@ -16,30 +16,26 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FilterFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.SortFieldExpressionVisitor;
 
 /**
- * Expression for an attribute.
+ * Immutable implementation of {@link AttributeExpression}.
  */
-public class AttributeExpressionImpl implements FilterFieldExpression, SortFieldExpression, ExistsFieldExpression {
+@Immutable
+final class AttributeExpressionImpl implements AttributeExpression {
 
     private final String key;
 
-    /**
-     * Constructor.
-     *
-     * @param key the attribute key
-     */
-    public AttributeExpressionImpl(final String key) {
+    AttributeExpressionImpl(final String key) {
         this.key = requireNonNull(key);
     }
 
-    /**
-     * @return the key
-     */
+    @Override
     public String getKey() {
         return key;
     }
@@ -65,35 +61,26 @@ public class AttributeExpressionImpl implements FilterFieldExpression, SortField
     }
 
     @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final AttributeExpressionImpl that = (AttributeExpressionImpl) o;
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
     public int hashCode() {
         return Objects.hash(key);
     }
 
-    @SuppressWarnings("squid:MethodCyclomaticComplexity")
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final AttributeExpressionImpl other = (AttributeExpressionImpl) obj;
-        if (key == null) {
-            if (other.key != null) {
-                return false;
-            }
-        } else if (!key.equals(other.key)) {
-            return false;
-        }
-        return true;
-    }
-
     @Override
     public String toString() {
-        return "AttributeExpression [key=" + key + "]";
+        return getClass().getSimpleName() + " [" +
+                "key=" + key +
+                "]";
     }
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ExistsFieldExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ExistsFieldExpression.java
@@ -27,8 +27,8 @@ public interface ExistsFieldExpression extends FieldExpression {
      * @param <T> The result type.
      * @return The result of the evaluation.
      */
-    <T> T acceptExistsVisitor(final ExistsFieldExpressionVisitor<T> visitor);
+    <T> T acceptExistsVisitor(ExistsFieldExpressionVisitor<T> visitor);
 
     @Override
-    <T> T accept(final FieldExpressionVisitor<T> visitor);
+    <T> T accept(FieldExpressionVisitor<T> visitor);
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Field expression for features itself with a given feature id.
+ *
+ * @since 2.0.0
+ */
+public interface FeatureExpression extends ExistsFieldExpression {
+
+    /**
+     * Creates an expression for existence of a feature.
+     *
+     * @param featureId the feature id.
+     * @return the created FeatureExpression
+     * @throws NullPointerException if {@code featureId} is {@code null}.
+     */
+    static FeatureExpression of(final String featureId) {
+        return new FeatureExpressionImpl(featureId);
+    }
+
+    /**
+     * @return the feature id.
+     */
+    String getFeatureId();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureExpressionImpl.java
@@ -16,22 +16,20 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 
 /**
- * Field expression for features itself with a given feature id.
+ * Immutable implementation of {@link FeatureExpression}.
  */
-public class FeatureExpressionImpl implements ExistsFieldExpression {
+@Immutable
+final class FeatureExpressionImpl implements FeatureExpression {
 
     private final String featureId;
 
-    /**
-     * Constructor.
-     *
-     * @param featureId the feature id.
-     */
-    public FeatureExpressionImpl(final String featureId) {
+    FeatureExpressionImpl(final String featureId) {
         this.featureId = requireNonNull(featureId);
     }
 
@@ -45,9 +43,7 @@ public class FeatureExpressionImpl implements ExistsFieldExpression {
         return visitor.visitFeature(featureId);
     }
 
-    /**
-     * @return the feature id.
-     */
+    @Override
     public String getFeatureId() {
         return featureId;
     }
@@ -73,6 +69,8 @@ public class FeatureExpressionImpl implements ExistsFieldExpression {
 
     @Override
     public String toString() {
-        return "FeatureExpression [featureId=" + featureId + "]";
+        return getClass().getSimpleName() + " [" +
+                "featureId=" + featureId +
+                "]";
     }
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertiesExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertiesExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Field expression for feature desired properties.
+ *
+ * @since 2.0.0
+ */
+public interface FeatureIdDesiredPropertiesExpression extends ExistsFieldExpression {
+
+    /**
+     * Creates an expression for existence of desired properties of a feature.
+     *
+     * @param featureId the feature id.
+     * @return the created FeatureIdDesiredPropertiesExpression
+     * @throws NullPointerException if {@code featureId} is {@code null}.
+     */
+    static FeatureIdDesiredPropertiesExpression of(final String featureId) {
+        return new FeatureIdDesiredPropertiesExpressionImpl(featureId);
+    }
+
+    /**
+     * @return the feature id.
+     */
+    String getFeatureId();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertiesExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertiesExpressionImpl.java
@@ -14,25 +14,21 @@ package org.eclipse.ditto.model.query.expression;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.base.common.ConditionChecker;
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 
 /**
- * Field expression for feature desired properties.
- *
- * @since 1.5.0
+ * Immutable implementation of {@link FeatureIdDesiredPropertiesExpression}.
  */
-public final class FeatureIdDesiredPropertiesExpressionImpl implements ExistsFieldExpression {
+@Immutable
+final class FeatureIdDesiredPropertiesExpressionImpl implements FeatureIdDesiredPropertiesExpression {
 
     private final String featureId;
 
-    /**
-     * Constructor.
-     *
-     * @param featureId the feature ID.
-     */
-    public FeatureIdDesiredPropertiesExpressionImpl(final String featureId) {
+    FeatureIdDesiredPropertiesExpressionImpl(final String featureId) {
         this.featureId = ConditionChecker.checkNotNull(featureId, "featureId");
     }
 
@@ -46,9 +42,7 @@ public final class FeatureIdDesiredPropertiesExpressionImpl implements ExistsFie
         return visitor.visitFeatureDesiredProperties(featureId);
     }
 
-    /**
-     * @return the feature ID.
-     */
+    @Override
     public String getFeatureId() {
         return featureId;
     }
@@ -72,7 +66,8 @@ public final class FeatureIdDesiredPropertiesExpressionImpl implements ExistsFie
 
     @Override
     public String toString() {
-        return "FeatureIdDesiredPropertiesExpression [featureId=" + featureId + "]";
+        return getClass().getSimpleName() + " [" +
+                "featureId=" + featureId +
+                "]";
     }
-
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertyExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertyExpression.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Field expression for a specific desired property with a given feature id.
+ *
+ * @since 2.0.0
+ */
+public interface FeatureIdDesiredPropertyExpression extends SortFieldExpression, FilterFieldExpression,
+        ExistsFieldExpression {
+
+    /**
+     * Creates an expression for a desired property belonging to a feature.
+     *
+     * @param featureId the feature id.
+     * @param desiredProperty the feature desired property path.
+     * @return the created FeatureIdDesiredPropertyExpression
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    static FeatureIdDesiredPropertyExpression of(final String featureId, final String desiredProperty) {
+        return new FeatureIdDesiredPropertyExpressionImpl(featureId, desiredProperty);
+    }
+
+    /**
+     * @return the feature id.
+     */
+    String getFeatureId();
+
+    /**
+     * @return the desiredProperty path.
+     */
+    String getDesiredProperty();
+
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertyExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdDesiredPropertyExpressionImpl.java
@@ -16,29 +16,23 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FilterFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.SortFieldExpressionVisitor;
 
 /**
- * Field expression for feature desired properties with a given feature id.
- *
- * @since 1.5.0
+ * Immutable implementation of {@link FeatureIdDesiredPropertyExpression}.
  */
-public class FeatureIdDesiredPropertyExpressionImpl
-        implements SortFieldExpression, FilterFieldExpression, ExistsFieldExpression {
+@Immutable
+final class FeatureIdDesiredPropertyExpressionImpl implements FeatureIdDesiredPropertyExpression {
 
     private final String desiredProperty;
     private final String featureId;
 
-    /**
-     * Constructor.
-     *
-     * @param featureId the feature id
-     * @param desiredProperty the feature desired property path
-     */
-    public FeatureIdDesiredPropertyExpressionImpl(final String featureId, final String desiredProperty) {
+    FeatureIdDesiredPropertyExpressionImpl(final String featureId, final String desiredProperty) {
         this.desiredProperty = requireNonNull(desiredProperty);
         this.featureId = requireNonNull(featureId);
     }
@@ -63,34 +57,29 @@ public class FeatureIdDesiredPropertyExpressionImpl
         return visitor.visitFeatureIdDesiredProperty(featureId, desiredProperty);
     }
 
-    /**
-     * @return the feature id.
-     */
+    @Override
     public String getFeatureId() {
         return featureId;
     }
 
-    /**
-     * @return the desiredProperty path.
-     */
+    @Override
     public String getDesiredProperty() {
         return desiredProperty;
     }
 
-    @SuppressWarnings("squid:MethodCyclomaticComplexity")
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
-        if ((o == null) || (getClass() != o.getClass())) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
         final FeatureIdDesiredPropertyExpressionImpl that = (FeatureIdDesiredPropertyExpressionImpl) o;
-        return Objects.equals(desiredProperty, that.desiredProperty) && Objects.equals(featureId, that.featureId);
+        return Objects.equals(desiredProperty, that.desiredProperty) &&
+                Objects.equals(featureId, that.featureId);
     }
 
-    @SuppressWarnings("squid:S109")
     @Override
     public int hashCode() {
         return Objects.hash(desiredProperty, featureId);
@@ -98,7 +87,9 @@ public class FeatureIdDesiredPropertyExpressionImpl
 
     @Override
     public String toString() {
-        return "FeatureIdDesiredPropertyExpression [featureId=" + featureId + ", desiredProperty=" + desiredProperty +
+        return getClass().getSimpleName() + " [" +
+                "desiredProperty=" + desiredProperty +
+                ", featureId=" + featureId +
                 "]";
     }
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertiesExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertiesExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Field expression for feature properties.
+ *
+ * @since 2.0.0
+ */
+public interface FeatureIdPropertiesExpression extends ExistsFieldExpression {
+
+    /**
+     * Creates an expression for existence of properties of a feature.
+     *
+     * @param featureId the feature id.
+     * @return the created FeatureIdDesiredPropertiesExpression
+     * @throws NullPointerException if {@code featureId} is {@code null}.
+     */
+    static FeatureIdPropertiesExpression of(final String featureId) {
+        return new FeatureIdPropertiesExpressionImpl(featureId);
+    }
+
+    /**
+     * @return the feature id.
+     */
+    String getFeatureId();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertiesExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertiesExpressionImpl.java
@@ -14,26 +14,21 @@ package org.eclipse.ditto.model.query.expression;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.base.common.ConditionChecker;
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 
 /**
- * Field expression for feature properties.
- *
- * @since 1.5.0
+ * Immutable implementation of {@link FeatureIdPropertiesExpression}.
  */
-public final class FeatureIdPropertiesExpressionImpl implements ExistsFieldExpression {
+@Immutable
+final class FeatureIdPropertiesExpressionImpl implements FeatureIdPropertiesExpression {
 
     private final String featureId;
 
-    /**
-     * Constructor.
-     *
-     * @param featureId the feature ID.
-     * @throws NullPointerException if {@code featureId} is {@code null}.
-     */
-    public FeatureIdPropertiesExpressionImpl(final String featureId) {
+    FeatureIdPropertiesExpressionImpl(final String featureId) {
         this.featureId = ConditionChecker.checkNotNull(featureId, "featureId");
     }
 
@@ -47,9 +42,7 @@ public final class FeatureIdPropertiesExpressionImpl implements ExistsFieldExpre
         return visitor.visitFeatureProperties(featureId);
     }
 
-    /**
-     * @return the feature ID.
-     */
+    @Override
     public String getFeatureId() {
         return featureId;
     }
@@ -73,7 +66,8 @@ public final class FeatureIdPropertiesExpressionImpl implements ExistsFieldExpre
 
     @Override
     public String toString() {
-        return "FeatureIdPropertiesExpression [featureId=" + featureId + "]";
+        return getClass().getSimpleName() + " [" +
+                "featureId=" + featureId +
+                "]";
     }
-
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertyExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertyExpression.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Field expression for a specific property with a given feature id.
+ *
+ * @since 2.0.0
+ */
+public interface FeatureIdPropertyExpression extends SortFieldExpression, FilterFieldExpression, ExistsFieldExpression {
+
+    /**
+     * Creates an expression for a property belonging to a feature.
+     *
+     * @param featureId the feature id.
+     * @param property the feature property path.
+     * @return the created FeatureIdPropertyExpression
+     * @throws NullPointerException if any argument is {@code null}.
+     */
+    static FeatureIdPropertyExpression of(final String featureId, final String property) {
+        return new FeatureIdPropertyExpressionImpl(featureId, property);
+    }
+
+    /**
+     * @return the feature id.
+     */
+    String getFeatureId();
+
+    /**
+     * @return the property path.
+     */
+    String getProperty();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertyExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FeatureIdPropertyExpressionImpl.java
@@ -16,27 +16,23 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
 
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FilterFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.SortFieldExpressionVisitor;
 
 /**
- * Field expression for feature properties with a given feature id.
+ * Immutable implementation of {@link FeatureIdPropertyExpression}.
  */
-public class FeatureIdPropertyExpressionImpl
-        implements SortFieldExpression, FilterFieldExpression, ExistsFieldExpression {
+@Immutable
+final class FeatureIdPropertyExpressionImpl implements FeatureIdPropertyExpression {
 
     private final String property;
     private final String featureId;
 
-    /**
-     * Constructor.
-     *
-     * @param featureId the feature id
-     * @param property the feature property path
-     */
-    public FeatureIdPropertyExpressionImpl(final String featureId, final String property) {
+    FeatureIdPropertyExpressionImpl(final String featureId, final String property) {
         this.property = requireNonNull(property);
         this.featureId = requireNonNull(featureId);
     }
@@ -61,16 +57,12 @@ public class FeatureIdPropertyExpressionImpl
         return visitor.visitFeatureIdProperty(featureId, property);
     }
 
-    /**
-     * @return the feature id.
-     */
+    @Override
     public String getFeatureId() {
         return featureId;
     }
 
-    /**
-     * @return the property path.
-     */
+    @Override
     public String getProperty() {
         return property;
     }
@@ -96,6 +88,9 @@ public class FeatureIdPropertyExpressionImpl
 
     @Override
     public String toString() {
-        return "FeatureIdPropertyExpression [featureId=" + featureId + ", property=" + property + "]";
+        return getClass().getSimpleName() + " [" +
+                "property=" + property +
+                ", featureId=" + featureId +
+                "]";
     }
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FilterFieldExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/FilterFieldExpression.java
@@ -27,8 +27,8 @@ public interface FilterFieldExpression extends FieldExpression {
      * @param <T> The result type.
      * @return The result of the evaluation.
      */
-    <T> T acceptFilterVisitor(final FilterFieldExpressionVisitor<T> visitor);
+    <T> T acceptFilterVisitor(FilterFieldExpressionVisitor<T> visitor);
 
     @Override
-    <T> T accept(final FieldExpressionVisitor<T> visitor);
+    <T> T accept(FieldExpressionVisitor<T> visitor);
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SimpleFieldExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SimpleFieldExpression.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.model.query.expression;
+
+/**
+ * Expression for a simple field.
+ *
+ * @since 2.0.0
+ */
+public interface SimpleFieldExpression extends FilterFieldExpression, SortFieldExpression, ExistsFieldExpression {
+
+    /**
+     * Creates an expression for a simple field.
+     *
+     * @param fieldName the field name.
+     * @return the created SimpleFieldExpression
+     * @throws NullPointerException if {@code fieldName} is {@code null}.
+     */
+    static SimpleFieldExpression of(final String fieldName) {
+        return new SimpleFieldExpressionImpl(fieldName);
+    }
+
+    /**
+     * @return the field name.
+     */
+    String getFieldName();
+}

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SimpleFieldExpressionImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SimpleFieldExpressionImpl.java
@@ -14,24 +14,24 @@ package org.eclipse.ditto.model.query.expression;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
 import org.eclipse.ditto.model.query.expression.visitors.ExistsFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.FilterFieldExpressionVisitor;
 import org.eclipse.ditto.model.query.expression.visitors.SortFieldExpressionVisitor;
 
 /**
- * Expression for a simple field, in contrast to e.g. {@link AttributeExpressionImpl}.
+ * Immutable implementation of {@link SimpleFieldExpression}.
  */
-public class SimpleFieldExpressionImpl implements FilterFieldExpression, SortFieldExpression, ExistsFieldExpression {
+@Immutable
+final class SimpleFieldExpressionImpl implements SimpleFieldExpression {
 
     private final String fieldName;
 
-    /**
-     * Creates a expression for a simple field.
-     *
-     * @param fieldName the field name
-     */
-    public SimpleFieldExpressionImpl(final String fieldName) {
+    SimpleFieldExpressionImpl(final String fieldName) {
         this.fieldName = requireNonNull(fieldName);
     }
 
@@ -55,47 +55,32 @@ public class SimpleFieldExpressionImpl implements FilterFieldExpression, SortFie
         return visitor.visitSimple(fieldName);
     }
 
-    /**
-     * @return the field name.
-     */
+    @Override
     public String getFieldName() {
         return fieldName;
     }
 
-    @SuppressWarnings("squid:S109")
     @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = (prime * result) + ((fieldName == null) ? 0 : fieldName.hashCode());
-        return result;
-    }
-
-    @SuppressWarnings("squid:MethodCyclomaticComplexity")
-    @Override
-    public boolean equals(final Object obj) {
-        if (this == obj) {
+    public boolean equals(final Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final SimpleFieldExpressionImpl other = (SimpleFieldExpressionImpl) obj;
-        if (fieldName == null) {
-            if (other.fieldName != null) {
-                return false;
-            }
-        } else if (!fieldName.equals(other.fieldName)) {
-            return false;
-        }
-        return true;
+        final SimpleFieldExpressionImpl that = (SimpleFieldExpressionImpl) o;
+        return Objects.equals(fieldName, that.fieldName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldName);
     }
 
     @Override
     public String toString() {
-        return "SimpleFieldExpression [fieldName=" + fieldName + "]";
+        return getClass().getSimpleName() + " [" +
+                "fieldName=" + fieldName +
+                "]";
     }
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SortFieldExpression.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/SortFieldExpression.java
@@ -30,14 +30,14 @@ public interface SortFieldExpression extends FilterFieldExpression, ExistsFieldE
      * @param <T> The result type.
      * @return The result of the evaluation.
      */
-    <T> T acceptSortVisitor(final SortFieldExpressionVisitor<T> visitor);
+    <T> T acceptSortVisitor(SortFieldExpressionVisitor<T> visitor);
 
     @Override
-    <T> T acceptFilterVisitor(final FilterFieldExpressionVisitor<T> visitor);
+    <T> T acceptFilterVisitor(FilterFieldExpressionVisitor<T> visitor);
 
     @Override
-    <T> T acceptExistsVisitor(final ExistsFieldExpressionVisitor<T> visitor);
+    <T> T acceptExistsVisitor(ExistsFieldExpressionVisitor<T> visitor);
 
     @Override
-    <T> T accept(final FieldExpressionVisitor<T> visitor);
+    <T> T accept(FieldExpressionVisitor<T> visitor);
 }

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactory.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactory.java
@@ -12,11 +12,24 @@
  */
 package org.eclipse.ditto.model.query.expression;
 
+import java.util.Map;
+
 /**
  * Factory for creating {@link FieldExpression}s for thing search.
  * The only relevant method is {@code filterByNamespace}; all others are only for tests.
  */
 public interface ThingsFieldExpressionFactory extends FieldExpressionFactory {
+
+    /**
+     * Creates a ThingsFieldExpressionFactory with custom field mappings.
+     *
+     * @param simpleFieldMappings the field mappings to apply.
+     * @return the created ThingsFieldExpressionFactory
+     * @since 2.0.0
+     */
+    static ThingsFieldExpressionFactory of(final Map<String, String> simpleFieldMappings) {
+        return new ThingsFieldExpressionFactoryImpl(simpleFieldMappings);
+    }
 
     /**
      * @return a filter expression for the given namespace

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactoryImpl.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactoryImpl.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.model.query.expression;
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.ditto.model.base.common.ConditionChecker.checkNotNull;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -23,31 +24,12 @@ import java.util.function.Supplier;
 /**
  * Implementation of {@link ThingsFieldExpressionFactory}.
  */
-public final class ThingsFieldExpressionFactoryImpl implements ThingsFieldExpressionFactory {
-
-    private static final Map<String, String> mongoSimpleFieldMappings = new HashMap<>();
-
-    static {
-        mongoSimpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
-        mongoSimpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
-    }
+final class ThingsFieldExpressionFactoryImpl implements ThingsFieldExpressionFactory {
 
     private final Map<String, String> simpleFieldMappings;
 
-    /**
-     * Creates a ThingsFieldExpressionFactory with default field mappings (MongoDB).
-     */
-    public ThingsFieldExpressionFactoryImpl() {
-        this(mongoSimpleFieldMappings);
-    }
-
-    /**
-     * Creates a ThingsFieldExpressionFactory with custom field mappings.
-     *
-     * @param simpleFieldMappings the field mappings to apply
-     */
-    public ThingsFieldExpressionFactoryImpl(final Map<String, String> simpleFieldMappings) {
-        this.simpleFieldMappings = simpleFieldMappings;
+    ThingsFieldExpressionFactoryImpl(final Map<String, String> simpleFieldMappings) {
+        this.simpleFieldMappings = Collections.unmodifiableMap(new HashMap<>(simpleFieldMappings));
     }
 
     @Override

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/visitors/FilterFieldExpressionVisitor.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/visitors/FilterFieldExpressionVisitor.java
@@ -15,8 +15,7 @@ package org.eclipse.ditto.model.query.expression.visitors;
 import org.eclipse.ditto.model.query.expression.FilterFieldExpression;
 
 /**
- * Compositional interpreter of
- * {@link FilterFieldExpression}.
+ * Compositional interpreter of {@link FilterFieldExpression}.
  */
 public interface FilterFieldExpressionVisitor<T> extends SortFieldExpressionVisitor<T> {
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/expression/visitors/SortFieldExpressionVisitor.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/expression/visitors/SortFieldExpressionVisitor.java
@@ -13,7 +13,7 @@
 package org.eclipse.ditto.model.query.expression.visitors;
 
 /**
- * Compositional interpreter of * {@link SortFieldExpressionVisitor}.
+ * Compositional interpreter of {@link SortFieldExpressionVisitor}.
  */
 public interface SortFieldExpressionVisitor<T> {
 

--- a/model/query/src/main/java/org/eclipse/ditto/model/query/things/ModelBasedThingsFieldExpressionFactory.java
+++ b/model/query/src/main/java/org/eclipse/ditto/model/query/things/ModelBasedThingsFieldExpressionFactory.java
@@ -26,7 +26,6 @@ import org.eclipse.ditto.model.query.expression.ExistsFieldExpression;
 import org.eclipse.ditto.model.query.expression.FilterFieldExpression;
 import org.eclipse.ditto.model.query.expression.SortFieldExpression;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Thing;
 
 /**
@@ -47,10 +46,21 @@ public final class ModelBasedThingsFieldExpressionFactory implements ThingsField
         filteringSimpleFieldMappings = Collections.unmodifiableMap(hashMap);
     }
 
+    private static final ModelBasedThingsFieldExpressionFactory INSTANCE = new ModelBasedThingsFieldExpressionFactory();
+
     private final ThingsFieldExpressionFactory delegate;
 
-    public ModelBasedThingsFieldExpressionFactory() {
-        this.delegate = new ThingsFieldExpressionFactoryImpl(filteringSimpleFieldMappings);
+    private ModelBasedThingsFieldExpressionFactory() {
+        this.delegate = ThingsFieldExpressionFactory.of(filteringSimpleFieldMappings);
+    }
+
+    /**
+     * Returns the ModelBasedThingsFieldExpressionFactory.
+     *
+     * @return the ModelBasedThingsFieldExpressionFactory.
+     */
+    public static ModelBasedThingsFieldExpressionFactory getInstance() {
+        return INSTANCE;
     }
 
     @Override

--- a/model/query/src/test/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactoryImplTest.java
+++ b/model/query/src/test/java/org/eclipse/ditto/model/query/expression/ThingsFieldExpressionFactoryImplTest.java
@@ -14,6 +14,9 @@ package org.eclipse.ditto.model.query.expression;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 
 /**
@@ -42,7 +45,13 @@ public final class ThingsFieldExpressionFactoryImplTest {
 
     private static final String KNOWN_THING_DEFINITION = "definition/example:test:definition";
 
-    private final ThingsFieldExpressionFactory ef = new ThingsFieldExpressionFactoryImpl();
+    private static final Map<String, String> SIMPLE_FIELD_MAPPINGS = new HashMap<>();
+    static {
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
+    }
+
+    private final ThingsFieldExpressionFactory ef = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     @Test(expected = NullPointerException.class)
     public void filterByWithNullPropertyName() {

--- a/model/query/src/test/java/org/eclipse/ditto/model/query/filter/ParameterPredicateVisitorTest.java
+++ b/model/query/src/test/java/org/eclipse/ditto/model/query/filter/ParameterPredicateVisitorTest.java
@@ -14,12 +14,14 @@ package org.eclipse.ditto.model.query.filter;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.assertj.core.api.Assertions;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
+import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
 import org.eclipse.ditto.model.query.expression.FieldExpressionUtil;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
+import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.rql.predicates.ast.LogicalNode;
 import org.eclipse.ditto.model.rql.predicates.ast.RootNode;
 import org.eclipse.ditto.model.rql.predicates.ast.SingleComparisonNode;
@@ -36,13 +38,17 @@ public final class ParameterPredicateVisitorTest {
     private static final String KNOWN_FIELD_VALUE_2 = "value2";
 
     private ParameterPredicateVisitor visitorUnderTest;
-    private CriteriaFactoryImpl cf;
-    private ThingsFieldExpressionFactoryImpl ef;
+    private CriteriaFactory cf;
+    private ThingsFieldExpressionFactory ef;
 
     @Before
     public void before() {
-        cf = new CriteriaFactoryImpl();
-        ef = new ThingsFieldExpressionFactoryImpl();
+        cf = CriteriaFactory.getInstance();
+
+        final Map<String, String> simpleFieldMappings = new HashMap<>();
+        simpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
+        simpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
+        ef = ThingsFieldExpressionFactory.of(simpleFieldMappings);
         visitorUnderTest = new ParameterPredicateVisitor(cf, ef);
     }
 

--- a/model/query/src/test/java/org/eclipse/ditto/model/query/things/ThingPredicateVisitorTest.java
+++ b/model/query/src/test/java/org/eclipse/ditto/model/query/things/ThingPredicateVisitorTest.java
@@ -20,9 +20,8 @@ import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.things.FeatureProperties;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
@@ -33,9 +32,8 @@ import org.junit.Test;
  */
 public final class ThingPredicateVisitorTest {
 
-    private static final CriteriaFactory criteriaFactory = new CriteriaFactoryImpl();
     private static final QueryFilterCriteriaFactory queryFilterCriteriaFactory =
-            new QueryFilterCriteriaFactory(criteriaFactory, new ModelBasedThingsFieldExpressionFactory());
+            QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance());
 
     private static final ThingId MATCHING_THING_ID = ThingId.of("org.eclipse.ditto", "foo-matching");
     private static final int MATCHING_THING_INTEGER = 42;

--- a/model/rql-parser/src/main/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParser.java
+++ b/model/rql-parser/src/main/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParser.java
@@ -21,7 +21,21 @@ import org.eclipse.ditto.model.rqlparser.internal.RqlPredicateParser$;
  */
 public class RqlPredicateParser implements PredicateParser {
 
+    private static final RqlPredicateParser INSTANCE = new RqlPredicateParser();
     private static final PredicateParser PARSER = RqlPredicateParser$.MODULE$;
+
+    private RqlPredicateParser() {
+        // private
+    }
+
+    /**
+     * Returns the RqlPredicateParser instance.
+     *
+     * @return the instance.
+     */
+    public static RqlPredicateParser getInstance() {
+        return INSTANCE;
+    }
 
     @Override
     public RootNode parse(final String input) {

--- a/model/rql-parser/src/test/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParserTest.java
+++ b/model/rql-parser/src/test/java/org/eclipse/ditto/model/rqlparser/RqlPredicateParserTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 public class RqlPredicateParserTest {
 
-    private final PredicateParser parser = new RqlPredicateParser();
+    private final PredicateParser parser = RqlPredicateParser.getInstance();
 
     @Test
     public void testComparisonEqualsWithNumberValue() throws ParserException {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/OutboundMappingProcessorActor.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/OutboundMappingProcessorActor.java
@@ -56,6 +56,7 @@ import org.eclipse.ditto.model.connectivity.Target;
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
 import org.eclipse.ditto.model.query.things.ThingPredicateVisitor;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.base.config.limits.DefaultLimitsConfig;
 import org.eclipse.ditto.services.base.config.limits.LimitsConfig;
@@ -637,7 +638,7 @@ public final class OutboundMappingProcessorActor
             // evaluate filter criteria again if signal enrichment is involved.
             final Signal<?> signal = outboundSignalWithExtra.getSource();
             final DittoHeaders dittoHeaders = signal.getDittoHeaders();
-            final Criteria criteria = QueryFilterCriteriaFactory.modelBased()
+            final Criteria criteria = QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance())
                     .filterCriteria(filter.get(), dittoHeaders);
             return outboundSignalWithExtra.getExtra()
                     .flatMap(extra -> ThingEventToThingConverter

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/SignalFilter.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/persistence/SignalFilter.java
@@ -36,6 +36,7 @@ import org.eclipse.ditto.model.connectivity.Topic;
 import org.eclipse.ditto.model.namespaces.NamespaceReader;
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.protocoladapter.TopicPath;
 import org.eclipse.ditto.services.connectivity.messaging.monitoring.ConnectionMonitor;
@@ -166,7 +167,8 @@ public final class SignalFilter {
      * mapped to a valid criterion
      */
     private static Criteria parseCriteria(final String filter, final DittoHeaders dittoHeaders) {
-        return QueryFilterCriteriaFactory.modelBased().filterCriteria(filter, dittoHeaders);
+        return QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance())
+                .filterCriteria(filter, dittoHeaders);
     }
 
     private static Optional<Topic> topicFromSignal(final Signal<?> signal) {

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidator.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/validation/ConnectionValidator.java
@@ -41,11 +41,8 @@ import org.eclipse.ditto.model.connectivity.Credentials;
 import org.eclipse.ditto.model.connectivity.PayloadMapping;
 import org.eclipse.ditto.model.connectivity.Source;
 import org.eclipse.ditto.model.connectivity.Target;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
-import org.eclipse.ditto.model.query.things.ModelBasedThingsFieldExpressionFactory;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.services.connectivity.config.ConnectionConfig;
 import org.eclipse.ditto.services.connectivity.config.ConnectivityConfig;
 import org.eclipse.ditto.services.connectivity.config.ConnectivityConfigProvider;
@@ -78,10 +75,7 @@ public final class ConnectionValidator {
         final Map<ConnectionType, AbstractProtocolValidator> theSpecMap = Arrays.stream(connectionSpecs)
                 .collect(Collectors.toMap(AbstractProtocolValidator::type, Function.identity()));
         this.specMap = Collections.unmodifiableMap(theSpecMap);
-
-        final CriteriaFactory criteriaFactory = new CriteriaFactoryImpl();
-        final ThingsFieldExpressionFactory fieldExpressionFactory = new ModelBasedThingsFieldExpressionFactory();
-        queryFilterCriteriaFactory = new QueryFilterCriteriaFactory(criteriaFactory, fieldExpressionFactory);
+        queryFilterCriteriaFactory = QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance());
     }
 
     /**

--- a/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilder.java
+++ b/services/gateway/endpoints/src/main/java/org/eclipse/ditto/services/gateway/endpoints/routes/sse/ThingsSseRouteBuilder.java
@@ -41,9 +41,8 @@ import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.model.base.exceptions.SignalEnrichmentFailedException;
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
-import org.eclipse.ditto.model.query.things.ModelBasedThingsFieldExpressionFactory;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingFieldSelector;
 import org.eclipse.ditto.model.things.ThingId;
@@ -151,7 +150,7 @@ public final class ThingsSseRouteBuilder extends RouteDirectives implements SseR
             final ActorRef pubSubMediator) {
         checkNotNull(streamingActor, "streamingActor");
         final QueryFilterCriteriaFactory queryFilterCriteriaFactory =
-                new QueryFilterCriteriaFactory(new CriteriaFactoryImpl(), new ModelBasedThingsFieldExpressionFactory());
+                QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance());
 
         return new ThingsSseRouteBuilder(streamingActor, streamingConfig, queryFilterCriteriaFactory, pubSubMediator);
     }

--- a/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
+++ b/services/gateway/streaming/src/main/java/org/eclipse/ditto/services/gateway/streaming/actors/StreamingSessionActor.java
@@ -40,11 +40,8 @@ import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
 import org.eclipse.ditto.model.jwt.JsonWebToken;
 import org.eclipse.ditto.model.namespaces.NamespaceReader;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
-import org.eclipse.ditto.model.query.things.ModelBasedThingsFieldExpressionFactory;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.protocoladapter.HeaderTranslator;
 import org.eclipse.ditto.protocoladapter.TopicPath;
@@ -666,11 +663,8 @@ final class StreamingSessionActor extends AbstractActorWithTimers {
     }
 
     private static Criteria parseCriteria(final String filter, final DittoHeaders dittoHeaders) {
-        final CriteriaFactory criteriaFactory = new CriteriaFactoryImpl();
-        final ThingsFieldExpressionFactory fieldExpressionFactory =
-                new ModelBasedThingsFieldExpressionFactory();
         final QueryFilterCriteriaFactory queryFilterCriteriaFactory =
-                new QueryFilterCriteriaFactory(criteriaFactory, fieldExpressionFactory);
+                QueryFilterCriteriaFactory.modelBased(RqlPredicateParser.getInstance());
 
         return queryFilterCriteriaFactory.filterCriteria(filter, dittoHeaders);
     }

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryParser.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/query/QueryParser.java
@@ -23,6 +23,8 @@ import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.query.filter.QueryFilterCriteriaFactory;
 import org.eclipse.ditto.model.rql.ParserException;
+import org.eclipse.ditto.model.rql.predicates.PredicateParser;
+import org.eclipse.ditto.model.rqlparser.RqlPredicateParser;
 import org.eclipse.ditto.model.thingsearchparser.RqlOptionParser;
 import org.eclipse.ditto.services.models.thingsearch.commands.sudo.SudoCountThings;
 import org.eclipse.ditto.services.models.thingsearch.query.filter.ParameterOptionVisitor;
@@ -43,12 +45,12 @@ public final class QueryParser {
     private final RqlOptionParser rqlOptionParser;
     private final QueryCriteriaValidator queryCriteriaValidator;
 
-    private QueryParser(final CriteriaFactory criteriaFactory,
-            final ThingsFieldExpressionFactory fieldExpressionFactory,
+    private QueryParser(final ThingsFieldExpressionFactory fieldExpressionFactory,
+            final PredicateParser predicateParser,
             final QueryBuilderFactory queryBuilderFactory,
             final QueryCriteriaValidator queryCriteriaValidator) {
 
-        this.queryFilterCriteriaFactory = new QueryFilterCriteriaFactory(criteriaFactory, fieldExpressionFactory);
+        this.queryFilterCriteriaFactory = QueryFilterCriteriaFactory.of(fieldExpressionFactory, predicateParser);
         this.fieldExpressionFactory = fieldExpressionFactory;
         this.queryBuilderFactory = queryBuilderFactory;
         this.queryCriteriaValidator = queryCriteriaValidator;
@@ -58,18 +60,17 @@ public final class QueryParser {
     /**
      * Create a QueryFactory.
      *
-     * @param criteriaFactory a factory to create criteria.
      * @param fieldExpressionFactory a factory to retrieve things field expressions.
      * @param queryBuilderFactory a factory to create a query builder.
      * @param queryCriteriaValidator a validator for queries.
      * @return the query factory.
      */
-    public static QueryParser of(final CriteriaFactory criteriaFactory,
-            final ThingsFieldExpressionFactory fieldExpressionFactory,
+    public static QueryParser of(final ThingsFieldExpressionFactory fieldExpressionFactory,
             final QueryBuilderFactory queryBuilderFactory,
             final QueryCriteriaValidator queryCriteriaValidator) {
 
-        return new QueryParser(criteriaFactory, fieldExpressionFactory, queryBuilderFactory, queryCriteriaValidator);
+        return new QueryParser(fieldExpressionFactory, RqlPredicateParser.getInstance(), queryBuilderFactory,
+                queryCriteriaValidator);
     }
 
     /**

--- a/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilder.java
+++ b/services/thingsearch/persistence/src/main/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilder.java
@@ -28,7 +28,7 @@ import org.eclipse.ditto.model.query.QueryBuilder;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.expression.SimpleFieldExpressionImpl;
+import org.eclipse.ditto.model.query.expression.SimpleFieldExpression;
 import org.eclipse.ditto.model.query.expression.SortFieldExpression;
 
 /**
@@ -49,7 +49,7 @@ final class MongoQueryBuilder implements QueryBuilder {
      */
     private static final int MAX_LIMIT_UNLIMITED = Integer.MAX_VALUE;
 
-    private static final SortFieldExpression ID_SORT_FIELD_EXPRESSION = new SimpleFieldExpressionImpl(FIELD_ID);
+    private static final SortFieldExpression ID_SORT_FIELD_EXPRESSION = SimpleFieldExpression.of(FIELD_ID);
 
     private static final List<SortOption> DEFAULT_SORT_OPTIONS =
             Collections.singletonList(new SortOption(ID_SORT_FIELD_EXPRESSION, SortDirection.ASC));

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/AbstractThingSearchPersistenceITBase.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/AbstractThingSearchPersistenceITBase.java
@@ -14,7 +14,9 @@ package org.eclipse.ditto.services.thingsearch.persistence;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
@@ -24,9 +26,8 @@ import org.bson.Document;
 import org.eclipse.ditto.model.query.Query;
 import org.eclipse.ditto.model.query.QueryBuilderFactory;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
+import org.eclipse.ditto.model.query.expression.FieldExpressionUtil;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.base.config.limits.DefaultLimitsConfig;
 import org.eclipse.ditto.services.thingsearch.common.model.ResultList;
@@ -66,8 +67,15 @@ public abstract class AbstractThingSearchPersistenceITBase {
 
     protected static final List<String> KNOWN_SUBJECTS = Collections.singletonList("abc:mySid");
 
-    protected static final CriteriaFactory cf = new CriteriaFactoryImpl();
-    protected static final ThingsFieldExpressionFactory fef = new ThingsFieldExpressionFactoryImpl();
+    private static final Map<String, String> mongoSimpleFieldMappings = new HashMap<>();
+
+    static {
+        mongoSimpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
+        mongoSimpleFieldMappings.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
+    }
+
+    protected static final CriteriaFactory cf = CriteriaFactory.getInstance();
+    protected static final ThingsFieldExpressionFactory fef = ThingsFieldExpressionFactory.of(mongoSimpleFieldMappings);
 
     protected static QueryBuilderFactory qbf;
 

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/AbstractReadPersistenceITBase.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/AbstractReadPersistenceITBase.java
@@ -14,7 +14,9 @@ package org.eclipse.ditto.services.thingsearch.persistence.read;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
@@ -31,6 +33,7 @@ import org.eclipse.ditto.model.policies.ResourceKey;
 import org.eclipse.ditto.model.policies.Subject;
 import org.eclipse.ditto.model.policies.SubjectType;
 import org.eclipse.ditto.model.query.criteria.Criteria;
+import org.eclipse.ditto.model.query.expression.FieldExpressionUtil;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.thingsearch.common.model.ResultList;
@@ -44,6 +47,12 @@ import org.junit.Before;
 public abstract class AbstractReadPersistenceITBase extends AbstractThingSearchPersistenceITBase {
 
     static final PolicyId POLICY_ID = PolicyId.of("global", "policy");
+
+    protected static final Map<String, String> SIMPLE_FIELD_MAPPINGS = new HashMap<>();
+    static {
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
+    }
 
     private Enforcer policyEnforcer;
 

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/ExistsIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/ExistsIT.java
@@ -27,9 +27,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Attributes;
 import org.eclipse.ditto.model.things.Feature;
 import org.eclipse.ditto.model.things.Features;
@@ -66,8 +64,8 @@ public final class ExistsIT extends AbstractReadPersistenceITBase {
     private static final String TAGS4 = "tags4";
     private static final String TAGS5 = "tags5";
 
-    private final CriteriaFactory cf = new CriteriaFactoryImpl();
-    private final ThingsFieldExpressionFactory ef = new ThingsFieldExpressionFactoryImpl();
+    private final CriteriaFactory cf = CriteriaFactory.getInstance();
+    private final ThingsFieldExpressionFactory ef = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     @Before
     public void createTestData() {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/FilterCriteriaIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/FilterCriteriaIT.java
@@ -19,9 +19,7 @@ import java.util.Collections;
 
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Attributes;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.thingsearch.persistence.TestConstants;
@@ -64,8 +62,8 @@ public final class FilterCriteriaIT extends AbstractReadPersistenceITBase {
     private static final String THING3_KNOWN_STR_REGEX_VALUE = "Teststring nummer drei"; // wildcard
     private static final String THING4_KNOWN_STR_REGEX_VALUE = "Der vierte und letzte Teststring"; // ends with
 
-    private final CriteriaFactory cf = new CriteriaFactoryImpl();
-    private final ThingsFieldExpressionFactory ef = new ThingsFieldExpressionFactoryImpl();
+    private final CriteriaFactory cf = CriteriaFactory.getInstance();
+    private final ThingsFieldExpressionFactory ef = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     @Before
     public void createTestData() {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/PagingIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/PagingIT.java
@@ -28,7 +28,6 @@ import org.eclipse.ditto.model.query.QueryBuilder;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.base.config.limits.DefaultLimitsConfig;
@@ -62,7 +61,7 @@ public final class PagingIT extends AbstractReadPersistenceITBase {
     private int maxPageSizeFromConfig;
     private int defaultPageSizeFromConfig;
 
-    private final ThingsFieldExpressionFactory eft = new ThingsFieldExpressionFactoryImpl();
+    private final ThingsFieldExpressionFactory eft = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     @BeforeClass
     public static void initTestFixture() {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SimpleCriteriaIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SimpleCriteriaIT.java
@@ -20,9 +20,7 @@ import java.util.stream.Stream;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.model.query.criteria.Criteria;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.thingsearch.persistence.TestConstants;
 import org.junit.Before;
@@ -53,8 +51,8 @@ public final class SimpleCriteriaIT extends AbstractReadPersistenceITBase {
     private static final int KNOWN_NUMBER_VALUE = 4711;
     private static final boolean KNOWN_BOOLEAN_VALUE = false;
 
-    private final CriteriaFactory cf = new CriteriaFactoryImpl();
-    private final ThingsFieldExpressionFactory ef = new ThingsFieldExpressionFactoryImpl();
+    private final CriteriaFactory cf = CriteriaFactory.getInstance();
+    private final ThingsFieldExpressionFactory ef = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     @Before
     public void createTestData() {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SortingIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SortingIT.java
@@ -28,14 +28,12 @@ import org.eclipse.ditto.model.query.Query;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
-import org.eclipse.ditto.model.query.expression.AttributeExpressionImpl;
-import org.eclipse.ditto.model.query.expression.FeatureIdDesiredPropertyExpressionImpl;
-import org.eclipse.ditto.model.query.expression.FeatureIdPropertyExpressionImpl;
+import org.eclipse.ditto.model.query.expression.AttributeExpression;
+import org.eclipse.ditto.model.query.expression.FeatureIdDesiredPropertyExpression;
+import org.eclipse.ditto.model.query.expression.FeatureIdPropertyExpression;
 import org.eclipse.ditto.model.query.expression.FieldExpression;
-import org.eclipse.ditto.model.query.expression.SimpleFieldExpressionImpl;
+import org.eclipse.ditto.model.query.expression.SimpleFieldExpression;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Feature;
 import org.eclipse.ditto.model.things.FeatureProperties;
 import org.eclipse.ditto.model.things.Features;
@@ -56,7 +54,7 @@ public final class SortingIT extends AbstractReadPersistenceITBase {
     private static final List<SortDirection> SORT_DIRECTIONS = Arrays.asList(SortDirection.values());
     private static final Random RANDOM = new Random();
 
-    private static final ThingsFieldExpressionFactory EFT = new ThingsFieldExpressionFactoryImpl();
+    private static final ThingsFieldExpressionFactory EFT = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     public static final String NAMESPACE = "thingsearch.read";
     private static final List<ThingId> THING_IDS = Arrays.asList(
@@ -77,7 +75,7 @@ public final class SortingIT extends AbstractReadPersistenceITBase {
         return Arrays.asList(SORT_DIRECTIONS.toArray());
     }
 
-    private final CriteriaFactory cf = new CriteriaFactoryImpl();
+    private final CriteriaFactory cf = CriteriaFactory.getInstance();
 
     @Parameterized.Parameter(0)
     public SortDirection testedSortDirection;
@@ -242,12 +240,12 @@ public final class SortingIT extends AbstractReadPersistenceITBase {
 
     private Function<Thing, String> extractStringField(final FieldExpression sortField) {
         return (thing) -> {
-            if (sortField instanceof SimpleFieldExpressionImpl) {
+            if (sortField instanceof SimpleFieldExpression) {
                 return thing.getEntityId().orElseThrow(IllegalStateException::new).toString();
             } else {
                 return thing.getAttributes()
                         .orElseThrow(IllegalStateException::new)
-                        .getValue(((AttributeExpressionImpl) sortField).getKey())
+                        .getValue(((AttributeExpression) sortField).getKey())
                         .orElseThrow(IllegalStateException::new)
                         .asString();
             }
@@ -256,26 +254,26 @@ public final class SortingIT extends AbstractReadPersistenceITBase {
 
     private Function<Thing, Long> extractLongField(final FieldExpression sortField) {
         return (thing) -> {
-            if (sortField instanceof AttributeExpressionImpl) {
+            if (sortField instanceof AttributeExpression) {
                 return thing.getAttributes()
                         .orElseThrow(IllegalStateException::new)
-                        .getValue(((AttributeExpressionImpl) sortField).getKey())
+                        .getValue(((AttributeExpression) sortField).getKey())
                         .orElseThrow(IllegalStateException::new)
                         .asLong();
-            } else if (sortField instanceof FeatureIdPropertyExpressionImpl) {
+            } else if (sortField instanceof FeatureIdPropertyExpression) {
                 return thing.getFeatures()
                         .orElseThrow(IllegalStateException::new)
-                        .getFeature(((FeatureIdPropertyExpressionImpl) sortField).getFeatureId())
+                        .getFeature(((FeatureIdPropertyExpression) sortField).getFeatureId())
                         .orElseThrow(IllegalStateException::new)
-                        .getProperty(((FeatureIdPropertyExpressionImpl) sortField).getProperty())
+                        .getProperty(((FeatureIdPropertyExpression) sortField).getProperty())
                         .orElseThrow(IllegalStateException::new)
                         .asLong();
-            } else if (sortField instanceof FeatureIdDesiredPropertyExpressionImpl) {
+            } else if (sortField instanceof FeatureIdDesiredPropertyExpression) {
                 return thing.getFeatures()
                         .orElseThrow(IllegalStateException::new)
-                        .getFeature(((FeatureIdDesiredPropertyExpressionImpl) sortField).getFeatureId())
+                        .getFeature(((FeatureIdDesiredPropertyExpression) sortField).getFeatureId())
                         .orElseThrow(IllegalStateException::new)
-                        .getDesiredProperty(((FeatureIdDesiredPropertyExpressionImpl) sortField).getDesiredProperty())
+                        .getDesiredProperty(((FeatureIdDesiredPropertyExpression) sortField).getDesiredProperty())
                         .orElseThrow(IllegalStateException::new)
                         .asLong();
             } else {

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SudoIT.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/SudoIT.java
@@ -24,9 +24,8 @@ import org.eclipse.ditto.model.policies.PolicyId;
 import org.eclipse.ditto.model.query.Query;
 import org.eclipse.ditto.model.query.QueryBuilderFactory;
 import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.expression.FieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
+import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
 import org.eclipse.ditto.model.things.ThingConstants;
 import org.eclipse.ditto.model.things.ThingId;
 import org.eclipse.ditto.services.base.config.limits.LimitsConfig;
@@ -52,8 +51,8 @@ public final class SudoIT extends AbstractReadPersistenceITBase {
     private static final Instant TIMESTAMP2 = Instant.ofEpochSecond(2L);
 
     private final FieldExpressionFactory ef =
-            new ThingsFieldExpressionFactoryImpl(Map.of("policyId", "policyId", "_modified", "_modified"));
-    private final CriteriaFactory cf = new CriteriaFactoryImpl();
+            ThingsFieldExpressionFactory.of(Map.of("policyId", "policyId", "_modified", "_modified"));
+    private final CriteriaFactory cf = CriteriaFactory.getInstance();
     private final QueryBuilderFactory qbf = new MongoQueryBuilderFactory(Mockito.mock(LimitsConfig.class));
 
     @Before

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/expression/visitors/GetSortBsonVisitorTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/expression/visitors/GetSortBsonVisitorTest.java
@@ -17,7 +17,7 @@ import java.util.Collections;
 import org.bson.Document;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
-import org.eclipse.ditto.model.query.expression.AttributeExpressionImpl;
+import org.eclipse.ditto.model.query.expression.AttributeExpression;
 import org.eclipse.ditto.model.query.expression.SortFieldExpression;
 import org.junit.Test;
 
@@ -28,7 +28,7 @@ public final class GetSortBsonVisitorTest {
 
     @Test
     public void handlesNullValues() {
-        final SortFieldExpression expression = new AttributeExpressionImpl("a/b/c/d/e/f/g");
+        final SortFieldExpression expression = AttributeExpression.of("a/b/c/d/e/f/g");
         final SortOption sortOption = new SortOption(expression, SortDirection.ASC);
 
         GetSortBsonVisitor.sortValuesAsArray(new Document(), Collections.singletonList(sortOption));

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilderLimitedTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilderLimitedTest.java
@@ -22,7 +22,7 @@ import org.eclipse.ditto.model.query.Query;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.expression.SimpleFieldExpressionImpl;
+import org.eclipse.ditto.model.query.expression.SimpleFieldExpression;
 import org.eclipse.ditto.services.base.config.limits.DefaultLimitsConfig;
 import org.eclipse.ditto.services.utils.config.ScopedConfig;
 import org.junit.Before;
@@ -39,7 +39,7 @@ import com.typesafe.config.ConfigFactory;
 public final class MongoQueryBuilderLimitedTest {
 
     private static final SortOption KNOWN_SORT_OPTION =
-            new SortOption(new SimpleFieldExpressionImpl(FIELD_ID), SortDirection.DESC);
+            new SortOption(SimpleFieldExpression.of(FIELD_ID), SortDirection.DESC);
 
     private static DefaultLimitsConfig limitsConfig;
 
@@ -85,7 +85,7 @@ public final class MongoQueryBuilderLimitedTest {
     @Test
     public void appendDefaultSortOption() {
         final SortOption defaultSortOption =
-                new SortOption(new SimpleFieldExpressionImpl(FIELD_ID), SortDirection.ASC);
+                new SortOption(SimpleFieldExpression.of(FIELD_ID), SortDirection.ASC);
         final List<SortOption> sortOptions = Collections.singletonList(Mockito.mock(SortOption.class));
         final Query query = underTest.sort(sortOptions).build();
 

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilderUnlimitedTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryBuilderUnlimitedTest.java
@@ -23,7 +23,7 @@ import org.eclipse.ditto.model.query.Query;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.expression.SimpleFieldExpressionImpl;
+import org.eclipse.ditto.model.query.expression.SimpleFieldExpression;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -33,7 +33,7 @@ import org.junit.Test;
 public final class MongoQueryBuilderUnlimitedTest {
 
     private static final SortOption KNOWN_SORT_OPTION =
-            new SortOption(new SimpleFieldExpressionImpl(FIELD_ID), SortDirection.DESC);
+            new SortOption(SimpleFieldExpression.of(FIELD_ID), SortDirection.DESC);
 
     private Criteria criteria;
     private MongoQueryBuilder underTest;

--- a/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryTest.java
+++ b/services/thingsearch/persistence/src/test/java/org/eclipse/ditto/services/thingsearch/persistence/read/query/MongoQueryTest.java
@@ -22,17 +22,19 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.bson.BsonDocument;
 import org.bson.conversions.Bson;
 import org.eclipse.ditto.model.query.SortDirection;
 import org.eclipse.ditto.model.query.SortOption;
 import org.eclipse.ditto.model.query.criteria.Criteria;
-import org.eclipse.ditto.model.query.expression.SimpleFieldExpressionImpl;
+import org.eclipse.ditto.model.query.expression.FieldExpressionUtil;
+import org.eclipse.ditto.model.query.expression.SimpleFieldExpression;
 import org.eclipse.ditto.model.query.expression.SortFieldExpression;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.services.base.config.limits.DefaultLimitsConfig;
 import org.eclipse.ditto.services.utils.config.ScopedConfig;
 import org.junit.Before;
@@ -51,7 +53,14 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class MongoQueryTest {
 
     private static final Criteria KNOWN_CRIT = mock(Criteria.class);
-    private static final ThingsFieldExpressionFactory EFT = new ThingsFieldExpressionFactoryImpl();
+
+    private static final Map<String, String> SIMPLE_FIELD_MAPPINGS = new HashMap<>();
+    static {
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_THING_ID, FieldExpressionUtil.FIELD_ID);
+        SIMPLE_FIELD_MAPPINGS.put(FieldExpressionUtil.FIELD_NAME_NAMESPACE, FieldExpressionUtil.FIELD_NAMESPACE);
+    }
+
+    private static final ThingsFieldExpressionFactory EFT = ThingsFieldExpressionFactory.of(SIMPLE_FIELD_MAPPINGS);
 
     private static int defaultPageSizeFromConfig;
 
@@ -73,7 +82,7 @@ public final class MongoQueryTest {
         knownSortOptions =
                 Arrays.asList(new SortOption(sortExp1, SortDirection.ASC),
                         new SortOption(sortExp2, SortDirection.DESC));
-        final String thingIdFieldName = ((SimpleFieldExpressionImpl) EFT.sortByThingId()).getFieldName();
+        final String thingIdFieldName = ((SimpleFieldExpression) EFT.sortByThingId()).getFieldName();
         final String attributeFieldName = "attributes.test";
         knownSortOptionsExpectedBson = Sorts.orderBy(Arrays.asList(
                 Sorts.ascending(thingIdFieldName),

--- a/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchRootActor.java
+++ b/services/thingsearch/starter/src/main/java/org/eclipse/ditto/services/thingsearch/starter/actors/SearchRootActor.java
@@ -23,11 +23,8 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.model.query.QueryBuilderFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactory;
-import org.eclipse.ditto.model.query.criteria.CriteriaFactoryImpl;
 import org.eclipse.ditto.model.query.expression.FieldExpressionUtil;
 import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactory;
-import org.eclipse.ditto.model.query.expression.ThingsFieldExpressionFactoryImpl;
 import org.eclipse.ditto.model.things.Thing;
 import org.eclipse.ditto.services.base.actors.DittoRootActor;
 import org.eclipse.ditto.services.base.config.limits.LimitsConfig;
@@ -147,11 +144,10 @@ public final class SearchRootActor extends DittoRootActor {
     }
 
     protected static QueryParser getQueryParser(final LimitsConfig limitsConfig, final ActorSystem actorSystem) {
-        final CriteriaFactory criteriaFactory = new CriteriaFactoryImpl();
         final ThingsFieldExpressionFactory fieldExpressionFactory = getThingsFieldExpressionFactory();
         final QueryBuilderFactory queryBuilderFactory = new MongoQueryBuilderFactory(limitsConfig);
         final QueryCriteriaValidator queryCriteriaValidator = QueryCriteriaValidator.get(actorSystem);
-        return QueryParser.of(criteriaFactory, fieldExpressionFactory, queryBuilderFactory, queryCriteriaValidator);
+        return QueryParser.of(fieldExpressionFactory, queryBuilderFactory, queryCriteriaValidator);
     }
 
     private ActorRef initializeHealthCheckActor(final SearchConfig searchConfig,
@@ -184,7 +180,7 @@ public final class SearchRootActor extends DittoRootActor {
         addMapping(mappings, Thing.JsonFields.MODIFIED);
         addMapping(mappings, Thing.JsonFields.CREATED);
         addMapping(mappings, Thing.JsonFields.DEFINITION);
-        return new ThingsFieldExpressionFactoryImpl(mappings);
+        return ThingsFieldExpressionFactory.of(mappings);
     }
 
     private static void addMapping(final Map<String, String> fieldMappings, final JsonFieldDefinition<?> definition) {

--- a/services/utils/search/src/main/java/org/eclipse/ditto/services/utils/search/SearchSourceBuilder.java
+++ b/services/utils/search/src/main/java/org/eclipse/ditto/services/utils/search/SearchSourceBuilder.java
@@ -341,7 +341,7 @@ public final class SearchSourceBuilder {
     private String validateFilter(@Nullable final String filter) {
         if (filter != null) {
             try {
-                new RqlPredicateParser().parse(filter);
+                RqlPredicateParser.getInstance().parse(filter);
             } catch (final ParserException e) {
                 throw InvalidRqlExpressionException.newBuilder()
                         .message("Invalid filter expression: " + filter)
@@ -355,7 +355,7 @@ public final class SearchSourceBuilder {
         // check sort expressions
         try {
             final ThingsFieldExpressionFactory fieldExpressionFactory =
-                    new ModelBasedThingsFieldExpressionFactory();
+                    ModelBasedThingsFieldExpressionFactory.getInstance();
             for (final SortOptionEntry entry : sort) {
                 fieldExpressionFactory.sortBy(entry.getPropertyPath().toString());
             }


### PR DESCRIPTION
Got rid of ditto-model-rql-parser dependency in ditto-model-query
* hid implementations of query expresssions behind interfaces
* made a lot of ditto-model-query classes package private
* created factory methods for creating instances