### PR TITLE
Update docker base image for ditto container images  

### DIFF
--- a/documentation/src/main/resources/openapi/sources/parameters/timeoutParam.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/timeoutParam.yml
@@ -15,9 +15,8 @@ description: |-
   acknowledgements via the `requested-acks` param. Can be specified without unit (then seconds are assumed) or
   together with `s`, `ms` or `m` unit. Example: `42s`, `1m`.
 
-  The default (if omitted) timeout is `10s`. Maximum value: `60s`.
-
-  A value of `0` applies fire and forget semantics for the command resulting in setting `response-required=false`.
+  The default (if omitted) and maximum timeout is `60s`. A value of `0` applies fire and forget semantics for
+  the command resulting in setting `response-required=false`.
 required: false
 schema:
   type: string

--- a/services/dockerfile-release
+++ b/services/dockerfile-release
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.9_11_openj9-0.23.0-alpine-slim
+FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.11_9_openj9-0.26.0-alpine-slim
 
 ARG MAVEN_REPO=https://repo.eclipse.org/service/local/artifact/maven/content
 ARG SERVICE_STARTER

--- a/services/dockerfile-snapshot
+++ b/services/dockerfile-snapshot
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.9_11_openj9-0.23.0-alpine-slim
+FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.11_9_openj9-0.26.0-alpine-slim
 
 ARG TARGET_DIR
 ARG SERVICE_STARTER


### PR DESCRIPTION
Use new version jdk-11.0.11_9_openj9-0.26.0-alpine-slim of adoptopenjdk/openjdk11-openj9 .

Signed-off-by: Stefan Maute <stefan.maute@bosch.io>