### PR TITLE
Fixing remaining known Ditto 2.0 bugs/issues

### DIFF
--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -69,7 +69,7 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
     protected AbstractDittoHeaders(final Map<String, String> headers) {
         checkNotNull(headers, "headers");
         if (headers instanceof AbstractDittoHeaders) {
-            // Share the map from the other AbstractDittoHeaders--it is not modifiable. Otherwise case is not preserved.
+            // Share the map from the other AbstractDittoHeaders -- it is not modifiable. Otherwise case is not preserved.
             this.headers = ((AbstractDittoHeaders) headers).headers;
         } else {
             this.headers = indexByLowerCase(headers);

--- a/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
+++ b/model/base/src/main/java/org/eclipse/ditto/model/base/headers/AbstractDittoHeaders.java
@@ -28,9 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -60,8 +58,6 @@ import org.eclipse.ditto.model.base.json.JsonSchemaVersion;
 @SuppressWarnings("squid:S2160")
 public abstract class AbstractDittoHeaders implements DittoHeaders {
 
-    private static final String ISSUER_DIVIDER = ":";
-
     final Map<String, Header> headers;
 
     /**
@@ -76,9 +72,7 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
             // Share the map from the other AbstractDittoHeaders--it is not modifiable. Otherwise case is not preserved.
             this.headers = ((AbstractDittoHeaders) headers).headers;
         } else {
-            final Map<String, String> headersWithOnlyPrefixedSubjects =
-                    keepAuthContextSubjectsWithIssuer(headers, (key, value) -> value);
-            this.headers = indexByLowerCase(headersWithOnlyPrefixedSubjects);
+            this.headers = indexByLowerCase(headers);
         }
     }
 
@@ -91,8 +85,7 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
     @SuppressWarnings("unused")
     protected AbstractDittoHeaders(final Map<String, Header> headers, final boolean flag) {
         checkNotNull(headers, "headers");
-        final Map<String, Header> candidate = keepAuthContextSubjectsWithIssuer(headers, Header::of);
-        this.headers = candidate != headers ? candidate : new LinkedHashMap<>(candidate);
+        this.headers = new LinkedHashMap<>(headers);
     }
 
     @Override
@@ -149,24 +142,6 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
         }
     }
 
-    private static <T extends CharSequence> Map<String, T> keepAuthContextSubjectsWithIssuer(
-            final Map<String, T> headers,
-            final BiFunction<String, String, T> fromString) {
-
-        if (headers.containsKey(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey())) {
-            final Map<String, T> newHeaders = new LinkedHashMap<>(headers);
-            final AuthorizationContext authContext =
-                    AuthorizationModelFactory.newAuthContext(getAuthorizationContextAsJson(headers));
-            final AuthorizationContext authContextWithoutDups = keepAuthContextSubjectsWithIssuer(authContext);
-            newHeaders.put(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey(),
-                    fromString.apply(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey(),
-                            authContextWithoutDups.toJsonString()));
-            return newHeaders;
-        } else {
-            return headers;
-        }
-    }
-
     private static JsonObject getAuthorizationContextAsJson(final Map<String, ? extends CharSequence> headers) {
         final CharSequence jsonObjectString = headers.get(DittoHeaderDefinition.AUTHORIZATION_CONTEXT.getKey());
         final JsonObject result;
@@ -176,27 +151,6 @@ public abstract class AbstractDittoHeaders implements DittoHeaders {
             result = JsonObject.empty();
         }
         return result;
-    }
-
-    protected static AuthorizationContext keepAuthContextSubjectsWithIssuer(final AuthorizationContext authContext) {
-        final Set<String> subjectsWithoutIssuer = authContext.getAuthorizationSubjects()
-                .stream()
-                .flatMap(authorizationSubject -> {
-                    final String authorizationSubjectId = authorizationSubject.getId();
-                    final String[] issuers = authorizationSubjectId.split(ISSUER_DIVIDER, 2);
-                    if (2 == issuers.length) {
-                        return Stream.of(issuers[1]);
-                    } else {
-                        return Stream.empty();
-                    }
-                })
-                .collect(Collectors.toSet());
-
-        final List<AuthorizationSubject> subjectsWithIssuer = authContext.stream()
-                .filter(subject -> !subjectsWithoutIssuer.contains(subject.getId()))
-                .collect(Collectors.toList());
-
-        return AuthorizationModelFactory.newAuthContext(authContext.getType(), subjectsWithIssuer);
     }
 
     @Override

--- a/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionId.java
+++ b/model/connectivity/src/main/java/org/eclipse/ditto/model/connectivity/ConnectionId.java
@@ -30,7 +30,7 @@ import org.eclipse.ditto.model.base.entity.id.TypedEntityId;
 @TypedEntityId(type = "connection")
 public final class ConnectionId extends AbstractEntityId {
 
-    static final String ID_REGEX = "[a-zA-Z0-9-_]{1,80}";
+    static final String ID_REGEX = "[a-zA-Z0-9-_:]{1,80}";
     static final Pattern ID_PATTERN = Pattern.compile(ID_REGEX);
 
     private ConnectionId(final String stringRepresentation, final boolean shouldValidate) {

--- a/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
+++ b/model/messages/src/test/java/org/eclipse/ditto/model/messages/ImmutableMessageHeadersTest.java
@@ -55,15 +55,13 @@ public final class ImmutableMessageHeadersTest {
     private static final ThingId THING_ID = ThingId.of("test.ns", "theThingId");
     private static final String SUBJECT = KnownMessageSubjects.CLAIM_SUBJECT;
 
-    private static final Collection<String>
-            AUTH_SUBJECTS_WITHOUT_DUPLICATES = Arrays.asList("test:JohnOldman", "test:FrankGrimes");
+    private static final Collection<String> AUTH_SUBJECTS = Arrays.asList("test:JohnOldman", "test:FrankGrimes");
     private static final AuthorizationContext AUTH_CONTEXT_WITHOUT_DUPLICATES =
             AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
-                    AUTH_SUBJECTS_WITHOUT_DUPLICATES.stream()
+                    AUTH_SUBJECTS.stream()
                             .map(AuthorizationSubject::newInstance)
                             .collect(Collectors.toList()));
-    private static final Collection<String> AUTH_SUBJECTS =
-            Arrays.asList("test:JohnOldman", "test:FrankGrimes", "JohnOldman", "FrankGrimes");
+
     private static final AuthorizationContext AUTH_CONTEXT =
             AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
                     AUTH_SUBJECTS.stream()

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -87,8 +87,12 @@ public abstract class AbstractEnforcement<C extends Signal<?>> {
             context.getStartedTimer()
                     .map(startedTimer -> startedTimer.tag("outcome", throwable != null ? "fail" : "success"))
                     .ifPresent(StartedTimer::stop);
-            result.getLog().withCorrelationId(result)
-                    .info("Completed enforcement with headers: <{}>", result.getDittoHeaders());
+            if (null != result) {
+                result.getLog().withCorrelationId(result)
+                        .info("Completed enforcement with outcome 'success' and headers: <{}>", result.getDittoHeaders());
+            } else {
+                log().info("Completed enforcement with outcome 'failed' and headers: <{}>", dittoHeaders());
+            }
             return Objects.requireNonNullElseGet(result,
                     () -> withMessageToReceiver(reportError("Error thrown during enforcement", throwable), sender()));
         };

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/AbstractEnforcement.java
@@ -87,6 +87,8 @@ public abstract class AbstractEnforcement<C extends Signal<?>> {
             context.getStartedTimer()
                     .map(startedTimer -> startedTimer.tag("outcome", throwable != null ? "fail" : "success"))
                     .ifPresent(StartedTimer::stop);
+            result.getLog().withCorrelationId(result)
+                    .info("Completed enforcement with headers: <{}>", result.getDittoHeaders());
             return Objects.requireNonNullElseGet(result,
                     () -> withMessageToReceiver(reportError("Error thrown during enforcement", throwable), sender()));
         };

--- a/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
+++ b/services/concierge/enforcement/src/main/java/org/eclipse/ditto/services/concierge/enforcement/LiveSignalEnforcement.java
@@ -309,7 +309,7 @@ public final class LiveSignalEnforcement extends AbstractEnforcement<SignalWithE
             final DistributedPub<T> pub) {
 
         // using pub/sub to publish the command to any interested parties (e.g. a Websocket):
-        log(signal).debug("Publish message to pub-sub");
+        log(signal).debug("Publish message to pub-sub: <{}>", signal);
         return addToResponseReceiver(signal).thenApply(newSignal ->
                 withMessageToReceiver(newSignal, pub.getPublisher(),
                         obj -> pub.wrapForPublicationWithAcks((S) obj, ackExtractor))

--- a/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublishTarget.java
+++ b/services/connectivity/messaging/src/main/java/org/eclipse/ditto/services/connectivity/messaging/kafka/KafkaPublishTarget.java
@@ -147,7 +147,7 @@ final class KafkaPublishTarget implements PublishTarget {
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", topic=" + topic +
+                "topic=" + topic +
                 ", key=" + key +
                 ", partition=" + partition +
                 "]";

--- a/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/controlflow/AbstractGraphActor.java
+++ b/services/utils/akka/src/main/java/org/eclipse/ditto/services/utils/akka/controlflow/AbstractGraphActor.java
@@ -134,7 +134,7 @@ public abstract class AbstractGraphActor<T, M> extends AbstractActor {
                         logger.error(exc, "Exception in stream of {}: {}",
                                 graphActorClassName, exc.getMessage());
                     }
-                    return Supervision.resume(); // in any case, resume!
+                    return (Supervision.Directive) Supervision.resume(); // in any case, resume!
                 }
         );
     }
@@ -147,9 +147,7 @@ public abstract class AbstractGraphActor<T, M> extends AbstractActor {
 
         return Source.<T>queue(getBufferSize(), OverflowStrategy.dropNew())
                 .map(this::incrementDequeueCounter)
-                .log("graph-actor-stream-1-dequeued", logger)
                 .via(Flow.fromFunction(this::beforeProcessMessage))
-                .log("graph-actor-stream-2-preprocessed", logger)
                 .to(createSink())
                 .withAttributes(streamLogLevels.and(getSupervisionStrategyAttribute()))
                 .run(materializer);

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
@@ -97,6 +97,7 @@ public final class Publisher extends AbstractActor {
      * @return a publish message.
      */
     public static Request publish(final Collection<String> topics, final SignalWithEntityId<?> message) {
+
         return new Publish(topics, message);
     }
 

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/Publisher.java
@@ -165,6 +165,9 @@ public final class Publisher extends AbstractActor {
 
         final List<Pair<ActorRef, PublishSignal>> subscribers =
                 publisherIndex.assignGroupsToSubscribers(signal, hashes);
+        log.withCorrelationId(signal).info("Publishing PublishSignal to subscribers: <{}>", subscribers.stream()
+                .map(Pair::first)
+                .collect(Collectors.toList()));
         subscribers.forEach(pair -> pair.first().tell(pair.second(), sender));
         return subscribers;
     }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
@@ -46,7 +47,7 @@ final class PublisherIndex<T> {
     private final Map<T, Map<ActorRef, Set<String>>> index;
     private final Map<ActorRef, Predicate<Collection<T>>> filterMap;
 
-    private PublisherIndex(final Map<T, Map<ActorRef, Set<String>>> index,
+    PublisherIndex(final Map<T, Map<ActorRef, Set<String>>> index,
             final Map<ActorRef, Predicate<Collection<T>>> filterMap) {
         this.index = index;
         this.filterMap = filterMap;
@@ -56,14 +57,29 @@ final class PublisherIndex<T> {
         return new PublisherIndex<>(Map.of(), Map.of());
     }
 
-    static PublisherIndex<Long> mergeExistingWithDeserializedMMap(final PublisherIndex<Long> publisherIndex,
-            final Map<ActorRef, List<Grouped<Long>>> mmap) {
-        final Map<Long, Map<ActorRef, Set<String>>> index = new HashMap<>(publisherIndex.index);
+    static <T> PublisherIndex<T> fromMultipleIndexes(final Collection<PublisherIndex<T>> indexes) {
+        final Map<T, Map<ActorRef, Set<String>>> combinedIndex = new HashMap<>();
+        indexes.stream()
+                .map(p -> p.index)
+                .forEach(index -> index.forEach((t, map) ->
+                        combinedIndex.compute(t, (theT, existingMap) -> {
+                            final Map<ActorRef, Set<String>> nonNullMap = existingMap == null ? new HashMap<>() :
+                                    existingMap;
+                            nonNullMap.putAll(map);
+                            return nonNullMap;
+                        })
+                        )
+                );
+        return new PublisherIndex<>(combinedIndex, Map.of());
+    }
+
+    static PublisherIndex<Long> fromDeserializedMMap(final Map<ActorRef, List<Grouped<Long>>> mmap) {
+        final Map<Long, Map<ActorRef, Set<String>>> index = new HashMap<>();
         mmap.forEach((subscriber, groupedList) ->
                 groupedList.forEach(grouped -> grouped.getValues()
                         .forEach(computeIndex(index, subscriber, grouped.getGroup().orElse("")))
                 ));
-        return new PublisherIndex<>(index, publisherIndex.filterMap);
+        return new PublisherIndex<>(index, Map.of());
     }
 
     static PublisherIndex<String> fromSubscriptionsReader(final SubscriptionsReader reader) {
@@ -76,11 +92,13 @@ final class PublisherIndex<T> {
         return new PublisherIndex<>(index, filterMap);
     }
 
-    List<Pair<ActorRef, PublishSignal>> assignGroupsToSubscribers(final SignalWithEntityId<?> signal, final Collection<T> topics) {
+    List<Pair<ActorRef, PublishSignal>> assignGroupsToSubscribers(final SignalWithEntityId<?> signal,
+            final Collection<T> topics) {
         return assignGroupsToSubscribers(signal, topics, null);
     }
 
-    List<Pair<ActorRef, PublishSignal>> assignGroupsToSubscribers(final SignalWithEntityId<?> signal, final Collection<T> topics,
+    List<Pair<ActorRef, PublishSignal>> assignGroupsToSubscribers(final SignalWithEntityId<?> signal,
+            final Collection<T> topics,
             @Nullable final Map<String, Integer> chosenGroups) {
         final Map<String, List<ActorRef>> groupToSubscribers = new HashMap<>();
         final Map<ActorRef, Map<String, Integer>> subscriberToChosenGroups = new HashMap<>();
@@ -134,4 +152,28 @@ final class PublisherIndex<T> {
         });
     }
 
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final PublisherIndex<?> that = (PublisherIndex<?>) o;
+        return index.equals(that.index) && filterMap.equals(that.filterMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(index, filterMap);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "index=" + index +
+                ", filterMap=" + filterMap +
+                "]";
+    }
 }

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/actors/PublisherIndex.java
@@ -70,6 +70,7 @@ final class PublisherIndex<T> {
                         })
                         )
                 );
+
         return new PublisherIndex<>(combinedIndex, Map.of());
     }
 
@@ -79,6 +80,7 @@ final class PublisherIndex<T> {
                 groupedList.forEach(grouped -> grouped.getValues()
                         .forEach(computeIndex(index, subscriber, grouped.getGroup().orElse("")))
                 ));
+
         return new PublisherIndex<>(index, Map.of());
     }
 
@@ -89,11 +91,13 @@ final class PublisherIndex<T> {
             data.getFilter().ifPresent(filter -> filterMap.put(subscriber, filter));
             data.getTopics().forEach(computeIndex(index, subscriber, data.getGroup().orElse("")));
         });
+
         return new PublisherIndex<>(index, filterMap);
     }
 
     List<Pair<ActorRef, PublishSignal>> assignGroupsToSubscribers(final SignalWithEntityId<?> signal,
             final Collection<T> topics) {
+
         return assignGroupsToSubscribers(signal, topics, null);
     }
 
@@ -161,6 +165,7 @@ final class PublisherIndex<T> {
             return false;
         }
         final PublisherIndex<?> that = (PublisherIndex<?>) o;
+
         return index.equals(that.index) && filterMap.equals(that.filterMap);
     }
 

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
@@ -85,9 +85,9 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
             final SubscriberData subscriberData = SubscriberData.of(topics, filter, group);
             subscriberDataMap.merge(subscriber, subscriberData, (oldData, newData) -> {
                 changed[0] = !oldData.getFilter().equals(newData.getFilter());
-                final Set<String> unionTopics = unionSet(oldData.getTopics(), newData.getTopics());
-                changed[0] |= !unionTopics.equals(oldData.getTopics());
-                return newData.withTopics(unionTopics);
+                // TODO YC check if when the unionSet of topics differ from the oldData.getTopics()
+                //  changed[0] should also be true
+                return newData.withTopics(unionSet(oldData.getTopics(), newData.getTopics()));
             });
 
             // add subscriber for each new topic; detect whether there is any change.

--- a/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
+++ b/services/utils/pubsub/src/main/java/org/eclipse/ditto/services/utils/pubsub/ddata/AbstractSubscriptions.java
@@ -79,10 +79,10 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
             @Nullable final String group) {
         if (!topics.isEmpty()) {
             // box the 'changed' flag in an array so that it can be assigned inside a closure.
-            final boolean[] changed = new boolean[1];
+            final var changed = new boolean[1];
 
             // add topics and filter.
-            final SubscriberData subscriberData = SubscriberData.of(topics, filter, group);
+            final var subscriberData = SubscriberData.of(topics, filter, group);
             subscriberDataMap.merge(subscriber, subscriberData, (oldData, newData) -> {
                 changed[0] = !oldData.getFilter().equals(newData.getFilter());
                 // TODO YC check if when the unionSet of topics differ from the oldData.getTopics()
@@ -113,7 +113,7 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
     @Override
     public boolean unsubscribe(final ActorRef subscriber, final Set<String> topics) {
         // box 'changed' flag for assignment inside closure
-        final boolean[] changed = new boolean[1];
+        final var changed = new boolean[1];
         subscriberDataMap.computeIfPresent(subscriber, (k, subscriberData) -> {
             final Set<String> previousTopics = subscriberData.getTopics();
             final List<String> removed = new ArrayList<>();
@@ -140,7 +140,7 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
     @Override
     public boolean removeSubscriber(final ActorRef subscriber) {
         // box 'changed' flag in array for assignment inside closure
-        final boolean[] changed = new boolean[1];
+        final var changed = new boolean[1];
         subscriberDataMap.computeIfPresent(subscriber, (k, data) -> {
             changed[0] = removeSubscriberForTopics(subscriber, data.getTopics());
             return null;
@@ -167,7 +167,7 @@ public abstract class AbstractSubscriptions<R, T extends DDataUpdate<R>> impleme
 
     private boolean removeSubscriberForTopics(final ActorRef subscriber, final Collection<String> topics) {
         // box 'changed' flag for assignment inside closure
-        final boolean[] changed = new boolean[1];
+        final var changed = new boolean[1];
         for (final String topic : topics) {
             topicDataMap.computeIfPresent(topic, (k, data) -> {
                 changed[0] |= data.removeSubscriber(subscriber);

--- a/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
+++ b/services/utils/pubsub/src/test/java/org/eclipse/ditto/services/utils/pubsub/PubSubFactoryTest.java
@@ -78,12 +78,16 @@ public final class PubSubFactoryTest {
 
     private ActorSystem system1;
     private ActorSystem system2;
+    private ActorSystem system3;
     private Cluster cluster1;
     private Cluster cluster2;
+    private Cluster cluster3;
     private TestPubSubFactory factory1;
     private TestPubSubFactory factory2;
+    private TestPubSubFactory factory3;
     private DistributedAcks distributedAcks1;
     private DistributedAcks distributedAcks2;
+    private DistributedAcks distributedAcks3;
     private AckExtractor<Acknowledgement> ackExtractor;
     private Map<String, ThingId> thingIdMap;
     private Map<String, DittoHeaders> dittoHeadersMap;
@@ -97,16 +101,22 @@ public final class PubSubFactoryTest {
         final CountDownLatch latch = new CountDownLatch(2);
         system1 = ActorSystem.create("actorSystem", getTestConf());
         system2 = ActorSystem.create("actorSystem", getTestConf());
+        system3 = ActorSystem.create("actorSystem", getTestConf());
         cluster1 = Cluster.get(system1);
         cluster2 = Cluster.get(system2);
+        cluster3 = Cluster.get(system3);
         cluster1.registerOnMemberUp(latch::countDown);
         cluster2.registerOnMemberUp(latch::countDown);
+        cluster3.registerOnMemberUp(latch::countDown);
         cluster1.join(cluster1.selfAddress());
         cluster2.join(cluster1.selfAddress());
+        cluster3.join(cluster1.selfAddress());
         final ActorContext context1 = newContext(system1);
         final ActorContext context2 = newContext(system2);
+        final ActorContext context3 = newContext(system3);
         distributedAcks1 = TestPubSubFactory.startDistributedAcks(context1);
         distributedAcks2 = TestPubSubFactory.startDistributedAcks(context2);
+        distributedAcks3 = TestPubSubFactory.startDistributedAcks(context3);
         thingIdMap = new ConcurrentHashMap<>();
         dittoHeadersMap = new ConcurrentHashMap<>();
         ackExtractor = AckExtractor.of(
@@ -115,6 +125,7 @@ public final class PubSubFactoryTest {
         );
         factory1 = TestPubSubFactory.of(context1, ackExtractor, distributedAcks1);
         factory2 = TestPubSubFactory.of(context2, ackExtractor, distributedAcks2);
+        factory3 = TestPubSubFactory.of(context3, ackExtractor, distributedAcks3);
         // wait for both members to be UP
         latch.await();
     }
@@ -537,10 +548,14 @@ public final class PubSubFactoryTest {
             final TestProbe subscriber2 = TestProbe.apply("subscriber2", system2);
             final TestProbe subscriber3 = TestProbe.apply("subscriber3", system1);
             final TestProbe subscriber4 = TestProbe.apply("subscriber4", system2);
+            final TestProbe subscriber5 = TestProbe.apply("subscriber5", system3);
+            final TestProbe subscriber6 = TestProbe.apply("subscriber6", system3);
 
-            final DistributedPub<Acknowledgement> pub = factory1.startDistributedPub();
+            final DistributedPub<Acknowledgement> pub1 = factory1.startDistributedPub();
+            final DistributedPub<Acknowledgement> pub2 = factory2.startDistributedPub();
             final DistributedSub sub1 = factory1.startDistributedSub();
             final DistributedSub sub2 = factory2.startDistributedSub();
+            final DistributedSub sub3 = factory3.startDistributedSub();
 
             // GIVEN: subscribers subscribe to the same topic as a group
             final String topic = "topic";
@@ -548,24 +563,30 @@ public final class PubSubFactoryTest {
             await(sub2.subscribeWithFilterAndGroup(List.of(topic), subscriber2.ref(), null, "group"));
             await(sub1.subscribeWithFilterAndGroup(List.of(topic), subscriber3.ref(), null, "group"));
             await(sub2.subscribeWithFilterAndGroup(List.of(topic), subscriber4.ref(), null, "group"));
+            await(sub3.subscribeWithFilterAndGroup(List.of(topic), subscriber5.ref(), null, "group"));
+            await(sub3.subscribeWithFilterAndGroup(List.of(topic), subscriber6.ref(), null, "group"));
 
             // WHEN: signals are published with different entity IDs differing by 1 in the last byte
-            pub.publish(signal(topic, 0), publisher.ref());
-            pub.publish(signal(topic, 1), publisher.ref());
-            pub.publish(signal(topic, 2), publisher.ref());
-            pub.publish(signal(topic, 3), publisher.ref());
+            pub1.publish(signal(topic, 0), publisher.ref());
+            pub1.publish(signal(topic, 1), publisher.ref());
+            pub2.publish(signal(topic, 2), publisher.ref());
+            pub2.publish(signal(topic, 3), publisher.ref());
+            pub2.publish(signal(topic, 4), publisher.ref());
+            pub1.publish(signal(topic, 5), publisher.ref());
 
             // THEN: exactly 1 subscriber gets each message.
             final Acknowledgement received1 = subscriber1.expectMsgClass(Acknowledgement.class);
             final Acknowledgement received2 = subscriber2.expectMsgClass(Acknowledgement.class);
             final Acknowledgement received3 = subscriber3.expectMsgClass(Acknowledgement.class);
             final Acknowledgement received4 = subscriber4.expectMsgClass(Acknowledgement.class);
+            final Acknowledgement received5 = subscriber5.expectMsgClass(Acknowledgement.class);
+            final Acknowledgement received6 = subscriber6.expectMsgClass(Acknowledgement.class);
             final Set<EntityId> thingIdSet =
                     Set.of(received1.getEntityId(), received2.getEntityId(), received3.getEntityId(),
-                            received4.getEntityId());
+                            received4.getEntityId(), received5.getEntityId(), received6.getEntityId());
             assertThat(thingIdSet.size())
                     .describedAs("Signals received by subscribers should have distinct entity IDs")
-                    .isEqualTo(4);
+                    .isEqualTo(6);
 
             // THEN: any subscriber receives no further messages.
             subscriber1.expectNoMessage();


### PR DESCRIPTION
* fixed bug in PublisherIndex which led to missing Ditto pub/sub messages in the clust
* removed authContext deduplication in AbstractDittoHeaders, no longer required with API 1 removed
* made ConnectionId also accept ":" in the ID in order to fix "lower bound" based cleanup
* added logging for enforcements (which headers were calculated)
* added logging about selected subscribers for Ditto pub/sub publishing