### PR TITLE
Support reading JWT from query parameter for WebSocket requests

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-auth.md
+++ b/documentation/src/main/resources/pages/ditto/basic-auth.md
@@ -46,8 +46,9 @@ for the following browser based requests:
    * sending along a JWT token as `Authorization` header with `Bearer` value
 * Establishing a [WebSocket](httpapi-protocol-bindings-websocket.html) connection for bidirectional communication with 
   Ditto via [Ditto Protocol](protocol-overview.html) JSON messages
-   * open: sending along the `Authorization` header containing the `Bearer` JWT token is not possible in the plain 
-     WebSocket API in the browser - Watch issue [#661](https://github.com/eclipse/ditto/issues/667) for fixing that
+   * sending along a JWT token as `Authorization` header with `Bearer` value (recommended)
+   * sending along a JWT token as query parameter `access_token` (use only if the websocket client does not 
+   support setting http headers e.g. plain WebSocket API of browsers)
 * Opening a [Server sent event](httpapi-sse.html) connection in order to receive change notifications of twins in the 
   browser
    * passing the `withCredentials: true` option when creating the SSE in the browser

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtExtractor.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtExtractor.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import java.util.Optional;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.services.gateway.security.HttpHeader;
+import org.eclipse.ditto.services.gateway.security.utils.HttpUtils;
+
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Default implementation of {@link org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtExtractor}
+ * extracting the JWT from the Authorization header.
+ */
+final class DefaultJwtExtractor implements JwtExtractor {
+
+    private static final String AUTHORIZATION_JWT = "Bearer";
+    private static final DefaultJwtExtractor INSTANCE = new DefaultJwtExtractor();
+
+    private DefaultJwtExtractor() {
+    }
+
+    public static JwtExtractor getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Optional<JsonWebToken> apply(final RequestContext requestContext, final DittoHeaders dittoHeaders) {
+        return HttpUtils.getRequestHeader(requestContext, HttpHeader.AUTHORIZATION.toString())
+                .map(ImmutableJsonWebToken::fromAuthorization);
+    }
+
+    @Override
+    public boolean isApplicable(final RequestContext requestContext) {
+        return HttpUtils.containsAuthorizationForPrefix(requestContext, AUTHORIZATION_JWT);
+    }
+
+    @Override
+    public String getErrorDescription() {
+        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer '.";
+    }
+}

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtExtractor.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtExtractor.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
+
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Extract a JsonWebToken from the given RequestContext or returns an empty Optional if no token is present.
+ */
+public interface JwtExtractor extends BiFunction<RequestContext, DittoHeaders, Optional<JsonWebToken>> {
+
+    /**
+     * Indicates whether the given {@link RequestContext request context} contains the required information to
+     * extract a JWT.
+     *
+     * @param requestContext the current request context
+     * @return {@code true} if the request context contains the required information
+     */
+    boolean isApplicable(RequestContext requestContext);
+
+    /**
+     * Builds an exception with detailed description where the token information was expected.
+     *
+     * @param dittoHeaders ditto headers of the current request
+     * @return the built expection
+     */
+    default Exception buildMissingJwtException(final DittoHeaders dittoHeaders) {
+        return GatewayAuthenticationFailedException
+                .newBuilder("The JWT was missing.")
+                .description(getErrorDescription())
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * @return detail information about the error and where the token information was expected.
+     */
+    String getErrorDescription();
+}

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtExtractor.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/JwtExtractor.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.services.gateway.security.authentication.jwt;
 
-
 import java.util.Optional;
 import java.util.function.BiFunction;
 
@@ -40,7 +39,7 @@ public interface JwtExtractor extends BiFunction<RequestContext, DittoHeaders, O
      * Builds an exception with detailed description where the token information was expected.
      *
      * @param dittoHeaders ditto headers of the current request
-     * @return the built expection
+     * @return the built exception
      */
     default Exception buildMissingJwtException(final DittoHeaders dittoHeaders) {
         return GatewayAuthenticationFailedException

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractor.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractor.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import java.util.Optional;
+
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.services.gateway.security.utils.HttpUtils;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
+
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Implementation of {@link org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtExtractor} extracting
+ * the JWT from the {@code access_token} query parameter.
+ */
+final class WebSocketJwtExtractor implements JwtExtractor {
+
+    private static final String ACCESS_TOKEN_PARAM = "access_token";
+    private static final WebSocketJwtExtractor INSTANCE = new WebSocketJwtExtractor();
+
+    private final JwtExtractor defaultExtractor = DefaultJwtExtractor.getInstance();
+
+    private WebSocketJwtExtractor() {
+    }
+
+    /**
+     * @return the singleton instance of WebSocketJwtExtractor
+     */
+    static JwtExtractor getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public Optional<JsonWebToken> apply(final RequestContext requestContext, final DittoHeaders dittoHeaders) {
+        final Optional<JsonWebToken> jwtFromHeader = defaultExtractor.apply(requestContext, dittoHeaders);
+        final Optional<JsonWebToken> jwtFromParameter = extractJwtFromParameter(requestContext);
+
+        if (jwtFromHeader.isPresent() && jwtFromParameter.isPresent()) {
+            throw buildMultipleJwtException(dittoHeaders);
+        }
+
+        return jwtFromHeader.or(() -> jwtFromParameter);
+    }
+
+    private Optional<JsonWebToken> extractJwtFromParameter(final RequestContext requestContext) {
+        return requestContext
+                .getRequest()
+                .getUri()
+                .query()
+                .get(ACCESS_TOKEN_PARAM)
+                .map(ImmutableJsonWebToken::fromToken);
+    }
+
+    @Override
+    public boolean isApplicable(final RequestContext requestContext) {
+        return defaultExtractor.isApplicable(requestContext) ||
+                HttpUtils.containsQueryParameter(requestContext, ACCESS_TOKEN_PARAM);
+    }
+
+    @Override
+    public String getErrorDescription() {
+        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer ' or as query parameter" +
+                " 'access_token'.";
+    }
+
+    private DittoRuntimeException buildMultipleJwtException(final DittoHeaders dittoHeaders) {
+        return GatewayAuthenticationFailedException
+                .newBuilder("Multiple JWTs provided.")
+                .description(
+                        "A JWT was provided both as a header and as query parameter. Only a single JWT is expected.")
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+}

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractor.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractor.java
@@ -73,7 +73,7 @@ final class WebSocketJwtExtractor implements JwtExtractor {
 
     @Override
     public String getErrorDescription() {
-        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer ' or as query parameter" +
+        return "Please provide a valid JWT in the 'Authorization' header prefixed with 'Bearer ' or as query parameter" +
                 " 'access_token'.";
     }
 

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/utils/HttpUtils.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/utils/HttpUtils.java
@@ -98,7 +98,7 @@ public final class HttpUtils {
     }
 
     /**
-     * Checks whether the given request contains a query parameter containing the access token.
+     * Checks whether the given request contains a query parameter matching the given {@code parameter}.
      *
      * @param requestContext the context of the request
      * @param parameter the name of the query parameter

--- a/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/utils/HttpUtils.java
+++ b/services/gateway/security/src/main/java/org/eclipse/ditto/services/gateway/security/utils/HttpUtils.java
@@ -97,6 +97,20 @@ public final class HttpUtils {
         return authorizationHeader.isPresent();
     }
 
+    /**
+     * Checks whether the given request contains a query parameter containing the access token.
+     *
+     * @param requestContext the context of the request
+     * @param parameter the name of the query parameter
+     * @return {@code true}, if the request contains a matching query parameter
+     */
+    public static boolean containsQueryParameter(final RequestContext requestContext, final String parameter) {
+        return requestContext.getRequest()
+                .getUri()
+                .query()
+                .get(parameter).isPresent();
+    }
+
     public static boolean basicAuthUsernameMatches(final RequestContext requestContext, final Pattern uuidPattern) {
         final HttpRequest httpRequest = requestContext.getRequest();
         return httpRequest.getHeader(Authorization.class)

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJwtAuthenticationProviderTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJwtAuthenticationProviderTest.java
@@ -1,0 +1,284 @@
+
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtTestConstants.VALID_JWT_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.eclipse.ditto.model.base.auth.AuthorizationContext;
+import org.eclipse.ditto.model.base.auth.AuthorizationSubject;
+import org.eclipse.ditto.model.base.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.model.base.common.BinaryValidationResult;
+import org.eclipse.ditto.model.base.common.HttpStatus;
+import org.eclipse.ditto.model.base.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.services.gateway.security.authentication.AuthenticationProvider;
+import org.eclipse.ditto.services.gateway.security.authentication.AuthenticationResult;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Provides tests for {@link JwtAuthenticationProvider}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+abstract class AbstractJwtAuthenticationProviderTest {
+
+    private static final HttpHeader VALID_AUTHORIZATION_HEADER =
+            HttpHeader.parse("authorization", "Bearer " + VALID_JWT_TOKEN);
+    private static final HttpHeader INVALID_AUTHORIZATION_HEADER =
+            HttpHeader.parse("authorization", "Basic " + VALID_JWT_TOKEN);
+    protected static final String
+            URI_WITH_ACCESS_TOKEN_PARAMETER = "https://localhost/ws/2?x=5&access_token=" + VALID_JWT_TOKEN;
+
+    @Rule public final TestName testName = new TestName();
+    @Rule public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @Mock protected JwtAuthenticationResultProvider authenticationContextProvider;
+    @Mock protected JwtValidator jwtValidator;
+
+    protected DittoHeaders knownDittoHeaders;
+
+    /**
+     * @return the JwtAuthenticationProvider instance under test
+     */
+    protected abstract JwtAuthenticationProvider getUnderTest();
+
+    /**
+     * @return whether the instance under test supports the access token parameter
+     */
+    protected abstract boolean supportsAccessTokenParameter();
+
+    /**
+     * @return the expected error description
+     */
+    protected abstract String getExpectedMissingJwtDescription();
+
+    @Test
+    public void isApplicableWithHeader() {
+        final RequestContext requestContext = mockRequestContext(VALID_AUTHORIZATION_HEADER);
+        softly.assertThat(getUnderTest().isApplicable(requestContext)).isTrue();
+    }
+
+    @Test
+    public void isApplicableWithAccessTokenParameter() {
+        final RequestContext requestContext = mockRequestContext(URI_WITH_ACCESS_TOKEN_PARAMETER);
+        softly.assertThat(getUnderTest().isApplicable(requestContext)).isEqualTo(supportsAccessTokenParameter());
+    }
+
+    @Test
+    public void isApplicableWithAccessTokenParameterAndHeader() {
+        final RequestContext requestContext = mockRequestContext(URI_WITH_ACCESS_TOKEN_PARAMETER,
+                VALID_AUTHORIZATION_HEADER);
+        softly.assertThat(getUnderTest().isApplicable(requestContext)).isTrue();
+    }
+
+    @Test
+    public void isApplicableWithoutAuthorizationHeaderOrAccessTokenParameter() {
+        final RequestContext requestContext = mockRequestContext();
+        softly.assertThat(getUnderTest().isApplicable(requestContext)).isFalse();
+    }
+
+    @Test
+    public void isApplicableWithInvalidAuthorizationHeader() {
+        final RequestContext requestContext = mockRequestContext(INVALID_AUTHORIZATION_HEADER);
+        softly.assertThat(getUnderTest().isApplicable(requestContext)).isFalse();
+    }
+
+    @Test
+    public void doExtractAuthenticationFromRequestHeaders() {
+        when(jwtValidator.validate(any(JsonWebToken.class)))
+                .thenReturn(CompletableFuture.completedFuture(BinaryValidationResult.valid()));
+        when(authenticationContextProvider.getAuthenticationResult(any(JsonWebToken.class), any(DittoHeaders.class)))
+                .thenReturn(JwtAuthenticationResult.successful(knownDittoHeaders,
+                        AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
+                                AuthorizationSubject.newInstance("myAuthSubj")),
+                        ImmutableJsonWebToken.fromToken(VALID_JWT_TOKEN)));
+        final RequestContext requestContext = mockRequestContext(VALID_AUTHORIZATION_HEADER);
+
+        authenticate(getUnderTest(), requestContext, true);
+    }
+
+    @Test
+    public void doExtractAuthenticationFromAccessTokenParameter() {
+        lenient().when(jwtValidator.validate(any(JsonWebToken.class)))
+                .thenReturn(CompletableFuture.completedFuture(BinaryValidationResult.valid()));
+        lenient().when(
+                authenticationContextProvider.getAuthenticationResult(any(JsonWebToken.class), any(DittoHeaders.class)))
+                .thenReturn(JwtAuthenticationResult.successful(knownDittoHeaders,
+                        AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED,
+                                AuthorizationSubject.newInstance("myAuthSubj")),
+                        ImmutableJsonWebToken.fromToken(VALID_JWT_TOKEN)));
+        final RequestContext requestContext =
+                mockRequestContext(URI_WITH_ACCESS_TOKEN_PARAMETER);
+
+        authenticate(getUnderTest(), requestContext, supportsAccessTokenParameter());
+    }
+
+    @Test
+    public void doExtractAuthenticationWhenAuthorizationContextProviderErrors() {
+        when(jwtValidator.validate(any(JsonWebToken.class)))
+                .thenReturn(CompletableFuture.completedFuture(BinaryValidationResult.valid()));
+        when(authenticationContextProvider.getAuthenticationResult(any(JsonWebToken.class), any(DittoHeaders.class)))
+                .thenThrow(new RuntimeException("Something happened"));
+        final RequestContext requestContext = mockRequestContext(VALID_AUTHORIZATION_HEADER);
+
+        final AuthenticationResult authenticationResult =
+                getUnderTest().authenticate(requestContext, knownDittoHeaders).join();
+
+        verify(authenticationContextProvider).getAuthenticationResult(any(JsonWebToken.class), any(DittoHeaders.class));
+        softly.assertThat(authenticationResult.isSuccess()).isFalse();
+        softly.assertThat(authenticationResult.getReasonOfFailure())
+                .isExactlyInstanceOf(GatewayAuthenticationFailedException.class);
+
+        final GatewayAuthenticationFailedException reasonOfFailure =
+                (GatewayAuthenticationFailedException) authenticationResult.getReasonOfFailure();
+
+        softly.assertThat(reasonOfFailure).hasMessage("The JWT could not be verified.");
+        softly.assertThat(reasonOfFailure.getDescription()).contains("Something happened");
+        softly.assertThat(reasonOfFailure.getDittoHeaders().getCorrelationId())
+                .isEqualTo(knownDittoHeaders.getCorrelationId());
+    }
+
+    @Test
+    public void doExtractAuthenticationWithMissingJwt() {
+        final RequestContext requestContext = mockRequestContext();
+
+        final AuthenticationResult authenticationResult =
+                getUnderTest().authenticate(requestContext, knownDittoHeaders).join();
+
+        softly.assertThat(authenticationResult.isSuccess()).isFalse();
+        softly.assertThat(authenticationResult.getReasonOfFailure())
+                .isInstanceOf(GatewayAuthenticationFailedException.class);
+        final DittoRuntimeException reasonOfFailureDre =
+                (DittoRuntimeException) authenticationResult.getReasonOfFailure();
+        softly.assertThat(reasonOfFailureDre).hasMessage("The JWT was missing.");
+        softly.assertThat(reasonOfFailureDre.getErrorCode()).isEqualTo("gateway:authentication.failed");
+        softly.assertThat(reasonOfFailureDre.getHttpStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        softly.assertThat(reasonOfFailureDre.getDittoHeaders().getCorrelationId())
+                .isEqualTo(knownDittoHeaders.getCorrelationId());
+        softly.assertThat(reasonOfFailureDre.getDescription())
+                .contains(getExpectedMissingJwtDescription());
+    }
+
+    @Test
+    public void doExtractAuthenticationWithInvalidJwtFromHeader() {
+        final RequestContext requestContext = mockRequestContext(VALID_AUTHORIZATION_HEADER);
+        doExtractAuthenticationWithInvalidJwt(getUnderTest(), requestContext);
+    }
+
+    protected void doExtractAuthenticationWithInvalidJwt(final AuthenticationProvider<AuthenticationResult> provider,
+            final RequestContext requestContext) {
+        when(jwtValidator.validate(any(JsonWebToken.class)))
+                .thenReturn(CompletableFuture.completedFuture(
+                        BinaryValidationResult.invalid(new IllegalStateException("foo"))));
+
+        final AuthenticationResult authenticationResult =
+                provider.authenticate(requestContext, knownDittoHeaders).join();
+
+        softly.assertThat(authenticationResult.isSuccess()).isFalse();
+        softly.assertThat(authenticationResult.getReasonOfFailure())
+                .isInstanceOf(GatewayAuthenticationFailedException.class);
+        final DittoRuntimeException reasonOfFailureDre =
+                (DittoRuntimeException) authenticationResult.getReasonOfFailure();
+        softly.assertThat(reasonOfFailureDre).hasMessage("The JWT could not be verified.");
+        softly.assertThat(reasonOfFailureDre.getErrorCode()).isEqualTo("gateway:authentication.failed");
+        softly.assertThat(reasonOfFailureDre.getHttpStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        softly.assertThat(reasonOfFailureDre.getDittoHeaders().getCorrelationId())
+                .isEqualTo(knownDittoHeaders.getCorrelationId());
+    }
+
+    @Test
+    public void toFailedAuthenticationResultExtractsDittoRuntimeExceptionFromCause() {
+        final DittoRuntimeException dre = PublicKeyProviderUnavailableException.newBuilder().build();
+        final IllegalStateException illegalStateException = new IllegalStateException("notExpected", dre);
+
+        final Throwable reasonOfFailure =
+                getUnderTest().toFailedAuthenticationResult(illegalStateException, knownDittoHeaders)
+                        .getReasonOfFailure();
+
+        softly.assertThat(reasonOfFailure).isEqualTo(dre);
+    }
+
+    @Test
+    public void toFailedAuthenticationResult() {
+        final DittoRuntimeException dre = PublicKeyProviderUnavailableException.newBuilder().build();
+        final AuthenticationResult authenticationResult =
+                getUnderTest().toFailedAuthenticationResult(dre, knownDittoHeaders);
+
+        softly.assertThat(authenticationResult.getReasonOfFailure()).isEqualTo(dre);
+    }
+
+    @Test
+    public void getTypeWithAuthorizationHeader() {
+        AssertionsForClassTypes.assertThat(getUnderTest().getType(mockRequestContext(VALID_AUTHORIZATION_HEADER)))
+                .isEqualTo(DittoAuthorizationContextType.JWT);
+    }
+
+    @Test
+    public void getTypeWithAccessTokenParameter() {
+        AssertionsForClassTypes.assertThat(getUnderTest().getType(mockRequestContext(URI_WITH_ACCESS_TOKEN_PARAMETER)))
+                .isEqualTo(DittoAuthorizationContextType.JWT);
+    }
+
+    private static RequestContext mockRequestContext(final HttpHeader... httpHeaders) {
+        final HttpRequest httpRequest = HttpRequest.create().addHeaders(Arrays.asList(httpHeaders));
+
+        final RequestContext requestContext = mock(RequestContext.class);
+        when(requestContext.getRequest()).thenReturn(httpRequest);
+        return requestContext;
+    }
+
+    protected static RequestContext mockRequestContext(final String uri) {
+        final HttpRequest httpRequest = HttpRequest.create(uri);
+        final RequestContext requestContext = mock(RequestContext.class);
+        when(requestContext.getRequest()).thenReturn(httpRequest);
+        return requestContext;
+    }
+
+    private static RequestContext mockRequestContext(final String uri, final HttpHeader... httpHeaders) {
+        final HttpRequest httpRequest = HttpRequest.create(uri).addHeaders(Arrays.asList(httpHeaders));
+        final RequestContext requestContext = mock(RequestContext.class);
+        when(requestContext.getRequest()).thenReturn(httpRequest);
+        return requestContext;
+    }
+
+    private void authenticate(final AuthenticationProvider<AuthenticationResult> provider,
+            final RequestContext requestContext,
+            final boolean expectedResult) {
+        final AuthenticationResult authenticationResult =
+                provider.authenticate(requestContext, knownDittoHeaders).join();
+        softly.assertThat(authenticationResult.isSuccess()).isEqualTo(expectedResult);
+    }
+
+}

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJwtAuthenticationProviderTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/AbstractJwtAuthenticationProviderTest.java
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2021 Contributors to the Eclipse Foundation
  *

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtExtractorTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/DefaultJwtExtractorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtTestConstants.VALID_JWT_TOKEN;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.model.jwt.JwtInvalidException;
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Tests {@link org.eclipse.ditto.services.gateway.security.authentication.jwt.DefaultJwtExtractor}.
+ */
+public class DefaultJwtExtractorTest {
+
+    private static final DittoHeaders DITTO_HEADERS = DittoHeaders.newBuilder().randomCorrelationId().build();
+    private static final HttpHeader VALID_AUTHORIZATION_HEADER =
+            HttpHeader.parse("authorization", "Bearer " + VALID_JWT_TOKEN);
+    private static final HttpHeader INVALID_AUTHORIZATION_HEADER =
+            HttpHeader.parse("authorization", "Basic " + VALID_JWT_TOKEN);
+
+    private final JwtExtractor underTest = DefaultJwtExtractor.getInstance();
+
+    @Test
+    public void extractJwtFromHeader() {
+        final RequestContext requestContext =
+                mockRequestContext(VALID_AUTHORIZATION_HEADER);
+        final JsonWebToken jsonWebToken = ImmutableJsonWebToken.fromToken(VALID_JWT_TOKEN);
+        assertThat(underTest.apply(requestContext, DITTO_HEADERS)).contains(jsonWebToken);
+    }
+
+    @Test(expected = JwtInvalidException.class)
+    public void extractInvalidJwtFromHeader() {
+        final RequestContext requestContext = mockRequestContext(INVALID_AUTHORIZATION_HEADER);
+        underTest.apply(requestContext, DITTO_HEADERS);
+    }
+
+    @Test
+    public void extractMissingJwtFromHeader() {
+        final RequestContext requestContext = mockRequestContext();
+        assertThat(underTest.apply(requestContext, DITTO_HEADERS)).isEmpty();
+    }
+
+    private static RequestContext mockRequestContext(final HttpHeader... httpHeaders) {
+        final HttpRequest httpRequest = HttpRequest.create().addHeaders(Arrays.asList(httpHeaders));
+
+        final RequestContext requestContext = mock(RequestContext.class);
+        when(requestContext.getRequest()).thenReturn(httpRequest);
+        return requestContext;
+    }
+
+}

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtAuthenticationProviderTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtAuthenticationProviderTest.java
@@ -14,21 +14,21 @@ package org.eclipse.ditto.services.gateway.security.authentication.jwt;
 
 import org.eclipse.ditto.model.base.headers.DittoHeaders;
 import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.junit.Test;
+
+import akka.http.javadsl.server.RequestContext;
 
 /**
  * Tests {@link JwtAuthenticationProvider}.
  */
-@RunWith(MockitoJUnitRunner.class)
-public final class JwtAuthenticationProviderTest extends AbstractJwtAuthenticationProviderTest {
+public final class WebSocketJwtAuthenticationProviderTest extends AbstractJwtAuthenticationProviderTest {
 
     private JwtAuthenticationProvider underTest;
 
     @Before
     public void setup() {
         knownDittoHeaders = DittoHeaders.newBuilder().correlationId(testName.getMethodName()).build();
-        underTest = JwtAuthenticationProvider.newInstance(authenticationContextProvider, jwtValidator);
+        underTest = JwtAuthenticationProvider.newWsInstance(authenticationContextProvider, jwtValidator);
     }
 
     @Override
@@ -38,11 +38,18 @@ public final class JwtAuthenticationProviderTest extends AbstractJwtAuthenticati
 
     @Override
     protected boolean supportsAccessTokenParameter() {
-        return false;
+        return true;
     }
 
     @Override
     protected String getExpectedMissingJwtDescription() {
-        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer '.";
+        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer ' or as query" +
+                " parameter 'access_token'.";
+    }
+
+    @Test
+    public void doExtractAuthenticationWithInvalidJwtFromAccessTokenParameter() {
+        final RequestContext requestContext = mockRequestContext(URI_WITH_ACCESS_TOKEN_PARAMETER);
+        doExtractAuthenticationWithInvalidJwt(getUnderTest(), requestContext);
     }
 }

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtAuthenticationProviderTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtAuthenticationProviderTest.java
@@ -43,7 +43,7 @@ public final class WebSocketJwtAuthenticationProviderTest extends AbstractJwtAut
 
     @Override
     protected String getExpectedMissingJwtDescription() {
-        return "Please provide a valid JWT in the authorization header prefixed with 'Bearer ' or as query" +
+        return "Please provide a valid JWT in the 'Authorization' header prefixed with 'Bearer ' or as query" +
                 " parameter 'access_token'.";
     }
 

--- a/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractorTest.java
+++ b/services/gateway/security/src/test/java/org/eclipse/ditto/services/gateway/security/authentication/jwt/WebSocketJwtExtractorTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.services.gateway.security.authentication.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.services.gateway.security.authentication.jwt.JwtTestConstants.VALID_JWT_TOKEN;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+
+import org.eclipse.ditto.model.base.headers.DittoHeaders;
+import org.eclipse.ditto.model.jwt.ImmutableJsonWebToken;
+import org.eclipse.ditto.model.jwt.JsonWebToken;
+import org.eclipse.ditto.model.jwt.JwtInvalidException;
+import org.eclipse.ditto.signals.commands.base.exceptions.GatewayAuthenticationFailedException;
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.HttpRequest;
+import akka.http.javadsl.server.RequestContext;
+
+/**
+ * Tests {@link org.eclipse.ditto.services.gateway.security.authentication.jwt.WebSocketJwtExtractor}.
+ */
+public class WebSocketJwtExtractorTest {
+
+    private static final DittoHeaders DITTO_HEADERS = DittoHeaders.newBuilder().randomCorrelationId().build();
+    private static final HttpHeader VALID_AUTHORIZATION_HEADER =
+            HttpHeader.parse("authorization", "Bearer " + VALID_JWT_TOKEN);
+    private static final String URI_WITH_TOKEN = "http://localhost/ws/2?access_token=" + VALID_JWT_TOKEN;
+    private static final String URI_WITH_INVALID_TOKEN = "http://localhost/ws/2?access_token=invalid_token";
+    private static final String URI_WITHOUT_TOKEN = "http://localhost/ws/2";
+
+    private final JwtExtractor underTest = WebSocketJwtExtractor.getInstance();
+
+    @Test
+    public void extractJwtFromParameter() {
+        final RequestContext requestContext = mockRequestContext(URI_WITH_TOKEN);
+        final JsonWebToken jsonWebToken = ImmutableJsonWebToken.fromToken(VALID_JWT_TOKEN);
+        assertThat(underTest.apply(requestContext, DITTO_HEADERS)).contains(jsonWebToken);
+    }
+
+    @Test
+    public void extractJwtFromHeader() {
+        final RequestContext requestContext = mockRequestContext(URI_WITHOUT_TOKEN, VALID_AUTHORIZATION_HEADER);
+        final JsonWebToken jsonWebToken = ImmutableJsonWebToken.fromToken(VALID_JWT_TOKEN);
+        assertThat(underTest.apply(requestContext, DITTO_HEADERS)).contains(jsonWebToken);
+    }
+
+    @Test(expected = JwtInvalidException.class)
+    public void extractInvalidJwtFromParameter() {
+        final RequestContext requestContext =
+                mockRequestContext(URI_WITH_INVALID_TOKEN);
+        underTest.apply(requestContext, DITTO_HEADERS);
+    }
+
+    @Test
+    public void extractMissingJwtFromParameter() {
+        final RequestContext requestContext = mockRequestContext(URI_WITHOUT_TOKEN);
+        assertThat(underTest.apply(requestContext, DITTO_HEADERS)).isEmpty();
+    }
+
+    @Test(expected = GatewayAuthenticationFailedException.class)
+    public void extractMultipleJwt() {
+        final RequestContext requestContext = mockRequestContext(URI_WITH_TOKEN, VALID_AUTHORIZATION_HEADER);
+        underTest.apply(requestContext, DITTO_HEADERS);
+    }
+
+    protected static RequestContext mockRequestContext(final String uri, final HttpHeader... headers) {
+        final HttpRequest httpRequest = HttpRequest.create(uri).addHeaders(Arrays.asList(headers));
+        final RequestContext requestContext = mock(RequestContext.class);
+        when(requestContext.getRequest()).thenReturn(httpRequest);
+        return requestContext;
+    }
+}


### PR DESCRIPTION
This PR fixes #667.

Due to the limitations described in #667 this PR allows to provide the JWT via the query parameter `access_token`. The parameter is only used for WebSocket requests. The existing means to specify a token (via the `Authorization` header) should be preferred whenever possible because of the security considerations mentioned in the [OAuth 2.0 specification](https://tools.ietf.org/html/rfc6750#section-2.3).