### PR TITLE
last minute Ditto 2.0 fixes

### DIFF
--- a/base/service/pom.xml
+++ b/base/service/pom.xml
@@ -77,6 +77,15 @@
         </dependency>
 
         <dependency>
+            <groupId>com.lightbend.akka.discovery</groupId>
+            <artifactId>akka-discovery-kubernetes-api_${scala.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.lightbend.akka.management</groupId>
+            <artifactId>akka-lease-kubernetes_${scala.version}</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.scullxbones</groupId>
             <artifactId>akka-persistence-mongo-common_${scala.version}</artifactId>
         </dependency>

--- a/concierge/service/pom.xml
+++ b/concierge/service/pom.xml
@@ -81,11 +81,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.lightbend.akka.discovery</groupId>
-            <artifactId>akka-discovery-kubernetes-api_${scala.version}</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -1158,8 +1158,14 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
             // THEN: The 2 commands land in different client actors
             underTest.tell(CreateSubscription.of(DittoHeaders.empty()), getRef());
             underTest.tell(CreateSubscription.of(DittoHeaders.empty()), getRef());
-            final WithSender<?> createSubscription1 = clientActorsProbe.expectMsgClass(WithSender.class);
-            final WithSender<?> createSubscription2 = clientActorsProbe.expectMsgClass(WithSender.class);
+            final WithSender<?> createSubscription1 = (WithSender<?>) clientActorsProbe.fishForMessage(
+                    scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS),
+                    "WithSender", PartialFunction.fromFunction(msg -> (msg instanceof WithSender<?> &&
+                            ((WithSender<?>) msg).getMessage() instanceof CreateSubscription)));
+            final WithSender<?> createSubscription2 = (WithSender<?>) clientActorsProbe.fishForMessage(
+                    scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS),
+                    "WithSender", PartialFunction.fromFunction(msg -> (msg instanceof WithSender<?> &&
+                            ((WithSender<?>) msg).getMessage() instanceof CreateSubscription)));
             assertThat(createSubscription1.getSender()).isNotEqualTo(createSubscription2.getSender());
         }};
     }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -1144,18 +1144,9 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
             expectMsgClass(CreateConnectionResponse.class);
             underTest.tell(OpenConnection.of(myConnectionId, DittoHeaders.empty()), getRef());
 
-            final WithSender<?> msg1 = clientActorsProbe.expectMsgClass(WithSender.class);
-            final WithSender<?> msg2 = clientActorsProbe.expectMsgClass(WithSender.class);
-            final WithSender<?> msg3 = clientActorsProbe.expectMsgClass(WithSender.class);
-            assertThat(List.of(
-                    msg1.getMessage().getClass(),
-                    msg2.getMessage().getClass(),
-                    msg3.getMessage().getClass()
-            )).containsExactlyInAnyOrder(
-                    EnableConnectionLogs.class,
-                    EnableConnectionLogs.class,
-                    OpenConnection.class);
-
+            clientActorsProbe.fishForMessage(scala.concurrent.duration.Duration.create(5, TimeUnit.SECONDS),
+                    "CreateConnection", PartialFunction.fromFunction(msg ->
+                            (msg instanceof WithSender<?> && ((WithSender<?>) msg).getMessage() instanceof OpenConnection)));
             clientActorsProbe.reply(new Status.Success("connected"));
             expectMsgClass(OpenConnectionResponse.class);
 

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/EmptyEvent.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/EmptyEvent.java
@@ -19,10 +19,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 
-import org.eclipse.ditto.base.model.entity.id.EntityId;
-import org.eclipse.ditto.base.model.entity.id.WithEntityId;
 import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.entity.type.EntityType;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonParsableEvent;
@@ -43,7 +40,7 @@ import org.eclipse.ditto.json.JsonValue;
  */
 @Immutable
 @JsonParsableEvent(name = EmptyEvent.NAME, typePrefix = EmptyEvent.TYPE_PREFIX)
-public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
+public final class EmptyEvent implements Event<EmptyEvent> {
 
     /**
      * Known effect of the "empty event" which shall keep an persistence actor always alive.
@@ -61,30 +58,14 @@ public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
 
     static final String TYPE = TYPE_PREFIX + NAME;
 
-    /**
-     * For already persisted events the {@link #JSON_ENTITY_TYPE} might not be present. In this case, fall back to this
-     * type.
-     * Should not have a relevance for EmptyEvent anyhow.
-     */
-    private static final EntityType UNKNOWN_ENTITY_TYPE = EntityType.of("unknown");
-
-    private static final JsonFieldDefinition<String> JSON_ENTITY_TYPE =
-            JsonFactory.newStringFieldDefinition("entityType", FieldType.REGULAR, JsonSchemaVersion.V_2);
-
-    private static final JsonFieldDefinition<String> JSON_ENTITY_ID =
-            JsonFactory.newStringFieldDefinition("entityId", FieldType.REGULAR, JsonSchemaVersion.V_2);
-
     private static final JsonFieldDefinition<JsonValue> JSON_EFFECT =
             JsonFactory.newJsonValueFieldDefinition("effect", FieldType.REGULAR, JsonSchemaVersion.V_2);
 
-    private final EntityId entityId;
     private final JsonValue effect;
     private final long revision;
     private final DittoHeaders dittoHeaders;
 
-    public EmptyEvent(final EntityId entityId, final JsonValue effect, final long revision,
-            final DittoHeaders dittoHeaders) {
-        this.entityId = entityId;
+    public EmptyEvent(final JsonValue effect, final long revision, final DittoHeaders dittoHeaders) {
         this.revision = revision;
         this.effect = effect;
         this.dittoHeaders = dittoHeaders;
@@ -104,13 +85,8 @@ public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
     public static EmptyEvent fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
         return new EventJsonDeserializer<EmptyEvent>(TYPE, jsonObject)
                 .deserialize((revision, timestamp, metadata) -> {
-                    final EntityType entityType = jsonObject.getValue(JSON_ENTITY_TYPE)
-                            .map(EntityType::of)
-                            .orElse(UNKNOWN_ENTITY_TYPE);
-                    final EntityId readEntityId =
-                            EntityId.of(entityType, jsonObject.getValueOrThrow(JSON_ENTITY_ID));
                     final JsonValue readEffect = jsonObject.getValueOrThrow(JSON_EFFECT);
-                    return new EmptyEvent(readEntityId, readEffect, revision, dittoHeaders);
+                    return new EmptyEvent(readEffect, revision, dittoHeaders);
                 });
     }
 
@@ -130,7 +106,7 @@ public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
 
     @Override
     public EmptyEvent setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return new EmptyEvent(entityId, effect, revision, dittoHeaders);
+        return new EmptyEvent(effect, revision, dittoHeaders);
     }
 
     @Override
@@ -148,15 +124,8 @@ public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
     public JsonObject toJson(final JsonSchemaVersion schemaVersion, final Predicate<JsonField> thePredicate) {
         final JsonObjectBuilder jsonObjectBuilder = JsonFactory.newObjectBuilder()
                 .set(JsonFields.TYPE, getType())
-                .set(JSON_ENTITY_TYPE, entityId.getEntityType().toString())
-                .set(JSON_ENTITY_ID, entityId.toString())
                 .set(JSON_EFFECT, effect);
         return jsonObjectBuilder.build();
-    }
-
-    @Override
-    public EntityId getEntityId() {
-        return entityId;
     }
 
     @Override
@@ -182,8 +151,7 @@ public final class EmptyEvent implements Event<EmptyEvent>, WithEntityId {
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "entityId=" + entityId +
-                ", effect=" + effect +
+                "effect=" + effect +
                 ", revision=" + revision +
                 ", dittoHeaders=" + dittoHeaders +
                 "]";

--- a/policies/service/pom.xml
+++ b/policies/service/pom.xml
@@ -99,11 +99,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.lightbend.akka.discovery</groupId>
-            <artifactId>akka-discovery-kubernetes-api_${scala.version}</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>

--- a/things/service/pom.xml
+++ b/things/service/pom.xml
@@ -109,11 +109,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.lightbend.akka.discovery</groupId>
-            <artifactId>akka-discovery-kubernetes-api_${scala.version}</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>


### PR DESCRIPTION
* added "akka-discovery-kubernetes-api" and "akka-lease-kubernetes" dependencies to ditto-base-service so that all services depend on it
* made EmptyEvent not require the added "eventType" JSON field in order to not break old events