### PR TITLE
fix MQTT publisher warnings when no MQTT consumer was present

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientData.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientData.java
@@ -74,14 +74,14 @@ public final class BaseClientData {
     }
 
     /**
-     * @return the ID of the Connection
+     * @return the ID of the connection
      */
     public ConnectionId getConnectionId() {
         return connectionId;
     }
 
     /**
-     * @return the managed Connection
+     * @return the managed connection
      */
     public Connection getConnection() {
         return connection;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3Validator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/Mqtt3Validator.java
@@ -164,7 +164,7 @@ public final class Mqtt3Validator extends AbstractMqttValidator {
         return !headerMapping.getMapping().isEmpty();
     }
 
-    private Boolean targetContainsOnlyAllowedHeaderMappings(final Target target, final DittoHeaders dittoHeaders) {
+    private boolean targetContainsOnlyAllowedHeaderMappings(final Target target, final DittoHeaders dittoHeaders) {
         return containsOnlyAllowedTargetMappings(target.getHeaderMapping(), dittoHeaders);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
@@ -26,8 +26,10 @@ import java.util.function.Consumer;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.connectivity.api.BaseClientState;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.Source;
+import org.eclipse.ditto.connectivity.model.signals.commands.modify.TestConnection;
 import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.BaseClientActor;
 import org.eclipse.ditto.connectivity.service.messaging.BaseClientData;
@@ -38,9 +40,7 @@ import org.eclipse.ditto.connectivity.service.messaging.internal.ConnectionFailu
 import org.eclipse.ditto.connectivity.service.messaging.internal.ImmutableConnectionFailure;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 import org.eclipse.ditto.connectivity.service.util.ConnectivityMdcEntryKey;
-import org.eclipse.ditto.connectivity.api.BaseClientState;
 import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
-import org.eclipse.ditto.connectivity.model.signals.commands.modify.TestConnection;
 
 import com.hivemq.client.mqtt.MqttClientState;
 import com.hivemq.client.mqtt.lifecycle.MqttClientDisconnectedListener;
@@ -196,7 +196,7 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
         final ClientWithCancelSwitch oldClient = getClient();
         final AbstractMqttSubscriptionHandler<S, P, R> oldSubscriptionHandler = getSubscriptionHandler();
         safelyDisconnectClient(oldClient, "consumer");
-        createSubscriberClientAndSubscriptionHandler();
+        createSubscriberClientAndSubscriptionHandler(!data.getConnection().getSources().isEmpty());
         oldSubscriptionHandler.stream().forEach(getSubscriptionHandler()::handleMqttConsumer);
         subscribeAndSendConn(false).whenComplete(
                 (result, error) -> logger.info("Consumer client restarted: result{}, error={]", result, error));
@@ -240,11 +240,13 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
     /**
      * Create a new client using the configuration of this actor.
      * On failure, send a ConnectionFailure to self.
+     *
+     * @param willSubscribe {@code true} whether the created client will subscribe to MQTT topics at all.
      */
-    private void createClientAndSubscriptionHandler() {
+    private void createClientAndSubscriptionHandler(final boolean willSubscribe) {
         final ActorRef self = getContext().getSelf();
         try {
-            createSubscriberClientAndSubscriptionHandler();
+            createSubscriberClientAndSubscriptionHandler(willSubscribe);
             if (mqttSpecificConfig.separatePublisherClient()) {
                 final String publisherClientId = resolvePublisherClientId(connection, mqttSpecificConfig);
                 final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
@@ -283,7 +285,7 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
         };
     }
 
-    private void createSubscriberClientAndSubscriptionHandler() {
+    private void createSubscriberClientAndSubscriptionHandler(final boolean willSubscribe) {
         final String mqttClientId = resolveMqttClientId(connection, mqttSpecificConfig);
         final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
         // apply last will config only if *no* separate publisher client is used
@@ -294,7 +296,13 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
                 null,
                 getMqttClientDisconnectedListener(cancelReconnect), connectionLogger);
         client = new ClientWithCancelSwitch(createdClient, cancelReconnect);
-        subscriptionHandler = createSubscriptionHandler(connection, createdClient, logger);
+
+        if (willSubscribe) {
+            // create a "real" subscription handler:
+            subscriptionHandler = createSubscriptionHandler(connection, createdClient, logger);
+        } else {
+            subscriptionHandler = new DummySubscriptionHandler<>(connection, logger);
+        }
     }
 
     private void resetClientAndSubscriptionHandler() {
@@ -363,7 +371,7 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
         // start publisher and consumer actors first.
         // after that, subscribe and connect in parallel in order to receive redelivered PUBLISH messages.
         if (client == null) {
-            createClientAndSubscriptionHandler();
+            createClientAndSubscriptionHandler(!connection.getSources().isEmpty());
             if (client == null) {
                 // client creation failed; a ConnectionFailure event will arrive and cause transition to failure state
                 return;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DummySubscriptionHandler.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DummySubscriptionHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.Source;
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
+
+/**
+ * Dummy/Noop subscriptions handler of MQTT connections which don't subscribe to any connection sources.
+ */
+final class DummySubscriptionHandler<S, P, R> extends AbstractMqttSubscriptionHandler<S, P, R> {
+
+    DummySubscriptionHandler(final Connection connection, final ThreadSafeDittoLoggingAdapter logger) {
+        // this DummySubscriptionHandler does not actually subscribe, but always return a null in the client future:
+        super(connection,
+                (subscribeMessage, callback, manualAcknowledgement) -> CompletableFuture.completedFuture(null), logger);
+    }
+
+    @Override
+    Optional<S> toMqttSubscribe(final Source source) {
+        return Optional.empty();
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DummySubscriptionHandler.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DummySubscriptionHandler.java
@@ -25,7 +25,7 @@ import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapt
 final class DummySubscriptionHandler<S, P, R> extends AbstractMqttSubscriptionHandler<S, P, R> {
 
     DummySubscriptionHandler(final Connection connection, final ThreadSafeDittoLoggingAdapter logger) {
-        // this DummySubscriptionHandler does not actually subscribe, but always return a null in the client future:
+        // this DummySubscriptionHandler does not actually subscribe, but always return a null in the client future.
         super(connection,
                 (subscribeMessage, callback, manualAcknowledgement) -> CompletableFuture.completedFuture(null), logger);
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt3PublisherActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt3PublisherActor.java
@@ -17,9 +17,8 @@ import java.nio.charset.Charset;
 import java.util.Optional;
 
 import org.eclipse.ditto.base.model.common.ByteBufferUtils;
-import org.eclipse.ditto.connectivity.model.Connection;
-import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttPublishTarget;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
+import org.eclipse.ditto.connectivity.model.Connection;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt3.Mqtt3Client;


### PR DESCRIPTION
* in combination with when "separatePublisherClient=true":
* create a dummy MQTT subscription handler in such cases which does not actually subscribe