### PR TITLE
Filter sensitive parameter/header values before logging

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestLoggingFilter.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestLoggingFilter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.endpoints.directives;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.Query;
+import akka.http.javadsl.model.Uri;
+
+/**
+ * Provides methods to redact sensitive parameter/header values from (raw) URIs and headers e.g. for logging purposes.
+ */
+final class RequestLoggingFilter {
+
+    private static final Set<String> FILTERED_PARAMETERS = Set.of("access_token");
+    private static final Set<String> FILTERED_HEADERS = Set.of("authorization");
+    private static final String REDACTED_VALUE = "***";
+
+    private RequestLoggingFilter() {}
+
+    /**
+     * Determines whether a {@link akka.http.javadsl.model.Query} contains parameters that need filtering.
+     *
+     * @param query the query to check
+     * @return {@code true} if the given Query requires filtering
+     */
+    static boolean requiresFiltering(final Query query) {
+        return FILTERED_PARAMETERS.stream().anyMatch(param -> query.get(param).isPresent());
+    }
+
+    /**
+     * Redacts unwanted parameter values with {@code ***} in a raw string uri.
+     *
+     * @param rawUri the raw uri to redact.
+     * @return the redacted raw uri
+     */
+    static String filterRawUri(final String rawUri) {
+        final int startFrom = rawUri.indexOf("?");
+        if (startFrom >= 0) { // contains parameters
+            String filteredRawUri = rawUri;
+            for (final String parameter : FILTERED_PARAMETERS) {
+                final int indexOfParameter = filteredRawUri.indexOf(parameter + "=");
+                if (indexOfParameter >= 0) {
+                    filteredRawUri = filteredRawUri.replaceAll(parameter + "=[^&]*", parameter + "=***");
+                }
+            }
+            return filteredRawUri;
+        } else {
+            return rawUri;
+        }
+    }
+
+    /**
+     * Redacts unwanted parameter values with {@code ***} in a Uri.
+     *
+     * @param uri the uri to redact.
+     * @return the redacted uri
+     */
+    static Uri filterUri(final Uri uri) {
+        return requiresFiltering(uri.query()) ? uri.query(filterQuery(uri.query())) : uri;
+    }
+
+    /**
+     * Redacts unwanted parameter values with {@code ***} in a Query object.
+     *
+     * @param query the query to redact.
+     * @return the redacted query
+     */
+    static Query filterQuery(final Query query) {
+        if (requiresFiltering(query)) {
+            final Map<String, String> queryMap = new HashMap<>(query.toMap());
+            FILTERED_PARAMETERS.forEach(param -> queryMap.put(param, REDACTED_VALUE));
+            return Query.create(queryMap);
+        } else {
+            return query;
+        }
+    }
+
+    /**
+     * Redacts unwanted header values with {@code ***} in an iterable of {@link akka.http.javadsl.model.HttpHeader}s.
+     *
+     * @param headers the headers to redact
+     * @return the redacted headers
+     */
+    static Iterable<HttpHeader> filterHeaders(final Iterable<HttpHeader> headers) {
+        return StreamSupport.stream(headers.spliterator(), false)
+                .map(header -> {
+                    if (FILTERED_HEADERS.contains(header.lowercaseName())) {
+                        return HttpHeader.parse(header.name(), REDACTED_VALUE);
+                    } else {
+                        return header;
+                    }
+                })
+                .collect(Collectors.toList());
+    }
+}

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestResultLoggingDirective.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestResultLoggingDirective.java
@@ -68,8 +68,10 @@ public final class RequestResultLoggingDirective {
                     final int statusCode = complete.getResponse().status().intValue();
                     logger.info("StatusCode of request {} '{}' was: {}", requestMethod, filteredRelativeRequestUri,
                             statusCode);
-                    final String filteredRawRequestUri = filterRawUri(HttpUtils.getRawRequestUri(request));
-                    logger.debug("Raw request URI was: {}", filteredRawRequestUri);
+                    if (logger.isDebugEnabled()) {
+                        final String filteredRawRequestUri = filterRawUri(HttpUtils.getRawRequestUri(request));
+                        logger.debug("Raw request URI was: {}", filteredRawRequestUri);
+                    }
                     request.getHeader(DITTO_TRACE_HEADERS)
                             .filter(unused -> TRACE_LOGGER.isDebugEnabled())
                             .ifPresent(unused -> TRACE_LOGGER.withCorrelationId(correlationId)

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestLoggingFilterTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestLoggingFilterTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.endpoints.directives;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Base64;
+import java.util.Set;
+import java.util.UUID;
+
+import org.junit.Test;
+
+import akka.http.javadsl.model.HttpHeader;
+import akka.http.javadsl.model.Uri;
+
+/**
+ * Tests {@link org.eclipse.ditto.gateway.service.endpoints.directives.RequestLoggingFilter}.
+ */
+public class RequestLoggingFilterTest {
+
+    private static final String TOKEN = UUID.randomUUID().toString();
+    private static final String BASIC_AUTH =
+            "Basic " + Base64.getEncoder().encodeToString("username:password".getBytes());
+    private static final String ACCESS_TOKEN = "access_token";
+
+    private static final Set<String> TEST_PARAMETERS = Set.of(
+            ACCESS_TOKEN + "=" + TOKEN,
+            "foo=bar&" + ACCESS_TOKEN + "=" + TOKEN,
+            ACCESS_TOKEN + "=" + TOKEN + "&foo=bar",
+            "foo=bar&" + ACCESS_TOKEN + "=" + TOKEN + "&bar=foo",
+            ACCESS_TOKEN + "=" + TOKEN + "&bar=foo&" + ACCESS_TOKEN + "=" + TOKEN
+    );
+
+    @Test
+    public void filterAccessTokenParameterInUri() {
+        TEST_PARAMETERS.forEach(this::filterAccessTokenParameterInUri);
+    }
+
+    private void filterAccessTokenParameterInUri(final String parameterString) {
+        final Uri uri = Uri.create("http://localhost:8080/api/2/things?" + parameterString);
+        assertThat(uri.query().get(ACCESS_TOKEN)).contains(TOKEN);
+        final Uri filteredUri = RequestLoggingFilter.filterUri(uri);
+        assertThat(filteredUri.query().get(ACCESS_TOKEN)).contains("***");
+    }
+
+    @Test
+    public void filterUriReturnsSameInstance() {
+        final Uri uri = Uri.create("http://localhost:8080/api/2/things?foo=bar");
+        final Uri filteredUri = RequestLoggingFilter.filterUri(uri);
+        assertThat(filteredUri).isSameAs(uri);
+    }
+
+    @Test
+    public void filterRawUriReturnsSameInstance() {
+        final String rawUri = Uri.create("http://localhost:8080/api/2/things?foo=bar").toString();
+        final String filteredRawUri = RequestLoggingFilter.filterRawUri(rawUri);
+        assertThat(filteredRawUri).isSameAs(rawUri);
+    }
+
+    @Test
+    public void filterAccessTokenParameterInRawUri() {
+        TEST_PARAMETERS.forEach(this::filterAccessTokenParameterInRawUri);
+    }
+
+    private void filterAccessTokenParameterInRawUri(final String parameterString) {
+        final String rawUri = Uri.create("http://localhost:8080/api/2/things?" + parameterString).toString();
+        assertThat(rawUri).contains("access_token=" + TOKEN);
+        final String filteredRawUri = RequestLoggingFilter.filterRawUri(rawUri);
+        assertThat(filteredRawUri).contains("access_token=***");
+        assertThat(filteredRawUri).doesNotContain(TOKEN);
+    }
+
+    @Test
+    public void filterAccessTokenParameterInHeaders() {
+        filterAccessTokenParameterInHeaders("authorization");
+        filterAccessTokenParameterInHeaders("Authorization");
+        filterAccessTokenParameterInHeaders("AuThOrIzAtIoN");
+    }
+
+    private void filterAccessTokenParameterInHeaders(final String name) {
+        final Iterable<HttpHeader> headers =
+                Set.of(HttpHeader.parse("foo", "bar"),
+                        HttpHeader.parse(name, BASIC_AUTH),
+                        HttpHeader.parse("eclipse", "ditto"));
+
+        final Iterable<HttpHeader> filteredHeaders = RequestLoggingFilter.filterHeaders(headers);
+
+        assertThat(filteredHeaders).hasSize(3);
+        assertThat(filteredHeaders).contains(HttpHeader.parse(name, "***"));
+    }
+}


### PR DESCRIPTION
Replace sensitive values (credentials/token) of known query parameters and HTTP headers with `***` before logging them.

Signed-off-by: Dominik Guggemos <dominik.guggemos@bosch.io>