### PR TITLE
Avoids throwing exceptions in ditto metrics 

### DIFF
--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/counter/KamonCounter.java
@@ -108,7 +108,8 @@ public final class KamonCounter implements Counter {
         if (kamonInternalCounter instanceof kamon.metric.Counter.LongAdder) {
             return ((kamon.metric.Counter.LongAdder) kamonInternalCounter).snapshot(false);
         }
-        throw new IllegalStateException(String.format("Could not get snapshot of Kamon counter with name <%s>!", name));
+        LOGGER.warn("Could not get snapshot of Kamon counter with name <{}>!", name);
+        return 0L;
     }
 
     private kamon.metric.Counter getKamonInternalCounter() {

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/gauge/KamonGauge.java
@@ -68,7 +68,8 @@ public class KamonGauge implements Gauge {
         if (kamonInternalGauge instanceof kamon.metric.Gauge.Volatile) {
             return (long) ((kamon.metric.Gauge.Volatile) kamonInternalGauge).snapshot(false);
         }
-        throw new IllegalStateException("Could not get value from kamon gauge");
+        LOGGER.warn("Could not get value from kamon gauge");
+        return 0L;
     }
 
     @Override

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/StartedKamonTimer.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/StartedKamonTimer.java
@@ -36,14 +36,14 @@ final class StartedKamonTimer implements StartedTimer {
     private final Map<String, StartedTimer> segments;
     private final long startTimestamp;
 
-    private boolean stopped;
+    @Nullable private StoppedTimer stoppedTimer;
 
     private StartedKamonTimer(final String name, final Map<String, String> tags) {
         this.name = name;
         this.tags = new HashMap<>(tags);
         this.segments = new HashMap<>();
         this.onStopHandlers = new ArrayList<>();
-        this.stopped = false;
+        this.stoppedTimer = null;
         this.startTimestamp = System.nanoTime();
         if (!this.tags.containsKey(SEGMENT_TAG)) {tag(SEGMENT_TAG, "overall");}
     }
@@ -54,7 +54,7 @@ final class StartedKamonTimer implements StartedTimer {
 
     @Override
     public StartedTimer tags(final Map<String, String> tags) {
-        if (stopped) {
+        if (isStopped()) {
             LOGGER.warn("Tried to append multiple tags to the stopped timer with name <{}>. Tags are ineffective.",
                     name);
         } else {
@@ -76,7 +76,7 @@ final class StartedKamonTimer implements StartedTimer {
 
     @Override
     public StartedTimer tag(final String key, final String value) {
-        if (stopped) {
+        if (isStopped()) {
             LOGGER.warn(
                     "Tried to append tag <{}> with value <{}> to the stopped timer with name <{}>. Tag is ineffective.",
                     key, value, name);
@@ -90,41 +90,41 @@ final class StartedKamonTimer implements StartedTimer {
     public StoppedTimer stop() {
 
         if (isRunning()) {
-            stopped = true;
-            return StoppedKamonTimer.fromStartedTimer(this);
+            stoppedTimer = StoppedKamonTimer.fromStartedTimer(this);
         }
-
-        throw new IllegalStateException(
-                String.format("Tried to stop the already stopped timer <%s> with segment <%s>.", name,
-                        getTag(SEGMENT_TAG)));
+        LOGGER.warn("Tried to stop the already stopped timer <{}> with segment <{}>.", name, getTag(SEGMENT_TAG));
+        return stoppedTimer;
     }
 
     @Override
     public boolean isRunning() {
-        return !stopped;
+        return stoppedTimer == null;
+    }
+
+    private boolean isStopped() {
+        return !isRunning();
     }
 
     @Override
     public StartedTimer startNewSegment(final String segmentName) {
-        verifyRunning();
-        final StartedTimer segment = PreparedKamonTimer.newTimer(name)
-                .tags(this.tags)
-                .tag(SEGMENT_TAG, segmentName)
-                .start();
-        this.segments.put(segmentName, segment);
-        return segment;
+        if (isRunning()) {
+            final StartedTimer segment = PreparedKamonTimer.newTimer(name)
+                    .tags(this.tags)
+                    .tag(SEGMENT_TAG, segmentName)
+                    .start();
+            this.segments.put(segmentName, segment);
+            return segment;
+        } else {
+            LOGGER.warn("Tried to start a new segment <{}> on a already stopped timer <{}> with segment <{}>.",
+                    segmentName, name, getTag(SEGMENT_TAG));
+            return this;
+        }
     }
 
     @Override
     public StartedTimer onStop(final OnStopHandler onStopHandler) {
         onStopHandlers.add(onStopHandler);
         return this;
-    }
-
-    private void verifyRunning() {
-        if (!isRunning()) {
-            throw new IllegalStateException("Timer has been stopped, already.");
-        }
     }
 
     @Override
@@ -156,7 +156,7 @@ final class StartedKamonTimer implements StartedTimer {
                 ", onStopHandlers=" + onStopHandlers +
                 ", segments=" + segments +
                 ", startTimestamp=" + startTimestamp +
-                ", stopped=" + stopped +
+                ", stoppedTimer=" + stoppedTimer +
                 "]";
     }
 }

--- a/internal/utils/metrics/src/test/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/StartedKamonTimerTest.java
+++ b/internal/utils/metrics/src/test/java/org/eclipse/ditto/internal/utils/metrics/instruments/timer/StartedKamonTimerTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.internal.utils.metrics.instruments.timer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -65,10 +66,10 @@ public class StartedKamonTimerTest {
         assertThat(sut.isRunning()).isFalse();
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void stopAStoppedTimerCausesException() {
+    @Test
+    public void stopAStoppedTimerCausesNoException() {
         sut.stop();
-        sut.stop();
+        assertThatCode(() -> sut.stop()).doesNotThrowAnyException();
     }
 
     @Test


### PR DESCRIPTION
Avoids throwing exceptions in ditto metrics and return more or lessreasonable return values in combination with a WARN log instead

* The reason for this is that we don't want productive code to break
  because of errors in metrics


The alternative could be checked exceptions and handle those exceptions all over our code. Could also be a valid option, but for a first fix this is the faster way.

@jufickel-b @thjaeckle What do you think? Should we use checked exceptions for this?