### PR TITLE
fixed parallelism of search-updater using "flatMapMerge"

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -548,4 +548,15 @@ signal-enrichment-cache-dispatcher {
   }
 }
 
+http-push-connection-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?HTTP_PUSH_CONNECTION_DISPATCHER_POOL_SIZE_MAX}
+  }
+}
+
 include "connectivity-extension"

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -458,3 +458,8 @@ signal-enrichment-cache-dispatcher {
   type = PinnedDispatcher
   executor = "thread-pool-executor"
 }
+
+http-push-connection-dispatcher {
+  type = PinnedDispatcher
+  executor = "thread-pool-executor"
+}

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -22,6 +22,7 @@ the following environment variables in order to configure the connection to the 
 
 * MONGO_DB_URI: Connection string to MongoDB
 * MONGO_DB_SSL_ENABLED: Enabled SSL connection to MongoDB
+* MONGO_DB_CONNECTION_MIN_POOL_SIZE: Configure MongoDB minimum connection pool size
 * MONGO_DB_CONNECTION_POOL_SIZE: Configure MongoDB connection pool size
 * MONGO_DB_READ_PREFERENCE: Configure MongoDB read preference
 * MONGO_DB_WRITE_CONCERN: Configure MongoDB write concern

--- a/internal/utils/config/src/main/resources/ditto-mongo.conf
+++ b/internal/utils/config/src/main/resources/ditto-mongo.conf
@@ -59,6 +59,9 @@ ditto.mongodb {
   }
 
   pool {
+    minSize = 0
+    minSize = ${?MONGO_DB_CONNECTION_MIN_POOL_SIZE}
+
     maxSize = 100
     maxSize = ${?MONGO_DB_CONNECTION_POOL_SIZE}
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClientBuilder.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClientBuilder.java
@@ -100,6 +100,15 @@ public interface DittoMongoClientBuilder {
         GeneralPropertiesStep maxQueryTime(@Nullable Duration maxQueryTime);
 
         /**
+         * Sets the minimum number of connections to the database always kept alive in the pool.
+         * Default is {@code 0} connections.
+         *
+         * @param minSize the minimum connection pool size.
+         * @return this builder instance to allow method chaining.
+         */
+        GeneralPropertiesStep connectionPoolMinSize(int minSize);
+
+        /**
          * Sets the maximum allowed number of connections to the database.
          * The connections are kept in a pool.
          * Default is {@code 100} connections.

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
@@ -285,6 +285,7 @@ public final class MongoClientWrapper implements DittoMongoClient {
             builder.connectionString(mongoDbConfig.getMongoDbUri());
 
             final MongoDbConfig.ConnectionPoolConfig connectionPoolConfig = mongoDbConfig.getConnectionPoolConfig();
+            builder.connectionPoolMinSize(connectionPoolConfig.getMinSize());
             builder.connectionPoolMaxSize(connectionPoolConfig.getMaxSize());
             builder.connectionPoolMaxWaitTime(connectionPoolConfig.getMaxWaitTime());
             builder.enableJmxListener(connectionPoolConfig.isJmxListenerEnabled());
@@ -333,6 +334,12 @@ public final class MongoClientWrapper implements DittoMongoClient {
         @Override
         public GeneralPropertiesStep defaultDatabaseName(final CharSequence databaseName) {
             defaultDatabaseName = checkNotNull(databaseName, "name of the default database").toString();
+            return this;
+        }
+
+        @Override
+        public GeneralPropertiesStep connectionPoolMinSize(final int minSize) {
+            mongoClientSettingsBuilder.applyToConnectionPoolSettings(builder -> builder.minSize(minSize));
             return this;
         }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoHealthChecker.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoHealthChecker.java
@@ -58,6 +58,7 @@ public final class MongoHealthChecker extends AbstractHealthCheckingActor {
         final DefaultMongoDbConfig mongoDbConfig = DefaultMongoDbConfig.of(
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config()));
         mongoClient = MongoClientWrapper.getBuilder(mongoDbConfig)
+                .connectionPoolMinSize(0)
                 .connectionPoolMaxSize(HEALTH_CHECK_MAX_POOL_SIZE)
                 .build();
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
@@ -30,11 +30,13 @@ public final class DefaultConnectionPoolConfig implements MongoDbConfig.Connecti
 
     private static final String CONFIG_PATH = "pool";
 
+    private final int minSize;
     private final int maxSize;
     private final Duration maxWaitTime;
     private final boolean jmxListenerEnabled;
 
     private DefaultConnectionPoolConfig(final ScopedConfig config) {
+        minSize = config.getInt(ConnectionPoolConfigValue.MIN_SIZE.getConfigPath());
         maxSize = config.getInt(ConnectionPoolConfigValue.MAX_SIZE.getConfigPath());
         maxWaitTime = config.getDuration(ConnectionPoolConfigValue.MAX_WAIT_TIME.getConfigPath());
         jmxListenerEnabled = config.getBoolean(ConnectionPoolConfigValue.JMX_LISTENER_ENABLED.getConfigPath());
@@ -50,6 +52,11 @@ public final class DefaultConnectionPoolConfig implements MongoDbConfig.Connecti
     public static DefaultConnectionPoolConfig of(final Config config) {
         return new DefaultConnectionPoolConfig(
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, ConnectionPoolConfigValue.values()));
+    }
+
+    @Override
+    public int getMinSize() {
+        return minSize;
     }
 
     @Override
@@ -76,20 +83,22 @@ public final class DefaultConnectionPoolConfig implements MongoDbConfig.Connecti
             return false;
         }
         final DefaultConnectionPoolConfig that = (DefaultConnectionPoolConfig) o;
-        return maxSize == that.maxSize &&
+        return minSize == that.minSize &&
+                maxSize == that.maxSize &&
                 jmxListenerEnabled == that.jmxListenerEnabled &&
                 Objects.equals(maxWaitTime, that.maxWaitTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxSize, maxWaitTime, jmxListenerEnabled);
+        return Objects.hash(minSize, maxSize, maxWaitTime, jmxListenerEnabled);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "maxSize=" + maxSize +
+                "minSize=" + minSize +
+                ", maxSize=" + maxSize +
                 ", maxWaitTime=" + maxWaitTime +
                 ", jmxListenerEnabled=" + jmxListenerEnabled +
                 "]";

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbConfig.java
@@ -218,6 +218,13 @@ public interface MongoDbConfig {
     interface ConnectionPoolConfig {
 
         /**
+         * Returns the minimum number of connections in the connection pool always to be kept alive.
+         *
+         * @return the minimum number of connections.
+         */
+        int getMinSize();
+
+        /**
          * Returns the maximum number of connections in the connection pool.
          *
          * @return the maximum number of connections.
@@ -243,6 +250,11 @@ public interface MongoDbConfig {
          * {@code ConnectionPoolConfig}.
          */
         enum ConnectionPoolConfigValue implements KnownConfigValue {
+
+            /**
+             * The minimum number of connections in the connection pool.
+             */
+            MIN_SIZE("minSize", 0),
 
             /**
              * The maximum number of connections in the connection pool.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -166,7 +166,7 @@ final class EnforcementFlow {
                             Source.fromIterator(changeMap.values()::iterator)
                                     .flatMapMerge(parallelism, metadataRef ->
                                             computeWriteModel(metadataRef, responseMap.get(metadataRef.getThingId()))
-                                                    .async()
+                                                    .async(MongoSearchUpdaterFlow.DISPATCHER_NAME, parallelism)
                                     )
                                     .withAttributes(Attributes.inputBuffer(parallelism, parallelism))
                     );
@@ -179,7 +179,8 @@ final class EnforcementFlow {
             final int parallelism, final Map<ThingId, Metadata> changeMap) {
 
         return Source.fromIterator(changeMap.entrySet()::iterator)
-                .flatMapMerge(parallelism, entry -> sudoRetrieveThing(entry).async())
+                .flatMapMerge(parallelism, entry -> sudoRetrieveThing(entry)
+                        .async(MongoSearchUpdaterFlow.DISPATCHER_NAME, parallelism))
                 .withAttributes(Attributes.inputBuffer(parallelism, parallelism))
                 .<Map<ThingId, SudoRetrieveThingResponse>>fold(new HashMap<>(), (map, response) -> {
                     map.put(getThingId(response), response);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/MongoSearchUpdaterFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/MongoSearchUpdaterFlow.java
@@ -52,6 +52,11 @@ final class MongoSearchUpdaterFlow {
     private static final String COUNT_THING_BULK_UPDATES_PER_BULK = "things_search_thing_bulkUpdate_updates_per_bulk";
     private static final String UPDATE_TYPE_TAG = "update_type";
 
+    /**
+     * Config key of the dispatcher for the search updater.
+     */
+    static final String DISPATCHER_NAME = "search-updater-dispatcher";
+
     private final MongoCollection<Document> collection;
     private final MongoCollection<Document> collectionWithAcknowledgements;
 
@@ -97,7 +102,7 @@ final class MongoSearchUpdaterFlow {
         final Flow<List<AbstractWriteModel>, WriteResultAndErrors, NotUsed> writeFlow =
                 Flow.<List<AbstractWriteModel>>create()
                         .flatMapMerge(parallelism, writeModels ->
-                                executeBulkWrite(shouldAcknowledge, writeModels).async())
+                                executeBulkWrite(shouldAcknowledge, writeModels).async(DISPATCHER_NAME, parallelism))
                         // never initiate more than "parallelism" writes against the persistence
                         .withAttributes(Attributes.inputBuffer(parallelism, parallelism));
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/MongoSearchUpdaterFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/MongoSearchUpdaterFlow.java
@@ -16,12 +16,12 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.bson.Document;
-import org.eclipse.ditto.thingsearch.service.common.config.PersistenceStreamConfig;
-import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
-import org.eclipse.ditto.thingsearch.service.persistence.write.model.WriteResultAndErrors;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.timer.StartedTimer;
+import org.eclipse.ditto.thingsearch.service.common.config.PersistenceStreamConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.WriteResultAndErrors;
 
 import com.mongodb.MongoBulkWriteException;
 import com.mongodb.client.model.BulkWriteOptions;
@@ -96,7 +96,8 @@ final class MongoSearchUpdaterFlow {
 
         final Flow<List<AbstractWriteModel>, WriteResultAndErrors, NotUsed> writeFlow =
                 Flow.<List<AbstractWriteModel>>create()
-                        .flatMapMerge(parallelism, writeModels -> executeBulkWrite(shouldAcknowledge, writeModels))
+                        .flatMapMerge(parallelism, writeModels ->
+                                executeBulkWrite(shouldAcknowledge, writeModels).async())
                         // never initiate more than "parallelism" writes against the persistence
                         .withAttributes(Attributes.inputBuffer(parallelism, parallelism));
 

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -11,6 +11,8 @@ ditto {
     database = ${?MONGO_DB_DATABASE}
 
     pool {
+      minSize = 0
+      minSize = ${?MONGO_DB_CONNECTION_MIN_POOL_SIZE}
       maxSize = 1000
       maxSize = ${?MONGO_DB_CONNECTION_POOL_SIZE}
       maxWaitTime = 30s

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -234,4 +234,15 @@ policy-enforcer-cache-dispatcher {
   }
 }
 
+search-updater-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?SEARCH_UPDATER_DISPATCHER_POOL_SIZE_MAX}
+  }
+}
+
 include "things-search-extension.conf"

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -16,18 +16,18 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.Map;
 
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.policies.model.Policy;
-import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.things.model.Thing;
-import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThing;
 import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
+import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.service.common.config.DefaultStreamConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.StreamConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
@@ -63,7 +63,7 @@ public final class EnforcementFlowTest {
 
     @BeforeClass
     public static void init() {
-        system = ActorSystem.create();
+        system = ActorSystem.create("test", ConfigFactory.load("actors-test.conf"));
     }
 
     @AfterClass

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorIT.java
@@ -25,17 +25,19 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 import org.bson.Document;
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.service.config.limits.DefaultLimitsConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
+import org.eclipse.ditto.internal.utils.persistence.mongo.MongoClientWrapper;
+import org.eclipse.ditto.internal.utils.test.mongo.MongoDbResource;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.auth.AuthorizationContext;
-import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
-import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.policies.model.enforcers.Enforcer;
-import org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
@@ -45,21 +47,19 @@ import org.eclipse.ditto.policies.model.Resource;
 import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.Subject;
 import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.base.service.config.limits.DefaultLimitsConfig;
-import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
-import org.eclipse.ditto.thingsearch.service.persistence.query.QueryParser;
-import org.eclipse.ditto.thingsearch.service.persistence.read.MongoThingsSearchPersistence;
-import org.eclipse.ditto.thingsearch.service.persistence.write.streaming.TestSearchUpdaterStream;
-import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
-import org.eclipse.ditto.internal.utils.persistence.mongo.MongoClientWrapper;
-import org.eclipse.ditto.internal.utils.test.mongo.MongoDbResource;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.QueryThings;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.QueryThingsResponse;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.StreamThings;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.ThingSearchQueryCommand;
+import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
+import org.eclipse.ditto.thingsearch.service.persistence.query.QueryParser;
+import org.eclipse.ditto.thingsearch.service.persistence.read.MongoThingsSearchPersistence;
+import org.eclipse.ditto.thingsearch.service.persistence.write.streaming.TestSearchUpdaterStream;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -110,6 +110,10 @@ public final class SearchActorIT {
     public void before() {
         actorSystem = ActorSystem.create(getClass().getSimpleName(),
                 ConfigFactory.parseString("search-dispatcher {\n" +
+                        "  type = PinnedDispatcher\n" +
+                        "  executor = \"thread-pool-executor\"\n" +
+                        "}\n" +
+                        "search-updater-dispatcher {\n" +
                         "  type = PinnedDispatcher\n" +
                         "  executor = \"thread-pool-executor\"\n" +
                         "}"));

--- a/thingsearch/service/src/test/resources/actors-test.conf
+++ b/thingsearch/service/src/test/resources/actors-test.conf
@@ -187,12 +187,6 @@ akka {
   }
 }
 
-search-dispatcher {
-  # one thread per query and a dedicated thread for the search actor
-  type = PinnedDispatcher
-  executor = "thread-pool-executor"
-}
-
 blocked-namespaces-dispatcher {
   type = Dispatcher
   executor = "fork-join-executor"
@@ -217,6 +211,17 @@ policy-enforcer-cache-dispatcher {
     max-pool-size-max = 256
     max-pool-size-max = ${?CACHE_DISPATCHER_POOL_SIZE_MAX}
     max-pool-size-max = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MAX}
+  }
+}
+
+search-updater-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?SEARCH_UPDATER_DISPATCHER_POOL_SIZE_MAX}
   }
 }
 

--- a/thingsearch/service/src/test/resources/test.conf
+++ b/thingsearch/service/src/test/resources/test.conf
@@ -143,3 +143,14 @@ blocked-namespaces-dispatcher {
   }
   throughput = 5
 }
+
+search-updater-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?SEARCH_UPDATER_DISPATCHER_POOL_SIZE_MAX}
+  }
+}


### PR DESCRIPTION
* added async() boundary which was missing and caused parallelism to not have an effect
* additionally made it possible to configure a minPoolSize for MongoDB connections