### PR TITLE
optimized MQTT protocol level acknowledgements

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -22,6 +22,7 @@ import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 /**
  * This class is the default implementation of {@link MqttConfig}.
@@ -30,6 +31,7 @@ import com.typesafe.config.Config;
 public final class DefaultMqttConfig implements MqttConfig {
 
     private static final String CONFIG_PATH = "mqtt";
+    private static final String RECONNECT_BACKOFF_PATH = "reconnect";
 
     private final int sourceBufferSize;
     private final int eventLoopThreads;
@@ -37,6 +39,7 @@ public final class DefaultMqttConfig implements MqttConfig {
     private final boolean reconnectForRedelivery;
     private final boolean useSeparateClientForPublisher;
     private final Duration reconnectForRedeliveryDelay;
+    private final BackOffConfig reconnectBackOffConfig;
 
     private DefaultMqttConfig(final ScopedConfig config) {
         sourceBufferSize = config.getInt(MqttConfigValue.SOURCE_BUFFER_SIZE.getConfigPath());
@@ -46,6 +49,9 @@ public final class DefaultMqttConfig implements MqttConfig {
         reconnectForRedeliveryDelay =
                 config.getDuration(MqttConfigValue.RECONNECT_FOR_REDELIVERY_DELAY.getConfigPath());
         useSeparateClientForPublisher = config.getBoolean(MqttConfigValue.SEPARATE_PUBLISHER_CLIENT.getConfigPath());
+        reconnectBackOffConfig = DefaultBackOffConfig.of(config.hasPath(RECONNECT_BACKOFF_PATH)
+                ? config.getConfig(RECONNECT_BACKOFF_PATH)
+                : ConfigFactory.parseString("backoff" + "={}"));
     }
 
     /**
@@ -90,6 +96,11 @@ public final class DefaultMqttConfig implements MqttConfig {
     }
 
     @Override
+    public BackOffConfig getReconnectBackOffConfig() {
+        return reconnectBackOffConfig;
+    }
+
+    @Override
     public boolean equals(@Nullable final Object o) {
         if (this == o) {
             return true;
@@ -103,13 +114,14 @@ public final class DefaultMqttConfig implements MqttConfig {
                 Objects.equals(cleanSession, that.cleanSession) &&
                 Objects.equals(reconnectForRedelivery, that.reconnectForRedelivery) &&
                 Objects.equals(reconnectForRedeliveryDelay, that.reconnectForRedeliveryDelay) &&
-                Objects.equals(useSeparateClientForPublisher, that.useSeparateClientForPublisher);
+                Objects.equals(useSeparateClientForPublisher, that.useSeparateClientForPublisher) &&
+                Objects.equals(reconnectBackOffConfig, that.reconnectBackOffConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(sourceBufferSize, eventLoopThreads, cleanSession, reconnectForRedelivery,
-                reconnectForRedeliveryDelay, useSeparateClientForPublisher);
+                reconnectForRedeliveryDelay, useSeparateClientForPublisher, reconnectBackOffConfig);
     }
 
     @Override
@@ -121,6 +133,7 @@ public final class DefaultMqttConfig implements MqttConfig {
                 ", reconnectForRedelivery=" + reconnectForRedelivery +
                 ", reconnectForRedeliveryDelay=" + reconnectForRedeliveryDelay +
                 ", useSeparateClientForPublisher=" + useSeparateClientForPublisher +
+                ", reconnectBackOffConfig=" + reconnectBackOffConfig +
                 "]";
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -32,12 +32,16 @@ public final class DefaultMqttConfig implements MqttConfig {
     private static final String CONFIG_PATH = "mqtt";
 
     private final int sourceBufferSize;
+    private final int eventLoopThreads;
+    private final boolean cleanSession;
     private final boolean reconnectForRedelivery;
     private final boolean useSeparateClientForPublisher;
     private final Duration reconnectForRedeliveryDelay;
 
     private DefaultMqttConfig(final ScopedConfig config) {
         sourceBufferSize = config.getInt(MqttConfigValue.SOURCE_BUFFER_SIZE.getConfigPath());
+        eventLoopThreads = config.getInt(MqttConfigValue.EVENT_LOOP_THREADS.getConfigPath());
+        cleanSession = config.getBoolean(MqttConfigValue.CLEAN_SESSION.getConfigPath());
         reconnectForRedelivery = config.getBoolean(MqttConfigValue.RECONNECT_FOR_REDELIVERY.getConfigPath());
         reconnectForRedeliveryDelay =
                 config.getDuration(MqttConfigValue.RECONNECT_FOR_REDELIVERY_DELAY.getConfigPath());
@@ -58,6 +62,16 @@ public final class DefaultMqttConfig implements MqttConfig {
     @Override
     public int getSourceBufferSize() {
         return sourceBufferSize;
+    }
+
+    @Override
+    public int getEventLoopThreads() {
+        return eventLoopThreads;
+    }
+
+    @Override
+    public boolean isCleanSession() {
+        return cleanSession;
     }
 
     @Override
@@ -85,6 +99,8 @@ public final class DefaultMqttConfig implements MqttConfig {
         }
         final DefaultMqttConfig that = (DefaultMqttConfig) o;
         return Objects.equals(sourceBufferSize, that.sourceBufferSize) &&
+                Objects.equals(eventLoopThreads, that.eventLoopThreads) &&
+                Objects.equals(cleanSession, that.cleanSession) &&
                 Objects.equals(reconnectForRedelivery, that.reconnectForRedelivery) &&
                 Objects.equals(reconnectForRedeliveryDelay, that.reconnectForRedeliveryDelay) &&
                 Objects.equals(useSeparateClientForPublisher, that.useSeparateClientForPublisher);
@@ -92,14 +108,16 @@ public final class DefaultMqttConfig implements MqttConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceBufferSize, reconnectForRedelivery, reconnectForRedeliveryDelay,
-                useSeparateClientForPublisher);
+        return Objects.hash(sourceBufferSize, eventLoopThreads, cleanSession, reconnectForRedelivery,
+                reconnectForRedeliveryDelay, useSeparateClientForPublisher);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "sourceBufferSize=" + sourceBufferSize +
+                ", eventLoopThreads=" + eventLoopThreads +
+                ", cleanSession=" + cleanSession +
                 ", reconnectForRedelivery=" + reconnectForRedelivery +
                 ", reconnectForRedeliveryDelay=" + reconnectForRedeliveryDelay +
                 ", useSeparateClientForPublisher=" + useSeparateClientForPublisher +

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
@@ -31,6 +31,24 @@ public interface MqttConfig {
      */
     int getSourceBufferSize();
 
+
+    /**
+     * Returns the number of threads to use for the underlying event loop of the MQTT client.
+     * When configured to {@code 0}, the size is determined based on {@code the available processor cores * 2}.
+     *
+     * @return the amount of event loop threads.
+     * @since 2.0.0
+     */
+    int getEventLoopThreads();
+
+    /**
+     * Indicates whether subscriber CONN messages should set clean-session or clean-start flag to true.
+     *
+     * @return the default setting of cleanSession.
+     * @since 2.0.0
+     */
+    boolean isCleanSession();
+
     /**
      * Indicates whether the client should reconnect to enforce a redelivery for a failed acknowledgement.
      *
@@ -66,6 +84,16 @@ public interface MqttConfig {
          * The maximum number of buffered messages for each MQTT source.
          */
         SOURCE_BUFFER_SIZE("source-buffer-size", 8),
+
+        /**
+         * The number of threads to use for the underlying event loop of the MQTT client.
+         */
+        EVENT_LOOP_THREADS("event-loop-threads", 0),
+
+        /**
+         * Indicates whether subscriber CONN messages should set clean-session or clean-start flag to true.
+         */
+        CLEAN_SESSION("clean-session", false),
 
         /**
          * Indicates whether the client should reconnect to enforce a redelivery for a failed acknowledgement.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
@@ -75,6 +75,14 @@ public interface MqttConfig {
     boolean shouldUseSeparatePublisherClient();
 
     /**
+     * Returns the reconnect backoff configuration to apply when reconnecting failed MQTT connections.
+     *
+     * @return the reconnect backoff configuration to apply.
+     * @since 2.0.0
+     */
+    BackOffConfig getReconnectBackOffConfig();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code MqttConfig}.
      */

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
@@ -103,7 +103,7 @@ public interface MqttConfig {
         /**
          * The amount of time that a reconnect will be delayed after a failed acknowledgement.
          */
-        RECONNECT_FOR_REDELIVERY_DELAY("reconnect-for-redelivery-delay", Duration.ofSeconds(2)),
+        RECONNECT_FOR_REDELIVERY_DELAY("reconnect-for-redelivery-delay", Duration.ofSeconds(10)),
 
         /**
          * Indicates whether a separate client should be used for publishing. This could be useful when

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -248,7 +248,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
     }
 
     private static boolean someFailedResponseRequiresRedelivery(final Collection<CommandResponse<?>> failedResponses) {
-        return failedResponses.isEmpty() || failedResponses.stream()
+        return failedResponses.stream()
                 .flatMap(BaseConsumerActor::extractAggregatedResponses)
                 .map(CommandResponse::getHttpStatus)
                 .anyMatch(BaseConsumerActor::requiresRedelivery);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/backoff/DuplicationRetryTimeoutStrategy.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/backoff/DuplicationRetryTimeoutStrategy.java
@@ -25,6 +25,8 @@ import org.eclipse.ditto.connectivity.service.config.TimeoutConfig;
  */
 final class DuplicationRetryTimeoutStrategy implements RetryTimeoutStrategy {
 
+    private static final Duration ZERO_MIN_DURATION_FIRST_INCREMENT = Duration.ofMillis(100);
+
     private final Duration minTimeout;
     private final Duration maxTimeout;
     private Duration currentTimeout;
@@ -54,6 +56,9 @@ final class DuplicationRetryTimeoutStrategy implements RetryTimeoutStrategy {
     public Duration getNextTimeout() {
         final Duration timeout = this.currentTimeout;
         this.increase();
+        if (timeout.isZero()) {
+            this.currentTimeout = ZERO_MIN_DURATION_FIRST_INCREMENT;
+        }
         return timeout;
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/backoff/RetryTimeoutStrategy.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/backoff/RetryTimeoutStrategy.java
@@ -15,10 +15,24 @@ package org.eclipse.ditto.connectivity.service.messaging.backoff;
 
 import java.time.Duration;
 
+import org.eclipse.ditto.connectivity.service.config.TimeoutConfig;
+
 /**
  * Retry timeout strategy that provides increasing timeouts for retrying to connect.
  */
-interface RetryTimeoutStrategy {
+public interface RetryTimeoutStrategy {
+
+    /**
+     * Creates a new RetryTimeoutStrategy duplicating the {@link #getNextTimeout()} until the configured max timeout
+     * of the passed {@code timeoutConfig} is reached with the formula: {@code timeout = minTimeout * 2^x}
+     *
+     * @param timeoutConfig the timeout config to apply.
+     * @return the created RetryTimeoutStrategy
+     * @since 2.0.0
+     */
+    static RetryTimeoutStrategy newDuplicationRetryTimeoutStrategy(final TimeoutConfig timeoutConfig) {
+        return DuplicationRetryTimeoutStrategy.fromConfig(timeoutConfig);
+    }
 
     /**
      * Resets the timeout and the current tries.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultEvictingQueue.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultEvictingQueue.java
@@ -100,7 +100,7 @@ final class DefaultEvictingQueue<E> extends AbstractQueue<E> implements Evicting
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", capacity=" + capacity +
+                "capacity=" + capacity +
                 ", elements=" + elements +
                 "]";
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultMuteableConnectionLogger.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultMuteableConnectionLogger.java
@@ -175,7 +175,7 @@ final class DefaultMuteableConnectionLogger implements MuteableConnectionLogger 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", connectionId=" + connectionId +
+                "connectionId=" + connectionId +
                 ", delegate=" + delegate +
                 ", active=" + active +
                 "]";

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/EvictingConnectionLogger.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/EvictingConnectionLogger.java
@@ -237,7 +237,7 @@ final class EvictingConnectionLogger implements ConnectionLogger {
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                ", category=" + category +
+                "category=" + category +
                 ", type=" + type +
                 ", successLogs=" + successLogs +
                 ", failureLogs=" + failureLogs +

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttSpecificConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/MqttSpecificConfig.java
@@ -74,6 +74,7 @@ public final class MqttSpecificConfig {
 
     private static Map<String, Object> toDefaultConfig(final MqttConfig mqttConfig) {
         final Map<String, Object> defaultMap = new HashMap<>();
+        defaultMap.put(CLEAN_SESSION, mqttConfig.isCleanSession());
         defaultMap.put(RECONNECT_FOR_REDELIVERY, mqttConfig.shouldReconnectForRedelivery());
         defaultMap.put(RECONNECT_FOR_REDELIVERY_DELAY, mqttConfig.getReconnectForRedeliveryDelay());
         defaultMap.put(SEPARATE_PUBLISHER_CLIENT, mqttConfig.shouldUseSeparatePublisherClient());
@@ -82,15 +83,9 @@ public final class MqttSpecificConfig {
 
     /**
      * @return whether subscriber CONN messages should set clean-session or clean-start flag to true.
-     * Default to the negation of "reconnectForRedelivery" (if reconnect for redelivery then persistent session,
-     * otherwise clean-session or clean-start.)
      */
     public boolean cleanSession() {
-        if (specificConfig.hasPath(CLEAN_SESSION)) {
-            return getSafely(() -> specificConfig.getBoolean(CLEAN_SESSION), false);
-        } else {
-            return !reconnectForRedelivery();
-        }
+        return specificConfig.getBoolean(CLEAN_SESSION);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -117,14 +117,19 @@ abstract class AbstractHiveMqttClientFactory {
             final boolean allowReconnect,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final int eventLoopThreads) {
 
         final URI uri = tunnelStateSupplier.get().getURI(connection);
 
         T builder = newBuilder
+                .executorConfig()
+                .nettyThreads(eventLoopThreads)
+                .applyExecutorConfig()
                 .transportConfig()
                 .applyTransportConfig()
-                .serverHost(uri.getHost()).serverPort(uri.getPort());
+                .serverHost(uri.getHost())
+                .serverPort(uri.getPort());
 
         if (allowReconnect && connection.isFailoverEnabled()) {
             builder = builder.automaticReconnectWithDefaultConfig();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq;
 
-import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -119,7 +118,7 @@ abstract class AbstractHiveMqttClientFactory {
             final ConnectionLogger connectionLogger,
             final int eventLoopThreads) {
 
-        final URI uri = tunnelStateSupplier.get().getURI(connection);
+        final var uri = tunnelStateSupplier.get().getURI(connection);
 
         T builder = newBuilder;
         if (eventLoopThreads > 0) {
@@ -135,7 +134,6 @@ abstract class AbstractHiveMqttClientFactory {
                 .serverPort(uri.getPort());
 
         if (isSecuredConnection(connection.getProtocol())) {
-
             // create DittoTrustManagerFactory to apply hostname verification
             // or to disable certificate check when the connection requires it
             MqttClientSslConfigBuilder sslConfigBuilder = MqttClientSslConfig.builder()
@@ -165,4 +163,5 @@ abstract class AbstractHiveMqttClientFactory {
     private static boolean isSecuredConnection(final String protocol) {
         return MQTT_SECURE_SCHEMES.contains(protocol.toLowerCase());
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -122,10 +122,14 @@ abstract class AbstractHiveMqttClientFactory {
 
         final URI uri = tunnelStateSupplier.get().getURI(connection);
 
-        T builder = newBuilder
-                .executorConfig()
-                .nettyThreads(eventLoopThreads)
-                .applyExecutorConfig()
+        T builder = newBuilder;
+        if (eventLoopThreads > 0) {
+            builder = builder.executorConfig()
+                    .nettyThreads(eventLoopThreads)
+                    .applyExecutorConfig();
+        }
+
+        builder = builder
                 .transportConfig()
                 .applyTransportConfig()
                 .serverHost(uri.getHost())

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -114,7 +114,6 @@ abstract class AbstractHiveMqttClientFactory {
             final T newBuilder,
             final Connection connection,
             final String identifier,
-            final boolean allowReconnect,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger,
@@ -134,10 +133,6 @@ abstract class AbstractHiveMqttClientFactory {
                 .applyTransportConfig()
                 .serverHost(uri.getHost())
                 .serverPort(uri.getPort());
-
-        if (allowReconnect && connection.isFailoverEnabled()) {
-            builder = builder.automaticReconnectWithDefaultConfig();
-        }
 
         if (isSecuredConnection(connection.getProtocol())) {
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
@@ -252,7 +252,8 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
             if (mqttSpecificConfig.separatePublisherClient()) {
                 final String publisherClientId = resolvePublisherClientId(connection, mqttSpecificConfig);
                 final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
-                final Q createdClient = getClientFactory().newClient(connection, publisherClientId, mqttSpecificConfig,
+                final Q createdClient = getClientFactory().newClient(connection, publisherClientId, mqttConfig,
+                        mqttSpecificConfig,
                         true,
                         true, // this is the publisher client, always respect last will config
                         null, getMqttClientDisconnectedListener(cancelReconnect), connectionLogger);
@@ -292,7 +293,7 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
         final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
         // apply last will config only if *no* separate publisher client is used
         final boolean applyLastWillConfig = !mqttSpecificConfig.separatePublisherClient();
-        final Q createdClient = getClientFactory().newClient(connection, mqttClientId, mqttSpecificConfig,
+        final Q createdClient = getClientFactory().newClient(connection, mqttClientId, mqttConfig, mqttSpecificConfig,
                 true,
                 applyLastWillConfig,
                 null,
@@ -323,7 +324,7 @@ abstract class AbstractMqttClientActor<S, P, Q, R> extends BaseClientActor {
         final Q testClient;
         try {
             testClient =
-                    getClientFactory().newClient(connectionToBeTested, mqttClientId, testMqttSpecificConfig,
+                    getClientFactory().newClient(connectionToBeTested, mqttClientId, mqttConfig, testMqttSpecificConfig,
                             false, false, connectionLogger);
         } catch (final Exception e) {
             return CompletableFuture.completedFuture(new Status.Failure(e.getCause()));

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
@@ -196,7 +196,7 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
 
     private Duration getReconnectForRedeliveryDelayWithLowerBound() {
         final Duration configuredDelay = mqttSpecificConfig.getReconnectForDeliveryDelay();
-        final Duration lowerBound = Duration.ofSeconds(1L);
+        final var lowerBound = Duration.ofSeconds(1L);
         return lowerBound.minus(configuredDelay).isNegative() ? configuredDelay : lowerBound;
     }
 
@@ -253,7 +253,7 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
             createSubscriberClientAndSubscriptionHandler(willSubscribe);
             if (mqttSpecificConfig.separatePublisherClient()) {
                 final String publisherClientId = resolvePublisherClientId(connection, mqttSpecificConfig);
-                final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
+                final var cancelReconnect = new AtomicBoolean(false);
                 final Q createdClient = getClientFactory().newClient(connection, publisherClientId, mqttConfig,
                         mqttSpecificConfig,
                         true, // this is the publisher client, always respect last will config
@@ -296,12 +296,11 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
             } else {
                 final boolean doReconnect = connection.isFailoverEnabled() && !cancelReconnect.get();
                 final long reconnectDelay = retryTimeoutStrategy.getNextTimeout().toMillis();
-                logger.info("Client with role <{}> disconnected, source: <{}> - reconnecting: <{}> with attempt no. <{}> and " +
-                                "delay <{}>ms",
-                        new Object[] {
-                                role, context.getSource(), doReconnect, retryTimeoutStrategy.getCurrentTries(),
-                                reconnectDelay
-                });
+                logger.info("Client with role <{}> disconnected, source: <{}> - reconnecting: <{}> " +
+                                "with current retries of <{}> and delay <{}>ms",
+                        new Object[]{role, context.getSource(), doReconnect, retryTimeoutStrategy.getCurrentTries(),
+                                reconnectDelay}
+                );
                 context.getReconnector()
                         .reconnect(doReconnect)
                         .delay(reconnectDelay, TimeUnit.MILLISECONDS);
@@ -311,7 +310,7 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
 
     private void createSubscriberClientAndSubscriptionHandler(final boolean willSubscribe) {
         final String mqttClientId = resolveMqttClientId(connection, mqttSpecificConfig);
-        final AtomicBoolean cancelReconnect = new AtomicBoolean(false);
+        final var cancelReconnect = new AtomicBoolean(false);
         // apply last will config only if *no* separate publisher client is used
         final boolean applyLastWillConfig = !mqttSpecificConfig.separatePublisherClient();
         final String clientRole = mqttSpecificConfig.separatePublisherClient() ? CONSUMER : CONSUMER + "+" + PUBLISHER;
@@ -433,8 +432,7 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
                 // otherwise return the connection failure directly
                 return connAckFuture;
             }
-        })
-                .exceptionally(InitializationResult::failed);
+        }).exceptionally(InitializationResult::failed);
     }
 
     private CompletableFuture<InitializationResult> sendConnAndExpectConnAck() {
@@ -621,4 +619,5 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
             return disconnectClient(mqttClient);
         }
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
@@ -232,8 +232,8 @@ abstract class AbstractMqttConsumerActor<P> extends BaseConsumerActor {
     private void reject(final ExternalMessage externalMessage, final P publish, final boolean redeliver,
             final ActorRef parent) {
         if (reconnectForRedelivery && redeliver) {
-            inboundAcknowledgedMonitor.exception(externalMessage,
-                    "Restarting connection for redeliveries due to unfulfilled acknowledgements.");
+            inboundAcknowledgedMonitor.exception(externalMessage, "Unfulfilled acknowledgements are " +
+                            "present, restarting consumer client in order to get redeliveries.");
             parent.tell(AbstractMqttClientActor.Control.RECONNECT_CONSUMER_CLIENT, getSelf());
         } else if (!redeliver) {
             // acknowledge messages for which redelivery does not make sense (e.g. 400 bad request or 403 forbidden)
@@ -242,9 +242,13 @@ abstract class AbstractMqttConsumerActor<P> extends BaseConsumerActor {
             inboundAcknowledgedMonitor.exception(externalMessage, "Unfulfilled acknowledgements are " +
                     "present, redelivery was NOT requested - therefore acknowledging the MQTT message!");
         } else {
+            // strictly speaking one should not acknowledge message for which a redelivery was asked for, the MQTT spec
+            //  however does not define that a MQTT broker should redeliver messages if an acknowledgement was not
+            //  received - UNLESS the client reconnects - see option "reconnectForRedelivery" for getting reconnects
+            acknowledge(externalMessage, publish);
             inboundAcknowledgedMonitor.exception(externalMessage, "Unfulfilled acknowledgements are " +
-                    "present, redelivery was requested - NOT acknowledging the MQTT message which should result in" +
-                    "redelivery by the MQTT broker!");
+                    "present, redelivery was requested - however MQTT broker would not redeliver the message without " +
+                    "a reconnect from the client - therefore acknowledging the MQTT message!");
         }
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttConsumerActor.java
@@ -176,7 +176,7 @@ abstract class AbstractMqttConsumerActor<P> extends BaseConsumerActor {
             final ByteBuffer payload = getPayload(message)
                     .map(ByteBuffer::asReadOnlyBuffer)
                     .orElse(ByteBufferUtils.empty());
-            final String textPayload = ByteBufferUtils.toUtf8String(payload);
+            final var textPayload = ByteBufferUtils.toUtf8String(payload);
             final String topic = getTopic(message);
             logger.debug("Received MQTT message on topic <{}>: {}", topic, textPayload);
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 import org.eclipse.ditto.connectivity.service.messaging.tunnel.SshTunnelState;
@@ -49,6 +50,7 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
     @Override
     public Mqtt3AsyncClient newClient(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -56,13 +58,14 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
 
-        return newClientBuilder(connection, identifier, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
-                connectedListener, disconnectedListener, connectionLogger).buildAsync();
+        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect,
+                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
     }
 
     @Override
     public Mqtt3ClientBuilder newClientBuilder(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -72,7 +75,7 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
 
         final Mqtt3ClientBuilder mqtt3ClientBuilder =
                 configureClientBuilder(MqttClient.builder().useMqttVersion3(), connection, identifier, allowReconnect,
-                        connectedListener, disconnectedListener, connectionLogger);
+                        connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
         configureSimpleAuth(mqtt3ClientBuilder.simpleAuth(), connection);
         if (applyLastWillConfig) {
             configureWillPublish(mqtt3ClientBuilder, mqttSpecificConfig);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
@@ -52,13 +52,12 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
 
-        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect,
+        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig,
                 applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
     }
 
@@ -67,14 +66,13 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
 
         final Mqtt3ClientBuilder mqtt3ClientBuilder =
-                configureClientBuilder(MqttClient.builder().useMqttVersion3(), connection, identifier, allowReconnect,
+                configureClientBuilder(MqttClient.builder().useMqttVersion3(), connection, identifier,
                         connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
         configureSimpleAuth(mqtt3ClientBuilder.simpleAuth(), connection);
         if (applyLastWillConfig) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
@@ -17,6 +17,7 @@ import java.util.function.Supplier;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 import org.eclipse.ditto.connectivity.service.messaging.tunnel.SshTunnelState;
@@ -48,6 +49,7 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
     @Override
     public Mqtt5AsyncClient newClient(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -55,13 +57,14 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
 
-        return newClientBuilder(connection, identifier, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
-                connectedListener, disconnectedListener, connectionLogger).buildAsync();
+        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect,
+                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
     }
 
     @Override
     public Mqtt5ClientBuilder newClientBuilder(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -70,7 +73,7 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             final ConnectionLogger connectionLogger) {
         final Mqtt5ClientBuilder mqtt5ClientBuilder =
                 configureClientBuilder(MqttClient.builder().useMqttVersion5(), connection, identifier, allowReconnect,
-                        connectedListener, disconnectedListener, connectionLogger);
+                        connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
         configureSimpleAuth(mqtt5ClientBuilder.simpleAuth(), connection);
         if (applyLastWillConfig) {
             configureWillPublish(mqtt5ClientBuilder, mqttSpecificConfig);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
@@ -51,13 +51,12 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
 
-        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect,
+        return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig,
                 applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
     }
 
@@ -66,13 +65,12 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
         final Mqtt5ClientBuilder mqtt5ClientBuilder =
-                configureClientBuilder(MqttClient.builder().useMqttVersion5(), connection, identifier, allowReconnect,
+                configureClientBuilder(MqttClient.builder().useMqttVersion5(), connection, identifier,
                         connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
         configureSimpleAuth(mqtt5ClientBuilder.simpleAuth(), connection);
         if (applyLastWillConfig) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt3ConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt3ConsumerActor.java
@@ -18,11 +18,11 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.EnforcementFilter;
 import org.eclipse.ditto.connectivity.model.Source;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
-import org.eclipse.ditto.base.model.signals.Signal;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt5ConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqtt5ConsumerActor.java
@@ -21,17 +21,17 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.connectivity.api.EnforcementFactoryFactory;
+import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
 import org.eclipse.ditto.connectivity.model.Enforcement;
 import org.eclipse.ditto.connectivity.model.EnforcementFilter;
 import org.eclipse.ditto.connectivity.model.EnforcementFilterFactory;
 import org.eclipse.ditto.connectivity.model.Source;
-import org.eclipse.ditto.internal.models.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
-import org.eclipse.ditto.connectivity.api.EnforcementFactoryFactory;
-import org.eclipse.ditto.connectivity.api.ExternalMessage;
-import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.internal.models.placeholders.PlaceholderFactory;
 
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5PayloadFormatIndicator;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 
@@ -34,6 +35,7 @@ interface HiveMqttClientFactory<Q, B> {
      *
      * @param connection the connection containing the configuration
      * @param identifier the identifier of the client
+     * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
      * @param allowReconnect whether client can be configured with automatic reconnect enabled, e.g. reconnect must
@@ -46,6 +48,7 @@ interface HiveMqttClientFactory<Q, B> {
      */
     Q newClient(Connection connection,
             String identifier,
+            MqttConfig mqttConfig,
             MqttSpecificConfig mqttSpecificConfig,
             boolean allowReconnect,
             boolean applyLastWillConfig,
@@ -58,6 +61,7 @@ interface HiveMqttClientFactory<Q, B> {
      *
      * @param connection the connection containing the configuration
      * @param identifier the identifier of the client
+     * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
      * @param allowReconnect whether client can be configured with automatic reconnect enabled, e.g. reconnect must
@@ -70,6 +74,7 @@ interface HiveMqttClientFactory<Q, B> {
      */
     B newClientBuilder(Connection connection,
             String identifier,
+            MqttConfig mqttConfig,
             MqttSpecificConfig mqttSpecificConfig,
             boolean allowReconnect,
             boolean applyLastWillConfig,
@@ -82,6 +87,7 @@ interface HiveMqttClientFactory<Q, B> {
      *
      * @param connection the connection containing the configuration
      * @param identifier the identifier of the client
+     * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
      * @param allowReconnect whether client can be configured with automatic reconnect enabled
@@ -91,11 +97,12 @@ interface HiveMqttClientFactory<Q, B> {
      */
     default Q newClient(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
             final ConnectionLogger connectionLogger) {
-        return newClient(connection, identifier, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
+        return newClient(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
                 null, null, connectionLogger);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
@@ -38,8 +38,6 @@ interface HiveMqttClientFactory<Q, B> {
      * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
-     * @param allowReconnect whether client can be configured with automatic reconnect enabled, e.g. reconnect must
-     * be disabled for testing a connection
      * @param applyLastWillConfig whether to apply the last will configuration
      * @param connectedListener the connected listener passed to the created client
      * @param disconnectedListener the disconnected listener passed to the created client
@@ -50,7 +48,6 @@ interface HiveMqttClientFactory<Q, B> {
             String identifier,
             MqttConfig mqttConfig,
             MqttSpecificConfig mqttSpecificConfig,
-            boolean allowReconnect,
             boolean applyLastWillConfig,
             @Nullable MqttClientConnectedListener connectedListener,
             @Nullable MqttClientDisconnectedListener disconnectedListener,
@@ -64,8 +61,6 @@ interface HiveMqttClientFactory<Q, B> {
      * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
-     * @param allowReconnect whether client can be configured with automatic reconnect enabled, e.g. reconnect must
-     * be disabled for testing a connection
      * @param applyLastWillConfig whether to apply the last will configuration
      * @param connectedListener the connected listener passed to the created client
      * @param disconnectedListener the disconnected listener passed to the created client
@@ -76,7 +71,6 @@ interface HiveMqttClientFactory<Q, B> {
             String identifier,
             MqttConfig mqttConfig,
             MqttSpecificConfig mqttSpecificConfig,
-            boolean allowReconnect,
             boolean applyLastWillConfig,
             @Nullable MqttClientConnectedListener connectedListener,
             @Nullable MqttClientDisconnectedListener disconnectedListener,
@@ -90,7 +84,6 @@ interface HiveMqttClientFactory<Q, B> {
      * @param mqttConfig the system's mqttConfig
      * @param mqttSpecificConfig the specific MQTT config to apply based on Ditto config merged with connection
      * specific config
-     * @param allowReconnect whether client can be configured with automatic reconnect enabled
      * @param applyLastWillConfig whether to apply the last will configuration
      * @param connectionLogger the connection logger
      * @return the new client.
@@ -99,10 +92,9 @@ interface HiveMqttClientFactory<Q, B> {
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             final ConnectionLogger connectionLogger) {
-        return newClient(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
+        return newClient(connection, identifier, mqttConfig, mqttSpecificConfig, applyLastWillConfig,
                 null, null, connectionLogger);
     }
 

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -175,11 +175,23 @@ ditto {
         source-buffer-size = 8
         source-buffer-size = ${?CONNECTIVITY_MQTT_SOURCE_BUFFER_SIZE}
 
+        # The number of threads to use for the underlying event loop of the MQTT client.
+        #  When configured to "0", the size is determined based on "the available processor cores * 2".
+        event-loop-threads = 0
+        event-loop-threads = ${?CONNECTIVITY_MQTT_EVENT_LOOP_THREADS}
+
+        ## The following configuration settings are used as defaults for "specificConfic" settings of each created MQTT
+        ##  connection - if not specified otherwise, those defaults are applied.
+
+        # Indicates whether subscriber CONN messages should set clean-session or clean-start flag to true.
+        clean-session = false
+        clean-session = ${?CONNECTIVITY_MQTT_CLEAN_SESSION}
+
         # Indicates whether the client should reconnect to enforce a redelivery for a failed acknowledgement.
         reconnect-for-redelivery = false
         reconnect-for-redelivery = ${?CONNECTIVITY_MQTT_RECONNECT_FOR_REDELIVERY}
 
-        #The amount of time that a reconnect will be delayed after a failed acknowledgement
+        # The amount of time that a reconnect will be delayed after a failed acknowledgement
         reconnect-for-redelivery-delay = 2s
         reconnect-for-redelivery-delay = ${?CONNECTIVITY_MQTT_RECONNECT_FOR_REDELIVERY_DELAY}
 

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -192,7 +192,7 @@ ditto {
         reconnect-for-redelivery = ${?CONNECTIVITY_MQTT_RECONNECT_FOR_REDELIVERY}
 
         # The amount of time that a reconnect will be delayed after a failed acknowledgement
-        reconnect-for-redelivery-delay = 2s
+        reconnect-for-redelivery-delay = 10s
         reconnect-for-redelivery-delay = ${?CONNECTIVITY_MQTT_RECONNECT_FOR_REDELIVERY_DELAY}
 
         # Indicates whether a separate client should be used for publishing. This could be useful when

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -199,6 +199,16 @@ ditto {
         # reconnect-for-redelivery is set to true to avoid that the publisher has downtimes.
         separate-publisher-client = false
         separate-publisher-client = ${?CONNECTIVITY_MQTT_SEPARATE_PUBLISHER_CLIENT}
+
+        reconnect.backoff.timeout {
+          # the minimum timeout for MQTT client reconnections - "0s" reconnects immediately
+          min-timeout = 0s
+          min-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MIN}
+
+          # the maximum timeout, once expontential backoff reached this max, the max is used instead
+          max-timeout = 1m
+          max-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MAX}
+        }
       }
 
       http-push {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt3ClientFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt3ClientFactory.java
@@ -31,6 +31,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 import org.mockito.Mockito;
@@ -103,6 +104,7 @@ class MockHiveMqtt3ClientFactory implements HiveMqtt3ClientFactory {
     @Override
     public Mqtt3AsyncClient newClient(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean reconnect,
             final boolean applyLastWillConfig,
@@ -174,6 +176,7 @@ class MockHiveMqtt3ClientFactory implements HiveMqtt3ClientFactory {
     @Override
     public Mqtt3ClientBuilder newClientBuilder(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -181,7 +184,7 @@ class MockHiveMqtt3ClientFactory implements HiveMqtt3ClientFactory {
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
         final Mqtt3Client client =
-                newClient(connection, identifier, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
+                newClient(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
                         connectedListener, disconnectedListener, connectionLogger);
         final Mqtt3ClientBuilder builder = Mockito.mock(Mqtt3ClientBuilder.class);
         Mockito.doReturn(client).when(builder).build();

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
@@ -44,6 +44,7 @@ import com.hivemq.client.mqtt.lifecycle.MqttClientDisconnectedListener;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5AsyncClient;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
 import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientConfig;
 import com.hivemq.client.mqtt.mqtt5.advanced.Mqtt5ClientAdvancedConfigBuilder;
 import com.hivemq.client.mqtt.mqtt5.advanced.interceptor.Mqtt5ClientInterceptorsBuilder;
 import com.hivemq.client.mqtt.mqtt5.lifecycle.Mqtt5ClientConnectedContext;
@@ -109,7 +110,6 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean reconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
@@ -133,7 +133,9 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
         when(client.connectWith()).thenReturn(send);
         when(send.send()).then(invocation -> {
             if (connectedListener != null) {
-                connectedListener.onConnected(mock(Mqtt5ClientConnectedContext.class));
+                final Mqtt5ClientConnectedContext mock = mock(Mqtt5ClientConnectedContext.class);
+                when(mock.getClientConfig()).thenReturn(mock(Mqtt5ClientConfig.class));
+                connectedListener.onConnected(mock);
             }
 
             // remember which clients are connected to verify disconnect later
@@ -181,13 +183,12 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
             final String identifier,
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
-            final boolean allowReconnect,
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
         final Mqtt5Client client =
-                newClient(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
+                newClient(connection, identifier, mqttConfig, mqttSpecificConfig, applyLastWillConfig,
                         connectedListener, disconnectedListener, connectionLogger);
         final Mqtt5ClientBuilder builder = Mockito.mock(Mqtt5ClientBuilder.class);
         final Mqtt5ClientAdvancedConfigBuilder.Nested<Mqtt5ClientBuilder> advancedConfig =

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
@@ -32,6 +32,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nullable;
 
 import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.MqttConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLogger;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.MqttSpecificConfig;
 import org.mockito.Mockito;
@@ -106,6 +107,7 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
     @Override
     public Mqtt5AsyncClient newClient(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean reconnect,
             final boolean applyLastWillConfig,
@@ -177,6 +179,7 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
     @Override
     public Mqtt5ClientBuilder newClientBuilder(final Connection connection,
             final String identifier,
+            final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean allowReconnect,
             final boolean applyLastWillConfig,
@@ -184,7 +187,7 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
             final ConnectionLogger connectionLogger) {
         final Mqtt5Client client =
-                newClient(connection, identifier, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
+                newClient(connection, identifier, mqttConfig, mqttSpecificConfig, allowReconnect, applyLastWillConfig,
                         connectedListener, disconnectedListener, connectionLogger);
         final Mqtt5ClientBuilder builder = Mockito.mock(Mqtt5ClientBuilder.class);
         final Mqtt5ClientAdvancedConfigBuilder.Nested<Mqtt5ClientBuilder> advancedConfig =

--- a/documentation/src/main/resources/pages/ditto/basic-connections.md
+++ b/documentation/src/main/resources/pages/ditto/basic-connections.md
@@ -166,7 +166,7 @@ acknowledgements are only requested if the "qos" header was either not present o
       "twin-persisted",
       "receiver-connection-id:my-custom-ack"
     ],
-    "filter": "fn:filter(header:qos,'ne',0)"
+    "filter": "fn:filter(header:qos,'ne','0')"
   }
 }
 ```

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
@@ -95,6 +95,25 @@ For Ditto acknowledgements with mixed successful/failed [status](protocol-specif
 * If none of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery:
    * acknowledges the received MQTT 3.1.1 message as redelivery does not make sense
 
+In order to enable acknowledgement processing only for MQTT messages received with QoS 1/2, the following configuration
+has to be applied:  
+```json
+{
+  "addresses": [
+    "<mqtt_topic>",
+    "..."
+  ],
+  "authorizationContext": [
+    "ditto:inbound-auth-subject",
+    "..."
+  ],
+  "qos": 1,
+  "acknowledgementRequests": {
+    "includes": [],
+    "filter": "fn:filter(header:mqtt.qos,'ne','0')"
+  }
+}
+```
 
 ### Target format
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
@@ -209,11 +209,9 @@ Default: not set - the ID of the Ditto [connection](basic-connections.html) is u
 
 Configures that the MQTT connection re-connects whenever a consumed message (via a connection source) with QoS 1 
 ("at least once") or 2 ("exactly once")
-is processed but cannot be [acknowledged](#source-acknowledgement-handling) successfully.<br/>
+is processed but cannot be [acknowledged](#source-acknowledgement-handling) successfully.   
 That causes that the MQTT broker will re-publish the message once the connection reconnected.   
-If configured to `false`, the MQTT message is 
-* either simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`) if redelivery was not required.
-* or simply not acknowledged if redelivery was required.
+If configured to `false`, the MQTT message is simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`).
 
 Default: `false`
 
@@ -222,7 +220,9 @@ Handle with care:
 * when set to `true` and there is also an MQTT target configured to publish messages,
   the messages to be published during the reconnection phase are lost
    * to fix that, configure `"separatePublisherClient"` also to `true` in order to publish via another MQTT connection
-* when set to `false`, MQTT messages with QoS 1 and 2 are redelivered based on the MQTT broker's strategy (e.g. how long to wait until a message is redelivered)
+* when set to `false`, MQTT messages with QoS 1 and 2 are redelivered based on the MQTT broker's strategy, 
+  but may not be redelivered at all as the MQTT specification does not require unacknowledged messages to be redelivered
+  without reconnection of the client
 
 #### cleanSession
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt.md
@@ -41,9 +41,8 @@ For an MQTT connection:
 * Source `"addresses"` are MQTT topics to subscribe to. Wildcards `+` and `#` are allowed.
 * `"authorizationContext"` may _not_ contain placeholders `{%raw%}{{ header:<header-name> }}{%endraw%}` as MQTT 3.1.1
   has no application headers.
-* The optional field `"qos"` sets the maximum Quality of Service to request when subscribing for messages. Its value
+* The required field `"qos"` sets the maximum Quality of Service to request when subscribing for messages. Its value
   can be `0` for at-most-once delivery, `1` for at-least-once delivery and `2` for exactly-once delivery.
-  The default value is `2` (exactly-once).
   Support of any Quality of Service depends on the external MQTT broker; [AWS IoT][awsiot] for example does not
   acknowledge subscriptions with `qos=2`.
 
@@ -91,8 +90,8 @@ For Ditto acknowledgements with successful [status](protocol-specification-acks.
 For Ditto acknowledgements with mixed successful/failed [status](protocol-specification-acks.html#combined-status-code):
 * If some of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery (e.g. based on a timeout):
    * based on the [specificConfig](#specific-configuration) [reconnectForDelivery](#reconnectforredelivery) either 
-      * closes and reconnects the MQTT connection in order to receive unACKed QoS 1/2 messages again 
-      * or simply acknowledges the received MQTT 3.1.1 message
+      * closes and reconnects the MQTT connection in order to immediately receive unACKed QoS 1/2 messages again 
+      * or simply doesn't acknowledge the received MQTT 3.1.1 message resulting in a redelivery of a QoS > 0 message by the MQTT broker
 * If none of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery:
    * acknowledges the received MQTT 3.1.1 message as redelivery does not make sense
 
@@ -112,8 +111,6 @@ has READ permission on the thing, which is associated with a message.
 The additional field `"qos"` sets the Quality of Service with which messages are published.
 Its value can be `0` for at-most-once delivery, `1` for at-least-once delivery and `2` for exactly-once delivery.
 Support of any Quality of Service depends on the external MQTT broker.
-The default value is `0` (at-most-once).
-
 
 ```json
 {
@@ -168,9 +165,9 @@ Overall example JSON of the MQTT `"specificConfig"`:
   "uri": "tcp://test.mosquitto.org:1883",
   "specificConfig": {
     "clientId": "my-awesome-mqtt-client-id",
-    "reconnectForRedelivery": true,
+    "reconnectForRedelivery": false,
     "cleanSession": false,
-    "separatePublisherClient": true,
+    "separatePublisherClient": false,
     "publisherId": "my-awesome-mqtt-publisher-client-id",
     "reconnectForRedeliveryDelay": "5s",
     "lastWillTopic": "my/last/will/topic",
@@ -195,31 +192,34 @@ Configures that the MQTT connection re-connects whenever a consumed message (via
 ("at least once") or 2 ("exactly once")
 is processed but cannot be [acknowledged](#source-acknowledgement-handling) successfully.<br/>
 That causes that the MQTT broker will re-publish the message once the connection reconnected.   
-If configured to `false`, the MQTT message is simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`).
+If configured to `false`, the MQTT message is 
+* either simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`) if redelivery was not required.
+* or simply not acknowledged if redelivery was required.
 
-Default: `true`
+Default: `false`
 
 Handle with care: 
 * when set to `true`, incoming QoS 0 messages are lost during the reconnection phase
 * when set to `true` and there is also an MQTT target configured to publish messages,
   the messages to be published during the reconnection phase are lost
    * to fix that, configure `"separatePublisherClient"` also to `true` in order to publish via another MQTT connection
-* when set to `false`, MQTT messages with QoS 1 and 2 could get lost (e.g. during downtime or connection issues)
+* when set to `false`, MQTT messages with QoS 1 and 2 are redelivered based on the MQTT broker's strategy (e.g. how long to wait until a message is redelivered)
 
 #### cleanSession
 
 Configure the MQTT client's `cleanSession` flag.
 
-Default: the negation of `"reconnectForRedelivery"`
+Default: `false`
 
 #### separatePublisherClient
 
-Configures whether to create a separate physical client and connection to the MQTT broker for publishing messages, or not. 
-By default (configured true), a single Ditto connection would open 2 MQTT connections/sessions: one for subscribing 
-and one for publishing. If configured to `false`, the same MQTT connection/session is used both: for subscribing to 
-messages, and for publishing messages.
+Configures whether to create a separate physical client and connection to the MQTT broker for publishing messages, or not.
+If configured to `true`, a single Ditto connection would open 2 MQTT connections/sessions: one for subscribing
+and one for publishing.  
+If configured to `false`, the same MQTT connection/session is used both: for subscribing to messages, and for publishing
+messages.
 
-Default: `true`
+Default: `false`
 
 #### publisherId
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
@@ -218,9 +218,7 @@ ID connects.
 Configures that the MQTT connection re-connects whenever a consumed message (via a connection source) with QoS 1 
 ("at least once") 2 ("exactly once") is processed but cannot be [acknowledged](#source-acknowledgement-handling) successfully.<br/>
 That causes that the MQTT broker will re-publish the message once the connection reconnected.   
-If configured to `false`, the MQTT message is 
-* either simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`) if redelivery was not required.
-* or simply not acknowledged if redelivery was required.
+If configured to `false`, the MQTT message is simply acknowledged (`PUBACK` or `PUBREC`, `PUBREL`).
 
 Default: `false`
 
@@ -229,7 +227,9 @@ Handle with care:
 * when set to `true` and there is also an MQTT target configured to publish messages,
   the messages to be published during the reconnection phase are lost
    * to fix that, configure `"separatePublisherClient"` also to `true` in order to publish via another MQTT connection
-* when set to `false`, MQTT messages with QoS 1 and 2 are redelivered based on the MQTT broker's strategy (e.g. how long to wait until a message is redelivered)
+* when set to `false`, MQTT messages with QoS 1 and 2 are redelivered based on the MQTT broker's strategy,
+  but may not be redelivered at all as the MQTT specification does not require unacknowledged messages to be redelivered
+  without reconnection of the client
 
 #### cleanSession
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-mqtt5.md
@@ -98,6 +98,25 @@ For Ditto acknowledgements with mixed successful/failed [status](protocol-specif
 * If none of the aggregated [acknowledgements](basic-acknowledgements.html#acknowledgements-acks) require redelivery:
    * acknowledges the received MQTT 5 message as redelivery does not make sense
 
+In order to enable acknowledgement processing only for MQTT messages received with QoS 1/2, the following configuration
+has to be applied:
+```json
+{
+  "addresses": [
+    "<mqtt_topic>",
+    "..."
+  ],
+  "authorizationContext": [
+    "ditto:inbound-auth-subject",
+    "..."
+  ],
+  "qos": 1,
+  "acknowledgementRequests": {
+    "includes": [],
+    "filter": "fn:filter(header:mqtt.qos,'ne','0')"
+  }
+}
+```
 
 ### Target format
 


### PR DESCRIPTION
* when "reconnectForRedelivery=false", sucessful MQTT ACKs are issued even when a redelivery of the message is expected -> kept this behavior as this is the only mechanism MQTT provides in order to provide message re-deliveries
* made "cleanSession" config not to be based on "reconnectForRedelivery" value - apply a default of "false", but make the default configurable in connectivity.conf
* added a new "event-loop-threads" option configuring the used HiveMQTT client to use a fixed amount of netty event-loop threads instead of having them dynamically calculcated by default based on the processor count
* reworked the manual re-connection in order to be super-fast (should be <5ms now for local MQTT broker), don't create the complete MQTT connection again, but reconnect the already instantiated client
* made min and max reconnection delays configurable, apply exponential backoff for manual reconnects
* adjusted MQTT docs