### PR TITLE
Several logging adjustments

### DIFF
--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ClientCertificateCredentials.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ClientCertificateCredentials.java
@@ -85,7 +85,7 @@ public final class ClientCertificateCredentials implements Credentials {
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "clientCertificate=" + clientCertificate +
-                ", clientKey=" + clientKey +
+                ", clientKey=***" + // clientKey omitted intentionally
                 "]";
     }
 

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/SshPublicKeyCredentials.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/SshPublicKeyCredentials.java
@@ -94,7 +94,7 @@ public final class SshPublicKeyCredentials implements Credentials {
         return getClass().getSimpleName() + " [" +
                 "username=" + username +
                 ", publicKey=" + publicKey +
-                // private key omitted intentionally
+                ", privateKey=***" + // private key omitted intentionally
                 "]";
     }
 

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/UserPasswordCredentials.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/UserPasswordCredentials.java
@@ -80,7 +80,7 @@ public final class UserPasswordCredentials implements Credentials {
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "username=" + username +
-                ", password=" + password +
+                ", password=***" + // password omitted intentionally
                 "]";
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ResponseCollectorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ResponseCollectorActor.java
@@ -19,11 +19,11 @@ import java.util.stream.Collectors;
 
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
-import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
-import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.messages.model.signals.commands.MessageCommandResponse;
+import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommandResponse;
 
 import akka.actor.AbstractActor;
@@ -164,9 +164,9 @@ public final class ResponseCollectorActor extends AbstractActor {
 
         @Override
         public String toString() {
-            return getClass().getSimpleName() +
-                    "[expectedCount=" + expectedCount +
-                    ",commandResponses=" + commandResponses +
+            return getClass().getSimpleName() + "[" +
+                    "expectedCount=" + expectedCount +
+                    ", commandResponses=" + commandResponses +
                     "]";
         }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtValidator.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DefaultJwtValidator.java
@@ -19,9 +19,9 @@ import java.util.concurrent.CompletableFuture;
 import javax.annotation.concurrent.ThreadSafe;
 
 import org.eclipse.ditto.base.model.common.BinaryValidationResult;
-import org.eclipse.ditto.jwt.model.JsonWebToken;
-import org.eclipse.ditto.internal.utils.jwt.JjwtDeserializer;
 import org.eclipse.ditto.base.model.signals.commands.exceptions.GatewayAuthenticationFailedException;
+import org.eclipse.ditto.internal.utils.jwt.JjwtDeserializer;
+import org.eclipse.ditto.jwt.model.JsonWebToken;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,7 +71,8 @@ public final class DefaultJwtValidator implements JwtValidator {
         try {
             return validateWithPublicKey(jsonWebToken, publicKey);
         } catch (final Exception e) {
-            LOGGER.info("Failed to parse JWT!", e);
+            LOGGER.info("Failed to parse/validate JWT due to <{}> with message: <{}>", e.getClass().getSimpleName(),
+                    e.getMessage());
             return BinaryValidationResult.invalid(e);
         }
     }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -33,21 +33,7 @@ import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
-import org.eclipse.ditto.policies.model.Label;
-import org.eclipse.ditto.policies.model.Policy;
-import org.eclipse.ditto.policies.model.PolicyEntry;
-import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.policies.model.PolicyLifecycle;
-import org.eclipse.ditto.policies.model.Subject;
-import org.eclipse.ditto.policies.model.SubjectAnnouncement;
-import org.eclipse.ditto.policies.model.SubjectExpiry;
-import org.eclipse.ditto.policies.model.SubjectId;
-import org.eclipse.ditto.policies.model.Subjects;
-import org.eclipse.ditto.policies.api.PolicyTag;
-import org.eclipse.ditto.policies.service.common.config.DittoPoliciesConfig;
-import org.eclipse.ditto.policies.service.common.config.PolicyConfig;
-import org.eclipse.ditto.policies.service.persistence.actors.strategies.commands.PolicyCommandStrategies;
-import org.eclipse.ditto.policies.service.persistence.actors.strategies.events.PolicyEventStrategies;
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.persistence.SnapshotAdapter;
@@ -58,12 +44,26 @@ import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrateg
 import org.eclipse.ditto.internal.utils.persistentactors.commands.DefaultContext;
 import org.eclipse.ditto.internal.utils.persistentactors.events.EventStrategy;
 import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
+import org.eclipse.ditto.policies.api.PolicyTag;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyLifecycle;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectAnnouncement;
+import org.eclipse.ditto.policies.model.SubjectExpiry;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.policies.model.signals.announcements.SubjectDeletionAnnouncement;
-import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAccessibleException;
 import org.eclipse.ditto.policies.model.signals.events.PolicyEvent;
 import org.eclipse.ditto.policies.model.signals.events.SubjectDeleted;
+import org.eclipse.ditto.policies.service.common.config.DittoPoliciesConfig;
+import org.eclipse.ditto.policies.service.common.config.PolicyConfig;
+import org.eclipse.ditto.policies.service.persistence.actors.strategies.commands.PolicyCommandStrategies;
+import org.eclipse.ditto.policies.service.persistence.actors.strategies.events.PolicyEventStrategies;
 
 import akka.actor.ActorRef;
 import akka.actor.Props;
@@ -424,20 +424,25 @@ public final class PolicyPersistenceActor
     private void sendPastDueAnnouncementsOfNewSubjects(@Nullable final Policy previousPolicy,
             @Nullable final Policy nextPolicy) {
 
-        final Set<Subject> previousSubjectIds =
-                streamAndFlatMapSubjects(previousPolicy, Optional::of).collect(Collectors.toSet());
-        final Stream<Subject> newSubjectsWithPastDueAnnouncements = streamAndFlatMapSubjects(nextPolicy,
-                subject -> {
-                    final var pastDue = getAnnouncementInstant(subject)
-                            .filter(instant -> !lastAnnouncement.isBefore(instant))
-                            .isPresent();
-                    if (pastDue && !previousSubjectIds.contains(subject)) {
-                        return Optional.of(subject);
-                    } else {
-                        return Optional.empty();
-                    }
-                });
-        publishExpiryAnnouncementsByTimestamp(newSubjectsWithPastDueAnnouncements);
+        // this only makes sense for previously existing policies:
+        if (null != previousPolicy &&
+                previousPolicy.getLifecycle().filter(PolicyLifecycle.DELETED::equals).isPresent()) {
+
+            final Set<Subject> previousSubjectIds =
+                    streamAndFlatMapSubjects(previousPolicy, Optional::of).collect(Collectors.toSet());
+            final Stream<Subject> newSubjectsWithPastDueAnnouncements = streamAndFlatMapSubjects(nextPolicy,
+                    subject -> {
+                        final var pastDue = getAnnouncementInstant(subject)
+                                .filter(instant -> !lastAnnouncement.isBefore(instant))
+                                .isPresent();
+                        if (pastDue && !previousSubjectIds.contains(subject)) {
+                            return Optional.of(subject);
+                        } else {
+                            return Optional.empty();
+                        }
+                    });
+            publishExpiryAnnouncementsByTimestamp(newSubjectsWithPastDueAnnouncements);
+        }
     }
 
     private static Duration truncateToOneDay(final Duration duration) {


### PR DESCRIPTION
* reduce logging of JWT parsing/validation errors to not contain stacktrace - fixes #1073
* don't log secrets by using asterisk in *Credentials implementations
* don't log empty `"Sending announcements for <{}>"` by doing the policy expiry announcement sending only for already existing, non-deleted policies