### PR TITLE
Fix mounting of ditto log files on host

### DIFF
--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -49,7 +49,7 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>concierge.log</file>
+                <file>/var/log/ditto/concierge.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern>concierge.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->

--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/concierge.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>concierge.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/connectivity.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>connectivity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/connectivity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -49,7 +49,7 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>connectivity.log</file>
+                <file>/var/log/ditto/connectivity.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern>connectivity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
        TZ: Europe/Berlin
 
   policies:
-    image: docker.io/eclipse/ditto-policies:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/policies:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -37,12 +37,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
       - MONGO_DB_HOSTNAME=mongodb
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
     # Set additional configuration options here
     # -Dditto.policies...
     command: java -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    # volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   things:
-    image: docker.io/eclipse/ditto-things:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/things:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -56,12 +62,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
       - MONGO_DB_HOSTNAME=mongodb
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
     # Set additional configuration options here
     # -Dditto.things...
     command: java -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    # volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   things-search:
-    image: docker.io/eclipse/ditto-things-search:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/thing-search:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -75,12 +87,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
       - MONGO_DB_HOSTNAME=mongodb
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
     # Set additional configuration options here
     # -Dditto.things-search...
     command: java -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    # volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   concierge:
-    image: docker.io/eclipse/ditto-concierge:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/concierge:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -94,12 +112,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
       - MONGO_DB_HOSTNAME=mongodb
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
     # Set additional configuration options here
     # -Dditto.concierge...
     command: java -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    # volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   connectivity:
-    image: docker.io/eclipse/ditto-connectivity:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/connectivity:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -114,12 +138,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
       - MONGO_DB_HOSTNAME=mongodb
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
     # Set additional configuration options here
     # -Dditto.connectivity...
     command: java -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    #volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   gateway:
-    image: docker.io/eclipse/ditto-gateway:${DITTO_VERSION:-latest}
+    image: thingsdev.azurecr.io/eclipse-ditto/gateway:${DITTO_VERSION:-latest}
     mem_limit: 384m
     networks:
       default:
@@ -136,12 +166,18 @@ services:
       - BIND_HOSTNAME=0.0.0.0
       - ENABLE_PRE_AUTHENTICATION=true
       - OPENJ9_JAVA_OPTIONS=-XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s
+      # in order to write logs into a file you can enable this by setting the following env variable
+      # the log file(s) can be found in /var/log/ditto directory on the host machine
+      # - DITTO_LOGGING_FILE_APPENDER=true
       # You may use the environment for setting the devops password
       #- DEVOPS_PASSWORD=foobar
     # Set additional configuration options here
     # -Dditto.gateway...
     # Setting the devops password via java VM environment
     command: java -Dditto.gateway.authentication.devops.password=foobar -jar starter.jar
+    # only needed if DITTO_LOGGING_FILE_APPENDER is set
+    # volumes:
+    #  - ditto_log_files:/var/log/ditto
 
   swagger-ui:
     image: docker.io/swaggerapi/swagger-ui:v3.38.0
@@ -164,3 +200,11 @@ services:
     depends_on:
       - gateway
       - swagger-ui
+
+volumes:
+  ditto_log_files:
+    driver: local
+    driver_opts:
+      type: none
+      device: /var/log/ditto
+      o: bind,uid=1000,gid=1000

--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -25,8 +25,8 @@ services:
        TZ: Europe/Berlin
 
   policies:
-    image: thingsdev.azurecr.io/eclipse-ditto/policies:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-policies:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:
@@ -48,8 +48,8 @@ services:
     #  - ditto_log_files:/var/log/ditto
 
   things:
-    image: thingsdev.azurecr.io/eclipse-ditto/things:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-things:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:
@@ -73,8 +73,8 @@ services:
     #  - ditto_log_files:/var/log/ditto
 
   things-search:
-    image: thingsdev.azurecr.io/eclipse-ditto/thing-search:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-things-search:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:
@@ -98,8 +98,8 @@ services:
     #  - ditto_log_files:/var/log/ditto
 
   concierge:
-    image: thingsdev.azurecr.io/eclipse-ditto/concierge:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-concierge:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:
@@ -123,8 +123,8 @@ services:
     #  - ditto_log_files:/var/log/ditto
 
   connectivity:
-    image: thingsdev.azurecr.io/eclipse-ditto/connectivity:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-connectivity:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:
@@ -149,8 +149,8 @@ services:
     #  - ditto_log_files:/var/log/ditto
 
   gateway:
-    image: thingsdev.azurecr.io/eclipse-ditto/gateway:${DITTO_VERSION:-latest}
-    mem_limit: 384m
+    image: docker.io/eclipse/ditto-gateway:${DITTO_VERSION:-latest}
+    mem_limit: 512m
     networks:
       default:
         aliases:

--- a/deployment/kubernetes/README.md
+++ b/deployment/kubernetes/README.md
@@ -78,7 +78,7 @@ Ditto uses the `latest` tag for its images. If you want to use a different versi
 ```bash
 kubectl apply -f deployment/kubernetes/deploymentFiles/ditto/
 # Start ditto services with an alternative version e.g. 0-SNAPSHOT
-# cat deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml | sed s/latest/2.0.1/ | kubectl apply -f -
+# cat deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml | sed s/latest/0-SNAPSHOT/ | kubectl apply -f -
 ```
 
 #### Start Swagger UI

--- a/deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml
+++ b/deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml
@@ -31,13 +31,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "512Mi"
-          limits:
-            # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "2Gi"
+        #resources:
+        #  requests:
+        #    cpu: "1"
+        #    memory: "512Mi"
+        #  limits:
+        #    # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto
@@ -132,13 +132,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "1Gi"
-          limits:
-            # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "4Gi"
+        #resources:
+        #  requests:
+        #    cpu: "1"
+        #    memory: "1Gi"
+        #  limits:
+        #    # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "4Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto
@@ -233,13 +233,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "1Gi"
-          limits:
-            # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "4Gi"
+        #resources:
+        #  requests:
+        #    cpu: "1"
+        #    memory: "1Gi"
+        #  limits:
+        #    # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "4Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto
@@ -334,13 +334,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "512Mi"
-          limits:
-            # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "2Gi"
+        #resources:
+        #  requests:
+        #    cpu: "1"
+        #    memory: "512Mi"
+        #  limits:
+        #    # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto
@@ -435,13 +435,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "1Gi"
-          limits:
-            # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "2Gi"
+        #resources:
+        #  requests:
+        #    cpu: "1"
+        #    memory: "1Gi"
+        #  limits:
+        #    # cpu: "" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto
@@ -535,13 +535,13 @@ spec:
         imagePullPolicy: IfNotPresent
         args: ["java", "-jar", "starter.jar"]
         # Resource can be managed by setting the following resource config.
-        resources:
-          requests:
-            cpu: "1"
-            memory: "512Mi"
-          limits:
-            # cpu: "{{ item.cpus }}" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
-            memory: "2Gi"
+        #resources:
+        #  requests:
+        #   cpu: "1"
+        #   memory: "512Mi"
+        #  limits:
+        #    # cpu: "{{ item.cpus }}" no cpu limit to avoid CFS scheduler limits see https://doc.akka.io/docs/akka/snapshot/additional/deploy.html#in-kubernetes
+        #    memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
             mountPath: /var/log/ditto

--- a/deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml
+++ b/deployment/kubernetes/deploymentFiles/ditto/ditto-cluster.yaml
@@ -22,6 +22,8 @@ spec:
         app: concierge
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
       restartPolicy: Always
       containers:
       - name: concierge
@@ -38,7 +40,7 @@ spec:
             memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -87,7 +89,7 @@ spec:
         #      key: mongodb-uri
         ### -
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:
@@ -121,6 +123,8 @@ spec:
         app: connectivity
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
       restartPolicy: Always
       containers:
       - name: connectivity
@@ -137,7 +141,7 @@ spec:
             memory: "4Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -186,7 +190,7 @@ spec:
         #      key: mongodb-uri
         ### -
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:
@@ -220,6 +224,8 @@ spec:
         app: things
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
       restartPolicy: Always
       containers:
       - name: things
@@ -236,7 +242,7 @@ spec:
             memory: "4Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -285,7 +291,7 @@ spec:
         #      key: mongodb-uri
         ### -
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:
@@ -319,6 +325,9 @@ spec:
         app: things-search
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
+      restartPolicy: Always
       containers:
       - name: things-search
         image: docker.io/eclipse/ditto-things-search:latest
@@ -334,7 +343,7 @@ spec:
             memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -383,7 +392,7 @@ spec:
         #      key: mongodb-uri
         ### -
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:
@@ -417,6 +426,9 @@ spec:
         app: policies
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
+      restartPolicy: Always
       containers:
       - name: policies
         image: docker.io/eclipse/ditto-policies:latest
@@ -432,7 +444,7 @@ spec:
             memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -480,7 +492,7 @@ spec:
         #      name: mongodb
         #      key: mongodb-uri
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:
@@ -514,6 +526,9 @@ spec:
         app: gateway
         actorSystemName: ditto-cluster
     spec:
+      securityContext:
+        fsGroup: 1000
+      restartPolicy: Always
       containers:
       - name: gateway
         image: docker.io/eclipse/ditto-gateway:latest
@@ -529,7 +544,7 @@ spec:
             memory: "2Gi"
         volumeMounts:
           - name: ditto-log-files
-            mountPath: /opt/ditto
+            mountPath: /var/log/ditto
         ports:
         - name: remoting
           containerPort: 2551
@@ -571,7 +586,7 @@ spec:
         - name: OPENJ9_JAVA_OPTIONS
           value: "-Xgcpolicy:gencon -Xgc:concurrentScavenge -XX:+IdleTuningGcOnIdle -XX:+ExitOnOutOfMemoryError -Xtune:virtualized -Xss512k -XX:MaxRAMPercentage=80 -Dakka.coordinated-shutdown.exit-jvm=on -Dakka.cluster.shutdown-after-unsuccessful-join-seed-nodes=120s"
         # in order to write logs into a file you can enable this by setting the following env variable
-        # the log file(s) can be found in /opt/ditto directory on the host machine
+        # the log file(s) can be found in /var/log/ditto directory on the host machine
         #- name: DITTO_LOGGING_FILE_APPENDER
         #  value: "true"
       volumes:

--- a/dockerfile-release
+++ b/dockerfile-release
@@ -17,7 +17,8 @@ ARG SERVICE_VERSION
 
 ENV HTTP_PORT=8080 \
     HOSTING_ENVIRONMENT=Docker \
-    DITTO_HOME=/opt/ditto
+    DITTO_HOME=/opt/ditto \
+    DITTO_LOGS=/var/log/ditto
 
 # Http port
 EXPOSE 8080
@@ -33,6 +34,8 @@ RUN set -x \
     && wget -q --show-progress -O ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar "${MAVEN_REPO}?r=ditto&g=org.eclipse.ditto&a=${SERVICE_STARTER}&v=${SERVICE_VERSION}&c=allinone" \
     && ln -s ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar starter.jar \
     && chown -R ditto:ditto $DITTO_HOME \
+    && cd $DITTO_LOGS \
+    && chown -R ditto:ditto $DITTO_LOGS \
     && apk del .tmp-deps
 
 USER ditto

--- a/dockerfile-snapshot
+++ b/dockerfile-snapshot
@@ -17,12 +17,13 @@ ARG SERVICE_VERSION
 
 ENV HTTP_PORT=8080 \
     HOSTING_ENVIRONMENT=Docker \
-    DITTO_HOME=/opt/ditto
+    DITTO_HOME=/opt/ditto \
+    DITTO_LOGS=/var/log/ditto
 
 # Http port
 EXPOSE 8080
 
-RUN mkdir -p $DITTO_HOME
+RUN mkdir -p $DITTO_HOME && mkdir -p $DITTO_LOGS
 
 RUN set -x \
     && apk upgrade --update-cache \
@@ -33,6 +34,8 @@ RUN set -x \
     && cd $DITTO_HOME \
     && ln -s ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar starter.jar \
     && chown -R ditto:ditto $DITTO_HOME \
+    && cd $DITTO_LOGS \
+    && chown -R ditto:ditto $DITTO_LOGS \
     && apk del .tmp-deps
 
 USER ditto

--- a/dockerfile-snapshot-arm64
+++ b/dockerfile-snapshot-arm64
@@ -17,7 +17,8 @@ ARG SERVICE_VERSION
 
 ENV HTTP_PORT=8080 \
     HOSTING_ENVIRONMENT=Docker \
-    DITTO_HOME=/opt/ditto
+    DITTO_HOME=/opt/ditto \
+    DITTO_LOGS=/var/log/ditto
 
 # Http port
 EXPOSE 8080
@@ -33,6 +34,8 @@ RUN set -x \
     && cd $DITTO_HOME \
     && ln -s ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar starter.jar \
     && chown -R ditto:ditto $DITTO_HOME \
+    && cd $DITTO_LOGS \
+    && chown -R ditto:ditto $DITTO_LOGS \
     && yum remove -y wget
 
 USER ditto

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/gateway.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>gateway.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/gateway.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -49,15 +49,15 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>connectivity.log</file>
+                <file>/var/log/ditto/gateway.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>connectivity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>gateway.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
-                    <customFields>{"appname":"connectivity","instance_index":"${INSTANCE_INDEX}"}</customFields>
+                    <customFields>{"appname":"gateway","instance_index":"${INSTANCE_INDEX}"}</customFields>
                 </encoder>
             </appender>
         </then>

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -49,7 +49,7 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>policies.log</file>
+                <file>/var/log/ditto/policies.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern>policies.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/policies.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>policies.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/policies.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/things.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>things.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/things.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -49,7 +49,7 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>things.log</file>
+                <file>/var/log/ditto/things.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern>things.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -49,7 +49,7 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>thing-search.log</file>
+                <file>/var/log/ditto/thing-search.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <fileNamePattern>thing-search.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -51,7 +51,7 @@
                 </filter>
                 <file>/var/log/ditto/thing-search.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>thing-search.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <fileNamePattern>/var/log/ditto/thing-search.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
                     <!-- Keep 30 days' worth of history capped at 1GB total size -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>


### PR DESCRIPTION
Extended docker-compose.yml with a volume to be able to access the ditto log files on the host system. 
Same for ditto-cluster.yaml. 