### PR TITLE
Fixed imports of ditto-connecticity-model OSGi bundle

### DIFF
--- a/connectivity/model/pom.xml
+++ b/connectivity/model/pom.xml
@@ -105,6 +105,7 @@
                 <configuration>
                     <instructions>
                         <Import-Package>
+                            !org.eclipse.ditto.utils.jsr305.annotations,
                             org.eclipse.ditto.*
                         </Import-Package>
                         <Export-Package>


### PR DESCRIPTION
The missing excluded import caused the bundle not to be able to be loaded successfully.