### PR TITLE
Enable separate configuration for minimum reconnect delay for MQTT broker disconnects

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -31,14 +31,15 @@ import com.typesafe.config.ConfigFactory;
 public final class DefaultMqttConfig implements MqttConfig {
 
     private static final String CONFIG_PATH = "mqtt";
-    private static final String RECONNECT_BACKOFF_PATH = "reconnect";
+    private static final String RECONNECT_PATH = "reconnect";
 
     private final int sourceBufferSize;
     private final int eventLoopThreads;
     private final boolean cleanSession;
     private final boolean reconnectForRedelivery;
-    private final boolean useSeparateClientForPublisher;
     private final Duration reconnectForRedeliveryDelay;
+    private final boolean useSeparateClientForPublisher;
+    private final Duration reconnectMinTimeoutForMqttBrokerInitiatedDisconnect;
     private final BackOffConfig reconnectBackOffConfig;
 
     private DefaultMqttConfig(final ScopedConfig config) {
@@ -49,8 +50,11 @@ public final class DefaultMqttConfig implements MqttConfig {
         reconnectForRedeliveryDelay =
                 config.getDuration(MqttConfigValue.RECONNECT_FOR_REDELIVERY_DELAY.getConfigPath());
         useSeparateClientForPublisher = config.getBoolean(MqttConfigValue.SEPARATE_PUBLISHER_CLIENT.getConfigPath());
-        reconnectBackOffConfig = DefaultBackOffConfig.of(config.hasPath(RECONNECT_BACKOFF_PATH)
-                ? config.getConfig(RECONNECT_BACKOFF_PATH)
+        reconnectMinTimeoutForMqttBrokerInitiatedDisconnect =
+                config.getDuration(MqttConfigValue.RECONNECT_MIN_TIMEOUT_FOR_MQTT_BROKER_INITIATED_DISCONNECT
+                        .getConfigPath());
+        reconnectBackOffConfig = DefaultBackOffConfig.of(config.hasPath(RECONNECT_PATH)
+                ? config.getConfig(RECONNECT_PATH)
                 : ConfigFactory.parseString("backoff" + "={}"));
     }
 
@@ -96,6 +100,11 @@ public final class DefaultMqttConfig implements MqttConfig {
     }
 
     @Override
+    public Duration getReconnectMinTimeoutForMqttBrokerInitiatedDisconnect() {
+        return reconnectMinTimeoutForMqttBrokerInitiatedDisconnect;
+    }
+
+    @Override
     public BackOffConfig getReconnectBackOffConfig() {
         return reconnectBackOffConfig;
     }
@@ -115,13 +124,16 @@ public final class DefaultMqttConfig implements MqttConfig {
                 Objects.equals(reconnectForRedelivery, that.reconnectForRedelivery) &&
                 Objects.equals(reconnectForRedeliveryDelay, that.reconnectForRedeliveryDelay) &&
                 Objects.equals(useSeparateClientForPublisher, that.useSeparateClientForPublisher) &&
+                Objects.equals(reconnectMinTimeoutForMqttBrokerInitiatedDisconnect,
+                        that.reconnectMinTimeoutForMqttBrokerInitiatedDisconnect) &&
                 Objects.equals(reconnectBackOffConfig, that.reconnectBackOffConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(sourceBufferSize, eventLoopThreads, cleanSession, reconnectForRedelivery,
-                reconnectForRedeliveryDelay, useSeparateClientForPublisher, reconnectBackOffConfig);
+                reconnectForRedeliveryDelay, useSeparateClientForPublisher,
+                reconnectMinTimeoutForMqttBrokerInitiatedDisconnect, reconnectBackOffConfig);
     }
 
     @Override
@@ -133,6 +145,8 @@ public final class DefaultMqttConfig implements MqttConfig {
                 ", reconnectForRedelivery=" + reconnectForRedelivery +
                 ", reconnectForRedeliveryDelay=" + reconnectForRedeliveryDelay +
                 ", useSeparateClientForPublisher=" + useSeparateClientForPublisher +
+                ", reconnectMinTimeoutForMqttBrokerInitiatedDisconnect=" +
+                reconnectMinTimeoutForMqttBrokerInitiatedDisconnect +
                 ", reconnectBackOffConfig=" + reconnectBackOffConfig +
                 "]";
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
@@ -83,6 +83,14 @@ public interface MqttConfig {
     BackOffConfig getReconnectBackOffConfig();
 
     /**
+     * Returns the minimum reconnect timeout for when the MQTT broker closed the MQTT connection.
+     *
+     * @return the minimum reconnect timeout for MQTT broker initiated connection closing.
+     * @since 2.1.0
+     */
+    Duration getReconnectMinTimeoutForMqttBrokerInitiatedDisconnect();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code MqttConfig}.
      */
@@ -117,7 +125,16 @@ public interface MqttConfig {
          * Indicates whether a separate client should be used for publishing. This could be useful when
          * {@link #shouldReconnectForRedelivery()} returns true to avoid that the publisher has downtimes.
          */
-        SEPARATE_PUBLISHER_CLIENT("separate-publisher-client", false);
+        SEPARATE_PUBLISHER_CLIENT("separate-publisher-client", false),
+
+        /**
+         * The minimum reconnect timeout for when the MQTT broker closed the MQTT connection.
+         *
+         * @since 2.1.0
+         */
+        RECONNECT_MIN_TIMEOUT_FOR_MQTT_BROKER_INITIATED_DISCONNECT(
+                "reconnect.min-timeout-for-mqtt-broker-initiated-disconnect",
+                Duration.ofSeconds(1));
 
         private final String path;
         private final Object defaultValue;

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -200,14 +200,20 @@ ditto {
         separate-publisher-client = false
         separate-publisher-client = ${?CONNECTIVITY_MQTT_SEPARATE_PUBLISHER_CLIENT}
 
-        reconnect.backoff.timeout {
-          # the minimum timeout for MQTT client reconnections - "0s" reconnects immediately
-          min-timeout = 0s
-          min-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MIN}
+        reconnect {
+          # The minimum reconnect timeout for when the MQTT broker closed the MQTT connection.
+          min-timeout-for-mqtt-broker-initiated-disconnect = 1s
+          min-timeout-for-mqtt-broker-initiated-disconnect = ${?CONNECTIVITY_MQTT_RECONNECT_MIN_TIMEOUT_FOR_MQTT_BROKER_INITIATED_DISCONNECT}
 
-          # the maximum timeout, once expontential backoff reached this max, the max is used instead
-          max-timeout = 1m
-          max-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MAX}
+          backoff.timeout {
+            # the minimum timeout for MQTT client reconnections - "0s" reconnects immediately
+            min-timeout = 0s
+            min-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MIN}
+
+            # the maximum timeout, once expontential backoff reached this max, the max is used instead
+            max-timeout = 1m
+            max-timeout = ${?CONNECTIVITY_MQTT_RECONNECT_BACKOFF_TIMEOUT_MAX}
+          }
         }
       }
 

--- a/connectivity/service/src/test/resources/connection-test.conf
+++ b/connectivity/service/src/test/resources/connection-test.conf
@@ -30,6 +30,12 @@ connection {
   mqtt {
     # maximum mumber of MQTT messages to buffer in a source (presumably for at-least-once and exactly-once delivery)
     source-buffer-size = 7
+
+    reconnect {
+      backoff {
+
+      }
+    }
   }
 
   amqp10 {

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -121,6 +121,12 @@ ditto {
       mqtt {
         reconnect-for-redelivery = true
         separate-publisher-client = true
+
+        reconnect {
+          backoff {
+
+          }
+        }
       }
     }
 


### PR DESCRIPTION
by default, 0ms were applied for those as well which might not be a good default and "DoS" MQTT brokers