### PR TITLE
Fix supervision in ConnectionPersistenceActor

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/ConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/ConnectionConfig.java
@@ -39,6 +39,12 @@ public interface ConnectionConfig extends WithSupervisorConfig, WithActivityChec
     Duration getClientActorAskTimeout();
 
     /**
+     * Returns how often the connection actor will retry starting a failing client actor. If exceeded, errors will
+     * be escalated to the supervisor, which will effectively cause the whole connection to be restarted.
+     */
+    int getClientActorRestartsBeforeEscalation();
+
+    /**
      * @return the list of allowed hostnames to which outgoing connections are allowed. This list overrides the list
      * of blocked hostnames.
      */
@@ -147,6 +153,11 @@ public interface ConnectionConfig extends WithSupervisorConfig, WithActivityChec
          * The amount of time for how long the connection actor waits for response from client actors.
          */
         CLIENT_ACTOR_ASK_TIMEOUT("client-actor-ask-timeout", Duration.ofSeconds(60L)),
+
+        /**
+         * How often the connection actor will retry starting a failing client actor before escalation to the supervisor.
+         */
+        CLIENT_ACTOR_RESTARTS_BEFORE_ESCALATION("client-actor-restarts-before-escalation", 3),
 
         /**
          * Whether to start all client actors on 1 node.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
@@ -39,6 +39,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     private static final String CONFIG_PATH = "connection";
 
     private final Duration clientActorAskTimeout;
+    private final int clientActorRestartsBeforeEscalation;
     private final Collection<String> allowedHostnames;
     private final Collection<String> blockedHostnames;
     private final SupervisorConfig supervisorConfig;
@@ -58,6 +59,8 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
 
     private DefaultConnectionConfig(final ConfigWithFallback config) {
         clientActorAskTimeout = config.getDuration(ConnectionConfigValue.CLIENT_ACTOR_ASK_TIMEOUT.getConfigPath());
+        clientActorRestartsBeforeEscalation = config.getInt(ConnectionConfigValue.CLIENT_ACTOR_RESTARTS_BEFORE_ESCALATION
+                .getConfigPath());
         allowedHostnames = fromCommaSeparatedString(config, ConnectionConfigValue.ALLOWED_HOSTNAMES);
         blockedHostnames = fromCommaSeparatedString(config, ConnectionConfigValue.BLOCKED_HOSTNAMES);
         supervisorConfig = DefaultSupervisorConfig.of(config);
@@ -98,6 +101,11 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     @Override
     public Duration getClientActorAskTimeout() {
         return clientActorAskTimeout;
+    }
+
+    @Override
+    public int getClientActorRestartsBeforeEscalation() {
+        return clientActorRestartsBeforeEscalation;
     }
 
     @Override
@@ -190,6 +198,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
         }
         final DefaultConnectionConfig that = (DefaultConnectionConfig) o;
         return Objects.equals(clientActorAskTimeout, that.clientActorAskTimeout) &&
+                Objects.equals(clientActorRestartsBeforeEscalation, that.clientActorRestartsBeforeEscalation) &&
                 Objects.equals(allowedHostnames, that.allowedHostnames) &&
                 Objects.equals(blockedHostnames, that.blockedHostnames) &&
                 Objects.equals(supervisorConfig, that.supervisorConfig) &&
@@ -210,9 +219,9 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(clientActorAskTimeout, allowedHostnames, blockedHostnames, supervisorConfig, snapshotConfig,
-                acknowledgementConfig, maxNumberOfTargets, maxNumberOfSources,
-                activityCheckConfig, amqp10Config, amqp091Config, mqttConfig, kafkaConfig,
+        return Objects.hash(clientActorAskTimeout, clientActorRestartsBeforeEscalation, allowedHostnames,
+                blockedHostnames, supervisorConfig, snapshotConfig, acknowledgementConfig, maxNumberOfTargets,
+                maxNumberOfSources, activityCheckConfig, amqp10Config, amqp091Config, mqttConfig, kafkaConfig,
                 httpPushConfig, ackLabelDeclareInterval, priorityUpdateInterval, allClientActorsOnOneNode);
     }
 
@@ -220,6 +229,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     public String toString() {
         return "DefaultConnectionConfig{" +
                 "clientActorAskTimeout=" + clientActorAskTimeout +
+                ", clientActorRestartsBeforeEscalation=" + clientActorRestartsBeforeEscalation +
                 ", allowedHostnames=" + allowedHostnames +
                 ", blockedHostnames=" + blockedHostnames +
                 ", supervisorConfig=" + supervisorConfig +

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
@@ -112,4 +112,13 @@ public final class ClientActorRefs {
     private static List<ActorRef> sort(final Map<ActorPath, ActorRef> refsByPath) {
         return refsByPath.values().stream().sorted(ActorRef::compareTo).collect(Collectors.toList());
     }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "refsByPath=" + refsByPath +
+                ", sortedRefs=" + sortedRefs +
+                "]";
+    }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -116,6 +116,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.actor.Status;
+import akka.actor.SupervisorStrategy;
 import akka.actor.Terminated;
 import akka.cluster.routing.ClusterRouterPool;
 import akka.cluster.routing.ClusterRouterPoolSettings;
@@ -151,6 +152,9 @@ public final class ConnectionPersistenceActor
     public static final String SNAPSHOT_PLUGIN_ID = "akka-contrib-mongodb-persistence-connection-snapshots";
 
     private static final Duration DEFAULT_RETRIEVE_STATUS_TIMEOUT = Duration.ofMillis(500L);
+
+    // never retry, just escalate. ConnectionSupervisorActor will handle restarting this actor
+    private static final SupervisorStrategy ESCALATE_ALWAYS_STRATEGY = OneForOneEscalateStrategy.escalateStrategy();
 
     private final ActorRef proxyActor;
     private final ClientActorPropsFactory propsFactory;
@@ -921,6 +925,11 @@ public final class ConnectionPersistenceActor
         origin.tell(statusResponse, getSelf());
     }
 
+    @Override
+    public SupervisorStrategy supervisorStrategy() {
+        return ESCALATE_ALWAYS_STRATEGY;
+    }
+
     private void startClientActorsIfRequired(final int clientCount) {
         if (entity != null && clientActorRouter == null && clientCount > 0) {
             log.info("Starting ClientActor for connection <{}> with <{}> clients.", entityId, clientCount);
@@ -928,7 +937,8 @@ public final class ConnectionPersistenceActor
             final ClusterRouterPoolSettings clusterRouterPoolSettings =
                     new ClusterRouterPoolSettings(clientCount, clientActorsPerNode(clientCount), true,
                             Set.of(CLUSTER_ROLE));
-            final Pool pool = new ConsistentHashingPool(clientCount);
+            final Pool pool = new ConsistentHashingPool(clientCount)
+                    .withSupervisorStrategy(OneForOneEscalateStrategy.withRetries(config.getClientActorRestartsBeforeEscalation()));
             final Props clusterRouterPoolProps =
                     new ClusterRouterPool(pool, clusterRouterPoolSettings).props(props);
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategy.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategy.java
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 package org.eclipse.ditto.connectivity.service.messaging.persistence;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkArgument;
@@ -29,7 +28,7 @@ import scala.collection.Iterable;
  * afterwards escalates failures. This stands in contrast to the original {@link akka.actor.OneForOneStrategy}
  * which stops instead of escalating.
  */
-class OneForOneEscalateStrategy extends SupervisorStrategy {
+final class OneForOneEscalateStrategy extends SupervisorStrategy {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OneForOneEscalateStrategy.class);
 
@@ -45,6 +44,7 @@ class OneForOneEscalateStrategy extends SupervisorStrategy {
      * will escalate errors.
      *
      * @param maxRetries how often a failing child should be restarted.
+     * @throws IllegalArgumentException if the passed in {@code maxRetries} is negative.
      * @return the strategy.
      */
     static OneForOneEscalateStrategy withRetries(final int maxRetries) {
@@ -53,7 +53,7 @@ class OneForOneEscalateStrategy extends SupervisorStrategy {
     }
 
     /**
-     * Create a supervisor strategy which escalates when a child fails.
+     * Create a supervisor strategy which immediately escalates when a child fails.
      *
      * @return the strategy.
      */
@@ -76,7 +76,7 @@ class OneForOneEscalateStrategy extends SupervisorStrategy {
                 return (Directive) SupervisorStrategy.escalate();
             }
             LOGGER.info("Child failed <{}> times, which is less than the maximum allowed number of <{}> failures." +
-                    " Will restart the child.",currentRetries, maxRetries, throwable);
+                    " Will restart the child.", currentRetries, maxRetries, throwable);
             return (Directive) SupervisorStrategy.restart();
         });
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategy.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategy.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging.persistence;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkArgument;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.ChildRestartStats;
+import akka.actor.SupervisorStrategy;
+import scala.PartialFunction;
+import scala.collection.Iterable;
+
+/**
+ * Implementation of {@link SupervisorStrategy}, which restarts supervised actors {@code maxRetries} times and
+ * afterwards escalates failures. This stands in contrast to the original {@link akka.actor.OneForOneStrategy}
+ * which stops instead of escalating.
+ */
+class OneForOneEscalateStrategy extends SupervisorStrategy {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OneForOneEscalateStrategy.class);
+
+    private final int maxRetries;
+    private int currentRetries = 0;
+
+    private OneForOneEscalateStrategy(final int maxRetries) {
+        this.maxRetries = maxRetries;
+    }
+
+    /**
+     * Create a supervisor strategy which tries to restart failing children {@code maxRetries} and afterwards
+     * will escalate errors.
+     *
+     * @param maxRetries how often a failing child should be restarted.
+     * @return the strategy.
+     */
+    static OneForOneEscalateStrategy withRetries(final int maxRetries) {
+        checkArgument(maxRetries, max -> max >= 0, () -> "Maximum retries must not be negative.");
+        return new OneForOneEscalateStrategy(maxRetries);
+    }
+
+    /**
+     * Create a supervisor strategy which escalates when a child fails.
+     *
+     * @return the strategy.
+     */
+    static OneForOneEscalateStrategy escalateStrategy() {
+        return withRetries(0);
+    }
+
+    @Override
+    public void handleChildTerminated(final akka.actor.ActorContext context, final ActorRef child,
+            final Iterable<ActorRef> children) {
+        LOGGER.debug("Child <{}> terminated. Ignoring. Remaining children: {}", child, children);
+    }
+
+    @Override
+    public PartialFunction<Throwable, Directive> decider() {
+        return PartialFunction.fromFunction(throwable -> {
+            if (currentRetries >= maxRetries) {
+                LOGGER.info("Child failed <{}> times, which exceeds the maximum allowed number of <{}> failures." +
+                        " Will escalate the failure.", currentRetries, maxRetries, throwable);
+                return (Directive) SupervisorStrategy.escalate();
+            }
+            LOGGER.info("Child failed <{}> times, which is less than the maximum allowed number of <{}> failures." +
+                    " Will restart the child.",currentRetries, maxRetries, throwable);
+            return (Directive) SupervisorStrategy.restart();
+        });
+    }
+
+    @Override
+    public void processFailure(final akka.actor.ActorContext context, final boolean restart,
+            final ActorRef child,
+            final Throwable cause, final ChildRestartStats stats, final Iterable<ChildRestartStats> children) {
+        // ignoring the arguments, because #decider will either escalate and this code is never reached, or it
+        // will use the restart directive, which will call this method with restart = true.
+        ++currentRetries;
+        LOGGER.debug("Restarting child <{}>", child);
+        restartChild(child, cause, false);
+    }
+
+}

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -59,6 +59,11 @@ ditto {
       client-actor-ask-timeout = 55s
       client-actor-ask-timeout = ${?CONNECTIVITY_CLIENT_ACTOR_ASK_TIMEOUT}
 
+      # how often the connection actor will retry starting a failing client actor. If exceeded, errors will be
+      # escalated to the supervisor, which will effectively cause the whole connection to be restarted.
+      client-actor-restarts-before-escalation = 3
+      client-actor-restarts-before-escalation = ${?CONNECTIVITY_CLIENT_ACTOR_RETRIES_BEFORE_ESCALATION}
+
       # Whether to start 1 client actor on each node or to start all client actors on the same node.
       # It is not possible to start multiple client actors on multiple nodes.
       all-client-actors-on-one-node = false

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
@@ -81,6 +81,10 @@ public final class DefaultConnectionConfigTest {
                 .as(ConnectionConfig.ConnectionConfigValue.CLIENT_ACTOR_ASK_TIMEOUT.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(10L));
 
+        softly.assertThat(underTest.getClientActorRestartsBeforeEscalation())
+                .as(ConnectionConfig.ConnectionConfigValue.CLIENT_ACTOR_RESTARTS_BEFORE_ESCALATION.getConfigPath())
+                .isEqualTo(7);
+
         softly.assertThat(underTest.getAllowedHostnames())
                 .as(ConnectionConfig.ConnectionConfigValue.ALLOWED_HOSTNAMES.getConfigPath())
                 .containsExactly("eclipse.org");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategyTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategyTest.java
@@ -10,7 +10,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0
  */
-
 package org.eclipse.ditto.connectivity.service.messaging.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategyTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/OneForOneEscalateStrategyTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import akka.actor.ActorContext;
+import akka.actor.ActorInitializationException;
+import akka.actor.ActorPath;
+import akka.actor.ChildRestartStats;
+import akka.actor.InternalActorRef;
+import scala.collection.Iterable;
+import scala.collection.immutable.List;
+
+/**
+ * Unit test for {@link OneForOneEscalateStrategy}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public final class OneForOneEscalateStrategyTest {
+
+    private final Iterable<ChildRestartStats> children = List.<ChildRestartStats>newBuilder().result();
+    @Mock
+    private ActorContext actorContext;
+    @Mock
+    private InternalActorRef child;
+    @Mock
+    private ChildRestartStats stats;
+    @Mock
+    private ActorPath path;
+
+    @Before
+    public void setUp() {
+        when(child.path()).thenReturn(path);
+        when(path.toString()).thenReturn("the-mocked-path");
+    }
+
+    @Test
+    public void restartsWhenChildHasFailure() {
+        final Throwable cause =
+                new ActorInitializationException(child, "failed for the test", new IllegalArgumentException());
+        final int retriesUntilEscalate = 3;
+
+        final OneForOneEscalateStrategy strategy = OneForOneEscalateStrategy.withRetries(retriesUntilEscalate);
+        for (int i = 0; i < retriesUntilEscalate; i++) {
+            assertThat(strategy.handleFailure(actorContext, child, cause, stats, children))
+                    .isTrue();
+        }
+        Mockito.verify(child, Mockito.times(retriesUntilEscalate)).restart(cause);
+    }
+
+    @Test
+    public void escalatesWhenChildHasTooManyFailures() {
+        final Throwable cause =
+                new ActorInitializationException(child, "failed for the test", new IllegalArgumentException());
+        final int retriesUntilEscalate = 3;
+        final OneForOneEscalateStrategy strategy = OneForOneEscalateStrategy.withRetries(retriesUntilEscalate);
+        for (int i = 0; i < retriesUntilEscalate; i++) {
+            assertThat(strategy.handleFailure(actorContext, child, cause, stats, children))
+                    .isTrue();
+        }
+
+        // the (retriesUntilEscalate + 1)-th call to #handleFailure should return 'false' (which means escalate)
+        assertThat(strategy.handleFailure(actorContext, child, cause, stats, children))
+                .isFalse();
+        // should only have called #restart retriesUntilEscalate times
+        Mockito.verify(child, Mockito.times(retriesUntilEscalate)).restart(cause);
+    }
+
+    @Test
+    public void escalateStrategyEscalatesOnTheFirstFailure() {
+        final Throwable cause =
+                new ActorInitializationException(child, "failed for the test", new IllegalArgumentException());
+        final OneForOneEscalateStrategy strategy = OneForOneEscalateStrategy.escalateStrategy();
+
+        assertThat(strategy.handleFailure(actorContext, child, cause, stats, children))
+                .isFalse();
+
+        Mockito.verify(child, never()).restart(cause);
+    }
+
+    @Test
+    public void instantiateWithNegativeRetriesFails() {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> OneForOneEscalateStrategy.withRetries(-1));
+    }
+
+}

--- a/connectivity/service/src/test/resources/connection-test.conf
+++ b/connectivity/service/src/test/resources/connection-test.conf
@@ -23,6 +23,8 @@ connection {
   # early the connection is not subscribed for events properly
   client-actor-ask-timeout = 10s
 
+  client-actor-restarts-before-escalation = 7
+
   all-client-actors-on-one-node = true
 
   ack-label-declare-interval = 99s

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -46,6 +46,8 @@ ditto {
       # Number of targets per connection
       max-target-number = 4
 
+      client-actor-restarts-before-escalation = 3
+
       supervisor {
         exponential-backoff {
           min = 1s


### PR DESCRIPTION
Fixes #1088:
Uses a supervisor strategy for the used `ClusterRouterPool`, which retries starting the `BaseClientActor` multiple times, before escalating exceptions (including `ActorInitializationException`) to the `ConnectionPersistenceActor`.
The `ConnectionPersistenceActor` will now always escalate exceptions, which will cause the `ConnectionSupervisorActor` to restart the failing `ConnectionPersistenceActor`.