### PR TITLE
Tolerate discrepancy in JWT for nbf and exp claims

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationFactory.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtAuthenticationFactory.java
@@ -68,7 +68,7 @@ public final class JwtAuthenticationFactory {
 
     public JwtValidator getJwtValidator() {
         if (null == jwtValidator) {
-            jwtValidator = DefaultJwtValidator.of(getPublicKeyProvider());
+            jwtValidator = DefaultJwtValidator.of(getPublicKeyProvider(), oAuthConfig);
         }
         return jwtValidator;
     }
@@ -93,7 +93,7 @@ public final class JwtAuthenticationFactory {
     }
 
     public JwtAuthenticationResultProvider newJwtAuthenticationResultProvider() {
-        final JwtAuthorizationSubjectsProvider authorizationSubjectsProvider =
+        final var authorizationSubjectsProvider =
                jwtAuthorizationSubjectsProviderFactory.newProvider(getJwtSubjectIssuersConfig());
 
         return DefaultJwtAuthenticationResultProvider.of(authorizationSubjectsProvider);

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.gateway.service.util.config.security;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,12 +49,14 @@ public final class DefaultOAuthConfig implements OAuthConfig {
     private static final String CONFIG_PATH = "oauth";
 
     private final String protocol;
+    private final Duration allowedClockSkew;
     private final Map<SubjectIssuer, SubjectIssuerConfig> openIdConnectIssuers;
     private final Map<SubjectIssuer, SubjectIssuerConfig> openIdConnectIssuersExtension;
     private final String tokenIntegrationSubject;
 
     private DefaultOAuthConfig(final ConfigWithFallback configWithFallback) {
         protocol = configWithFallback.getString(OAuthConfigValue.PROTOCOL.getConfigPath());
+        allowedClockSkew = configWithFallback.getDuration(OAuthConfigValue.ALLOWED_CLOCK_SKEW.getConfigPath());
         openIdConnectIssuers = loadIssuers(configWithFallback, OAuthConfigValue.OPENID_CONNECT_ISSUERS);
         openIdConnectIssuersExtension =
                 loadIssuers(configWithFallback, OAuthConfigValue.OPENID_CONNECT_ISSUERS_EXTENSION);
@@ -84,6 +87,11 @@ public final class DefaultOAuthConfig implements OAuthConfig {
     }
 
     @Override
+    public Duration getAllowedClockSkew() {
+        return allowedClockSkew;
+    }
+
+    @Override
     public Map<SubjectIssuer, SubjectIssuerConfig> getOpenIdConnectIssuers() {
         return openIdConnectIssuers;
     }
@@ -104,6 +112,7 @@ public final class DefaultOAuthConfig implements OAuthConfig {
         if (o == null || getClass() != o.getClass()) return false;
         final DefaultOAuthConfig that = (DefaultOAuthConfig) o;
         return Objects.equals(protocol, that.protocol)
+                && Objects.equals(allowedClockSkew, that.allowedClockSkew)
                 && Objects.equals(openIdConnectIssuers, that.openIdConnectIssuers)
                 && Objects.equals(openIdConnectIssuersExtension, that.openIdConnectIssuersExtension)
                 && Objects.equals(tokenIntegrationSubject, that.tokenIntegrationSubject);
@@ -111,13 +120,15 @@ public final class DefaultOAuthConfig implements OAuthConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(protocol, openIdConnectIssuers, openIdConnectIssuersExtension, tokenIntegrationSubject);
+        return Objects.hash(protocol, allowedClockSkew, openIdConnectIssuers, openIdConnectIssuersExtension,
+                tokenIntegrationSubject);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "protocol=" + protocol +
+                ", allowedClocSkew=" + allowedClockSkew +
                 ", openIdConnectIssuers=" + openIdConnectIssuers +
                 ", openIdConnectIssuersExtension=" + openIdConnectIssuersExtension +
                 ", tokenIntegrationSubject=" + tokenIntegrationSubject +

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/OAuthConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/OAuthConfig.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.gateway.service.util.config.security;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,6 +35,14 @@ public interface OAuthConfig {
      * @return the protocol with which to access all OAuth endpoints.
      */
     String getProtocol();
+
+    /**
+     * Returns the allowed clock skew in seconds to tolerate when verifying the local time against the {@code exp}
+     * and {@code nbf} claims.
+     *
+     * @return the allowed clock skew in seconds.
+     */
+    Duration getAllowedClockSkew();
 
     /**
      * Returns all supported openid connect issuers.
@@ -59,6 +68,7 @@ public interface OAuthConfig {
 
     enum OAuthConfigValue implements KnownConfigValue {
         PROTOCOL("protocol", "https"),
+        ALLOWED_CLOCK_SKEW("allowed-clock-skew", Duration.ofSeconds(10)),
         OPENID_CONNECT_ISSUERS("openid-connect-issuers", Collections.emptyMap()),
         OPENID_CONNECT_ISSUERS_EXTENSION("openid-connect-issuers-extension", Collections.emptyMap()),
         TOKEN_INTEGRATION_SUBJECT("token-integration-subject", "integration:{{policy-entry:label}}:{{jwt:aud}}");

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -169,6 +169,11 @@ ditto {
         protocol = "https"
         protocol = ${?OAUTH_PROTOCOL}
 
+        # configure the amount of clock skew in seconds to tolerate when verifying the local time against the exp
+        # and nbf claims
+        allowed-clock-skew = 10s
+        allowed-clock-skew = ${?OAUTH_ALLOWED_CLOCK_SKEW}
+
         # map <subject-issuer, configObject> of all supported OpenID Connect authorization servers
         # issuer should not contain the protocol (e.g. https://)
         openid-connect-issuers = {

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtTestConstants.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtTestConstants.java
@@ -16,6 +16,7 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.time.Instant;
 import java.util.Date;
 
 import javax.annotation.concurrent.Immutable;
@@ -32,6 +33,8 @@ final class JwtTestConstants {
     static final String VALID_JWT_TOKEN;
     static final String UNSIGNED_JWT_TOKEN;
     static final String EXPIRED_JWT_TOKEN;
+    static final String VALID_NBF_AHEAD_OF_TIME_JWT_TOKEN;
+    static final String INVALID_NBF_AHEAD_OF_TIME_JWT_TOKEN;
     static final PublicKey PUBLIC_KEY_2;
 
     static final String KEY_ID = "pFXsMxGhnXJgzg9aO9xYUTYegCP4XsnuGhQEeQaAQrI";
@@ -55,6 +58,8 @@ final class JwtTestConstants {
             VALID_JWT_TOKEN = createJwt();
             UNSIGNED_JWT_TOKEN = createUnsignedJwt();
             EXPIRED_JWT_TOKEN = createExpiredJwt();
+            VALID_NBF_AHEAD_OF_TIME_JWT_TOKEN = createNotBeforeAheadOfTimeJwt(Date.from(Instant.now().plusSeconds(10)));
+            INVALID_NBF_AHEAD_OF_TIME_JWT_TOKEN = createNotBeforeAheadOfTimeJwt(Date.from(Instant.now().plusSeconds(15)));
         } catch (final Exception e) {
             throw new IllegalStateException(e);
         }
@@ -79,7 +84,16 @@ final class JwtTestConstants {
         return Jwts.builder()
                 .setHeaderParam("kid", KEY_ID)
                 .setIssuer(ISSUER)
-                .setExpiration(new Date())
+                .setExpiration(Date.from(Instant.now().minusSeconds(10)))
+                .signWith(PRIVATE_KEY, SignatureAlgorithm.RS256)
+                .compact();
+    }
+
+    private static String createNotBeforeAheadOfTimeJwt(final Date nbf) {
+        return Jwts.builder()
+                .setHeaderParam("kid", KEY_ID)
+                .setIssuer(ISSUER)
+                .setNotBefore(nbf)
                 .signWith(PRIVATE_KEY, SignatureAlgorithm.RS256)
                 .compact();
     }

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtValidatorTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtValidatorTest.java
@@ -53,6 +53,12 @@ public final class JwtValidatorTest {
     private static final JsonWebToken INVALID_JSON_WEB_TOKEN =
             ImmutableJsonWebToken.fromToken(JwtTestConstants.EXPIRED_JWT_TOKEN);
 
+    private static final JsonWebToken VALID_JSON_WEB_TOKEN_WITH_NBF_AHEAD_OF_TIME =
+            ImmutableJsonWebToken.fromToken(JwtTestConstants.VALID_NBF_AHEAD_OF_TIME_JWT_TOKEN);
+
+    private static final JsonWebToken INVALID_JSON_WEB_TOKEN_WITH_NBF_AHEAD_OF_TIME =
+            ImmutableJsonWebToken.fromToken(JwtTestConstants.INVALID_NBF_AHEAD_OF_TIME_JWT_TOKEN);
+
     @Mock
     private PublicKeyProvider publicKeyProvider;
 
@@ -66,6 +72,32 @@ public final class JwtValidatorTest {
         final BinaryValidationResult jwtValidationResult = underTest.validate(VALID_JSON_WEB_TOKEN).get();
 
         assertThat(jwtValidationResult.isValid()).isTrue();
+    }
+
+    @Test
+    public void validateTokenWithNbfAheadOfTime() throws ExecutionException, InterruptedException {
+        when(publicKeyProvider.getPublicKey(JwtTestConstants.ISSUER, JwtTestConstants.KEY_ID)).thenReturn(
+                CompletableFuture.completedFuture(Optional.of(JwtTestConstants.PUBLIC_KEY)));
+
+        final JwtValidator underTest = DefaultJwtValidator.of(publicKeyProvider);
+
+        final BinaryValidationResult jwtValidationResult =
+                underTest.validate(VALID_JSON_WEB_TOKEN_WITH_NBF_AHEAD_OF_TIME).get();
+
+        assertThat(jwtValidationResult.isValid()).isTrue();
+    }
+
+    @Test
+    public void validateFailsIfNbfIsTooFarInTheFuture() throws ExecutionException, InterruptedException {
+        when(publicKeyProvider.getPublicKey(JwtTestConstants.ISSUER, JwtTestConstants.KEY_ID)).thenReturn(
+                CompletableFuture.completedFuture(Optional.of(JwtTestConstants.PUBLIC_KEY)));
+
+        final JwtValidator underTest = DefaultJwtValidator.of(publicKeyProvider);
+
+        final BinaryValidationResult jwtValidationResult =
+                underTest.validate(INVALID_JSON_WEB_TOKEN_WITH_NBF_AHEAD_OF_TIME).get();
+
+        assertThat(jwtValidationResult.isValid()).isFalse();
     }
 
     @Test

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
@@ -17,6 +17,7 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 
@@ -69,6 +70,8 @@ public final class DefaultOAuthConfigTest {
 
         softly.assertThat(underTest.getProtocol()).isEqualTo("https");
 
+        softly.assertThat(underTest.getAllowedClockSkew()).isEqualTo(Duration.ofSeconds(10));
+
         softly.assertThat(underTest.getOpenIdConnectIssuers())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getConfigPath())
                 .isEqualTo(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getDefaultValue());
@@ -86,6 +89,8 @@ public final class DefaultOAuthConfigTest {
         final DefaultOAuthConfig underTest = DefaultOAuthConfig.of(oauthConfig);
 
         softly.assertThat(underTest.getProtocol()).isEqualTo("http");
+
+        softly.assertThat(underTest.getAllowedClockSkew()).isEqualTo(Duration.ofSeconds(20));
 
         softly.assertThat(underTest.getOpenIdConnectIssuers())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getConfigPath())

--- a/gateway/service/src/test/resources/oauth-test.conf
+++ b/gateway/service/src/test/resources/oauth-test.conf
@@ -1,5 +1,6 @@
 oauth {
   protocol = http
+  allowed-clock-skew = 20s
   token-integration-subject = "ditto:ditto"
   openid-connect-issuers = {
     google = {


### PR DESCRIPTION
set allowed clock skew to 10 seconds to tolerate discrepancy when verifying local time against exp and nbf claims in JWT;


