### PR TITLE
Improved subject deletion announcement granularity to milli seconds

### DIFF
--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/AbstractPolicyCommandStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/AbstractPolicyCommandStrategy.java
@@ -157,7 +157,7 @@ abstract class AbstractPolicyCommandStrategy<C extends Command<C>, E extends Pol
      * @return the adjusted PolicyEntry or - if not adjusted - the original.
      */
     protected PolicyEntry potentiallyAdjustPolicyEntry(final PolicyEntry policyEntry) {
-        final Subjects adjustedSubjects = potentiallyAdjustSubjects(policyEntry.getSubjects());
+        final var adjustedSubjects = potentiallyAdjustSubjects(policyEntry.getSubjects());
         return PolicyEntry.newInstance(policyEntry.getLabel(), adjustedSubjects, policyEntry.getResources());
     }
 
@@ -196,8 +196,8 @@ abstract class AbstractPolicyCommandStrategy<C extends Command<C>, E extends Pol
         final Optional<SubjectExpiry> expiryOptional = subject.getExpiry();
         final Optional<SubjectAnnouncement> announcementOptional = subject.getAnnouncement();
         if (expiryOptional.isPresent() || announcementOptional.isPresent()) {
-            final SubjectExpiry subjectExpiry = expiryOptional.map(this::roundPolicySubjectExpiry).orElse(null);
-            final SubjectAnnouncement subjectAnnouncement =
+            final var subjectExpiry = expiryOptional.map(this::roundPolicySubjectExpiry).orElse(null);
+            final var subjectAnnouncement =
                     announcementOptional.map(this::roundSubjectAnnouncement).orElse(null);
             return Subject.newInstance(subject.getId(), subject.getType(), subjectExpiry, subjectAnnouncement);
         } else {
@@ -290,7 +290,7 @@ abstract class AbstractPolicyCommandStrategy<C extends Command<C>, E extends Pol
                 .filter(SubjectExpiry::isExpired)
                 .findFirst()
                 .map(subjectExpiry -> {
-                    final String expiryString = subjectExpiry.getTimestamp().toString();
+                    final var expiryString = subjectExpiry.getTimestamp().toString();
                     return ResultFactory.newErrorResult(
                             SubjectExpiryInvalidException.newBuilderTimestampInThePast(expiryString)
                                     .dittoHeaders(dittoHeaders)
@@ -339,11 +339,12 @@ abstract class AbstractPolicyCommandStrategy<C extends Command<C>, E extends Pol
     }
 
     private static Duration roundUpDuration(final Duration duration, final Duration granularity) {
-        final long granularitySeconds = Math.max(1L, granularity.getSeconds());
-        final long durationSeconds = Math.max(granularitySeconds, duration.getSeconds());
-        final long roundedUpSeconds =
-                ((durationSeconds + granularitySeconds - 1L) / granularitySeconds) * granularitySeconds;
-        return Duration.ofSeconds(roundedUpSeconds);
+        final long granularityMillis = Math.max(1L, granularity.toMillis());
+        final long durationMillis = Math.max(granularityMillis, duration.toMillis());
+        final long roundedUpMillis =
+                ((durationMillis + granularityMillis - 1L) / granularityMillis) * granularityMillis;
+
+        return Duration.ofMillis(roundedUpMillis);
     }
 
     private static class PolicyExpiryGranularity {

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -29,7 +29,7 @@ ditto {
       subject-expiry-granularity = ${?POLICY_SUBJECT_EXPIRY_GRANULARITY}
 
       # To which duration the notify-before duration of each subject-expiry is rounded up.
-      # Minimum value: 1s
+      # Minimum value: 1ms
       subject-deletion-announcement-granularity = 1m
       subject-deletion-announcement-granularity = ${?POLICY_SUBJECT_DELETION_ANNOUNCEMENT_GRANULARITY}
 

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ActivateTokenIntegrationStrategyTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ActivateTokenIntegrationStrategyTest.java
@@ -87,12 +87,12 @@ public final class ActivateTokenIntegrationStrategyTest extends AbstractPolicyCo
     public void roundUpNotifyBeforeDuration() {
         final CommandStrategy.Context<PolicyId> context = getDefaultContext();
         final Instant expiry = Instant.now().plus(Duration.ofDays(1L));
-        final DittoDuration duration = DittoDuration.parseDuration("4s");
-        final DittoDuration roundedUpDuration = DittoDuration.parseDuration("6s");
+        final DittoDuration duration = DittoDuration.parseDuration("2ms");
+        final DittoDuration roundedUpDuration = DittoDuration.parseDuration("5ms");
         final SubjectId subjectId = SubjectId.newInstance(SubjectIssuer.INTEGRATION, LABEL + ":this-is-me");
         final DittoHeaders dittoHeaders = buildActivateTokenIntegrationHeaders();
 
-        // announcement duration is rounded up if it is not a multiple of the configured granularity (3s)
+        // announcement duration is rounded up if it is not a multiple of the configured granularity (5ms)
         final ActivateTokenIntegration commandToRoundUp =
                 ActivateTokenIntegration.of(context.getState(), LABEL, Collections.singleton(subjectId),
                         SubjectExpiry.newInstance(expiry), SubjectAnnouncement.of(duration, false), dittoHeaders);
@@ -100,7 +100,7 @@ public final class ActivateTokenIntegrationStrategyTest extends AbstractPolicyCo
                 applyStrategy(underTest, context, TestConstants.Policy.POLICY, commandToRoundUp));
         assertThat(event.getSubject().getAnnouncement().orElseThrow().getBeforeExpiry()).contains(roundedUpDuration);
 
-        // announcement duration is not rounded up if it is a multiple of the configured granularity (3s)
+        // announcement duration is not rounded up if it is a multiple of the configured granularity (5ms)
         final ActivateTokenIntegration commandToNotRoundUp =
                 ActivateTokenIntegration.of(context.getState(), LABEL, Collections.singleton(subjectId),
                         SubjectExpiry.newInstance(expiry), SubjectAnnouncement.of(roundedUpDuration, false),

--- a/policies/service/src/test/resources/activate-token-integration-test.conf
+++ b/policies/service/src/test/resources/activate-token-integration-test.conf
@@ -1,2 +1,2 @@
 include "policy-test.conf"
-policy.subject-deletion-announcement-granularity = 3s
+policy.subject-deletion-announcement-granularity = 5ms


### PR DESCRIPTION
made it possible to round policy announcements to milli seconds; 
min granularity is now 1ms;


