### PR TITLE
increase connectivity updating-state-timeout from default 5s to 15s

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -549,6 +549,10 @@ akka {
       # don't passivate shards by default as Ditto AbstractShardedPersistenceActor decides that on its own - default is 120s:
       passivate-idle-entity-after = "off"
 
+      # Timeout of waiting for update the distributed state (update will be retried if the timeout happened)
+      # Also used as timeout for writes of remember entities when that is enabled
+      updating-state-timeout = 15s
+
       entity-recovery-strategy = "constant"
       entity-recovery-constant-rate-strategy {
         # Sets the frequency at which a batch of entity actors is started.


### PR DESCRIPTION
this fixes cluster starting problems in connectivity service