### PR TITLE
Prevent misconfiguration of config values

### DIFF
--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/DefaultThrottlingConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/DefaultThrottlingConfig.java
@@ -32,8 +32,8 @@ final class DefaultThrottlingConfig implements ThrottlingConfig {
     private final int limit;
 
     private DefaultThrottlingConfig(final ScopedConfig config) {
-        interval = config.getDuration(ConfigValue.INTERVAL.getConfigPath());
-        limit = config.getInt(ConfigValue.LIMIT.getConfigPath());
+        interval = config.getNonNegativeDurationOrThrow(ConfigValue.INTERVAL);
+        limit = config.getPositiveIntOrThrow(ConfigValue.LIMIT);
     }
 
     static DefaultThrottlingConfig of(final Config config) {

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/http/DefaultHttpConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/http/DefaultHttpConfig.java
@@ -37,8 +37,9 @@ public final class DefaultHttpConfig implements HttpConfig, WithConfigPath {
 
     private DefaultHttpConfig(final ConfigWithFallback config) {
         hostname = config.getString(HttpConfigValue.HOSTNAME.getConfigPath());
-        port = config.getInt(HttpConfigValue.PORT.getConfigPath());
-        coordinatedShutdownTimeout = config.getDuration(HttpConfigValue.COORDINATED_SHUTDOWN_TIMEOUT.getConfigPath());
+        port = config.getPositiveIntOrThrow(HttpConfigValue.PORT);
+        coordinatedShutdownTimeout =
+                config.getNonNegativeAndNonZeroDurationOrThrow(HttpConfigValue.COORDINATED_SHUTDOWN_TIMEOUT);
     }
 
     /**

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/http/DefaultHttpConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/http/DefaultHttpConfig.java
@@ -37,7 +37,7 @@ public final class DefaultHttpConfig implements HttpConfig, WithConfigPath {
 
     private DefaultHttpConfig(final ConfigWithFallback config) {
         hostname = config.getString(HttpConfigValue.HOSTNAME.getConfigPath());
-        port = config.getPositiveIntOrThrow(HttpConfigValue.PORT);
+        port = config.getNonNegativeIntOrThrow(HttpConfigValue.PORT);
         coordinatedShutdownTimeout =
                 config.getNonNegativeAndNonZeroDurationOrThrow(HttpConfigValue.COORDINATED_SHUTDOWN_TIMEOUT);
     }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
@@ -42,11 +42,11 @@ public final class DefaultLimitsConfig implements LimitsConfig, WithConfigPath {
     private final int thingsSearchMaxPageSize;
 
     private DefaultLimitsConfig(final ConfigWithFallback config) {
-        headersMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.HEADERS_MAX_SIZE);
+        headersMaxSize = config.getNonNegativeBytesOrThrow(LimitsConfigValue.HEADERS_MAX_SIZE);
         authSubjectsMaxSize = config.getPositiveIntOrThrow(LimitsConfigValue.AUTH_SUBJECTS_MAX_SIZE);
-        thingsMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.THINGS_MAX_SIZE);
-        policiesMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.POLICIES_MAX_SIZE);
-        messagesMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.MESSAGES_MAX_SIZE);
+        thingsMaxSize = config.getNonNegativeBytesOrThrow(LimitsConfigValue.THINGS_MAX_SIZE);
+        policiesMaxSize = config.getNonNegativeBytesOrThrow(LimitsConfigValue.POLICIES_MAX_SIZE);
+        messagesMaxSize = config.getNonNegativeBytesOrThrow(LimitsConfigValue.MESSAGES_MAX_SIZE);
         thingsSearchDefaultPageSize = config.getPositiveIntOrThrow(LimitsConfigValue.THINGS_SEARCH_DEFAULT_PAGE_SIZE);
         thingsSearchMaxPageSize = config.getPositiveIntOrThrow(LimitsConfigValue.THINGS_SEARCH_MAX_PAGE_SIZE);
     }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/limits/DefaultLimitsConfig.java
@@ -42,13 +42,13 @@ public final class DefaultLimitsConfig implements LimitsConfig, WithConfigPath {
     private final int thingsSearchMaxPageSize;
 
     private DefaultLimitsConfig(final ConfigWithFallback config) {
-        headersMaxSize = config.getBytes(LimitsConfigValue.HEADERS_MAX_SIZE.getConfigPath());
-        authSubjectsMaxSize = config.getInt(LimitsConfigValue.AUTH_SUBJECTS_MAX_SIZE.getConfigPath());
-        thingsMaxSize = config.getBytes(LimitsConfigValue.THINGS_MAX_SIZE.getConfigPath());
-        policiesMaxSize = config.getBytes(LimitsConfigValue.POLICIES_MAX_SIZE.getConfigPath());
-        messagesMaxSize = config.getBytes(LimitsConfigValue.MESSAGES_MAX_SIZE.getConfigPath());
-        thingsSearchDefaultPageSize = config.getInt(LimitsConfigValue.THINGS_SEARCH_DEFAULT_PAGE_SIZE.getConfigPath());
-        thingsSearchMaxPageSize = config.getInt(LimitsConfigValue.THINGS_SEARCH_MAX_PAGE_SIZE.getConfigPath());
+        headersMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.HEADERS_MAX_SIZE);
+        authSubjectsMaxSize = config.getPositiveIntOrThrow(LimitsConfigValue.AUTH_SUBJECTS_MAX_SIZE);
+        thingsMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.THINGS_MAX_SIZE);
+        policiesMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.POLICIES_MAX_SIZE);
+        messagesMaxSize = config.getGreaterZeroBytesOrThrow(LimitsConfigValue.MESSAGES_MAX_SIZE);
+        thingsSearchDefaultPageSize = config.getPositiveIntOrThrow(LimitsConfigValue.THINGS_SEARCH_DEFAULT_PAGE_SIZE);
+        thingsSearchMaxPageSize = config.getPositiveIntOrThrow(LimitsConfigValue.THINGS_SEARCH_MAX_PAGE_SIZE);
     }
 
     /**

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
@@ -36,11 +36,11 @@ public final class DefaultExponentialBackOffConfig implements ExponentialBackOff
     private final Duration corruptedReceiveTimeout;
 
     private DefaultExponentialBackOffConfig(final ScopedConfig config) {
-        min = config.getDuration(ExponentialBackOffConfigValue.MIN.getConfigPath());
-        max = config.getDuration(ExponentialBackOffConfigValue.MAX.getConfigPath());
-        randomFactor = config.getDouble(ExponentialBackOffConfigValue.RANDOM_FACTOR.getConfigPath());
+        min = config.getNonNegativeAndNonZeroDurationOrThrow(ExponentialBackOffConfigValue.MIN);
+        max = config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.MAX);
+        randomFactor = config.getGreaterZeroDoubleOrThrow(ExponentialBackOffConfigValue.RANDOM_FACTOR);
         corruptedReceiveTimeout =
-                config.getDuration(ExponentialBackOffConfigValue.CORRUPTED_RECEIVE_TIMEOUT.getConfigPath());
+                config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.CORRUPTED_RECEIVE_TIMEOUT);
     }
 
     /**

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
@@ -38,7 +38,7 @@ public final class DefaultExponentialBackOffConfig implements ExponentialBackOff
     private DefaultExponentialBackOffConfig(final ScopedConfig config) {
         min = config.getNonNegativeAndNonZeroDurationOrThrow(ExponentialBackOffConfigValue.MIN);
         max = config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.MAX);
-        randomFactor = config.getGreaterZeroDoubleOrThrow(ExponentialBackOffConfigValue.RANDOM_FACTOR);
+        randomFactor = config.getNonNegativeDoubleOrThrow(ExponentialBackOffConfigValue.RANDOM_FACTOR);
         corruptedReceiveTimeout =
                 config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.CORRUPTED_RECEIVE_TIMEOUT);
     }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultExponentialBackOffConfig.java
@@ -36,9 +36,9 @@ public final class DefaultExponentialBackOffConfig implements ExponentialBackOff
     private final Duration corruptedReceiveTimeout;
 
     private DefaultExponentialBackOffConfig(final ScopedConfig config) {
-        min = config.getNonNegativeAndNonZeroDurationOrThrow(ExponentialBackOffConfigValue.MIN);
+        min = config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.MIN);
         max = config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.MAX);
-        randomFactor = config.getNonNegativeDoubleOrThrow(ExponentialBackOffConfigValue.RANDOM_FACTOR);
+        randomFactor = config.getPositiveDoubleOrThrow(ExponentialBackOffConfigValue.RANDOM_FACTOR);
         corruptedReceiveTimeout =
                 config.getNonNegativeDurationOrThrow(ExponentialBackOffConfigValue.CORRUPTED_RECEIVE_TIMEOUT);
     }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultSupervisorConfig.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/config/supervision/DefaultSupervisorConfig.java
@@ -62,6 +62,7 @@ public final class DefaultSupervisorConfig implements SupervisorConfig {
             return false;
         }
         final DefaultSupervisorConfig that = (DefaultSupervisorConfig) o;
+
         return Objects.equals(exponentialBackOffConfig, that.exponentialBackOffConfig);
     }
 

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCachesConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCachesConfig.java
@@ -37,7 +37,7 @@ public final class DefaultCachesConfig implements CachesConfig {
     private final CacheConfig enforcerCacheConfig;
 
     private DefaultCachesConfig(final ScopedConfig config) {
-        askTimeout = config.getDuration(CachesConfigValue.ASK_TIMEOUT.getConfigPath());
+        askTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(CachesConfigValue.ASK_TIMEOUT);
         idCacheConfig = DefaultCacheConfig.of(config, "id");
         enforcerCacheConfig = DefaultCacheConfig.of(config, "enforcer");
     }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCreditDecisionConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCreditDecisionConfig.java
@@ -38,9 +38,9 @@ final class DefaultCreditDecisionConfig implements CreditDecisionConfig {
         this.interval = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.INTERVAL);
         this.metricReportTimeout = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.METRIC_REPORT_TIMEOUT);
         this.timerThreshold = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.TIMER_THRESHOLD);
-        this.creditPerBatch = conf.getGreaterZeroIntOrThrow(ConfigValue.CREDIT_PER_BATCH);
-        creditForRequests = conf.getGreaterZeroIntOrThrow(ConfigValue.CREDIT_FOR_REQUESTS);
-        maxPendingRequests = conf.getGreaterZeroIntOrThrow(ConfigValue.MAX_PENDING_REQUESTS);
+        this.creditPerBatch = conf.getNonNegativeIntOrThrow(ConfigValue.CREDIT_PER_BATCH);
+        creditForRequests = conf.getNonNegativeIntOrThrow(ConfigValue.CREDIT_FOR_REQUESTS);
+        maxPendingRequests = conf.getNonNegativeIntOrThrow(ConfigValue.MAX_PENDING_REQUESTS);
     }
 
     static CreditDecisionConfig of(final Config config) {

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCreditDecisionConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultCreditDecisionConfig.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -33,13 +34,13 @@ final class DefaultCreditDecisionConfig implements CreditDecisionConfig {
     private final int creditForRequests;
     private final int maxPendingRequests;
 
-    private DefaultCreditDecisionConfig(final Config conf) {
-        this.interval = conf.getDuration(ConfigValue.INTERVAL.getConfigPath());
-        this.metricReportTimeout = conf.getDuration(ConfigValue.METRIC_REPORT_TIMEOUT.getConfigPath());
-        this.timerThreshold = conf.getDuration(ConfigValue.TIMER_THRESHOLD.getConfigPath());
-        this.creditPerBatch = conf.getInt(ConfigValue.CREDIT_PER_BATCH.getConfigPath());
-        creditForRequests = conf.getInt(ConfigValue.CREDIT_FOR_REQUESTS.getConfigPath());
-        maxPendingRequests = conf.getInt(ConfigValue.MAX_PENDING_REQUESTS.getConfigPath());
+    private DefaultCreditDecisionConfig(final ScopedConfig conf) {
+        this.interval = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.INTERVAL);
+        this.metricReportTimeout = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.METRIC_REPORT_TIMEOUT);
+        this.timerThreshold = conf.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.TIMER_THRESHOLD);
+        this.creditPerBatch = conf.getGreaterZeroIntOrThrow(ConfigValue.CREDIT_PER_BATCH);
+        creditForRequests = conf.getGreaterZeroIntOrThrow(ConfigValue.CREDIT_FOR_REQUESTS);
+        maxPendingRequests = conf.getGreaterZeroIntOrThrow(ConfigValue.MAX_PENDING_REQUESTS);
     }
 
     static CreditDecisionConfig of(final Config config) {
@@ -109,4 +110,5 @@ final class DefaultCreditDecisionConfig implements CreditDecisionConfig {
                 ", maxPendingRequests" + maxPendingRequests +
                 "]";
     }
+
 }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultEnforcementConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultEnforcementConfig.java
@@ -34,8 +34,8 @@ public final class DefaultEnforcementConfig implements EnforcementConfig {
     private final boolean globalLiveResponseDispatching;
 
     private DefaultEnforcementConfig(final ConfigWithFallback configWithFallback) {
-        askTimeout = configWithFallback.getDuration(EnforcementConfigValue.ASK_TIMEOUT.getConfigPath());
-        bufferSize = configWithFallback.getInt(EnforcementConfigValue.BUFFER_SIZE.getConfigPath());
+        askTimeout = configWithFallback.getNonNegativeAndNonZeroDurationOrThrow(EnforcementConfigValue.ASK_TIMEOUT);
+        bufferSize = configWithFallback.getPositiveIntOrThrow(EnforcementConfigValue.BUFFER_SIZE);
         globalLiveResponseDispatching =
                 configWithFallback.getBoolean(EnforcementConfigValue.GLOBAL_LIVE_RESPONSE_DISPATCHING.getConfigPath());
     }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
@@ -40,7 +40,7 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
         this.enabled = config.getBoolean(ConfigValue.ENABLED.getConfigPath());
         this.quietPeriod = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.QUIET_PERIOD);
         this.cleanupTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.CLEANUP_TIMEOUT);
-        this.parallelism = config.getNonNegativeIntOrThrow(ConfigValue.PARALLELISM);
+        this.parallelism = config.getPositiveIntOrThrow(ConfigValue.PARALLELISM);
         this.keptCreditDecisions = config.getPositiveIntOrThrow(ConfigValue.KEEP_CREDIT_DECISIONS);
         this.keptActions = config.getPositiveIntOrThrow(ConfigValue.KEEP_ACTIONS);
         this.keptEvents = config.getPositiveIntOrThrow(ConfigValue.KEEP_EVENTS);

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -34,14 +35,14 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
     private final PersistenceIdsConfig persistenceIdsConfig;
     private final Config config;
 
-    private DefaultPersistenceCleanupConfig(final Config config) {
+    private DefaultPersistenceCleanupConfig(final ScopedConfig config) {
         this.enabled = config.getBoolean(ConfigValue.ENABLED.getConfigPath());
-        this.quietPeriod = config.getDuration(ConfigValue.QUIET_PERIOD.getConfigPath());
-        this.cleanupTimeout = config.getDuration(ConfigValue.CLEANUP_TIMEOUT.getConfigPath());
-        this.parallelism = config.getInt(ConfigValue.PARALLELISM.getConfigPath());
-        this.keptCreditDecisions = config.getInt(ConfigValue.KEEP_CREDIT_DECISIONS.getConfigPath());
-        this.keptActions = config.getInt(ConfigValue.KEEP_ACTIONS.getConfigPath());
-        this.keptEvents = config.getInt(ConfigValue.KEEP_EVENTS.getConfigPath());
+        this.quietPeriod = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.QUIET_PERIOD);
+        this.cleanupTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.CLEANUP_TIMEOUT);
+        this.parallelism = config.getGreaterZeroIntOrThrow(ConfigValue.PARALLELISM);
+        this.keptCreditDecisions = config.getPositiveIntOrThrow(ConfigValue.KEEP_CREDIT_DECISIONS);
+        this.keptActions = config.getPositiveIntOrThrow(ConfigValue.KEEP_ACTIONS);
+        this.keptEvents = config.getPositiveIntOrThrow(ConfigValue.KEEP_EVENTS);
         this.creditDecisionConfig = DefaultCreditDecisionConfig.of(config);
         this.persistenceIdsConfig = DefaultPersistenceIdsConfig.of(config);
         this.config = config;
@@ -53,7 +54,8 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
     }
 
     static PersistenceCleanupConfig updated(final Config extractedConfig) {
-        return new DefaultPersistenceCleanupConfig(extractedConfig);
+        return new DefaultPersistenceCleanupConfig(
+                ConfigWithFallback.newInstance(extractedConfig, CONFIG_PATH, ConfigValue.values()));
     }
 
     @Override
@@ -145,4 +147,5 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
                 ", persistenceIdsConfig" + persistenceIdsConfig +
                 "]";
     }
+
 }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.Objects;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
@@ -55,7 +56,7 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
 
     static PersistenceCleanupConfig updated(final Config extractedConfig) {
         return new DefaultPersistenceCleanupConfig(
-                ConfigWithFallback.newInstance(extractedConfig, CONFIG_PATH, ConfigValue.values()));
+                ConfigWithFallback.newInstance(extractedConfig, new KnownConfigValue[0]));
     }
 
     @Override

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceCleanupConfig.java
@@ -39,7 +39,7 @@ final class DefaultPersistenceCleanupConfig implements PersistenceCleanupConfig 
         this.enabled = config.getBoolean(ConfigValue.ENABLED.getConfigPath());
         this.quietPeriod = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.QUIET_PERIOD);
         this.cleanupTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.CLEANUP_TIMEOUT);
-        this.parallelism = config.getGreaterZeroIntOrThrow(ConfigValue.PARALLELISM);
+        this.parallelism = config.getNonNegativeIntOrThrow(ConfigValue.PARALLELISM);
         this.keptCreditDecisions = config.getPositiveIntOrThrow(ConfigValue.KEEP_CREDIT_DECISIONS);
         this.keptActions = config.getPositiveIntOrThrow(ConfigValue.KEEP_ACTIONS);
         this.keptEvents = config.getPositiveIntOrThrow(ConfigValue.KEEP_EVENTS);

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceIdsConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceIdsConfig.java
@@ -42,7 +42,7 @@ final class DefaultPersistenceIdsConfig implements PersistenceIdsConfig {
         streamIdleTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.STREAM_IDLE_TIMEOUT);
         minBackoff = config.getNonNegativeDurationOrThrow(ConfigValue.MIN_BACKOFF);
         maxBackoff = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.MAX_BACKOFF);
-        maxRestarts = config.getGreaterZeroIntOrThrow(ConfigValue.MAX_RESTARTS);
+        maxRestarts = config.getNonNegativeIntOrThrow(ConfigValue.MAX_RESTARTS);
         recovery = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.RECOVERY);
     }
 

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceIdsConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultPersistenceIdsConfig.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -35,14 +36,14 @@ final class DefaultPersistenceIdsConfig implements PersistenceIdsConfig {
     private final int maxRestarts;
     private final Duration recovery;
 
-    private DefaultPersistenceIdsConfig(final Config config) {
-        burst = config.getInt(ConfigValue.BURST.getConfigPath());
-        streamRequestTimeout = config.getDuration(ConfigValue.STREAM_REQUEST_TIMEOUT.getConfigPath());
-        streamIdleTimeout = config.getDuration(ConfigValue.STREAM_IDLE_TIMEOUT.getConfigPath());
-        minBackoff = config.getDuration(ConfigValue.MIN_BACKOFF.getConfigPath());
-        maxBackoff = config.getDuration(ConfigValue.MAX_BACKOFF.getConfigPath());
-        maxRestarts = config.getInt(ConfigValue.MAX_RESTARTS.getConfigPath());
-        recovery = config.getDuration(ConfigValue.RECOVERY.getConfigPath());
+    private DefaultPersistenceIdsConfig(final ScopedConfig config) {
+        burst = config.getPositiveIntOrThrow(ConfigValue.BURST);
+        streamRequestTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.STREAM_REQUEST_TIMEOUT);
+        streamIdleTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.STREAM_IDLE_TIMEOUT);
+        minBackoff = config.getNonNegativeDurationOrThrow(ConfigValue.MIN_BACKOFF);
+        maxBackoff = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.MAX_BACKOFF);
+        maxRestarts = config.getGreaterZeroIntOrThrow(ConfigValue.MAX_RESTARTS);
+        recovery = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.RECOVERY);
     }
 
     static PersistenceIdsConfig of(final Config config) {
@@ -117,4 +118,5 @@ final class DefaultPersistenceIdsConfig implements PersistenceIdsConfig {
                 ", recovery" + recovery +
                 "]";
     }
+
 }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
@@ -36,7 +36,7 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
     private DefaultThingsAggregatorConfig(final ScopedConfig config) {
         singleRetrieveThingTimeout =
                 config.getNonNegativeAndNonZeroDurationOrThrow(ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT);
-        maxParallelism = config.getNonNegativeIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
+        maxParallelism = config.getPositiveIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
     }
 
     /**

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
@@ -35,8 +35,8 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
 
     private DefaultThingsAggregatorConfig(final ScopedConfig config) {
         singleRetrieveThingTimeout =
-                config.getDuration(ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT.getConfigPath());
-        maxParallelism = config.getInt(ThingsAggregatorConfigValue.MAX_PARALLELISM.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT);
+        maxParallelism = config.getGreaterZeroIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
     }
 
     /**

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DefaultThingsAggregatorConfig.java
@@ -36,7 +36,7 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
     private DefaultThingsAggregatorConfig(final ScopedConfig config) {
         singleRetrieveThingTimeout =
                 config.getNonNegativeAndNonZeroDurationOrThrow(ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT);
-        maxParallelism = config.getGreaterZeroIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
+        maxParallelism = config.getNonNegativeIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
     }
 
     /**

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DittoConciergeConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DittoConciergeConfig.java
@@ -49,7 +49,6 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
         serviceSpecificConfig = DittoServiceConfig.of(dittoScopedConfig, CONFIG_PATH);
         mongoDbConfig = DefaultMongoDbConfig.of(dittoScopedConfig);
         healthCheckConfig = DefaultHealthCheckConfig.of(dittoScopedConfig);
-
         enforcementConfig = DefaultEnforcementConfig.of(serviceSpecificConfig);
         cachesConfig = DefaultCachesConfig.of(serviceSpecificConfig);
         thingsAggregatorConfig = DefaultThingsAggregatorConfig.of(serviceSpecificConfig);

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceCleanupConfig.java
@@ -150,4 +150,5 @@ public interface PersistenceCleanupConfig extends BackgroundStreamingConfig {
             return defaultValue;
         }
     }
+
 }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceCleanupConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceCleanupConfig.java
@@ -113,7 +113,7 @@ public interface PersistenceCleanupConfig extends BackgroundStreamingConfig {
         CLEANUP_TIMEOUT("cleanup-timeout", Duration.ofSeconds(30L)),
 
         /**
-         * Number of clewanup commands to execute in parallel.
+         * Number of cleanup commands to execute in parallel.
          */
         PARALLELISM("parallelism", 1),
 

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceIdsConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/PersistenceIdsConfig.java
@@ -129,4 +129,5 @@ public interface PersistenceIdsConfig {
             return path;
         }
     }
+
 }

--- a/concierge/service/src/main/resources/concierge.conf
+++ b/concierge/service/src/main/resources/concierge.conf
@@ -59,8 +59,10 @@ ditto {
     }
 
     things-aggregator {
+
       single-retrieve-thing-timeout = 30s
       single-retrieve-thing-timeout = ${?THINGS_AGGREGATOR_SINGLE_RETRIEVE_THING_TIMEOUT}
+
       max-parallelism = 20
       max-parallelism = ${?THINGS_AGGREGATOR_MAX_PARALLELISM}
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp091Config.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp091Config.java
@@ -34,7 +34,7 @@ public final class DefaultAmqp091Config implements Amqp091Config {
     private final Duration publisherPendingAckTTL;
 
     private DefaultAmqp091Config(final ScopedConfig config) {
-        publisherPendingAckTTL = config.getDuration(ConfigValue.PUBLISHER_PENDING_ACK_TTL.getConfigPath());
+        publisherPendingAckTTL = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.PUBLISHER_PENDING_ACK_TTL);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp10Config.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp10Config.java
@@ -51,7 +51,7 @@ public final class DefaultAmqp10Config implements Amqp10Config, WithStringMapDec
 
     private DefaultAmqp10Config(final ScopedConfig config) {
         consumerRateLimitEnabled = config.getBoolean(Amqp10ConfigValue.CONSUMER_RATE_LIMIT_ENABLED.getConfigPath());
-        consumerMaxInFlight = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.CONSUMER_MAX_IN_FLIGHT);
+        consumerMaxInFlight = config.getNonNegativeIntOrThrow(Amqp10ConfigValue.CONSUMER_MAX_IN_FLIGHT);
         consumerRedeliveryExpectationTimeout =
                 config.getNonNegativeAndNonZeroDurationOrThrow(Amqp10ConfigValue.CONSUMER_REDELIVERY_EXPECTATION_TIMEOUT);
         producerCacheSize = config.getPositiveIntOrThrow(Amqp10ConfigValue.PRODUCER_CACHE_SIZE);
@@ -61,13 +61,13 @@ public final class DefaultAmqp10Config implements Amqp10Config, WithStringMapDec
         consumerThrottlingConfig = ThrottlingConfig.of(config.hasPath(CONSUMER_PATH)
                 ? config.getConfig(CONSUMER_PATH)
                 : ConfigFactory.empty());
-        maxQueueSize = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.MAX_QUEUE_SIZE);
-        messagePublishingParallelism = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.MESSAGE_PUBLISHING_PARALLELISM);
+        maxQueueSize = config.getNonNegativeIntOrThrow(Amqp10ConfigValue.MAX_QUEUE_SIZE);
+        messagePublishingParallelism = config.getNonNegativeIntOrThrow(Amqp10ConfigValue.MESSAGE_PUBLISHING_PARALLELISM);
         globalConnectTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_CONNECT_TIMEOUT);
         globalSendTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_SEND_TIMEOUT);
         globalRequestTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_REQUEST_TIMEOUT);
         globalPrefetchPolicyAllCount =
-                config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.GLOBAL_PREFETCH_POLICY_ALL_COUNT);
+                config.getNonNegativeIntOrThrow(Amqp10ConfigValue.GLOBAL_PREFETCH_POLICY_ALL_COUNT);
         hmacAlgorithms = asStringMap(config, HttpPushConfig.ConfigValue.HMAC_ALGORITHMS.getConfigPath());
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp10Config.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultAmqp10Config.java
@@ -51,23 +51,23 @@ public final class DefaultAmqp10Config implements Amqp10Config, WithStringMapDec
 
     private DefaultAmqp10Config(final ScopedConfig config) {
         consumerRateLimitEnabled = config.getBoolean(Amqp10ConfigValue.CONSUMER_RATE_LIMIT_ENABLED.getConfigPath());
-        consumerMaxInFlight = config.getInt(Amqp10ConfigValue.CONSUMER_MAX_IN_FLIGHT.getConfigPath());
+        consumerMaxInFlight = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.CONSUMER_MAX_IN_FLIGHT);
         consumerRedeliveryExpectationTimeout =
-                config.getDuration(Amqp10ConfigValue.CONSUMER_REDELIVERY_EXPECTATION_TIMEOUT.getConfigPath());
-        producerCacheSize = config.getInt(Amqp10ConfigValue.PRODUCER_CACHE_SIZE.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(Amqp10ConfigValue.CONSUMER_REDELIVERY_EXPECTATION_TIMEOUT);
+        producerCacheSize = config.getPositiveIntOrThrow(Amqp10ConfigValue.PRODUCER_CACHE_SIZE);
         backOffConfig = DefaultBackOffConfig.of(config.hasPath(BACKOFF_PATH)
                 ? config
                 : ConfigFactory.parseString(BACKOFF_PATH + "={}"));
         consumerThrottlingConfig = ThrottlingConfig.of(config.hasPath(CONSUMER_PATH)
                 ? config.getConfig(CONSUMER_PATH)
                 : ConfigFactory.empty());
-        maxQueueSize = config.getInt(Amqp10ConfigValue.MAX_QUEUE_SIZE.getConfigPath());
-        messagePublishingParallelism = config.getInt(Amqp10ConfigValue.MESSAGE_PUBLISHING_PARALLELISM.getConfigPath());
-        globalConnectTimeout = config.getDuration(Amqp10ConfigValue.GLOBAL_CONNECT_TIMEOUT.getConfigPath());
-        globalSendTimeout = config.getDuration(Amqp10ConfigValue.GLOBAL_SEND_TIMEOUT.getConfigPath());
-        globalRequestTimeout = config.getDuration(Amqp10ConfigValue.GLOBAL_REQUEST_TIMEOUT.getConfigPath());
+        maxQueueSize = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.MAX_QUEUE_SIZE);
+        messagePublishingParallelism = config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.MESSAGE_PUBLISHING_PARALLELISM);
+        globalConnectTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_CONNECT_TIMEOUT);
+        globalSendTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_SEND_TIMEOUT);
+        globalRequestTimeout = config.getNonNegativeDurationOrThrow(Amqp10ConfigValue.GLOBAL_REQUEST_TIMEOUT);
         globalPrefetchPolicyAllCount =
-                config.getInt(Amqp10ConfigValue.GLOBAL_PREFETCH_POLICY_ALL_COUNT.getConfigPath());
+                config.getGreaterZeroIntOrThrow(Amqp10ConfigValue.GLOBAL_PREFETCH_POLICY_ALL_COUNT);
         hmacAlgorithms = asStringMap(config, HttpPushConfig.ConfigValue.HMAC_ALGORITHMS.getConfigPath());
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultBackOffConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultBackOffConfig.java
@@ -54,13 +54,6 @@ public final class DefaultBackOffConfig implements BackOffConfig {
 
 
     @Override
-    public String toString() {
-        return getClass().getSimpleName() + " [" +
-                "timeoutConfig=" + timeoutConfig +
-                "]";
-    }
-
-    @Override
     public boolean equals(@Nullable final Object o) {
         if (this == o) {
             return true;
@@ -75,6 +68,13 @@ public final class DefaultBackOffConfig implements BackOffConfig {
     @Override
     public int hashCode() {
         return Objects.hash(timeoutConfig);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "timeoutConfig=" + timeoutConfig +
+                "]";
     }
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultClientConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultClientConfig.java
@@ -44,19 +44,21 @@ public final class DefaultClientConfig implements ClientConfig {
     private final Duration clientActorRefsNotificationDelay;
 
     private DefaultClientConfig(final ScopedConfig config) {
-        initTimeout = config.getDuration(ClientConfigValue.INIT_TIMEOUT.getConfigPath());
-        connectingMinTimeout = config.getDuration(ClientConfigValue.CONNECTING_MIN_TIMEOUT.getConfigPath());
-        connectingMaxTimeout = config.getDuration(ClientConfigValue.CONNECTING_MAX_TIMEOUT.getConfigPath());
-        disconnectingMaxTimeout = config.getDuration(ClientConfigValue.DISCONNECTING_MAX_TIMEOUT.getConfigPath());
-        disconnectAnnouncementTimeout = config.getDuration(
-                ClientConfigValue.DISCONNECT_ANNOUNCEMENT_TIMEOUT.getConfigPath());
-        subscriptionManagerTimeout = config.getDuration(ClientConfigValue.SUBSCRIPTION_MANAGER_TIMEOUT.getConfigPath());
-        connectingMaxTries = config.getInt(ClientConfigValue.CONNECTING_MAX_TRIES.getConfigPath());
-        testingTimeout = config.getDuration(ClientConfigValue.TESTING_TIMEOUT.getConfigPath());
-        minBackoff = config.getDuration(ClientConfigValue.MIN_BACKOFF.getConfigPath());
-        maxBackoff = config.getDuration(ClientConfigValue.MAX_BACKOFF.getConfigPath());
+        initTimeout = config.getNonNegativeDurationOrThrow(ClientConfigValue.INIT_TIMEOUT);
+        connectingMinTimeout = config.getNonNegativeDurationOrThrow(ClientConfigValue.CONNECTING_MIN_TIMEOUT);
+        connectingMaxTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ClientConfigValue.CONNECTING_MAX_TIMEOUT);
+        disconnectingMaxTimeout =
+                config.getNonNegativeAndNonZeroDurationOrThrow(ClientConfigValue.DISCONNECTING_MAX_TIMEOUT);
+        disconnectAnnouncementTimeout = config.getNonNegativeDurationOrThrow(
+                ClientConfigValue.DISCONNECT_ANNOUNCEMENT_TIMEOUT);
+        subscriptionManagerTimeout =
+                config.getNonNegativeDurationOrThrow(ClientConfigValue.SUBSCRIPTION_MANAGER_TIMEOUT);
+        connectingMaxTries = config.getPositiveIntOrThrow(ClientConfigValue.CONNECTING_MAX_TRIES);
+        testingTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ClientConfigValue.TESTING_TIMEOUT);
+        minBackoff = config.getNonNegativeDurationOrThrow(ClientConfigValue.MIN_BACKOFF);
+        maxBackoff = config.getNonNegativeAndNonZeroDurationOrThrow(ClientConfigValue.MAX_BACKOFF);
         clientActorRefsNotificationDelay =
-                config.getDuration(ClientConfigValue.CLIENT_ACTOR_REFS_NOTIFICATION_DELAY.getConfigPath());
+                config.getNonNegativeDurationOrThrow(ClientConfigValue.CLIENT_ACTOR_REFS_NOTIFICATION_DELAY);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
@@ -58,9 +58,10 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     private final boolean allClientActorsOnOneNode;
 
     private DefaultConnectionConfig(final ConfigWithFallback config) {
-        clientActorAskTimeout = config.getDuration(ConnectionConfigValue.CLIENT_ACTOR_ASK_TIMEOUT.getConfigPath());
-        clientActorRestartsBeforeEscalation = config.getInt(ConnectionConfigValue.CLIENT_ACTOR_RESTARTS_BEFORE_ESCALATION
-                .getConfigPath());
+        clientActorAskTimeout =
+                config.getNonNegativeAndNonZeroDurationOrThrow(ConnectionConfigValue.CLIENT_ACTOR_ASK_TIMEOUT);
+        clientActorRestartsBeforeEscalation =
+                config.getPositiveIntOrThrow(ConnectionConfigValue.CLIENT_ACTOR_RESTARTS_BEFORE_ESCALATION);
         allowedHostnames = fromCommaSeparatedString(config, ConnectionConfigValue.ALLOWED_HOSTNAMES);
         blockedHostnames = fromCommaSeparatedString(config, ConnectionConfigValue.BLOCKED_HOSTNAMES);
         supervisorConfig = DefaultSupervisorConfig.of(config);
@@ -72,12 +73,14 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
         kafkaConfig = DefaultKafkaConfig.of(config);
         httpPushConfig = DefaultHttpPushConfig.of(config);
         activityCheckConfig = DefaultActivityCheckConfig.of(config);
-        maxNumberOfTargets = config.getInt(ConnectionConfigValue.MAX_TARGET_NUMBER.getConfigPath());
-        maxNumberOfSources = config.getInt(ConnectionConfigValue.MAX_SOURCE_NUMBER.getConfigPath());
-        ackLabelDeclareInterval = config.getDuration(ConnectionConfigValue.ACK_LABEL_DECLARE_INTERVAL.getConfigPath());
+        maxNumberOfTargets = config.getGreaterZeroIntOrThrow(ConnectionConfigValue.MAX_TARGET_NUMBER);
+        maxNumberOfSources = config.getGreaterZeroIntOrThrow(ConnectionConfigValue.MAX_SOURCE_NUMBER);
+        ackLabelDeclareInterval =
+                config.getNonNegativeAndNonZeroDurationOrThrow(ConnectionConfigValue.ACK_LABEL_DECLARE_INTERVAL);
         allClientActorsOnOneNode =
                 config.getBoolean(ConnectionConfigValue.ALL_CLIENT_ACTORS_ON_ONE_NODE.getConfigPath());
-        priorityUpdateInterval = config.getDuration(ConnectionConfigValue.PRIORITY_UPDATE_INTERVAL.getConfigPath());
+        priorityUpdateInterval =
+                config.getNonNegativeAndNonZeroDurationOrThrow(ConnectionConfigValue.PRIORITY_UPDATE_INTERVAL);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
@@ -97,7 +97,8 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
 
     private Collection<String> fromCommaSeparatedString(final ConfigWithFallback config,
             final ConnectionConfigValue configValue) {
-        final String commaSeparated = config.getString(configValue.getConfigPath());
+        final var commaSeparated = config.getString(configValue.getConfigPath());
+
         return List.of(commaSeparated.split(","));
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
@@ -73,8 +73,8 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
         kafkaConfig = DefaultKafkaConfig.of(config);
         httpPushConfig = DefaultHttpPushConfig.of(config);
         activityCheckConfig = DefaultActivityCheckConfig.of(config);
-        maxNumberOfTargets = config.getGreaterZeroIntOrThrow(ConnectionConfigValue.MAX_TARGET_NUMBER);
-        maxNumberOfSources = config.getGreaterZeroIntOrThrow(ConnectionConfigValue.MAX_SOURCE_NUMBER);
+        maxNumberOfTargets = config.getNonNegativeIntOrThrow(ConnectionConfigValue.MAX_TARGET_NUMBER);
+        maxNumberOfSources = config.getNonNegativeIntOrThrow(ConnectionConfigValue.MAX_SOURCE_NUMBER);
         ackLabelDeclareInterval =
                 config.getNonNegativeAndNonZeroDurationOrThrow(ConnectionConfigValue.ACK_LABEL_DECLARE_INTERVAL);
         allClientActorsOnOneNode =

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
@@ -34,9 +34,9 @@ public final class DefaultConnectionIdsRetrievalConfig implements ConnectionIdsR
 
     private DefaultConnectionIdsRetrievalConfig(final ScopedConfig config) {
         readJournalBatchSize =
-                config.getGreaterZeroIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE);
+                config.getNonNegativeIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE);
         readSnapshotBatchSize =
-                config.getGreaterZeroIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE);
+                config.getNonNegativeIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
@@ -33,9 +33,10 @@ public final class DefaultConnectionIdsRetrievalConfig implements ConnectionIdsR
     private final int readSnapshotBatchSize;
 
     private DefaultConnectionIdsRetrievalConfig(final ScopedConfig config) {
-        readJournalBatchSize = config.getInt(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE.getConfigPath());
+        readJournalBatchSize =
+                config.getGreaterZeroIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE);
         readSnapshotBatchSize =
-                config.getInt(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE.getConfigPath());
+                config.getGreaterZeroIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE);
     }
 
     /**
@@ -46,7 +47,7 @@ public final class DefaultConnectionIdsRetrievalConfig implements ConnectionIdsR
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultConnectionIdsRetrievalConfig of(final Config config) {
-        final ConfigWithFallback reconnectScopedConfig =
+        final var reconnectScopedConfig =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, ConnectionIdsRetrievalConfigValue.values());
 
         return new DefaultConnectionIdsRetrievalConfig(reconnectScopedConfig);
@@ -82,4 +83,5 @@ public final class DefaultConnectionIdsRetrievalConfig implements ConnectionIdsR
                 ", readSnapshotBatchSize=" + readSnapshotBatchSize +
                 "]";
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionIdsRetrievalConfig.java
@@ -34,9 +34,9 @@ public final class DefaultConnectionIdsRetrievalConfig implements ConnectionIdsR
 
     private DefaultConnectionIdsRetrievalConfig(final ScopedConfig config) {
         readJournalBatchSize =
-                config.getNonNegativeIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE);
+                config.getPositiveIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_JOURNAL_BATCH_SIZE);
         readSnapshotBatchSize =
-                config.getNonNegativeIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE);
+                config.getPositiveIntOrThrow(ConnectionIdsRetrievalConfigValue.READ_SNAPSHOT_BATCH_SIZE);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
@@ -39,7 +39,7 @@ final class DefaultHttpPushConfig implements HttpPushConfig, WithStringMapDecodi
     private final Map<String, String> hmacAlgorithms;
 
     private DefaultHttpPushConfig(final ScopedConfig config) {
-        maxQueueSize = config.getGreaterZeroIntOrThrow(ConfigValue.MAX_QUEUE_SIZE);
+        maxQueueSize = config.getNonNegativeIntOrThrow(ConfigValue.MAX_QUEUE_SIZE);
         requestTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.REQUEST_TIMEOUT);
         httpProxyConfig = DefaultHttpProxyConfig.ofProxy(config);
         hmacAlgorithms = asStringMap(config, ConfigValue.HMAC_ALGORITHMS.getConfigPath());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
@@ -39,7 +39,7 @@ final class DefaultHttpPushConfig implements HttpPushConfig, WithStringMapDecodi
     private final Map<String, String> hmacAlgorithms;
 
     private DefaultHttpPushConfig(final ScopedConfig config) {
-        maxQueueSize = config.getNonNegativeIntOrThrow(ConfigValue.MAX_QUEUE_SIZE);
+        maxQueueSize = config.getPositiveIntOrThrow(ConfigValue.MAX_QUEUE_SIZE);
         requestTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.REQUEST_TIMEOUT);
         httpProxyConfig = DefaultHttpProxyConfig.ofProxy(config);
         hmacAlgorithms = asStringMap(config, ConfigValue.HMAC_ALGORITHMS.getConfigPath());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultHttpPushConfig.java
@@ -21,7 +21,6 @@ import javax.annotation.concurrent.Immutable;
 import org.eclipse.ditto.base.service.config.http.DefaultHttpProxyConfig;
 import org.eclipse.ditto.base.service.config.http.HttpProxyConfig;
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
-import org.eclipse.ditto.internal.utils.config.DittoConfigError;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
@@ -40,11 +39,8 @@ final class DefaultHttpPushConfig implements HttpPushConfig, WithStringMapDecodi
     private final Map<String, String> hmacAlgorithms;
 
     private DefaultHttpPushConfig(final ScopedConfig config) {
-        maxQueueSize = config.getInt(ConfigValue.MAX_QUEUE_SIZE.getConfigPath());
-        requestTimeout = config.getDuration(ConfigValue.REQUEST_TIMEOUT.getConfigPath());
-        if (requestTimeout.isNegative() || requestTimeout.isZero()) {
-            throw new DittoConfigError("Request timeout must be greater than 0");
-        }
+        maxQueueSize = config.getGreaterZeroIntOrThrow(ConfigValue.MAX_QUEUE_SIZE);
+        requestTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.REQUEST_TIMEOUT);
         httpProxyConfig = DefaultHttpProxyConfig.ofProxy(config);
         hmacAlgorithms = asStringMap(config, ConfigValue.HMAC_ALGORITHMS.getConfigPath());
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaConsumerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaConsumerConfig.java
@@ -84,4 +84,5 @@ public final class DefaultKafkaConsumerConfig implements KafkaConsumerConfig {
                 ", alpakkaConfig=" + alpakkaConfig +
                 "]";
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -37,12 +38,12 @@ public final class DefaultKafkaProducerConfig implements KafkaProducerConfig {
     private final double randomFactor;
     private final Config alpakkaConfig;
 
-    private DefaultKafkaProducerConfig(final Config kafkaProducerScopedConfig) {
-        queueSize = kafkaProducerScopedConfig.getInt(ConfigValue.QUEUE_SIZE.getConfigPath());
-        parallelism = kafkaProducerScopedConfig.getInt(ConfigValue.PARALLELISM.getConfigPath());
-        minBackoff = kafkaProducerScopedConfig.getDuration(ConfigValue.MIN_BACKOFF.getConfigPath());
-        maxBackoff = kafkaProducerScopedConfig.getDuration(ConfigValue.MAX_BACKOFF.getConfigPath());
-        randomFactor = kafkaProducerScopedConfig.getDouble(ConfigValue.RANDOM_FACTOR.getConfigPath());
+    private DefaultKafkaProducerConfig(final ScopedConfig kafkaProducerScopedConfig) {
+        queueSize = kafkaProducerScopedConfig.getGreaterZeroIntOrThrow(ConfigValue.QUEUE_SIZE);
+        parallelism = kafkaProducerScopedConfig.getGreaterZeroIntOrThrow(ConfigValue.PARALLELISM);
+        minBackoff = kafkaProducerScopedConfig.getNonNegativeDurationOrThrow(ConfigValue.MIN_BACKOFF);
+        maxBackoff = kafkaProducerScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.MAX_BACKOFF);
+        randomFactor = kafkaProducerScopedConfig.getGreaterZeroDoubleOrThrow(ConfigValue.RANDOM_FACTOR);
         alpakkaConfig = kafkaProducerScopedConfig.getConfig(ALPAKKA_PATH);
     }
 
@@ -55,8 +56,7 @@ public final class DefaultKafkaProducerConfig implements KafkaProducerConfig {
      */
     public static DefaultKafkaProducerConfig of(final Config config) {
         return new DefaultKafkaProducerConfig(
-                ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValue.values())
-        );
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValue.values()));
     }
 
     @Override
@@ -118,4 +118,5 @@ public final class DefaultKafkaProducerConfig implements KafkaProducerConfig {
                 ", alpakkaConfig=" + alpakkaConfig +
                 "]";
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
@@ -39,11 +39,11 @@ public final class DefaultKafkaProducerConfig implements KafkaProducerConfig {
     private final Config alpakkaConfig;
 
     private DefaultKafkaProducerConfig(final ScopedConfig kafkaProducerScopedConfig) {
-        queueSize = kafkaProducerScopedConfig.getNonNegativeIntOrThrow(ConfigValue.QUEUE_SIZE);
-        parallelism = kafkaProducerScopedConfig.getNonNegativeIntOrThrow(ConfigValue.PARALLELISM);
+        queueSize = kafkaProducerScopedConfig.getPositiveIntOrThrow(ConfigValue.QUEUE_SIZE);
+        parallelism = kafkaProducerScopedConfig.getPositiveIntOrThrow(ConfigValue.PARALLELISM);
         minBackoff = kafkaProducerScopedConfig.getNonNegativeDurationOrThrow(ConfigValue.MIN_BACKOFF);
         maxBackoff = kafkaProducerScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.MAX_BACKOFF);
-        randomFactor = kafkaProducerScopedConfig.getNonNegativeDoubleOrThrow(ConfigValue.RANDOM_FACTOR);
+        randomFactor = kafkaProducerScopedConfig.getPositiveDoubleOrThrow(ConfigValue.RANDOM_FACTOR);
         alpakkaConfig = kafkaProducerScopedConfig.getConfig(ALPAKKA_PATH);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultKafkaProducerConfig.java
@@ -39,11 +39,11 @@ public final class DefaultKafkaProducerConfig implements KafkaProducerConfig {
     private final Config alpakkaConfig;
 
     private DefaultKafkaProducerConfig(final ScopedConfig kafkaProducerScopedConfig) {
-        queueSize = kafkaProducerScopedConfig.getGreaterZeroIntOrThrow(ConfigValue.QUEUE_SIZE);
-        parallelism = kafkaProducerScopedConfig.getGreaterZeroIntOrThrow(ConfigValue.PARALLELISM);
+        queueSize = kafkaProducerScopedConfig.getNonNegativeIntOrThrow(ConfigValue.QUEUE_SIZE);
+        parallelism = kafkaProducerScopedConfig.getNonNegativeIntOrThrow(ConfigValue.PARALLELISM);
         minBackoff = kafkaProducerScopedConfig.getNonNegativeDurationOrThrow(ConfigValue.MIN_BACKOFF);
         maxBackoff = kafkaProducerScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ConfigValue.MAX_BACKOFF);
-        randomFactor = kafkaProducerScopedConfig.getGreaterZeroDoubleOrThrow(ConfigValue.RANDOM_FACTOR);
+        randomFactor = kafkaProducerScopedConfig.getNonNegativeDoubleOrThrow(ConfigValue.RANDOM_FACTOR);
         alpakkaConfig = kafkaProducerScopedConfig.getConfig(ALPAKKA_PATH);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMonitoringLoggerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMonitoringLoggerConfig.java
@@ -38,9 +38,9 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
     private final Duration loggingActiveCheckInterval;
 
     private DefaultMonitoringLoggerConfig(final ConfigWithFallback config) {
-        successCapacity = config.getGreaterZeroIntOrThrow(MonitoringLoggerConfigValue.SUCCESS_CAPACITY);
-        failureCapacity = config.getGreaterZeroIntOrThrow(MonitoringLoggerConfigValue.FAILURE_CAPACITY);
-        maxLogSizeInBytes = config.getGreaterZeroLongOrThrow(MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES);
+        successCapacity = config.getNonNegativeIntOrThrow(MonitoringLoggerConfigValue.SUCCESS_CAPACITY);
+        failureCapacity = config.getNonNegativeIntOrThrow(MonitoringLoggerConfigValue.FAILURE_CAPACITY);
+        maxLogSizeInBytes = config.getNonNegativeLongOrThrow(MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES);
         logDuration = config.getNonNegativeAndNonZeroDurationOrThrow(MonitoringLoggerConfigValue.LOG_DURATION);
         loggingActiveCheckInterval =
                 config.getNonNegativeAndNonZeroDurationOrThrow(MonitoringLoggerConfigValue.LOGGING_ACTIVE_CHECK_INTERVAL);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMonitoringLoggerConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMonitoringLoggerConfig.java
@@ -38,12 +38,12 @@ public final class DefaultMonitoringLoggerConfig implements MonitoringLoggerConf
     private final Duration loggingActiveCheckInterval;
 
     private DefaultMonitoringLoggerConfig(final ConfigWithFallback config) {
-        successCapacity = config.getInt(MonitoringLoggerConfigValue.SUCCESS_CAPACITY.getConfigPath());
-        failureCapacity = config.getInt(MonitoringLoggerConfigValue.FAILURE_CAPACITY.getConfigPath());
-        maxLogSizeInBytes = config.getLong(MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES.getConfigPath());
-        logDuration = config.getDuration(MonitoringLoggerConfigValue.LOG_DURATION.getConfigPath());
+        successCapacity = config.getGreaterZeroIntOrThrow(MonitoringLoggerConfigValue.SUCCESS_CAPACITY);
+        failureCapacity = config.getGreaterZeroIntOrThrow(MonitoringLoggerConfigValue.FAILURE_CAPACITY);
+        maxLogSizeInBytes = config.getGreaterZeroLongOrThrow(MonitoringLoggerConfigValue.MAX_LOG_SIZE_BYTES);
+        logDuration = config.getNonNegativeAndNonZeroDurationOrThrow(MonitoringLoggerConfigValue.LOG_DURATION);
         loggingActiveCheckInterval =
-                config.getDuration(MonitoringLoggerConfigValue.LOGGING_ACTIVE_CHECK_INTERVAL.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(MonitoringLoggerConfigValue.LOGGING_ACTIVE_CHECK_INTERVAL);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -33,7 +33,6 @@ public final class DefaultMqttConfig implements MqttConfig {
     private static final String CONFIG_PATH = "mqtt";
     private static final String RECONNECT_PATH = "reconnect";
 
-    private final int sourceBufferSize;
     private final int eventLoopThreads;
     private final boolean cleanSession;
     private final boolean reconnectForRedelivery;
@@ -43,7 +42,6 @@ public final class DefaultMqttConfig implements MqttConfig {
     private final BackOffConfig reconnectBackOffConfig;
 
     private DefaultMqttConfig(final ScopedConfig config) {
-        sourceBufferSize = config.getNonNegativeIntOrThrow(MqttConfigValue.SOURCE_BUFFER_SIZE);
         eventLoopThreads = config.getNonNegativeIntOrThrow(MqttConfigValue.EVENT_LOOP_THREADS);
         cleanSession = config.getBoolean(MqttConfigValue.CLEAN_SESSION.getConfigPath());
         reconnectForRedelivery = config.getBoolean(MqttConfigValue.RECONNECT_FOR_REDELIVERY.getConfigPath());
@@ -66,11 +64,6 @@ public final class DefaultMqttConfig implements MqttConfig {
      */
     public static DefaultMqttConfig of(final Config config) {
         return new DefaultMqttConfig(ConfigWithFallback.newInstance(config, CONFIG_PATH, MqttConfigValue.values()));
-    }
-
-    @Override
-    public int getSourceBufferSize() {
-        return sourceBufferSize;
     }
 
     @Override
@@ -117,8 +110,7 @@ public final class DefaultMqttConfig implements MqttConfig {
             return false;
         }
         final DefaultMqttConfig that = (DefaultMqttConfig) o;
-        return Objects.equals(sourceBufferSize, that.sourceBufferSize) &&
-                Objects.equals(eventLoopThreads, that.eventLoopThreads) &&
+        return Objects.equals(eventLoopThreads, that.eventLoopThreads) &&
                 Objects.equals(cleanSession, that.cleanSession) &&
                 Objects.equals(reconnectForRedelivery, that.reconnectForRedelivery) &&
                 Objects.equals(reconnectForRedeliveryDelay, that.reconnectForRedeliveryDelay) &&
@@ -130,7 +122,7 @@ public final class DefaultMqttConfig implements MqttConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(sourceBufferSize, eventLoopThreads, cleanSession, reconnectForRedelivery,
+        return Objects.hash(eventLoopThreads, cleanSession, reconnectForRedelivery,
                 reconnectForRedeliveryDelay, useSeparateClientForPublisher,
                 reconnectMinTimeoutForMqttBrokerInitiatedDisconnect, reconnectBackOffConfig);
     }
@@ -138,8 +130,7 @@ public final class DefaultMqttConfig implements MqttConfig {
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "sourceBufferSize=" + sourceBufferSize +
-                ", eventLoopThreads=" + eventLoopThreads +
+                "eventLoopThreads=" + eventLoopThreads +
                 ", cleanSession=" + cleanSession +
                 ", reconnectForRedelivery=" + reconnectForRedelivery +
                 ", reconnectForRedeliveryDelay=" + reconnectForRedeliveryDelay +

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -43,7 +43,7 @@ public final class DefaultMqttConfig implements MqttConfig {
     private final BackOffConfig reconnectBackOffConfig;
 
     private DefaultMqttConfig(final ScopedConfig config) {
-        sourceBufferSize = config.getGreaterZeroIntOrThrow(MqttConfigValue.SOURCE_BUFFER_SIZE);
+        sourceBufferSize = config.getNonNegativeIntOrThrow(MqttConfigValue.SOURCE_BUFFER_SIZE);
         eventLoopThreads = config.getPositiveIntOrThrow(MqttConfigValue.EVENT_LOOP_THREADS);
         cleanSession = config.getBoolean(MqttConfigValue.CLEAN_SESSION.getConfigPath());
         reconnectForRedelivery = config.getBoolean(MqttConfigValue.RECONNECT_FOR_REDELIVERY.getConfigPath());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -44,7 +44,7 @@ public final class DefaultMqttConfig implements MqttConfig {
 
     private DefaultMqttConfig(final ScopedConfig config) {
         sourceBufferSize = config.getNonNegativeIntOrThrow(MqttConfigValue.SOURCE_BUFFER_SIZE);
-        eventLoopThreads = config.getPositiveIntOrThrow(MqttConfigValue.EVENT_LOOP_THREADS);
+        eventLoopThreads = config.getNonNegativeIntOrThrow(MqttConfigValue.EVENT_LOOP_THREADS);
         cleanSession = config.getBoolean(MqttConfigValue.CLEAN_SESSION.getConfigPath());
         reconnectForRedelivery = config.getBoolean(MqttConfigValue.RECONNECT_FOR_REDELIVERY.getConfigPath());
         reconnectForRedeliveryDelay =

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultMqttConfig.java
@@ -43,16 +43,15 @@ public final class DefaultMqttConfig implements MqttConfig {
     private final BackOffConfig reconnectBackOffConfig;
 
     private DefaultMqttConfig(final ScopedConfig config) {
-        sourceBufferSize = config.getInt(MqttConfigValue.SOURCE_BUFFER_SIZE.getConfigPath());
-        eventLoopThreads = config.getInt(MqttConfigValue.EVENT_LOOP_THREADS.getConfigPath());
+        sourceBufferSize = config.getGreaterZeroIntOrThrow(MqttConfigValue.SOURCE_BUFFER_SIZE);
+        eventLoopThreads = config.getPositiveIntOrThrow(MqttConfigValue.EVENT_LOOP_THREADS);
         cleanSession = config.getBoolean(MqttConfigValue.CLEAN_SESSION.getConfigPath());
         reconnectForRedelivery = config.getBoolean(MqttConfigValue.RECONNECT_FOR_REDELIVERY.getConfigPath());
         reconnectForRedeliveryDelay =
-                config.getDuration(MqttConfigValue.RECONNECT_FOR_REDELIVERY_DELAY.getConfigPath());
+                config.getNonNegativeDurationOrThrow(MqttConfigValue.RECONNECT_FOR_REDELIVERY_DELAY);
         useSeparateClientForPublisher = config.getBoolean(MqttConfigValue.SEPARATE_PUBLISHER_CLIENT.getConfigPath());
         reconnectMinTimeoutForMqttBrokerInitiatedDisconnect =
-                config.getDuration(MqttConfigValue.RECONNECT_MIN_TIMEOUT_FOR_MQTT_BROKER_INITIATED_DISCONNECT
-                        .getConfigPath());
+                config.getNonNegativeDurationOrThrow(MqttConfigValue.RECONNECT_MIN_TIMEOUT_FOR_MQTT_BROKER_INITIATED_DISCONNECT);
         reconnectBackOffConfig = DefaultBackOffConfig.of(config.hasPath(RECONNECT_PATH)
                 ? config.getConfig(RECONNECT_PATH)
                 : ConfigFactory.parseString("backoff" + "={}"));

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTimeoutConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTimeoutConfig.java
@@ -35,8 +35,8 @@ public final class DefaultTimeoutConfig implements TimeoutConfig {
     private final Duration maxTimeout;
 
     private DefaultTimeoutConfig(final ScopedConfig config) {
-        minTimeout = config.getDuration(TimeoutConfigValue.MIN_TIMEOUT.getConfigPath());
-        maxTimeout = config.getDuration(TimeoutConfigValue.MAX_TIMEOUT.getConfigPath());
+        minTimeout = config.getNonNegativeDurationOrThrow(TimeoutConfigValue.MIN_TIMEOUT);
+        maxTimeout = config.getNonNegativeAndNonZeroDurationOrThrow(TimeoutConfigValue.MAX_TIMEOUT);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTunnelConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTunnelConfig.java
@@ -36,9 +36,9 @@ public final class DefaultTunnelConfig implements TunnelConfig {
     private final boolean socketKeepalive;
 
     private DefaultTunnelConfig(final ScopedConfig config) {
-        workers = config.getInt(TunnelConfigValue.WORKERS.getConfigPath());
-        heartbeatInterval = config.getDuration(TunnelConfigValue.HEARTBEAT_INTERVAL.getConfigPath());
-        idleTimeout = config.getDuration(TunnelConfigValue.IDLE_TIMEOUT.getConfigPath());
+        workers = config.getPositiveIntOrThrow(TunnelConfigValue.WORKERS);
+        heartbeatInterval = config.getNonNegativeAndNonZeroDurationOrThrow(TunnelConfigValue.HEARTBEAT_INTERVAL);
+        idleTimeout = config.getNonNegativeDurationOrThrow(TunnelConfigValue.IDLE_TIMEOUT);
         socketKeepalive = config.getBoolean(TunnelConfigValue.SOCKET_KEEPALIVE.getConfigPath());
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTunnelConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultTunnelConfig.java
@@ -36,7 +36,7 @@ public final class DefaultTunnelConfig implements TunnelConfig {
     private final boolean socketKeepalive;
 
     private DefaultTunnelConfig(final ScopedConfig config) {
-        workers = config.getPositiveIntOrThrow(TunnelConfigValue.WORKERS);
+        workers = config.getNonNegativeIntOrThrow(TunnelConfigValue.WORKERS);
         heartbeatInterval = config.getNonNegativeAndNonZeroDurationOrThrow(TunnelConfigValue.HEARTBEAT_INTERVAL);
         idleTimeout = config.getNonNegativeDurationOrThrow(TunnelConfigValue.IDLE_TIMEOUT);
         socketKeepalive = config.getBoolean(TunnelConfigValue.SOCKET_KEEPALIVE.getConfigPath());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/MqttConfig.java
@@ -25,14 +25,6 @@ import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 public interface MqttConfig {
 
     /**
-     * Returns the maximum number of buffered messages for each MQTT source.
-     *
-     * @return the buffer size.
-     */
-    int getSourceBufferSize();
-
-
-    /**
      * Returns the number of threads to use for the underlying event loop of the MQTT client.
      * When configured to {@code 0}, the size is determined based on {@code the available processor cores * 2}.
      *
@@ -95,11 +87,6 @@ public interface MqttConfig {
      * {@code MqttConfig}.
      */
     enum MqttConfigValue implements KnownConfigValue {
-
-        /**
-         * The maximum number of buffered messages for each MQTT source.
-         */
-        SOURCE_BUFFER_SIZE("source-buffer-size", 8),
 
         /**
          * The number of threads to use for the underlying event loop of the MQTT client.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
@@ -38,7 +38,7 @@ public final class DefaultJavaScriptConfig implements JavaScriptConfig {
         maxScriptSizeBytes = config.getPositiveIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_SIZE_BYTES);
         maxScriptExecutionTime =
                 config.getNonNegativeAndNonZeroDurationOrThrow(JavaScriptConfigValue.MAX_SCRIPT_EXECUTION_TIME);
-        maxScriptStackDepth = config.getGreaterZeroIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH);
+        maxScriptStackDepth = config.getNonNegativeIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
@@ -35,9 +35,10 @@ public final class DefaultJavaScriptConfig implements JavaScriptConfig {
     private final int maxScriptStackDepth;
 
     private DefaultJavaScriptConfig(final ScopedConfig config) {
-        maxScriptSizeBytes = config.getInt(JavaScriptConfigValue.MAX_SCRIPT_SIZE_BYTES.getConfigPath());
-        maxScriptExecutionTime = config.getDuration(JavaScriptConfigValue.MAX_SCRIPT_EXECUTION_TIME.getConfigPath());
-        maxScriptStackDepth = config.getInt(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH.getConfigPath());
+        maxScriptSizeBytes = config.getPositiveIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_SIZE_BYTES);
+        maxScriptExecutionTime =
+                config.getNonNegativeAndNonZeroDurationOrThrow(JavaScriptConfigValue.MAX_SCRIPT_EXECUTION_TIME);
+        maxScriptStackDepth = config.getGreaterZeroIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/javascript/DefaultJavaScriptConfig.java
@@ -38,7 +38,7 @@ public final class DefaultJavaScriptConfig implements JavaScriptConfig {
         maxScriptSizeBytes = config.getPositiveIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_SIZE_BYTES);
         maxScriptExecutionTime =
                 config.getNonNegativeAndNonZeroDurationOrThrow(JavaScriptConfigValue.MAX_SCRIPT_EXECUTION_TIME);
-        maxScriptStackDepth = config.getNonNegativeIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH);
+        maxScriptStackDepth = config.getPositiveIntOrThrow(JavaScriptConfigValue.MAX_SCRIPT_STACK_DEPTH);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMapperLimitsConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMapperLimitsConfig.java
@@ -37,12 +37,12 @@ public class DefaultMapperLimitsConfig implements MapperLimitsConfig {
 
     private DefaultMapperLimitsConfig(final ScopedConfig config) {
 
-        maxSourceMappers = config.getInt(MapperLimitsConfigValue.MAX_SOURCE_MAPPERS.getConfigPath());
+        maxSourceMappers = config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_SOURCE_MAPPERS);
         maxMappedInboundMessages =
-                config.getInt(MapperLimitsConfigValue.MAX_MAPPED_INBOUND_MESSAGE.getConfigPath());
-        maxTargetMappers = config.getInt(MapperLimitsConfigValue.MAX_TARGET_MAPPERS.getConfigPath());
+                config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_INBOUND_MESSAGE);
+        maxTargetMappers = config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_TARGET_MAPPERS);
         maxMappedOutboundMessages =
-                config.getInt(MapperLimitsConfigValue.MAX_MAPPED_OUTBOUND_MESSAGE.getConfigPath());
+                config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_OUTBOUND_MESSAGE);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMapperLimitsConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMapperLimitsConfig.java
@@ -37,12 +37,12 @@ public class DefaultMapperLimitsConfig implements MapperLimitsConfig {
 
     private DefaultMapperLimitsConfig(final ScopedConfig config) {
 
-        maxSourceMappers = config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_SOURCE_MAPPERS);
+        maxSourceMappers = config.getNonNegativeIntOrThrow(MapperLimitsConfigValue.MAX_SOURCE_MAPPERS);
         maxMappedInboundMessages =
-                config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_INBOUND_MESSAGE);
-        maxTargetMappers = config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_TARGET_MAPPERS);
+                config.getNonNegativeIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_INBOUND_MESSAGE);
+        maxTargetMappers = config.getNonNegativeIntOrThrow(MapperLimitsConfigValue.MAX_TARGET_MAPPERS);
         maxMappedOutboundMessages =
-                config.getGreaterZeroIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_OUTBOUND_MESSAGE);
+                config.getNonNegativeIntOrThrow(MapperLimitsConfigValue.MAX_MAPPED_OUTBOUND_MESSAGE);
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
@@ -38,9 +38,9 @@ public final class DefaultMappingConfig implements MappingConfig {
     private final MapperLimitsConfig mapperLimitsConfig;
 
     private DefaultMappingConfig(final ScopedConfig config) {
-        bufferSize = config.getGreaterZeroIntOrThrow(MappingConfigValue.BUFFER_SIZE);
-        parallelism = config.getGreaterZeroIntOrThrow(MappingConfigValue.PARALLELISM);
-        maxPoolSize = config.getGreaterZeroIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
+        bufferSize = config.getNonNegativeIntOrThrow(MappingConfigValue.BUFFER_SIZE);
+        parallelism = config.getNonNegativeIntOrThrow(MappingConfigValue.PARALLELISM);
+        maxPoolSize = config.getNonNegativeIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
         mapperLimitsConfig = DefaultMapperLimitsConfig.of(config);
         javaScriptConfig = DefaultJavaScriptConfig.of(config);
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
@@ -39,8 +39,8 @@ public final class DefaultMappingConfig implements MappingConfig {
 
     private DefaultMappingConfig(final ScopedConfig config) {
         bufferSize = config.getNonNegativeIntOrThrow(MappingConfigValue.BUFFER_SIZE);
-        parallelism = config.getNonNegativeIntOrThrow(MappingConfigValue.PARALLELISM);
-        maxPoolSize = config.getNonNegativeIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
+        parallelism = config.getPositiveIntOrThrow(MappingConfigValue.PARALLELISM);
+        maxPoolSize = config.getPositiveIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
         mapperLimitsConfig = DefaultMapperLimitsConfig.of(config);
         javaScriptConfig = DefaultJavaScriptConfig.of(config);
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
@@ -38,9 +38,9 @@ public final class DefaultMappingConfig implements MappingConfig {
     private final MapperLimitsConfig mapperLimitsConfig;
 
     private DefaultMappingConfig(final ScopedConfig config) {
-        bufferSize = config.getInt(MappingConfigValue.BUFFER_SIZE.getConfigPath());
-        parallelism = config.getInt(MappingConfigValue.PARALLELISM.getConfigPath());
-        maxPoolSize = config.getInt(MappingConfigValue.MAX_POOL_SIZE.getConfigPath());
+        bufferSize = config.getGreaterZeroIntOrThrow(MappingConfigValue.BUFFER_SIZE);
+        parallelism = config.getGreaterZeroIntOrThrow(MappingConfigValue.PARALLELISM);
+        maxPoolSize = config.getGreaterZeroIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
         mapperLimitsConfig = DefaultMapperLimitsConfig.of(config);
         javaScriptConfig = DefaultJavaScriptConfig.of(config);
     }
@@ -53,7 +53,7 @@ public final class DefaultMappingConfig implements MappingConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultMappingConfig of(final Config config) {
-        final ConfigWithFallback mappingScopedConfig =
+        final var mappingScopedConfig =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, MappingConfigValue.values());
 
         return new DefaultMappingConfig(mappingScopedConfig);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/MapperLimitsConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/MapperLimitsConfig.java
@@ -83,7 +83,7 @@ public interface MapperLimitsConfig {
         private final String path;
         private final Object defaultValue;
 
-        private MapperLimitsConfigValue(final String thePath, final Object theDefaultValue) {
+        MapperLimitsConfigValue(final String thePath, final Object theDefaultValue) {
             path = thePath;
             defaultValue = theDefaultValue;
         }

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -444,9 +444,12 @@ ditto {
     }
 
     client {
-      # Initial timeout when connecting to a remote system. If the connection could not be established after this time, the
-      # service will try to reconnect. If a failure happened during connecting, then the service will wait for at least
-      # this time until it will try to reconnect. The max timeout is defined in connecting-max-timeout.
+      # Initial timeout after the init process is triggered.
+      init-timeout = 5s
+      init-timeout = ${?CONNECTIVITY_CLIENT_INIT_TIMEOUT}
+      # Initial timeout when connecting to a remote system. If the connection could not be established after this time,
+      # the service will try to reconnect. If a failure happened during connecting, then the service will wait
+      # for at least this time until it will try to reconnect. The max timeout is defined in connecting-max-timeout.
       connecting-min-timeout = 60s
       connecting-min-timeout = ${?CONNECTIVITY_CLIENT_CONNECTING_MIN_TIMEOUT}
       # Max timeout (until reconnecting) when connecting to a remote system.

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
@@ -114,12 +114,6 @@ public final class DefaultConnectionConfigTest {
                         .as(SnapshotConfig.SnapshotConfigValue.THRESHOLD.getConfigPath())
                         .isEqualTo(20));
 
-        softly.assertThat(underTest.getMqttConfig())
-                .as("mqttConfig")
-                .satisfies(mqttConfig -> softly.assertThat(mqttConfig.getSourceBufferSize())
-                        .as(MqttConfig.MqttConfigValue.SOURCE_BUFFER_SIZE.getConfigPath())
-                        .isEqualTo(7));
-
         softly.assertThat(underTest.getHttpPushConfig())
                 .as("httpPushConfig")
                 .satisfies(httpPushConfig -> softly.assertThat(httpPushConfig.getMaxQueueSize())

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/proxy/config/DefaultStatisticsConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/proxy/config/DefaultStatisticsConfig.java
@@ -39,9 +39,9 @@ final class DefaultStatisticsConfig implements StatisticsConfig, WithConfigPath 
     private final List<StatisticsShardConfig> shards;
 
     private DefaultStatisticsConfig(final ScopedConfig scopedConfig) {
-        askTimeout = scopedConfig.getDuration(ConfigValues.ASK_TIMEOUT.getConfigPath());
-        updateInterval = scopedConfig.getDuration(ConfigValues.UPDATE_INTERVAL.getConfigPath());
-        detailsExpireAfter = scopedConfig.getDuration(ConfigValues.DETAILS_EXPIRE_AFTER.getConfigPath());
+        askTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ConfigValues.ASK_TIMEOUT);
+        updateInterval = scopedConfig.getNonNegativeDurationOrThrow(ConfigValues.UPDATE_INTERVAL);
+        detailsExpireAfter = scopedConfig.getNonNegativeDurationOrThrow(ConfigValues.DETAILS_EXPIRE_AFTER);
         shards = scopedConfig.getConfigList(ConfigValues.SHARDS.getConfigPath())
                 .stream()
                 .map(DefaultStatisticsShardConfig::of)

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultClaimMessageConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultClaimMessageConfig.java
@@ -34,8 +34,8 @@ public final class DefaultClaimMessageConfig implements MessageConfig {
     private final Duration maxTimeout;
 
     private DefaultClaimMessageConfig(final ScopedConfig scopedConfig) {
-        defaultTimeout = scopedConfig.getDuration(MessageConfigValue.DEFAULT_TIMEOUT.getConfigPath());
-        maxTimeout = scopedConfig.getDuration(MessageConfigValue.MAX_TIMEOUT.getConfigPath());
+        defaultTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(MessageConfigValue.DEFAULT_TIMEOUT);
+        maxTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(MessageConfigValue.MAX_TIMEOUT);
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultCommandConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultCommandConfig.java
@@ -36,8 +36,8 @@ public final class DefaultCommandConfig implements CommandConfig {
     private final Duration maxTimeout;
 
     private DefaultCommandConfig(final ScopedConfig scopedConfig) {
-        defaultTimeout = scopedConfig.getDuration(CommandConfigValue.DEFAULT_TIMEOUT.getConfigPath());
-        maxTimeout = scopedConfig.getDuration(CommandConfigValue.MAX_TIMEOUT.getConfigPath());
+        defaultTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(CommandConfigValue.DEFAULT_TIMEOUT);
+        maxTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(CommandConfigValue.MAX_TIMEOUT);
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultMessageConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultMessageConfig.java
@@ -34,8 +34,8 @@ public final class DefaultMessageConfig implements MessageConfig {
     private final Duration maxTimeout;
 
     private DefaultMessageConfig(final ScopedConfig scopedConfig) {
-        defaultTimeout = scopedConfig.getDuration(MessageConfigValue.DEFAULT_TIMEOUT.getConfigPath());
-        maxTimeout = scopedConfig.getDuration(MessageConfigValue.MAX_TIMEOUT.getConfigPath());
+        defaultTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(MessageConfigValue.DEFAULT_TIMEOUT);
+        maxTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(MessageConfigValue.MAX_TIMEOUT);
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultPublicHealthConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultPublicHealthConfig.java
@@ -33,7 +33,7 @@ public final class DefaultPublicHealthConfig implements PublicHealthConfig {
     private final Duration cacheTimeout;
 
     private DefaultPublicHealthConfig(final ScopedConfig scopedConfig) {
-        cacheTimeout = scopedConfig.getDuration(PublicHealthConfigValue.CACHE_TIMEOUT.getConfigPath());
+        cacheTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(PublicHealthConfigValue.CACHE_TIMEOUT);
     }
 
     /**

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/health/DefaultHealthCheckConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/health/DefaultHealthCheckConfig.java
@@ -39,7 +39,7 @@ public final class DefaultHealthCheckConfig implements HealthCheckConfig {
     private DefaultHealthCheckConfig(final ScopedConfig scopedConfig,
             final BasicHealthCheckConfig basicHealthCheckConfig, final ClusterRolesConfig clusterRolesConfig) {
 
-        serviceTimeout = scopedConfig.getDuration(HealthCheckConfigValue.SERVICE_TIMEOUT.getConfigPath());
+        serviceTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(HealthCheckConfigValue.SERVICE_TIMEOUT);
         this.basicHealthCheckConfig = basicHealthCheckConfig;
         this.clusterRolesConfig = clusterRolesConfig;
     }
@@ -52,7 +52,7 @@ public final class DefaultHealthCheckConfig implements HealthCheckConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultHealthCheckConfig of(final Config config) {
-        final ConfigWithFallback configWithFallback =
+        final var configWithFallback =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, HealthCheckConfigValue.values());
 
         return new DefaultHealthCheckConfig(configWithFallback, DefaultBasicHealthCheckConfig.of(config),

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultCachesConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultCachesConfig.java
@@ -44,7 +44,8 @@ public final class DefaultCachesConfig implements CachesConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultCachesConfig of(final Config config) {
-        final DefaultScopedConfig cacheScopedConfig = DefaultScopedConfig.newInstance(config, CONFIG_PATH);
+        final var cacheScopedConfig = DefaultScopedConfig.newInstance(config, CONFIG_PATH);
+
         return new DefaultCachesConfig(DefaultCacheConfig.of(cacheScopedConfig, "publickeys"));
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultDevOpsConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultDevOpsConfig.java
@@ -62,10 +62,10 @@ public final class DefaultDevOpsConfig implements DevOpsConfig {
     private static DevopsAuthenticationMethod getDevopsAuthenticationMethod(final ConfigWithFallback configWithFallback,
             final DevOpsConfigValue devOpsConfigValue) {
 
-        final String methodName = configWithFallback.getString(devOpsConfigValue.getConfigPath());
+        final var methodName = configWithFallback.getString(devOpsConfigValue.getConfigPath());
         return DevopsAuthenticationMethod.fromMethodName(methodName)
                 .orElseThrow(() -> {
-                    final String message =
+                    final var message =
                             String.format("Could not find devops authentication method with name <%s>", methodName);
                     return new DittoConfigError(message);
                 });

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
@@ -29,9 +29,9 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import org.eclipse.ditto.policies.model.SubjectIssuer;
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
 import org.eclipse.ditto.utils.jsr305.annotations.AllValuesAreNonnullByDefault;
 
 import com.typesafe.config.Config;
@@ -67,6 +67,7 @@ public final class DefaultOAuthConfig implements OAuthConfig {
     private static Map<SubjectIssuer, SubjectIssuerConfig> loadIssuers(final ConfigWithFallback config,
             final KnownConfigValue configValue) {
         final ConfigObject issuersConfig = config.getObject(configValue.getConfigPath());
+
         return issuersConfig.entrySet().stream().collect(SubjectIssuerCollector.toSubjectIssuerMap());
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultGatewaySignalEnrichmentConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultGatewaySignalEnrichmentConfig.java
@@ -38,8 +38,8 @@ public final class DefaultGatewaySignalEnrichmentConfig implements GatewaySignal
     private final CacheConfig cacheConfig;
 
     private DefaultGatewaySignalEnrichmentConfig(final ConfigWithFallback configWithFallback) {
-        this.askTimeout = configWithFallback.getDuration(
-                CachingSignalEnrichmentFacadeConfigValue.ASK_TIMEOUT.getConfigPath());
+        this.askTimeout = configWithFallback.getNonNegativeAndNonZeroDurationOrThrow(
+                CachingSignalEnrichmentFacadeConfigValue.ASK_TIMEOUT);
         cacheConfig = DefaultCacheConfig.of(configWithFallback, CACHE_CONFIG_PATH);
         cachingEnabled =
                 configWithFallback.getBoolean(CachingSignalEnrichmentFacadeConfigValue.CACHING_ENABLED.getConfigPath());
@@ -111,4 +111,5 @@ public final class DefaultGatewaySignalEnrichmentConfig implements GatewaySignal
                 ", cachingEnabled" + cachingEnabled +
                 "]";
     }
+
 }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultStreamingConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultStreamingConfig.java
@@ -40,10 +40,10 @@ public final class DefaultStreamingConfig implements StreamingConfig {
 
     private DefaultStreamingConfig(final ScopedConfig scopedConfig) {
         sessionCounterScrapeInterval =
-                scopedConfig.getDuration(StreamingConfigValue.SESSION_COUNTER_SCRAPE_INTERVAL.getConfigPath());
-        parallelism = scopedConfig.getInt(StreamingConfigValue.PARALLELISM.getConfigPath());
+                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(StreamingConfigValue.SESSION_COUNTER_SCRAPE_INTERVAL);
+        parallelism = scopedConfig.getPositiveIntOrThrow(StreamingConfigValue.PARALLELISM);
         acknowledgementConfig = DefaultAcknowledgementConfig.of(scopedConfig);
-        searchIdleTimeout = scopedConfig.getDuration(StreamingConfigValue.SEARCH_IDLE_TIMEOUT.getConfigPath());
+        searchIdleTimeout = scopedConfig.getNonNegativeDurationOrThrow(StreamingConfigValue.SEARCH_IDLE_TIMEOUT);
         websocketConfig = DefaultWebsocketConfig.of(scopedConfig);
         sseConfig = DefaultSseConfig.of(scopedConfig);
         signalEnrichmentConfig = DefaultGatewaySignalEnrichmentConfig.of(scopedConfig);

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultWebsocketConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultWebsocketConfig.java
@@ -39,7 +39,7 @@ final class DefaultWebsocketConfig implements WebsocketConfig {
         publisherBackpressureBufferSize =
                 scopedConfig.getPositiveIntOrThrow(WebsocketConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE);
         throttlingRejectionFactor =
-                scopedConfig.getGreaterZeroDoubleOrThrow(WebsocketConfigValue.THROTTLING_REJECTION_FACTOR);
+                scopedConfig.getNonNegativeDoubleOrThrow(WebsocketConfigValue.THROTTLING_REJECTION_FACTOR);
         throttlingConfig = ThrottlingConfig.of(scopedConfig);
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultWebsocketConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/streaming/DefaultWebsocketConfig.java
@@ -35,11 +35,11 @@ final class DefaultWebsocketConfig implements WebsocketConfig {
 
     private DefaultWebsocketConfig(final ScopedConfig scopedConfig) {
         subscriberBackpressureQueueSize =
-                scopedConfig.getInt(WebsocketConfigValue.SUBSCRIBER_BACKPRESSURE_QUEUE_SIZE.getConfigPath());
+                scopedConfig.getPositiveIntOrThrow(WebsocketConfigValue.SUBSCRIBER_BACKPRESSURE_QUEUE_SIZE);
         publisherBackpressureBufferSize =
-                scopedConfig.getInt(WebsocketConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE.getConfigPath());
+                scopedConfig.getPositiveIntOrThrow(WebsocketConfigValue.PUBLISHER_BACKPRESSURE_BUFFER_SIZE);
         throttlingRejectionFactor =
-                scopedConfig.getDouble(WebsocketConfigValue.THROTTLING_REJECTION_FACTOR.getConfigPath());
+                scopedConfig.getGreaterZeroDoubleOrThrow(WebsocketConfigValue.THROTTLING_REJECTION_FACTOR);
         throttlingConfig = ThrottlingConfig.of(scopedConfig);
     }
 

--- a/internal/models/acks/src/main/java/org/eclipse/ditto/internal/models/acks/config/DefaultAcknowledgementConfig.java
+++ b/internal/models/acks/src/main/java/org/eclipse/ditto/internal/models/acks/config/DefaultAcknowledgementConfig.java
@@ -46,7 +46,7 @@ public final class DefaultAcknowledgementConfig implements AcknowledgementConfig
         collectorFallbackAskTimeout =
                 config.getNonNegativeAndNonZeroDurationOrThrow(AcknowledgementConfigValue.COLLECTOR_FALLBACK_ASK_TIMEOUT);
         issuedMaxBytes =
-                config.getGreaterZeroIntOrThrow(AcknowledgementConfigValue.ISSUED_MAX_BYTES);
+                config.getNonNegativeIntOrThrow(AcknowledgementConfigValue.ISSUED_MAX_BYTES);
     }
 
     /**

--- a/internal/models/acks/src/main/java/org/eclipse/ditto/internal/models/acks/config/DefaultAcknowledgementConfig.java
+++ b/internal/models/acks/src/main/java/org/eclipse/ditto/internal/models/acks/config/DefaultAcknowledgementConfig.java
@@ -40,13 +40,13 @@ public final class DefaultAcknowledgementConfig implements AcknowledgementConfig
 
     private DefaultAcknowledgementConfig(final ScopedConfig config) {
         forwarderFallbackTimeout =
-                config.getDuration(AcknowledgementConfigValue.FORWARDER_FALLBACK_TIMEOUT.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(AcknowledgementConfigValue.FORWARDER_FALLBACK_TIMEOUT);
         collectorFallbackLifetime =
-                config.getDuration(AcknowledgementConfigValue.COLLECTOR_FALLBACK_LIFETIME.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(AcknowledgementConfigValue.COLLECTOR_FALLBACK_LIFETIME);
         collectorFallbackAskTimeout =
-                config.getDuration(AcknowledgementConfigValue.COLLECTOR_FALLBACK_ASK_TIMEOUT.getConfigPath());
+                config.getNonNegativeAndNonZeroDurationOrThrow(AcknowledgementConfigValue.COLLECTOR_FALLBACK_ASK_TIMEOUT);
         issuedMaxBytes =
-                config.getInt(AcknowledgementConfigValue.ISSUED_MAX_BYTES.getConfigPath());
+                config.getGreaterZeroIntOrThrow(AcknowledgementConfigValue.ISSUED_MAX_BYTES);
     }
 
     /**

--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DefaultSignalEnrichmentConfig.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DefaultSignalEnrichmentConfig.java
@@ -90,4 +90,5 @@ public final class DefaultSignalEnrichmentConfig implements SignalEnrichmentConf
                 ", config=" + config +
                 "]";
     }
+
 }

--- a/internal/utils/akka/src/main/java/org/eclipse/ditto/internal/utils/akka/actors/ModifyConfigBehavior.java
+++ b/internal/utils/akka/src/main/java/org/eclipse/ditto/internal/utils/akka/actors/ModifyConfigBehavior.java
@@ -12,9 +12,9 @@
  */
 package org.eclipse.ditto.internal.utils.akka.actors;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.base.api.common.ModifyConfig;
 import org.eclipse.ditto.base.api.common.ModifyConfigResponse;
+import org.eclipse.ditto.json.JsonObject;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -45,10 +45,10 @@ public interface ModifyConfigBehavior extends Actor {
     default AbstractActor.Receive modifyConfigBehavior() {
         return ReceiveBuilder.create()
                 .match(ModifyConfig.class, cmd -> {
-                    final Config newConfig = setConfig(ConfigFactory.parseString(cmd.getConfig().toString()));
-                    final JsonObject newConfigJson =
+                    final var newConfig = setConfig(ConfigFactory.parseString(cmd.getConfig().toString()));
+                    final var newConfigJson =
                             JsonObject.of(newConfig.root().render(ConfigRenderOptions.concise()));
-                    final ModifyConfigResponse response =
+                    final var response =
                             ModifyConfigResponse.of(newConfigJson, cmd.getDittoHeaders());
                     sender().tell(response, self());
                 })

--- a/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/config/DefaultCacheConfig.java
+++ b/internal/utils/cache/src/main/java/org/eclipse/ditto/internal/utils/cache/config/DefaultCacheConfig.java
@@ -35,10 +35,10 @@ public final class DefaultCacheConfig implements CacheConfig {
     private final Duration expireAfterCreate;
 
     private DefaultCacheConfig(final ConfigWithFallback configWithFallback) {
-        maximumSize = configWithFallback.getLong(CacheConfigValue.MAXIMUM_SIZE.getConfigPath());
-        expireAfterWrite = configWithFallback.getDuration(CacheConfigValue.EXPIRE_AFTER_WRITE.getConfigPath());
-        expireAfterAccess = configWithFallback.getDuration(CacheConfigValue.EXPIRE_AFTER_ACCESS.getConfigPath());
-        expireAfterCreate = configWithFallback.getDuration(CacheConfigValue.EXPIRE_AFTER_CREATE.getConfigPath());
+        maximumSize = configWithFallback.getPositiveLongOrThrow(CacheConfigValue.MAXIMUM_SIZE);
+        expireAfterWrite = configWithFallback.getNonNegativeDurationOrThrow(CacheConfigValue.EXPIRE_AFTER_WRITE);
+        expireAfterAccess = configWithFallback.getNonNegativeDurationOrThrow(CacheConfigValue.EXPIRE_AFTER_ACCESS);
+        expireAfterCreate = configWithFallback.getNonNegativeDurationOrThrow(CacheConfigValue.EXPIRE_AFTER_CREATE);
     }
 
     /**

--- a/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/config/DefaultClusterConfig.java
+++ b/internal/utils/cluster/src/main/java/org/eclipse/ditto/internal/utils/cluster/config/DefaultClusterConfig.java
@@ -33,7 +33,7 @@ public final class DefaultClusterConfig implements ClusterConfig {
     private final List<String> clusterStatusRolesBlocklist;
 
     private DefaultClusterConfig(final ConfigWithFallback config) {
-        numberOfShards = config.getInt(ClusterConfigValue.NUMBER_OF_SHARDS.getConfigPath());
+        numberOfShards = config.getPositiveIntOrThrow(ClusterConfigValue.NUMBER_OF_SHARDS);
         clusterStatusRolesBlocklist = Collections.unmodifiableList(
                 new ArrayList<>(
                         config.getStringList(ClusterConfigValue.CLUSTER_STATUS_ROLES_BLOCKLIST.getConfigPath())));
@@ -86,4 +86,5 @@ public final class DefaultClusterConfig implements ClusterConfig {
                 ", clusterStatusRolesBlocklist=" + clusterStatusRolesBlocklist +
                 "]";
     }
+
 }

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ConfigWithFallback.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ConfigWithFallback.java
@@ -106,7 +106,7 @@ public final class ConfigWithFallback implements ScopedConfig, ConfigMergeable {
         validateArgument(originalConfig, "original Config");
         validateArgument(fallBackValues, "fall-back values");
 
-        Config baseConfig = originalConfig;
+        var baseConfig = originalConfig;
         if (0 < fallBackValues.length) {
             baseConfig = baseConfig.withFallback(arrayToConfig(fallBackValues));
         }

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/DefaultScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/DefaultScopedConfig.java
@@ -100,7 +100,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return originalConfig.getConfig(configPath);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get nested Config at <{0}>!";
+            final var msgPattern = "Failed to get nested Config at <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, configPath), e);
         }
     }
@@ -211,7 +211,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getIsNull(path);
         } catch (final ConfigException.Missing e) {
-            final String msgPattern = "Failed to check whether the value at path <{0}> is null!";
+            final var msgPattern = "Failed to check whether the value at path <{0}> is null!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -221,7 +221,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getBoolean(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get boolean value for path <{0}>!";
+            final var msgPattern = "Failed to get boolean value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -231,7 +231,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getNumber(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get Number for path <{0}>!";
+            final var msgPattern = "Failed to get Number for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -241,7 +241,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return tryToGetIntValue(path);
         } catch(final ConfigException.Missing | ConfigException.WrongType | NumberFormatException e) {
-            final String msgPattern = "Failed to get int value for path <{0}>!";
+            final var msgPattern = "Failed to get int value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -250,7 +250,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getInt(path);
         } catch (final ConfigException.WrongType e) {
-            final ConfigValue configValue = config.getValue(path);
+            final var configValue = config.getValue(path);
             if (ConfigValueType.STRING == configValue.valueType()) {
                 return Integer.parseInt(String.valueOf(configValue.unwrapped()));
             }
@@ -263,7 +263,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return tryToGetLongValue(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType | NumberFormatException e) {
-            final String msgPattern = "Failed to get long value for path <{0}>!";
+            final var msgPattern = "Failed to get long value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -272,7 +272,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getLong(path);
         } catch (final ConfigException.WrongType e) {
-            final ConfigValue configValue = config.getValue(path);
+            final var configValue = config.getValue(path);
             if (ConfigValueType.STRING == configValue.valueType()) {
                 return Long.parseLong(String.valueOf(configValue.unwrapped()));
             }
@@ -285,7 +285,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return tryToGetDoubleValue(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType | NumberFormatException e) {
-            final String msgPattern = "Failed to get double value for path <{0}>!";
+            final var msgPattern = "Failed to get double value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -294,7 +294,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDouble(path);
         } catch (final ConfigException.WrongType e) {
-            final ConfigValue configValue = config.getValue(path);
+            final var configValue = config.getValue(path);
             if (ConfigValueType.STRING == configValue.valueType()) {
                 return Double.parseDouble(String.valueOf(configValue.unwrapped()));
             }
@@ -307,7 +307,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getString(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get String value for path <{0}>!";
+            final var msgPattern = "Failed to get String value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -317,7 +317,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getEnum(enumClass, path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get Enum for path <{0}>!";
+            final var msgPattern = "Failed to get Enum for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -327,7 +327,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getObject(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get ConfigObject for path <{0}>!";
+            final var msgPattern = "Failed to get ConfigObject for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -337,7 +337,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getConfig(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get Config for path <{0}>!";
+            final var msgPattern = "Failed to get Config for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -347,7 +347,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getAnyRef(path);
         } catch (final ConfigException.Missing e) {
-            final String msgPattern = "Failed to get the unwrapped Java object for path <{0}>!";
+            final var msgPattern = "Failed to get the unwrapped Java object for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -357,7 +357,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getValue(path);
         } catch (final ConfigException.Missing e) {
-            final String msgPattern = "Failed to get ConfigValue for path <{0}>!";
+            final var msgPattern = "Failed to get ConfigValue for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -367,7 +367,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getBytes(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get long value for path <{0}>!";
+            final var msgPattern = "Failed to get long value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -377,7 +377,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getMemorySize(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get memory size for path <{0}>!";
+            final var msgPattern = "Failed to get memory size for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -399,7 +399,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDuration(path, unit);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get duration as long value for path <{0}>!";
+            final var msgPattern = "Failed to get duration as long value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -409,7 +409,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDuration(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get Duration value for path <{0}>!";
+            final var msgPattern = "Failed to get Duration value for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -419,7 +419,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getPeriod(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType | ConfigException.BadValue e) {
-            final String msgPattern = "Failed to get Period for path <{0}>!";
+            final var msgPattern = "Failed to get Period for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -429,7 +429,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getTemporal(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType | ConfigException.BadValue e) {
-            final String msgPattern = "Failed to get TemporalAmount for path <{0}>!";
+            final var msgPattern = "Failed to get TemporalAmount for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -439,7 +439,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get ConfigList for path <{0}>!";
+            final var msgPattern = "Failed to get ConfigList for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -449,7 +449,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getBooleanList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of boolean values for path <{0}>!";
+            final var msgPattern = "Failed to get List of boolean values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -459,7 +459,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getNumberList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of Numbers for path <{0}>!";
+            final var msgPattern = "Failed to get List of Numbers for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -469,7 +469,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getIntList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of int values for path <{0}>!";
+            final var msgPattern = "Failed to get List of int values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -479,7 +479,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getLongList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of long values for path <{0}>!";
+            final var msgPattern = "Failed to get List of long values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -489,7 +489,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDoubleList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of double values for path <{0}>!";
+            final var msgPattern = "Failed to get List of double values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -499,7 +499,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getStringList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of String values for path <{0}>!";
+            final var msgPattern = "Failed to get List of String values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -509,7 +509,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getEnumList(enumClass, path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of Enums for path <{0}>!";
+            final var msgPattern = "Failed to get List of Enums for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -519,7 +519,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getObjectList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of ConfigObjects for path <{0}>!";
+            final var msgPattern = "Failed to get List of ConfigObjects for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -529,7 +529,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getConfigList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of Configs for path <{0}>!";
+            final var msgPattern = "Failed to get List of Configs for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -539,7 +539,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getAnyRefList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List with elements of any kind for path <{0}>!";
+            final var msgPattern = "Failed to get List with elements of any kind for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -549,7 +549,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getBytesList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of byte sizes for path <{0}>!";
+            final var msgPattern = "Failed to get List of byte sizes for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -559,7 +559,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getMemorySizeList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of memory sizes for path <{0}>!";
+            final var msgPattern = "Failed to get List of memory sizes for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -581,7 +581,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDurationList(path, unit);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of duration long values for path <{0}>!";
+            final var msgPattern = "Failed to get List of duration long values for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }
@@ -591,7 +591,7 @@ public final class DefaultScopedConfig implements ScopedConfig {
         try {
             return config.getDurationList(path);
         } catch (final ConfigException.Missing | ConfigException.WrongType e) {
-            final String msgPattern = "Failed to get List of Durations for path <{0}>!";
+            final var msgPattern = "Failed to get List of Durations for path <{0}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, appendToConfigPath(path)), e);
         }
     }

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
@@ -83,9 +83,26 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @throws DittoConfigError if the Duration at the config path is negative.
      */
     default Duration getNonNegativeDurationOrThrow(final WithConfigPath withConfigPath) {
-        final Duration result = getDuration(withConfigPath.getConfigPath());
+        final var result = getDuration(withConfigPath.getConfigPath());
         if (result.isNegative()) {
-            final String msgPattern = "The duration at <{0}> must not be negative but it was <{1}>!";
+            final var msgPattern = "The duration at <{0}> must not be negative but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getDuration(String)} but with the guarantee that the returned Duration is non-negative
+     * and non-zero.
+     *
+     * @param withConfigPath provides the config path to get the Duration value for.
+     * @return the duration.
+     * @throws DittoConfigError if the Duration at the config path is negative or zero.
+     */
+    default Duration getNonNegativeAndNonZeroDurationOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getDuration(withConfigPath.getConfigPath());
+        if (result.isNegative() && result.isZero()) {
+            final var msgPattern = "The duration at <{0}> must not be negative and not zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;
@@ -99,9 +116,25 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @throws DittoConfigError if the int value at the config path is zero or negative.
      */
     default int getPositiveIntOrThrow(final WithConfigPath withConfigPath) {
-        final int result = getInt(withConfigPath.getConfigPath());
+        final var result = getInt(withConfigPath.getConfigPath());
         if (1 > result) {
-            final String msgPattern = "The int value at <{0}> must be positive but it was <{1}>!";
+            final var msgPattern = "The int value at <{0}> must be positive but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getInt(String)} but with the guarantee that the returned value is not negative.
+     *
+     * @param withConfigPath provides the config path to get the int value for.
+     * @return the int value.
+     * @throws DittoConfigError if the int value at the config path is negative.
+     */
+    default int getGreaterZeroIntOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getInt(withConfigPath.getConfigPath());
+        if (result < 0) {
+            final var msgPattern = "The int value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
@@ -147,9 +147,9 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @return the int value.
      * @throws DittoConfigError if the int value at the config path is less equal zero.
      */
-    default int getGreaterZeroIntOrThrow(final WithConfigPath withConfigPath) {
+    default int getNonNegativeIntOrThrow(final WithConfigPath withConfigPath) {
         final var result = getInt(withConfigPath.getConfigPath());
-        if (0 >= result) {
+        if (0 > result) {
             final var msgPattern = "The int value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
@@ -163,9 +163,9 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @return the int value.
      * @throws DittoConfigError if the long value at the config path is less equal zero.
      */
-    default long getGreaterZeroLongOrThrow(final WithConfigPath withConfigPath) {
+    default long getNonNegativeLongOrThrow(final WithConfigPath withConfigPath) {
         final var result = getLong(withConfigPath.getConfigPath());
-        if (0 >= result) {
+        if (0 > result) {
             final var msgPattern = "The long value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
@@ -179,9 +179,9 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @return the int value.
      * @throws DittoConfigError if the double value at the config path is less equal zero.
      */
-    default double getGreaterZeroDoubleOrThrow(final WithConfigPath withConfigPath) {
+    default double getNonNegativeDoubleOrThrow(final WithConfigPath withConfigPath) {
         final var result = getDouble(withConfigPath.getConfigPath());
-        if (0.0 >= result) {
+        if (0.0 > result) {
             final var msgPattern = "The double value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
@@ -195,9 +195,9 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * @return the int value.
      * @throws DittoConfigError if the bytes value at the config path is less equal zero.
      */
-    default long getGreaterZeroBytesOrThrow(final WithConfigPath withConfigPath) {
+    default long getNonNegativeBytesOrThrow(final WithConfigPath withConfigPath) {
         final var result = getBytes(withConfigPath.getConfigPath());
-        if (0L >= result) {
+        if (0L > result) {
             final var msgPattern = "The bytes value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
@@ -76,7 +76,7 @@ public interface ScopedConfig extends Config, WithConfigPath {
     String DITTO_SCOPE = "ditto";
 
     /**
-     * Same as {@link #getDuration(String)} but with the guarantee that the returned Duration is non-negative.
+     * Same as {@link #getDuration(String)} but with the guarantee that the returned Duration is positive.
      *
      * @param withConfigPath provides the config path to get the Duration value for.
      * @return the duration.
@@ -128,13 +128,29 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * Same as {@link #getLong(String)} but with the guarantee that the returned value is positive.
      *
      * @param withConfigPath provides the config path to get the long value for.
-     * @return the int value.
+     * @return the long value.
      * @throws DittoConfigError if the long value at the config path is zero or negative.
      */
     default long getPositiveLongOrThrow(final WithConfigPath withConfigPath) {
         final var result = getLong(withConfigPath.getConfigPath());
         if (1L > result) {
             final var msgPattern = "The long value at <{0}> must be positive but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getDouble(String)} but with the guarantee that the returned value is positive.
+     *
+     * @param withConfigPath provides the config path to get the double value for.
+     * @return the double value.
+     * @throws DittoConfigError if the long value at the config path is zero or negative.
+     */
+    default double getPositiveDoubleOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getDouble(withConfigPath.getConfigPath());
+        if (0.0 >= result) {
+            final var msgPattern = "The double value at <{0}> must be positive but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;
@@ -160,7 +176,7 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * Same as {@link #getLong(String)} but with the guarantee that the returned long is greater zero.
      *
      * @param withConfigPath provides the config path to get the long value for.
-     * @return the int value.
+     * @return the long value.
      * @throws DittoConfigError if the long value at the config path is negative.
      */
     default long getNonNegativeLongOrThrow(final WithConfigPath withConfigPath) {
@@ -176,7 +192,7 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * Same as {@link #getDouble(String)} but with the guarantee that the returned double is not negative.
      *
      * @param withConfigPath provides the config path to get the double value for.
-     * @return the int value.
+     * @return the double value.
      * @throws DittoConfigError if the double value at the config path is negative.
      */
     default double getNonNegativeDoubleOrThrow(final WithConfigPath withConfigPath) {
@@ -192,7 +208,7 @@ public interface ScopedConfig extends Config, WithConfigPath {
      * Same as {@link #getBytes(String)} but with the guarantee that the returned long is greater zero.
      *
      * @param withConfigPath provides the config path to get the bytes value for.
-     * @return the int value.
+     * @return the bytes value.
      * @throws DittoConfigError if the bytes value at the config path is negative.
      */
     default long getNonNegativeBytesOrThrow(final WithConfigPath withConfigPath) {

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
@@ -101,7 +101,7 @@ public interface ScopedConfig extends Config, WithConfigPath {
      */
     default Duration getNonNegativeAndNonZeroDurationOrThrow(final WithConfigPath withConfigPath) {
         final var result = getDuration(withConfigPath.getConfigPath());
-        if (result.isNegative() && result.isZero()) {
+        if (result.isNegative() || result.isZero()) {
             final var msgPattern = "The duration at <{0}> must not be negative and not zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
@@ -125,16 +125,80 @@ public interface ScopedConfig extends Config, WithConfigPath {
     }
 
     /**
-     * Same as {@link #getInt(String)} but with the guarantee that the returned value is not negative.
+     * Same as {@link #getLong(String)} but with the guarantee that the returned value is positive.
+     *
+     * @param withConfigPath provides the config path to get the long value for.
+     * @return the int value.
+     * @throws DittoConfigError if the long value at the config path is zero or negative.
+     */
+    default long getPositiveLongOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getLong(withConfigPath.getConfigPath());
+        if (1L > result) {
+            final var msgPattern = "The long value at <{0}> must be positive but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getInt(String)} but with the guarantee that the returned int is greater zero.
      *
      * @param withConfigPath provides the config path to get the int value for.
      * @return the int value.
-     * @throws DittoConfigError if the int value at the config path is negative.
+     * @throws DittoConfigError if the int value at the config path is less equal zero.
      */
     default int getGreaterZeroIntOrThrow(final WithConfigPath withConfigPath) {
         final var result = getInt(withConfigPath.getConfigPath());
-        if (result < 0) {
+        if (0 >= result) {
             final var msgPattern = "The int value at <{0}> must be greater zero but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getLong(String)} but with the guarantee that the returned long is greater zero.
+     *
+     * @param withConfigPath provides the config path to get the long value for.
+     * @return the int value.
+     * @throws DittoConfigError if the long value at the config path is less equal zero.
+     */
+    default long getGreaterZeroLongOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getLong(withConfigPath.getConfigPath());
+        if (0 >= result) {
+            final var msgPattern = "The long value at <{0}> must be greater zero but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getDouble(String)} but with the guarantee that the returned double is not negative.
+     *
+     * @param withConfigPath provides the config path to get the double value for.
+     * @return the int value.
+     * @throws DittoConfigError if the double value at the config path is less equal zero.
+     */
+    default double getGreaterZeroDoubleOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getDouble(withConfigPath.getConfigPath());
+        if (0.0 >= result) {
+            final var msgPattern = "The double value at <{0}> must be greater zero but it was <{1}>!";
+            throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
+        }
+        return result;
+    }
+
+    /**
+     * Same as {@link #getBytes(String)} but with the guarantee that the returned long is greater zero.
+     *
+     * @param withConfigPath provides the config path to get the bytes value for.
+     * @return the int value.
+     * @throws DittoConfigError if the bytes value at the config path is less equal zero.
+     */
+    default long getGreaterZeroBytesOrThrow(final WithConfigPath withConfigPath) {
+        final var result = getBytes(withConfigPath.getConfigPath());
+        if (0L >= result) {
+            final var msgPattern = "The bytes value at <{0}> must be greater zero but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;

--- a/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
+++ b/internal/utils/config/src/main/java/org/eclipse/ditto/internal/utils/config/ScopedConfig.java
@@ -145,12 +145,12 @@ public interface ScopedConfig extends Config, WithConfigPath {
      *
      * @param withConfigPath provides the config path to get the int value for.
      * @return the int value.
-     * @throws DittoConfigError if the int value at the config path is less equal zero.
+     * @throws DittoConfigError if the int value at the config path is negative.
      */
     default int getNonNegativeIntOrThrow(final WithConfigPath withConfigPath) {
         final var result = getInt(withConfigPath.getConfigPath());
         if (0 > result) {
-            final var msgPattern = "The int value at <{0}> must be greater zero but it was <{1}>!";
+            final var msgPattern = "The int value at <{0}> must not be negative but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;
@@ -161,12 +161,12 @@ public interface ScopedConfig extends Config, WithConfigPath {
      *
      * @param withConfigPath provides the config path to get the long value for.
      * @return the int value.
-     * @throws DittoConfigError if the long value at the config path is less equal zero.
+     * @throws DittoConfigError if the long value at the config path is negative.
      */
     default long getNonNegativeLongOrThrow(final WithConfigPath withConfigPath) {
         final var result = getLong(withConfigPath.getConfigPath());
         if (0 > result) {
-            final var msgPattern = "The long value at <{0}> must be greater zero but it was <{1}>!";
+            final var msgPattern = "The long value at <{0}> must not be negative but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;
@@ -177,12 +177,12 @@ public interface ScopedConfig extends Config, WithConfigPath {
      *
      * @param withConfigPath provides the config path to get the double value for.
      * @return the int value.
-     * @throws DittoConfigError if the double value at the config path is less equal zero.
+     * @throws DittoConfigError if the double value at the config path is negative.
      */
     default double getNonNegativeDoubleOrThrow(final WithConfigPath withConfigPath) {
         final var result = getDouble(withConfigPath.getConfigPath());
         if (0.0 > result) {
-            final var msgPattern = "The double value at <{0}> must be greater zero but it was <{1}>!";
+            final var msgPattern = "The double value at <{0}> must not be negative but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;
@@ -193,12 +193,12 @@ public interface ScopedConfig extends Config, WithConfigPath {
      *
      * @param withConfigPath provides the config path to get the bytes value for.
      * @return the int value.
-     * @throws DittoConfigError if the bytes value at the config path is less equal zero.
+     * @throws DittoConfigError if the bytes value at the config path is negative.
      */
     default long getNonNegativeBytesOrThrow(final WithConfigPath withConfigPath) {
         final var result = getBytes(withConfigPath.getConfigPath());
         if (0L > result) {
-            final var msgPattern = "The bytes value at <{0}> must be greater zero but it was <{1}>!";
+            final var msgPattern = "The bytes value at <{0}> must not be negative but it was <{1}>!";
             throw new DittoConfigError(MessageFormat.format(msgPattern, withConfigPath.getConfigPath(), result));
         }
         return result;

--- a/internal/utils/config/src/test/resources/test.conf
+++ b/internal/utils/config/src/test/resources/test.conf
@@ -5,7 +5,7 @@ ditto {
 
   concierge {
     caches {
-      ask-timeout = 0s
+      ask-timeout = 10s
 
       id {
         maximum-size = 80000

--- a/internal/utils/config/src/test/resources/test.conf
+++ b/internal/utils/config/src/test/resources/test.conf
@@ -5,7 +5,7 @@ ditto {
 
   concierge {
     caches {
-      ask-timeout = 10s
+      ask-timeout = 0s
 
       id {
         maximum-size = 80000

--- a/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultAkkaReplicatorConfig.java
+++ b/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultAkkaReplicatorConfig.java
@@ -78,9 +78,9 @@ class DefaultAkkaReplicatorConfig implements AkkaReplicatorConfig {
 
         // TODO Ditto issue #439: replace ConfigWithFallback - it breaks AbstractConfigValue.withFallback!
         // Workaround: re-parse my config
-        final ConfigWithFallback configWithFallback = ConfigWithFallback.newInstance(config, CONFIG_PATH,
+        final var configWithFallback = ConfigWithFallback.newInstance(config, CONFIG_PATH,
                 AkkaReplicatorConfigValue.values());
-        final Config fallback =
+        final var fallback =
                 ConfigFactory.parseString(configWithFallback.root().render(ConfigRenderOptions.concise()));
 
         return new DefaultAkkaReplicatorConfig(ConfigFactory.parseMap(specificConfig)

--- a/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
+++ b/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
@@ -86,7 +86,7 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
     public static DefaultDistributedDataConfig of(final Config config, final CharSequence replicatorName,
             final CharSequence replicatorRole) {
 
-        final ConfigWithFallback configWithFallback =
+        final var configWithFallback =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, DistributedDataConfigValue.values());
 
         return new DefaultDistributedDataConfig(configWithFallback, replicatorName, replicatorRole);
@@ -171,4 +171,5 @@ class DefaultDistributedDataConfig implements DistributedDataConfig {
         }
         return (Replicator.WriteConsistency) writeConsistency;
     }
+
 }

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
@@ -20,6 +20,13 @@ import java.util.Deque;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
+import org.eclipse.ditto.base.api.common.Shutdown;
+import org.eclipse.ditto.base.api.common.ShutdownResponse;
+import org.eclipse.ditto.internal.utils.akka.actors.ModifyConfigBehavior;
+import org.eclipse.ditto.internal.utils.akka.actors.RetrieveConfigBehavior;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.config.DittoConfigError;
 import org.eclipse.ditto.internal.utils.health.config.BackgroundStreamingConfig;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
@@ -27,13 +34,6 @@ import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
-import org.eclipse.ditto.internal.utils.akka.actors.ModifyConfigBehavior;
-import org.eclipse.ditto.internal.utils.akka.actors.RetrieveConfigBehavior;
-import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
-import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
-import org.eclipse.ditto.internal.utils.config.DittoConfigError;
-import org.eclipse.ditto.base.api.common.Shutdown;
-import org.eclipse.ditto.base.api.common.ShutdownResponse;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/AbstractBackgroundStreamingActorWithConfigWithStatusReport.java
@@ -164,10 +164,10 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
     @Override
     public Config setConfig(final Config config) {
-        final C previousConfig = this.config;
+        final var previousConfig = this.config;
         // TODO Ditto issue #439: replace ConfigWithFallback - it breaks AbstractConfigValue.withFallback!
         // Workaround: re-parse my config
-        final Config fallback = ConfigFactory.parseString(getConfig().root().render(ConfigRenderOptions.concise()));
+        final var fallback = ConfigFactory.parseString(getConfig().root().render(ConfigRenderOptions.concise()));
         try {
             this.config = parseConfig(config.withFallback(fallback));
         } catch (final DittoConfigError | ConfigException e) {
@@ -180,7 +180,7 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
     }
 
     private Receive sleeping() {
-        final ReceiveBuilder sleepingReceiveBuilder = ReceiveBuilder.create();
+        final var sleepingReceiveBuilder = ReceiveBuilder.create();
         preEnhanceSleepingBehavior(sleepingReceiveBuilder);
         return sleepingReceiveBuilder.match(WokeUp.class, this::wokeUp)
                 .match(Event.class, this::addCustomEventToLog)
@@ -193,7 +193,7 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
     }
 
     private Receive streaming() {
-        final ReceiveBuilder streamingReceiveBuilder = ReceiveBuilder.create();
+        final var streamingReceiveBuilder = ReceiveBuilder.create();
         preEnhanceStreamingBehavior(streamingReceiveBuilder);
         return streamingReceiveBuilder
                 .match(StreamTerminated.class, this::streamTerminated)
@@ -255,11 +255,13 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
         if (config.isEnabled()) {
             final Duration wakeUpDelay = config.getQuietPeriod();
-            final String message = String.format("Restarting in <%s>.", wakeUpDelay);
+            final var message = String.format("Restarting in <%s>.", wakeUpDelay);
+            log.info(message);
             scheduleWakeUp(wakeUpDelay);
             getSender().tell(ShutdownResponse.of(message, shutdown.getDittoHeaders()), getSelf());
         } else {
-            final String message = "Not restarting stream because I am disabled.";
+            final var message = "Not restarting stream because I am disabled.";
+            log.info(message);
             getSender().tell(ShutdownResponse.of(message, shutdown.getDittoHeaders()), getSelf());
         }
     }
@@ -280,7 +282,7 @@ public abstract class AbstractBackgroundStreamingActorWithConfigWithStatusReport
 
         materializedValues.second()
                 .<Void>handle((result, error) -> {
-                    final String description = String.format("Stream terminated. Result=<%s> Error=<%s>",
+                    final var description = String.format("Stream terminated. Result=<%s> Error=<%s>",
                             result, error);
                     if (error != null) {
                         log.error(error, description);

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultBasicHealthCheckConfig.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultBasicHealthCheckConfig.java
@@ -36,7 +36,7 @@ public final class DefaultBasicHealthCheckConfig implements BasicHealthCheckConf
 
     private DefaultBasicHealthCheckConfig(final ScopedConfig scopedConfig) {
         enabled = scopedConfig.getBoolean(HealthCheckConfigValue.ENABLED.getConfigPath());
-        interval = scopedConfig.getDuration(HealthCheckConfigValue.INTERVAL.getConfigPath());
+        interval = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(HealthCheckConfigValue.INTERVAL);
     }
 
     /**

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultHealthCheckConfig.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultHealthCheckConfig.java
@@ -44,7 +44,7 @@ public final class DefaultHealthCheckConfig implements HealthCheckConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultHealthCheckConfig of(final Config config) {
-        final DefaultBasicHealthCheckConfig basicHealthCheckConfig = DefaultBasicHealthCheckConfig.of(config);
+        final var basicHealthCheckConfig = DefaultBasicHealthCheckConfig.of(config);
 
         final String healthCheckConfigPath = basicHealthCheckConfig.getConfigPath();
         final PersistenceConfig persistenceConfig;

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultMetricsReporterConfig.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultMetricsReporterConfig.java
@@ -34,8 +34,8 @@ public final class DefaultMetricsReporterConfig implements MetricsReporterConfig
     private final int history;
 
     private DefaultMetricsReporterConfig(final ScopedConfig scopedConfig) {
-        resolution = scopedConfig.getDuration(MetricsReporterConfigValue.RESOLUTION.getConfigPath());
-        history = scopedConfig.getInt(MetricsReporterConfigValue.HISTORY.getConfigPath());
+        resolution = scopedConfig.getNonNegativeDurationOrThrow(MetricsReporterConfigValue.RESOLUTION);
+        history = scopedConfig.getPositiveIntOrThrow(MetricsReporterConfigValue.HISTORY);
     }
 
     /**

--- a/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultPersistenceConfig.java
+++ b/internal/utils/health/src/main/java/org/eclipse/ditto/internal/utils/health/config/DefaultPersistenceConfig.java
@@ -36,7 +36,7 @@ public final class DefaultPersistenceConfig implements PersistenceConfig {
 
     private DefaultPersistenceConfig(final ScopedConfig scopedConfig) {
         enabled = scopedConfig.getBoolean(PersistenceConfigValue.ENABLED.getConfigPath());
-        timeout = scopedConfig.getDuration(PersistenceConfigValue.TIMEOUT.getConfigPath());
+        timeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(PersistenceConfigValue.TIMEOUT);
         metricsReporterConfig = DefaultMetricsReporterConfig.of(scopedConfig);
     }
 
@@ -95,4 +95,5 @@ public final class DefaultPersistenceConfig implements PersistenceConfig {
                 ", metricsReporterConfig=" + metricsReporterConfig +
                 "]";
     }
+
 }

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
@@ -38,7 +38,7 @@ public final class DefaultMetricsConfig implements MetricsConfig {
         systemMetricEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.SYSTEM_METRICS_ENABLED.getConfigPath());
         prometheusEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.PROMETHEUS_ENABLED.getConfigPath());
         prometheusHostname = metricsScopedConfig.getString(MetricsConfigValue.PROMETHEUS_HOSTNAME.getConfigPath());
-        prometheusPort = metricsScopedConfig.getPositiveIntOrThrow(MetricsConfigValue.PROMETHEUS_PORT);
+        prometheusPort = metricsScopedConfig.getNonNegativeIntOrThrow(MetricsConfigValue.PROMETHEUS_PORT);
     }
 
     /**

--- a/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
+++ b/internal/utils/metrics/src/main/java/org/eclipse/ditto/internal/utils/metrics/config/DefaultMetricsConfig.java
@@ -38,7 +38,7 @@ public final class DefaultMetricsConfig implements MetricsConfig {
         systemMetricEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.SYSTEM_METRICS_ENABLED.getConfigPath());
         prometheusEnabled = metricsScopedConfig.getBoolean(MetricsConfigValue.PROMETHEUS_ENABLED.getConfigPath());
         prometheusHostname = metricsScopedConfig.getString(MetricsConfigValue.PROMETHEUS_HOSTNAME.getConfigPath());
-        prometheusPort = metricsScopedConfig.getInt(MetricsConfigValue.PROMETHEUS_PORT.getConfigPath());
+        prometheusPort = metricsScopedConfig.getPositiveIntOrThrow(MetricsConfigValue.PROMETHEUS_PORT);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfig.java
@@ -34,8 +34,10 @@ public final class DefaultActivityCheckConfig implements ActivityCheckConfig {
     private final Duration deletedInterval;
 
     private DefaultActivityCheckConfig(final ScopedConfig scopedConfig) {
-        inactiveInterval = scopedConfig.getDuration(ActivityCheckConfigValue.INACTIVE_INTERVAL.getConfigPath());
-        deletedInterval = scopedConfig.getDuration(ActivityCheckConfigValue.DELETED_INTERVAL.getConfigPath());
+        inactiveInterval =
+                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ActivityCheckConfigValue.INACTIVE_INTERVAL);
+        deletedInterval =
+                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ActivityCheckConfigValue.DELETED_INTERVAL);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfig.java
@@ -35,9 +35,9 @@ public final class DefaultActivityCheckConfig implements ActivityCheckConfig {
 
     private DefaultActivityCheckConfig(final ScopedConfig scopedConfig) {
         inactiveInterval =
-                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ActivityCheckConfigValue.INACTIVE_INTERVAL);
+                scopedConfig.getNonNegativeDurationOrThrow(ActivityCheckConfigValue.INACTIVE_INTERVAL);
         deletedInterval =
-                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(ActivityCheckConfigValue.DELETED_INTERVAL);
+                scopedConfig.getNonNegativeDurationOrThrow(ActivityCheckConfigValue.DELETED_INTERVAL);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultCircuitBreakerConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultCircuitBreakerConfig.java
@@ -33,7 +33,7 @@ public final class DefaultCircuitBreakerConfig implements MongoDbConfig.CircuitB
     private final TimeoutConfig timeoutConfig;
 
     private DefaultCircuitBreakerConfig(final ScopedConfig config) {
-        maxFailures = config.getInt(CircuitBreakerConfigValue.MAX_FAILURES.getConfigPath());
+        maxFailures = config.getPositiveIntOrThrow(CircuitBreakerConfigValue.MAX_FAILURES);
         timeoutConfig = DefaultTimeoutConfig.of(config);
     }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
@@ -36,9 +36,9 @@ public final class DefaultConnectionPoolConfig implements MongoDbConfig.Connecti
     private final boolean jmxListenerEnabled;
 
     private DefaultConnectionPoolConfig(final ScopedConfig config) {
-        minSize = config.getInt(ConnectionPoolConfigValue.MIN_SIZE.getConfigPath());
-        maxSize = config.getInt(ConnectionPoolConfigValue.MAX_SIZE.getConfigPath());
-        maxWaitTime = config.getDuration(ConnectionPoolConfigValue.MAX_WAIT_TIME.getConfigPath());
+        minSize = config.getGreaterZeroIntOrThrow(ConnectionPoolConfigValue.MIN_SIZE);
+        maxSize = config.getGreaterZeroIntOrThrow(ConnectionPoolConfigValue.MAX_SIZE);
+        maxWaitTime = config.getNonNegativeDurationOrThrow(ConnectionPoolConfigValue.MAX_WAIT_TIME);
         jmxListenerEnabled = config.getBoolean(ConnectionPoolConfigValue.JMX_LISTENER_ENABLED.getConfigPath());
     }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultConnectionPoolConfig.java
@@ -36,8 +36,8 @@ public final class DefaultConnectionPoolConfig implements MongoDbConfig.Connecti
     private final boolean jmxListenerEnabled;
 
     private DefaultConnectionPoolConfig(final ScopedConfig config) {
-        minSize = config.getGreaterZeroIntOrThrow(ConnectionPoolConfigValue.MIN_SIZE);
-        maxSize = config.getGreaterZeroIntOrThrow(ConnectionPoolConfigValue.MAX_SIZE);
+        minSize = config.getNonNegativeIntOrThrow(ConnectionPoolConfigValue.MIN_SIZE);
+        maxSize = config.getNonNegativeIntOrThrow(ConnectionPoolConfigValue.MAX_SIZE);
         maxWaitTime = config.getNonNegativeDurationOrThrow(ConnectionPoolConfigValue.MAX_WAIT_TIME);
         jmxListenerEnabled = config.getBoolean(ConnectionPoolConfigValue.JMX_LISTENER_ENABLED.getConfigPath());
     }

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultMongoDbConfig.java
@@ -42,9 +42,9 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
     private final DefaultMonitoringConfig monitoringConfig;
 
     private DefaultMongoDbConfig(final ConfigWithFallback config) {
-        maxQueryTime = config.getDuration(MongoDbConfigValue.MAX_QUERY_TIME.getConfigPath());
+        maxQueryTime = config.getNonNegativeAndNonZeroDurationOrThrow(MongoDbConfigValue.MAX_QUERY_TIME);
         optionsConfig = DefaultOptionsConfig.of(config);
-        final String configuredUri = config.getString(MongoDbConfigValue.URI.getConfigPath());
+        final var configuredUri = config.getString(MongoDbConfigValue.URI.getConfigPath());
         final Map<String, Object> configuredExtraUriOptions = optionsConfig.extraUriOptions();
 
         final String sslKey = OptionsConfig.OptionsConfigValue.SSL_ENABLED.getConfigPath();
@@ -69,7 +69,8 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultMongoDbConfig of(final Config config) {
-        final ConfigWithFallback configWithFallback = appendFallbackValues(config);
+        final var configWithFallback = appendFallbackValues(config);
+
         return new DefaultMongoDbConfig(configWithFallback);
     }
 
@@ -79,7 +80,8 @@ public final class DefaultMongoDbConfig implements MongoDbConfig {
 
     private static String determineMongoDbUri(final String configuredMongoUri,
             final Map<String, Object> extraUriOptions) {
-        final MongoDbUriSupplier mongoDbUriSupplier = MongoDbUriSupplier.of(configuredMongoUri, extraUriOptions);
+        final var mongoDbUriSupplier = MongoDbUriSupplier.of(configuredMongoUri, extraUriOptions);
+
         return mongoDbUriSupplier.get();
     }
 

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultOptionsConfig.java
@@ -48,7 +48,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
 
     private DefaultOptionsConfig(final ScopedConfig config) {
         sslEnabled = config.getBoolean(OptionsConfigValue.SSL_ENABLED.getConfigPath());
-        final String readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
+        final var readPreferenceString = config.getString(OptionsConfigValue.READ_PREFERENCE.getConfigPath());
         readPreference = ReadPreference.ofReadPreference(readPreferenceString)
                 .orElseThrow(() -> {
                     final String msg =
@@ -56,7 +56,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
                                     readPreferenceString);
                     return new DittoConfigError(msg);
                 });
-        final String readConcernString = config.getString(OptionsConfigValue.READ_CONCERN.getConfigPath());
+        final var readConcernString = config.getString(OptionsConfigValue.READ_CONCERN.getConfigPath());
         readConcern = ReadConcern.ofReadConcern(readConcernString)
                 .orElseThrow(() -> {
                     final String msg =
@@ -64,7 +64,7 @@ public final class DefaultOptionsConfig implements MongoDbConfig.OptionsConfig {
                                     readConcernString);
                     return new DittoConfigError(msg);
                 });
-        final String writeConcernString = config.getString(OptionsConfigValue.WRITE_CONCERN.getConfigPath());
+        final var writeConcernString = config.getString(OptionsConfigValue.WRITE_CONCERN.getConfigPath());
         writeConcern = Optional.ofNullable(WriteConcern.valueOf(writeConcernString)).orElseThrow(() -> {
             final String msg =
                     MessageFormat.format("Could not parse a WriteConcern from configured string <{0}>",

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
@@ -35,7 +35,7 @@ public final class DefaultSnapshotConfig implements SnapshotConfig {
 
     private DefaultSnapshotConfig(final ScopedConfig config) {
         interval = config.getNonNegativeAndNonZeroDurationOrThrow(SnapshotConfigValue.INTERVAL);
-        threshold = config.getNonNegativeIntOrThrow((SnapshotConfigValue.THRESHOLD));
+        threshold = config.getNonNegativeLongOrThrow((SnapshotConfigValue.THRESHOLD));
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
@@ -12,14 +12,12 @@
  */
 package org.eclipse.ditto.internal.utils.persistence.mongo.config;
 
-import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.Objects;
 
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
-import org.eclipse.ditto.internal.utils.config.DittoConfigError;
 import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
@@ -36,17 +34,8 @@ public final class DefaultSnapshotConfig implements SnapshotConfig {
     private final long threshold;
 
     private DefaultSnapshotConfig(final ScopedConfig config) {
-        interval = config.getDuration(SnapshotConfigValue.INTERVAL.getConfigPath());
-        threshold = getThreshold(config);
-    }
-
-    private static long getThreshold(final ScopedConfig config) {
-        final long result = config.getLong(SnapshotConfigValue.THRESHOLD.getConfigPath());
-        if (1 > result) {
-            final String msgPattern = "The snapshot threshold must be positive but it was <{0}>!";
-            throw new DittoConfigError(MessageFormat.format(msgPattern, result));
-        }
-        return result;
+        interval = config.getNonNegativeAndNonZeroDurationOrThrow(SnapshotConfigValue.INTERVAL);
+        threshold = config.getPositiveLongOrThrow(SnapshotConfigValue.THRESHOLD);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
@@ -35,7 +35,7 @@ public final class DefaultSnapshotConfig implements SnapshotConfig {
 
     private DefaultSnapshotConfig(final ScopedConfig config) {
         interval = config.getNonNegativeAndNonZeroDurationOrThrow(SnapshotConfigValue.INTERVAL);
-        threshold = config.getPositiveLongOrThrow(SnapshotConfigValue.THRESHOLD);
+        threshold = config.getNonNegativeIntOrThrow((SnapshotConfigValue.THRESHOLD));
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfig.java
@@ -35,7 +35,7 @@ public final class DefaultSnapshotConfig implements SnapshotConfig {
 
     private DefaultSnapshotConfig(final ScopedConfig config) {
         interval = config.getNonNegativeAndNonZeroDurationOrThrow(SnapshotConfigValue.INTERVAL);
-        threshold = config.getNonNegativeLongOrThrow((SnapshotConfigValue.THRESHOLD));
+        threshold = config.getPositiveLongOrThrow((SnapshotConfigValue.THRESHOLD));
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultTagsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultTagsConfig.java
@@ -30,8 +30,8 @@ public final class DefaultTagsConfig implements TagsConfig {
 
     private final int streamingCacheSize;
 
-    private DefaultTagsConfig(final Config config) {
-        streamingCacheSize = config.getInt(TagsConfigValue.STREAMING_CACHE_SIZE.getConfigPath());
+    private DefaultTagsConfig(final ConfigWithFallback config) {
+        streamingCacheSize = config.getPositiveIntOrThrow(TagsConfigValue.STREAMING_CACHE_SIZE);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultTimeoutConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultTimeoutConfig.java
@@ -34,8 +34,8 @@ public final class DefaultTimeoutConfig implements MongoDbConfig.CircuitBreakerC
     private final Duration reset;
 
     private DefaultTimeoutConfig(final ScopedConfig config) {
-        call = config.getDuration(TimeoutConfigValue.CALL.getConfigPath());
-        reset = config.getDuration(TimeoutConfigValue.RESET.getConfigPath());
+        call = config.getNonNegativeAndNonZeroDurationOrThrow(TimeoutConfigValue.CALL);
+        reset = config.getNonNegativeAndNonZeroDurationOrThrow(TimeoutConfigValue.RESET);
     }
 
     /**

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/operations/DefaultPersistenceOperationsConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/operations/DefaultPersistenceOperationsConfig.java
@@ -33,8 +33,8 @@ public final class DefaultPersistenceOperationsConfig implements PersistenceOper
     private final Duration delayAfterPersistenceActorShutdown;
 
     private DefaultPersistenceOperationsConfig(final ConfigWithFallback configWithFallback) {
-        delayAfterPersistenceActorShutdown = configWithFallback.getDuration(
-                PersistenceOperationsConfigValue.DELAY_AFTER_PERSISTENCE_ACTOR_SHUTDOWN.getConfigPath());
+        delayAfterPersistenceActorShutdown = configWithFallback.getNonNegativeDurationOrThrow(
+                PersistenceOperationsConfigValue.DELAY_AFTER_PERSISTENCE_ACTOR_SHUTDOWN);
     }
 
     /**

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfigTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultActivityCheckConfigTest.java
@@ -74,7 +74,7 @@ public final class DefaultActivityCheckConfigTest {
 
         softly.assertThat(underTest.getInactiveInterval())
                 .as(ActivityCheckConfig.ActivityCheckConfigValue.INACTIVE_INTERVAL.getConfigPath())
-                .isEqualTo(Duration.ofDays(-1L));
+                .isEqualTo(Duration.ofDays(1L));
         softly.assertThat(underTest.getDeletedInterval())
                 .as(ActivityCheckConfig.ActivityCheckConfigValue.DELETED_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofDays(100L));

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfigTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfigTest.java
@@ -76,6 +76,6 @@ public final class DefaultSnapshotConfigTest {
                 .isEqualTo(Duration.ofDays(100L));
         softly.assertThat(underTest.getThreshold())
                 .as(SnapshotConfig.SnapshotConfigValue.THRESHOLD.getConfigPath())
-                .isEqualTo(1);
+                .isEqualTo(2);
     }
 }

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfigTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultSnapshotConfigTest.java
@@ -76,6 +76,6 @@ public final class DefaultSnapshotConfigTest {
                 .isEqualTo(Duration.ofDays(100L));
         softly.assertThat(underTest.getThreshold())
                 .as(SnapshotConfig.SnapshotConfigValue.THRESHOLD.getConfigPath())
-                .isEqualTo(2);
+                .isEqualTo(1);
     }
 }

--- a/internal/utils/persistence/src/test/resources/activity-check-test.conf
+++ b/internal/utils/persistence/src/test/resources/activity-check-test.conf
@@ -1,4 +1,4 @@
 activity-check {
-  inactive-interval = -1d
+  inactive-interval = 1d
   deleted-interval = 100d
 }

--- a/internal/utils/persistence/src/test/resources/snapshot-test.conf
+++ b/internal/utils/persistence/src/test/resources/snapshot-test.conf
@@ -1,4 +1,4 @@
 snapshot {
   interval = 100d
-  threshold = 0
+  threshold = 1
 }

--- a/internal/utils/persistence/src/test/resources/snapshot-test.conf
+++ b/internal/utils/persistence/src/test/resources/snapshot-test.conf
@@ -1,4 +1,4 @@
 snapshot {
   interval = 100d
-  threshold = 2
+  threshold = 0
 }

--- a/internal/utils/persistence/src/test/resources/snapshot-test.conf
+++ b/internal/utils/persistence/src/test/resources/snapshot-test.conf
@@ -1,4 +1,4 @@
 snapshot {
   interval = 100d
-  threshold = 1
+  threshold = 2
 }

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistentActorWithTimersAndCleanup.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistentActorWithTimersAndCleanup.java
@@ -16,13 +16,13 @@ import java.util.Optional;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistence;
+import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistenceResponse;
 import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.entity.type.EntityType;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
-import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistence;
-import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistenceResponse;
 
 import akka.actor.ActorRef;
 import akka.persistence.AbstractPersistentActorWithTimers;
@@ -117,13 +117,13 @@ public abstract class AbstractPersistentActorWithTimersAndCleanup extends Abstra
     private EntityId extractEntityIdFromPersistenceId(final String persistenceId) {
         final int indexOfSeparator = persistenceId.indexOf(':');
         if (indexOfSeparator < 0) {
-            final String message =
+            final var message =
                     String.format("Persistence ID <%s> wasn't prefixed with an entity type.", persistenceId);
             log.error(message);
             throw new IllegalArgumentException(message);
         }
-        final String id = persistenceId.substring(indexOfSeparator + 1);
-        final EntityType type = EntityType.of(persistenceId.substring(0, indexOfSeparator));
+        final var id = persistenceId.substring(indexOfSeparator + 1);
+        final var type = EntityType.of(persistenceId.substring(0, indexOfSeparator));
         return EntityId.of(type, id);
     }
 
@@ -191,7 +191,7 @@ public abstract class AbstractPersistentActorWithTimersAndCleanup extends Abstra
         final long maxSnapSeqNoToDelete = latestSnapshotSequenceNumber - 1;
         log.info("Starting cleanup for '{}', deleting snapshots to sequence number {} and events to {}.",
                 persistenceId(), maxSnapSeqNoToDelete, maxEventSeqNoToDelete);
-        final SnapshotSelectionCriteria deletionCriteria =
+        final var deletionCriteria =
                 SnapshotSelectionCriteria.create(maxSnapSeqNoToDelete, Long.MAX_VALUE);
         deleteMessages(maxEventSeqNoToDelete);
         deleteSnapshots(deletionCriteria);

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/config/DefaultPingConfig.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/config/DefaultPingConfig.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
-import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -37,11 +36,11 @@ public final class DefaultPingConfig implements PingConfig {
     private final int readJournalBatchSize;
     private final StreamingOrder streamingOrder;
 
-    private DefaultPingConfig(final ScopedConfig config, final RateConfig theRateConfig) {
+    private DefaultPingConfig(final ConfigWithFallback config, final RateConfig theRateConfig) {
         journalTag = config.getString(PingConfigValue.JOURNAL_TAG.getConfigPath());
-        initialDelay = config.getDuration(PingConfigValue.INITIAL_DELAY.getConfigPath());
-        interval = config.getDuration(PingConfigValue.INTERVAL.getConfigPath());
-        readJournalBatchSize = config.getInt(PingConfigValue.READ_JOURNAL_BATCH_SIZE.getConfigPath());
+        initialDelay = config.getNonNegativeDurationOrThrow(PingConfigValue.INITIAL_DELAY);
+        interval = config.getNonNegativeAndNonZeroDurationOrThrow(PingConfigValue.INTERVAL);
+        readJournalBatchSize = config.getPositiveIntOrThrow(PingConfigValue.READ_JOURNAL_BATCH_SIZE);
         streamingOrder = config.getEnum(StreamingOrder.class, PingConfigValue.STREAMING_ORDER.getConfigPath());
         rateConfig = theRateConfig;
     }
@@ -54,7 +53,7 @@ public final class DefaultPingConfig implements PingConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultPingConfig of(final Config config) {
-        final ConfigWithFallback reconnectScopedConfig =
+        final var reconnectScopedConfig =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, PingConfigValue.values());
 
         return new DefaultPingConfig(reconnectScopedConfig, DefaultRateConfig.of(reconnectScopedConfig));

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/config/DefaultRateConfig.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/config/DefaultRateConfig.java
@@ -18,7 +18,6 @@ import java.util.Objects;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
-import org.eclipse.ditto.internal.utils.config.ScopedConfig;
 
 import com.typesafe.config.Config;
 
@@ -33,9 +32,9 @@ public final class DefaultRateConfig implements RateConfig {
     private final Duration frequency;
     private final int entityAmount;
 
-    private DefaultRateConfig(final ScopedConfig config) {
-        frequency = config.getDuration(RateConfigValue.FREQUENCY.getConfigPath());
-        entityAmount = config.getInt(RateConfigValue.ENTITIES.getConfigPath());
+    private DefaultRateConfig(final ConfigWithFallback config) {
+        frequency = config.getNonNegativeAndNonZeroDurationOrThrow(RateConfigValue.FREQUENCY);
+        entityAmount = config.getPositiveIntOrThrow(RateConfigValue.ENTITIES);
     }
 
     /**

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyConfig.java
@@ -48,9 +48,10 @@ public final class DefaultPolicyConfig implements PolicyConfig {
         activityCheckConfig = DefaultActivityCheckConfig.of(scopedConfig);
         snapshotConfig = DefaultSnapshotConfig.of(scopedConfig);
         policySubjectExpiryGranularity =
-                scopedConfig.getDuration(PolicyConfigValue.SUBJECT_EXPIRY_GRANULARITY.getConfigPath());
+                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(PolicyConfigValue.SUBJECT_EXPIRY_GRANULARITY);
         policySubjectDeletionAnnouncementGranularity =
-                scopedConfig.getDuration(PolicyConfigValue.SUBJECT_DELETION_ANNOUNCEMENT_GRANULARITY.getConfigPath());
+                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(
+                        PolicyConfigValue.SUBJECT_DELETION_ANNOUNCEMENT_GRANULARITY);
         subjectIdResolver = scopedConfig.getString(PolicyConfigValue.SUBJECT_ID_RESOLVER.getConfigPath());
     }
 

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyConfig.java
@@ -48,9 +48,9 @@ public final class DefaultPolicyConfig implements PolicyConfig {
         activityCheckConfig = DefaultActivityCheckConfig.of(scopedConfig);
         snapshotConfig = DefaultSnapshotConfig.of(scopedConfig);
         policySubjectExpiryGranularity =
-                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(PolicyConfigValue.SUBJECT_EXPIRY_GRANULARITY);
+                scopedConfig.getNonNegativeDurationOrThrow(PolicyConfigValue.SUBJECT_EXPIRY_GRANULARITY);
         policySubjectDeletionAnnouncementGranularity =
-                scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(
+                scopedConfig.getNonNegativeDurationOrThrow(
                         PolicyConfigValue.SUBJECT_DELETION_ANNOUNCEMENT_GRANULARITY);
         subjectIdResolver = scopedConfig.getString(PolicyConfigValue.SUBJECT_ID_RESOLVER.getConfigPath());
     }
@@ -63,8 +63,9 @@ public final class DefaultPolicyConfig implements PolicyConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultPolicyConfig of(final Config config) {
-        final ConfigWithFallback mappingScopedConfig =
+        final var mappingScopedConfig =
                 ConfigWithFallback.newInstance(config, CONFIG_PATH, PolicyConfigValue.values());
+
         return new DefaultPolicyConfig(mappingScopedConfig);
     }
 

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/starter/PoliciesRootActorTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/starter/PoliciesRootActorTest.java
@@ -13,10 +13,10 @@
 package org.eclipse.ditto.policies.service.starter;
 
 import org.eclipse.ditto.base.service.actors.AbstractDittoRootActorTest;
+import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.policies.service.common.config.DittoPoliciesConfig;
 import org.eclipse.ditto.policies.service.common.config.PoliciesConfig;
 import org.eclipse.ditto.policies.service.persistence.serializer.PolicyMongoSnapshotAdapter;
-import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 
 import akka.actor.ActorSystem;
 import akka.actor.Props;
@@ -35,6 +35,7 @@ public final class PoliciesRootActorTest extends AbstractDittoRootActorTest {
     protected Props getRootActorProps(final ActorSystem system) {
         final PoliciesConfig config =
                 DittoPoliciesConfig.of(DefaultScopedConfig.dittoScoped(system.settings().config()));
+
         return PoliciesRootActor.props(config, new PolicyMongoSnapshotAdapter(), system.deadLetters());
     }
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultPersistenceStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultPersistenceStreamConfig.java
@@ -44,8 +44,8 @@ public final class DefaultPersistenceStreamConfig implements PersistenceStreamCo
             final DefaultStreamStageConfig defaultStreamStageConfig) {
 
         maxBulkSize = persistenceStreamScopedConfig.getInt(PersistenceStreamConfigValue.MAX_BULK_SIZE.getConfigPath());
-        ackDelay = persistenceStreamScopedConfig.getDuration(PersistenceStreamConfigValue.ACK_DELAY.getConfigPath());
-        final String writeConcernString = persistenceStreamScopedConfig.getString(
+        ackDelay = persistenceStreamScopedConfig.getNonNegativeDurationOrThrow(PersistenceStreamConfigValue.ACK_DELAY);
+        final var writeConcernString = persistenceStreamScopedConfig.getString(
                 PersistenceStreamConfigValue.WITH_ACKS_WRITE_CONCERN.getConfigPath());
         withAcknowledgementsWriteConcern = Optional.ofNullable(WriteConcern.valueOf(writeConcernString))
                 .orElseThrow(() -> {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamCacheConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamCacheConfig.java
@@ -40,7 +40,7 @@ public final class DefaultStreamCacheConfig implements StreamCacheConfig {
             final DefaultCacheConfig genericCacheConfig) {
 
         dispatcherName = streamCacheScopedConfig.getString(StreamCacheConfigValue.DISPATCHER_NAME.getConfigPath());
-        retryDelay = streamCacheScopedConfig.getDuration(StreamCacheConfigValue.RETRY_DELAY.getConfigPath());
+        retryDelay = streamCacheScopedConfig.getNonNegativeDurationOrThrow(StreamCacheConfigValue.RETRY_DELAY);
         this.genericCacheConfig = genericCacheConfig;
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
@@ -39,7 +39,7 @@ public final class DefaultStreamConfig implements StreamConfig {
 
     private DefaultStreamConfig(final ConfigWithFallback streamScopedConfig) {
         maxArraySize = streamScopedConfig.getNonNegativeIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
-        writeInterval = streamScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(StreamConfigValue.WRITE_INTERVAL);
+        writeInterval = streamScopedConfig.getNonNegativeDurationOrThrow(StreamConfigValue.WRITE_INTERVAL);
         askTimeout = streamScopedConfig.getNonNegativeDurationOrThrow(StreamConfigValue.ASK_TIMEOUT);
         retrievalConfig = DefaultStreamStageConfig.getInstance(streamScopedConfig, RETRIEVAL_CONFIG_PATH);
         persistenceStreamConfig = DefaultPersistenceStreamConfig.of(streamScopedConfig);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
@@ -38,9 +38,9 @@ public final class DefaultStreamConfig implements StreamConfig {
     private final DefaultStreamCacheConfig streamCacheConfig;
 
     private DefaultStreamConfig(final ConfigWithFallback streamScopedConfig) {
-        maxArraySize = streamScopedConfig.getInt(StreamConfigValue.MAX_ARRAY_SIZE.getConfigPath());
-        writeInterval = streamScopedConfig.getDuration(StreamConfigValue.WRITE_INTERVAL.getConfigPath());
-        askTimeout = streamScopedConfig.getDuration(StreamConfigValue.ASK_TIMEOUT.getConfigPath());
+        maxArraySize = streamScopedConfig.getGreaterZeroIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
+        writeInterval = streamScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(StreamConfigValue.WRITE_INTERVAL);
+        askTimeout = streamScopedConfig.getNonNegativeDurationOrThrow(StreamConfigValue.ASK_TIMEOUT);
         retrievalConfig = DefaultStreamStageConfig.getInstance(streamScopedConfig, RETRIEVAL_CONFIG_PATH);
         persistenceStreamConfig = DefaultPersistenceStreamConfig.of(streamScopedConfig);
         streamCacheConfig = DefaultStreamCacheConfig.of(streamScopedConfig);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
@@ -38,7 +38,7 @@ public final class DefaultStreamConfig implements StreamConfig {
     private final DefaultStreamCacheConfig streamCacheConfig;
 
     private DefaultStreamConfig(final ConfigWithFallback streamScopedConfig) {
-        maxArraySize = streamScopedConfig.getGreaterZeroIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
+        maxArraySize = streamScopedConfig.getNonNegativeIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
         writeInterval = streamScopedConfig.getNonNegativeAndNonZeroDurationOrThrow(StreamConfigValue.WRITE_INTERVAL);
         askTimeout = streamScopedConfig.getNonNegativeDurationOrThrow(StreamConfigValue.ASK_TIMEOUT);
         retrievalConfig = DefaultStreamStageConfig.getInstance(streamScopedConfig, RETRIEVAL_CONFIG_PATH);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamStageConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamStageConfig.java
@@ -48,7 +48,7 @@ public final class DefaultStreamStageConfig implements StreamStageConfig {
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
      */
     public static DefaultStreamStageConfig getInstance(final Config config, final String configPath) {
-        final ConfigWithFallback configWithFallback =
+        final var configWithFallback =
                 ConfigWithFallback.newInstance(config, configPath, StreamStageConfigValue.values());
         return new DefaultStreamStageConfig(configWithFallback, DefaultExponentialBackOffConfig.of(configWithFallback));
     }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
@@ -41,7 +41,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     private DefaultUpdaterConfig(final ConfigWithFallback updaterScopedConfig) {
         maxIdleTime = updaterScopedConfig.getNonNegativeDurationOrThrow(UpdaterConfigValue.MAX_IDLE_TIME);
         shardingStatePollInterval =
-                updaterScopedConfig.getDuration(UpdaterConfigValue.SHARDING_STATE_POLL_INTERVAL.getConfigPath());
+                updaterScopedConfig.getNonNegativeDurationOrThrow(UpdaterConfigValue.SHARDING_STATE_POLL_INTERVAL);
         eventProcessingActive =
                 updaterScopedConfig.getBoolean(UpdaterConfigValue.EVENT_PROCESSING_ACTIVE.getConfigPath());
         backgroundSyncConfig = DefaultBackgroundSyncConfig.fromUpdaterConfig(updaterScopedConfig);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
@@ -33,15 +33,13 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     static final String CONFIG_PATH = "updater";
 
     private final Duration maxIdleTime;
-    private final int maxBulkSize;
     private final Duration shardingStatePollInterval;
     private final boolean eventProcessingActive;
     private final BackgroundSyncConfig backgroundSyncConfig;
     private final StreamConfig streamConfig;
 
     private DefaultUpdaterConfig(final ConfigWithFallback updaterScopedConfig) {
-        maxIdleTime = updaterScopedConfig.getDuration(UpdaterConfigValue.MAX_IDLE_TIME.getConfigPath());
-        maxBulkSize = updaterScopedConfig.getInt(UpdaterConfigValue.MAX_BULK_SIZE.getConfigPath());
+        maxIdleTime = updaterScopedConfig.getNonNegativeDurationOrThrow(UpdaterConfigValue.MAX_IDLE_TIME);
         shardingStatePollInterval =
                 updaterScopedConfig.getDuration(UpdaterConfigValue.SHARDING_STATE_POLL_INTERVAL.getConfigPath());
         eventProcessingActive =
@@ -65,11 +63,6 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     @Override
     public Duration getMaxIdleTime() {
         return maxIdleTime;
-    }
-
-    @Override
-    public int getMaxBulkSize() {
-        return maxBulkSize;
     }
 
     @Override
@@ -101,8 +94,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
             return false;
         }
         final DefaultUpdaterConfig that = (DefaultUpdaterConfig) o;
-        return maxBulkSize == that.maxBulkSize &&
-                eventProcessingActive == that.eventProcessingActive &&
+        return eventProcessingActive == that.eventProcessingActive &&
                 Objects.equals(maxIdleTime, that.maxIdleTime) &&
                 Objects.equals(shardingStatePollInterval, that.shardingStatePollInterval) &&
                 Objects.equals(backgroundSyncConfig, that.backgroundSyncConfig) &&
@@ -111,7 +103,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxIdleTime, maxBulkSize, shardingStatePollInterval, eventProcessingActive,
+        return Objects.hash(maxIdleTime, shardingStatePollInterval, eventProcessingActive,
                 backgroundSyncConfig, streamConfig);
     }
 
@@ -119,7 +111,6 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "maxIdleTime=" + maxIdleTime +
-                ", maxBulkSize=" + maxBulkSize +
                 ", shardingStatePollInterval=" + shardingStatePollInterval +
                 ", eventProcessingActive=" + eventProcessingActive +
                 ", backgroundSyncConfig=" + backgroundSyncConfig +

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
@@ -58,10 +58,11 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
         mongoDbConfig = DefaultMongoDbConfig.of(dittoScopedConfig);
         healthCheckConfig = DefaultHealthCheckConfig.of(dittoScopedConfig);
 
-        final ConfigWithFallback configWithFallback =
+        final var configWithFallback =
                 ConfigWithFallback.newInstance(dittoScopedConfig, CONFIG_PATH, SearchConfigValue.values());
         mongoHintsByNamespace = configWithFallback.getStringOrNull(SearchConfigValue.MONGO_HINTS_BY_NAMESPACE);
-        queryCriteriaValidator = configWithFallback.getStringOrNull(SearchConfigValue.QUERY_CRITERIA_VALIDATOR);
+        queryCriteriaValidator =
+                configWithFallback.getString(SearchConfigValue.QUERY_CRITERIA_VALIDATOR.getConfigPath());
         updaterConfig = DefaultUpdaterConfig.of(configWithFallback);
         indexInitializationConfig = DefaultIndexInitializationConfig.of(configWithFallback);
     }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterConfig.java
@@ -32,13 +32,6 @@ public interface UpdaterConfig {
     Duration getMaxIdleTime();
 
     /**
-     * Returns the amount of write operations to perform in one bulk.
-     *
-     * @return the max bulk size.
-     */
-    int getMaxBulkSize();
-
-    /**
      * Returns how often things-updater polls local sharding state and how often the new-event-forwarder polls
      * cluster state.
      *
@@ -77,11 +70,6 @@ public interface UpdaterConfig {
          * Determines the lifetime of an idling ThingUpdater.
          */
         MAX_IDLE_TIME("max-idle-time", Duration.ofHours(25L)),
-
-        /**
-         * Determines how many write operations to perform in one bulk.
-         */
-        MAX_BULK_SIZE("max-bulk-size", Integer.MAX_VALUE),
 
         /**
          * How often sharding state is polled. The intervening events are lost after shard rebalancing

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -23,25 +23,24 @@ import javax.annotation.Nullable;
 
 import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
-import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.base.service.actors.ShutdownBehaviour;
-import org.eclipse.ditto.policies.api.PolicyReferenceTag;
-import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.internal.models.streaming.IdentifiableStreamingMessage;
-import org.eclipse.ditto.things.api.ThingTag;
-import org.eclipse.ditto.thingsearch.api.commands.sudo.UpdateThing;
-import org.eclipse.ditto.thingsearch.api.commands.sudo.UpdateThingResponse;
-import org.eclipse.ditto.thingsearch.service.common.config.DittoSearchConfig;
-import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
-import org.eclipse.ditto.thingsearch.service.persistence.write.streaming.ConsistencyLag;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.akka.streaming.StreamAck;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.timer.StartedTimer;
+import org.eclipse.ditto.policies.api.PolicyReferenceTag;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.things.api.ThingTag;
+import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
+import org.eclipse.ditto.thingsearch.api.commands.sudo.UpdateThing;
+import org.eclipse.ditto.thingsearch.api.commands.sudo.UpdateThingResponse;
+import org.eclipse.ditto.thingsearch.service.common.config.DittoSearchConfig;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
+import org.eclipse.ditto.thingsearch.service.persistence.write.streaming.ConsistencyLag;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -71,7 +70,7 @@ final class ThingUpdater extends AbstractActor {
     @SuppressWarnings("unused") //It is used via reflection. See props method.
     private ThingUpdater(final ActorRef pubSubMediator, final ActorRef changeQueueActor) {
         log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
-        final DittoSearchConfig dittoSearchConfig = DittoSearchConfig.of(
+        final var dittoSearchConfig = DittoSearchConfig.of(
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
         );
         thingId = tryToGetThingId();
@@ -181,8 +180,8 @@ final class ThingUpdater extends AbstractActor {
                     thingId, thingRevision, policyId, policyRevision, policyReferenceTag.asIdentifierString());
         }
 
-        final PolicyTag policyTag = policyReferenceTag.getPolicyTag();
-        final PolicyId policyIdOfTag = policyTag.getEntityId();
+        final var policyTag = policyReferenceTag.getPolicyTag();
+        final var policyIdOfTag = policyTag.getEntityId();
         if (!Objects.equals(policyId, policyIdOfTag) || policyRevision < policyTag.getRevision()) {
             this.policyId = policyIdOfTag;
             policyRevision = policyTag.getRevision();

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -22,12 +22,15 @@ ditto {
     }
 
     breaker {
-      maxFailures = 5 # defines ater how many failures the circuit breaker should open
+      # defines ater how many failures the circuit breaker should open
+      maxFailures = 5
       maxFailures = ${?BREAKER_MAXFAILURES}
       timeout {
-        call = 5s # MongoDB Timeouts causing the circuitBreaker to open - "0s" disables timeouts opening the breaker
+        # MongoDB Timeouts causing the circuitBreaker to open - "0s" disables timeouts opening the breaker
+        call = 5s
         call = ${?BREAKER_TIMEOUT}
-        reset = 10s # after this time in "Open" state, the cicuitBreaker is "Half-opened" again
+        # after this time in "Open" state, the cicuitBreaker is "Half-opened" again
+        reset = 10s
         reset = ${?BREAKER_RESET}
       }
     }
@@ -38,6 +41,7 @@ ditto {
       connection-pool = true
       commands = ${?MONGODB_MONITORING_CONNECTION_POOL_ENABLED}
     }
+
   }
 
   things-search {
@@ -45,7 +49,7 @@ ditto {
     mongo-hints-by-namespace = ${?MONGO_HINTS_BY_NAMESPACE}
 
     index-initialization {
-      #indices should be created within this application
+      # indices should be created within this application
       enabled = true
       enabled = ${?INDEX_INITIALIZATION_ENABLED}
     }
@@ -57,7 +61,7 @@ ditto {
       event-processing-active = true
       event-processing-active = ${?EVENT_PROCESSING_ACTIVE}
 
-      // how often to poll shard region for state updates
+      # how often to poll shard region for state updates
       sharding-state-poll-interval = 15s
       sharding-state-poll-interval = ${?SHARDING_STATE_POLL_INTERVAL}
 
@@ -97,33 +101,35 @@ ditto {
         max-backoff = 2m
         max-backoff = ${?BACKGROUND_SYNC_MAX_BACKOFF}
 
-        max-restarts = 180 // give up stream resumption after about 6 hours = 180 * 120s
+        # give up stream resumption after about 6 hours = 180 * 120s
+        max-restarts = 180
         max-restarts = ${?BACKGROUND_SYNC_MAX_RESTARTS}
 
-        recovery = 5m // assume upstream healthy if no error happened for this long
+        # assume upstream healthy if no error happened for this long
+        recovery = 5m
         recovery = ${?BACKGROUND_SYNC_RECOCVERY}
       }
 
       stream {
-        // arrays bigger than this are not indexed
+        # arrays bigger than this are not indexed
         max-array-size = 0
         max-array-size = ${?THINGS_SEARCH_UPDATER_STREAM_MAX_ARRAY_SIZE}
 
-        // minimum delay between event dumps
+        # minimum delay between event dumps must be at least 1s
         write-interval = 1s
         write-interval = ${?THINGS_SEARCH_UPDATER_STREAM_WRITE_INTERVAL}
 
-        // timeout for messages to Things-shard
+        # timeout for messages to Things-shard
         ask-timeout = 30s
         ask-timeout = ${?THINGS_SEARCH_UPDATER_STREAM_ASK_TIMEOUT}
 
-        // retrieval of things and policy-enforcers
+        # retrieval of things and policy-enforcers
         retrieval {
-          // upper bound of parallel SudoRetrieveThing commands (by extension, parallel loads of policy enforcer cache)
+          # upper bound of parallel SudoRetrieveThing commands (by extension, parallel loads of policy enforcer cache)
           parallelism = 16
           parallelism = ${?THINGS_SEARCH_UPDATER_STREAM_RETRIEVAL_PARALLELISM}
 
-          // back-offs in case of failure
+          # back-offs in case of failure
           exponential-backoff {
             min = 1s
             max = 2m
@@ -131,25 +137,25 @@ ditto {
           }
         }
 
-        // writing into the persistence
+        # writing into the persistence
         persistence {
-          // how many bulk writes to request in parallel; must be a power of 2
+          # how many bulk writes to request in parallel; must be a power of 2
           parallelism = 2
           parallelism = ${?THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_PARALLELISM}
 
-          // how many write operations to perform in one bulk
+          # how many write operations to perform in one bulk
           max-bulk-size = 250
           max-bulk-size = ${?THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_MAX_BULK_SIZE}
 
-          // how long to wait after DB acknowledgement before sending "search-persisted" acknowledgement
+          # how long to wait after DB acknowledgement before sending "search-persisted" acknowledgement
           ack-delay = 0s
           ack-delay = ${?THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_ACK_DELAY}
 
-          // mongoDB write concern to use for search updates requiring acknowledgement
+          # mongoDB write concern to use for search updates requiring acknowledgement
           with-acks-writeConcern = journaled
           with-acks-writeConcern = ${?THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_WITH_ACKS_WRITE_CONCERN}
 
-          // backoffs in case of failure
+          # backoffs in case of failure
           exponential-backoff {
             min = 1s
             max = 2m
@@ -158,10 +164,10 @@ ditto {
         }
 
         cache {
-          // name of the dispatcher to run async cache loaders, which do not block threads
+          # name of the dispatcher to run async cache loaders, which do not block threads
           dispatcher = "policy-enforcer-cache-dispatcher"
 
-          // delay before retrying a cache query if the cached value is out of date
+          # delay before retrying a cache query if the cached value is out of date
           retry-delay = 1s
           retry-delay = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_RETRY_DELAY}
 
@@ -176,10 +182,10 @@ ditto {
           expire-after-access = 30m
           expire-after-access = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_EXPIRY_AFTER_ACCESS}
         }
+
       }
     }
   }
-
 }
 
 akka {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfigTest.java
@@ -59,9 +59,6 @@ public final class DefaultUpdaterConfigTest {
     public void gettersReturnDefaultValuesIfNotConfigured() {
         final DefaultUpdaterConfig underTest = DefaultUpdaterConfig.of(ConfigFactory.empty());
 
-        softly.assertThat(underTest.getMaxBulkSize())
-                .as(UpdaterConfigValue.MAX_BULK_SIZE.getConfigPath())
-                .isEqualTo(UpdaterConfigValue.MAX_BULK_SIZE.getDefaultValue());
         softly.assertThat(underTest.isEventProcessingActive())
                 .as(UpdaterConfigValue.EVENT_PROCESSING_ACTIVE.getConfigPath())
                 .isEqualTo(UpdaterConfigValue.EVENT_PROCESSING_ACTIVE.getDefaultValue());
@@ -75,9 +72,6 @@ public final class DefaultUpdaterConfigTest {
         final DefaultUpdaterConfig underTest = DefaultUpdaterConfig.of(updaterTestConfig);
         final Config updaterScopedRawConfig = updaterTestConfig.getConfig(DefaultUpdaterConfig.CONFIG_PATH);
 
-        softly.assertThat(underTest.getMaxBulkSize())
-                .as(UpdaterConfigValue.MAX_BULK_SIZE.getConfigPath())
-                .isEqualTo(updaterScopedRawConfig.getInt(UpdaterConfigValue.MAX_BULK_SIZE.getConfigPath()));
         softly.assertThat(underTest.isEventProcessingActive())
                 .as(UpdaterConfigValue.EVENT_PROCESSING_ACTIVE.getConfigPath())
                 .isEqualTo(

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -15,21 +15,21 @@ package org.eclipse.ditto.thingsearch.service.updater.actors;
 import java.time.Instant;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.ditto.base.api.common.Shutdown;
+import org.eclipse.ditto.base.api.common.ShutdownReasonFactory;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.akka.streaming.StreamAck;
+import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
+import org.eclipse.ditto.policies.api.PolicyReferenceTag;
+import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.things.api.ThingTag;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.policies.api.PolicyReferenceTag;
-import org.eclipse.ditto.policies.api.PolicyTag;
-import org.eclipse.ditto.things.api.ThingTag;
-import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
-import org.eclipse.ditto.internal.utils.akka.streaming.StreamAck;
-import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
-import org.eclipse.ditto.base.api.common.Shutdown;
-import org.eclipse.ditto.base.api.common.ShutdownReasonFactory;
 import org.eclipse.ditto.things.model.signals.events.ThingCreated;
 import org.eclipse.ditto.things.model.signals.events.ThingModified;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -69,7 +69,6 @@ public final class ThingUpdaterTest {
         final Config config = ConfigFactory.load("test");
         startActorSystem(config);
     }
-
 
     @After
     public void tearDownBase() {
@@ -277,4 +276,5 @@ public final class ThingUpdaterTest {
         return actorSystem.actorOf(ThingUpdater.props(pubSubTestProbe.ref(), changeQueueTestProbe.ref()),
                 THING_ID.toString());
     }
+
 }

--- a/thingsearch/service/src/test/resources/test.conf
+++ b/thingsearch/service/src/test/resources/test.conf
@@ -19,7 +19,7 @@ ditto {
   }
 
   things-search {
-    query-criteria-validator = "org.eclipse.ditto.thingsearch.service.persistence.query.validation.DefaultQueryCriteriaValidator"
+    query-criteria-validator.implementation = "org.eclipse.ditto.thingsearch.service.persistence.query.validation.DefaultQueryCriteriaValidator"
 
     query {
       mongodb.timeout = 5s
@@ -118,7 +118,7 @@ akka {
 
     # duration to wait in expectMsg and friends outside of within() block
     # by default
-    single-expect-default = 3s
+    single-expect-default = 5s
 
     # The timeout that is added as an implicit by DefaultTimeout trait
     default-timeout = 5s

--- a/thingsearch/service/src/test/resources/updater-test.conf
+++ b/thingsearch/service/src/test/resources/updater-test.conf
@@ -1,5 +1,4 @@
 updater {
-  max-bulk-size = 1337
 
   event-processing-active = false
 


### PR DESCRIPTION
With this PR miss configuration of config values should be prevented.
E.g. if a duration in the config file is not in the expected range than a DittoConfigError exception is thrown when starting the Ditto service. 