### PR TITLE
Fix spurious ConnectionNotAccessibleException during TestConnection; stabilize DefaultEvictingQueue

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -185,6 +185,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
     private final ConnectivityCounterRegistry connectionCounterRegistry;
     private final ConnectionLoggerRegistry connectionLoggerRegistry;
     protected final ConnectionLogger connectionLogger;
+    private final boolean dryRun;
 
     private final ConnectionContextProvider connectionContextProvider;
     protected ConnectionContext connectionContext;
@@ -246,6 +247,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                 ConnectionPersistenceActor.getSubscriptionPrefixLength(connection.getClientCount());
 
         // Send init message to allow for unsafe initialization of subclasses.
+        dryRun = dittoHeaders.isDryRun();
         startInitialization(dittoHeaders);
     }
 
@@ -286,7 +288,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         initialize();
 
         // inform connection actor of my presence if there are other client actors
-        if (connection.getClientCount() > 1) {
+        if (connection.getClientCount() > 1 && !dryRun) {
             connectionActor.tell(getSelf(), getSelf());
             startTimerWithFixedDelay(Control.REFRESH_CLIENT_ACTOR_REFS.name(), Control.REFRESH_CLIENT_ACTOR_REFS,
                     clientActorRefsNotificationDelay);
@@ -1178,11 +1180,10 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         // All these method calls are NOT thread-safe. Do NOT inline.
         final CompletionStage<Status.Status> publisherReady = startPublisherActor();
         final CompletionStage<Status.Status> consumersReady = startConsumerActors(clientConnected);
-        final boolean isDryRun = isDryRun();
 
         return publisherReady
                 .thenCompose(unused -> consumersReady)
-                .thenCompose(unused -> subscribeAndDeclareAcknowledgementLabels(isDryRun))
+                .thenCompose(unused -> subscribeAndDeclareAcknowledgementLabels(dryRun))
                 .thenApply(unused -> InitializationResult.success())
                 .exceptionally(InitializationResult::failed);
     }
@@ -1740,7 +1741,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
     }
 
     protected boolean isDryRun() {
-        return TESTING.equals(stateName());
+        return dryRun;
     }
 
     private String nextChildActorName(final String prefix) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultEvictingQueue.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/DefaultEvictingQueue.java
@@ -62,13 +62,15 @@ final class DefaultEvictingQueue<E> extends AbstractQueue<E> implements Evicting
 
     @Override
     public boolean offer(@Nullable final E e) {
+        final var result = elements.offer(e);
         if (size.getAndIncrement() >= capacity) {
             poll();
         }
-        return elements.offer(e);
+        return result;
     }
 
     @Override
+    @Nullable
     public E poll() {
         final E pollResult = elements.poll();
         if (pollResult != null) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/EvictingQueue.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/EvictingQueue.java
@@ -75,6 +75,6 @@ interface EvictingQueue<E> extends Queue<E> {
      *         this time due to insertion restrictions
      */
     @Override
-    boolean addAll(Collection<? extends E> c);
+    boolean addAll(@Nullable Collection<? extends E> c);
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -577,7 +577,10 @@ public final class ConnectionPersistenceActor
     protected Receive matchAnyWhenDeleted() {
         return createInitializationAndConfigUpdateBehavior()
                 .orElse(ReceiveBuilder.create()
-                        .match(Control.class, msg -> log.debug("Ignoring control message when deleted: <{}>", msg))
+                        .match(Control.class, msg ->
+                                log.warning("Ignoring control message when deleted: <{}>", msg))
+                        .match(ActorRef.class, msg ->
+                                log.warning("Ignoring ActorRef message from client actor when deleted: <{}>", msg))
                         .build())
                 .orElse(super.matchAnyWhenDeleted());
     }
@@ -686,7 +689,11 @@ public final class ConnectionPersistenceActor
     private void testConnection(final StagedCommand command) {
         final ActorRef origin = command.getSender();
         final ActorRef self = getSelf();
-        final TestConnection testConnection = (TestConnection) command.getCommand();
+        final DittoHeaders headersWithDryRun = command.getDittoHeaders()
+                .toBuilder()
+                .dryRun(true)
+                .build();
+        final TestConnection testConnection = (TestConnection) command.getCommand().setDittoHeaders(headersWithDryRun);
 
         if (clientActorRouter != null) {
             // client actor is already running, so either another TestConnection command is currently executed or the


### PR DESCRIPTION
Fixed ConnectionNotAccessibleException received by client actors during TEST_CONNECTION due to actor ref broadcasting.

DefaultEvictingQueue had a small chance to increase in size due to polling when the queue is empty.