### PR TITLE
Stabilize jwt-validator-test

### DIFF
--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtTestConstants.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtTestConstants.java
@@ -59,7 +59,8 @@ final class JwtTestConstants {
             UNSIGNED_JWT_TOKEN = createUnsignedJwt();
             EXPIRED_JWT_TOKEN = createExpiredJwt();
             VALID_NBF_AHEAD_OF_TIME_JWT_TOKEN = createNotBeforeAheadOfTimeJwt(Date.from(Instant.now().plusSeconds(10)));
-            INVALID_NBF_AHEAD_OF_TIME_JWT_TOKEN = createNotBeforeAheadOfTimeJwt(Date.from(Instant.now().plusSeconds(15)));
+            INVALID_NBF_AHEAD_OF_TIME_JWT_TOKEN =
+                    createNotBeforeAheadOfTimeJwt(Date.from(Instant.now().plusSeconds(30)));
         } catch (final Exception e) {
             throw new IllegalStateException(e);
         }


### PR DESCRIPTION
The test is flaky on slower systems. Increased the time the token was issued to improve stability.