### PR TITLE
fix AbstractSSLContextTest for JDK >= 11.0.12

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          distribution: 'adopt'
+          distribution: 'zulu'
           java-version: 11
 
       - name: Cache local Maven repository

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/AbstractSSLContextTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/AbstractSSLContextTest.java
@@ -23,7 +23,6 @@ import java.net.Socket;
 import java.util.concurrent.CompletableFuture;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLServerSocket;
 
@@ -205,7 +204,10 @@ public abstract class AbstractSSLContextTest {
                         .getSocketFactory()
                         .createSocket(serverSocket.getInetAddress(), serverSocket.getLocalPort())) {
 
-            assertThatExceptionOfType(SSLException.class).isThrownBy(() -> underTest.getOutputStream().write(234));
+            // for JDK 11 < 11.0.12, an SSLException is expected:
+            // for JDK 11 >= 11.0.12, an SocketException is expected:
+            // both are IOExceptions:
+            assertThatExceptionOfType(IOException.class).isThrownBy(() -> underTest.getOutputStream().write(234));
         }
     }
 


### PR DESCRIPTION
OpenJDK changed a behavior don't wrapping `SocketException`s in `SSLException`s for JDK >= 11.0.12: https://bugs.openjdk.java.net/browse/JDK-8259662
Adjusted unit test to check for their common base exception `IOException`.