### PR TITLE
Reduce unnecessary error logs

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpClientActor.java
@@ -18,7 +18,6 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -395,32 +394,6 @@ public final class AmqpClientActor extends BaseClientActor implements ExceptionL
             disconnectConnectionHandler = null;
         }
         super.cleanupFurtherResourcesOnConnectionTimeout(currentState);
-    }
-
-    @Override
-    protected boolean isEventUpToDate(final Object event, final BaseClientState state,
-            @Nullable final ActorRef sender) {
-        if (getSelf().equals(sender)) {
-            // events from self are always relevant
-            return true;
-        }
-        switch (state) {
-            case CONNECTED:
-                // while connected, events from publisher or consumer child actors are relevant
-                return sender != null &&
-                        sender.path().toStringWithoutAddress().startsWith(getSelf().path().toStringWithoutAddress()) &&
-                        (sender.path().name().startsWith(AmqpConsumerActor.ACTOR_NAME_PREFIX) ||
-                                sender.path().name().startsWith(AmqpPublisherActor.ACTOR_NAME_PREFIX));
-            case CONNECTING:
-                return Objects.equals(sender, connectConnectionHandler);
-            case DISCONNECTING:
-                return Objects.equals(sender, disconnectConnectionHandler);
-            case TESTING:
-            default:
-                // no need to check testConnectionHandler because test runs only once during this actor's lifetime
-                // ignore random events by default - they could come from a connection handler that is already dead
-                return false;
-        }
     }
 
     @Override

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -71,9 +71,6 @@
 
     <logger name="org.apache.kafka" level="WARN"/>
 
-    <!-- Turn off FailoverProvider logging because it logs every retry at ERROR -->
-    <logger name="org.apache.qpid.jms.provider.failover.FailoverProvider" level="OFF"/>
-
     <!-- Log level for the application -->
     <logger name="org.eclipse.ditto" level="${LOG_LEVEL_APPLICATION:-INFO}"/>
 

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -71,6 +71,9 @@
 
     <logger name="org.apache.kafka" level="WARN"/>
 
+    <!-- Turn off FailoverProvider logging because it logs every retry at ERROR -->
+    <logger name="org.apache.qpid.jms.provider.failover.FailoverProvider" level="OFF"/>
+
     <!-- Log level for the application -->
     <logger name="org.eclipse.ditto" level="${LOG_LEVEL_APPLICATION:-INFO}"/>
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
@@ -240,6 +240,7 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
         if (HttpStatus.CREATED.equals(commandResponse.getHttpStatus()) && optionalEntityId.isPresent()) {
             responseLocationUri =
                     getUriForLocationHeader(httpRequest, optionalEntityId.get(), commandResponse.getResourcePath());
+            logger.debug("Setting responseLocationUri=<{}> from request <{}>", responseLocationUri, httpRequest);
         }
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
@@ -485,10 +485,7 @@ public abstract class AbstractHttpRequestActor extends AbstractActor {
             completionResponse = createHttpResponse(HttpStatus.ACCEPTED);
         }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Responding with HTTP response code <{}>.", completionResponse.status().intValue());
-            logger.debug("Responding with entity <{}>.", completionResponse.entity());
-        }
+        logger.debug("Responding with HTTP response <{}>.", completionResponse);
         httpResponseFuture.complete(completionResponse);
 
         stop();

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/UriForLocationHeaderSupplier.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/UriForLocationHeaderSupplier.java
@@ -41,7 +41,7 @@ final class UriForLocationHeaderSupplier implements Supplier<Uri> {
     public Uri get() {
         final Uri requestUri = httpRequest.getUri().query(Query.EMPTY); // strip query params
         if (isRequestIdempotent()) {
-            return requestUri.query(Query.EMPTY);
+            return requestUri;
         }
         return Uri.create(removeTrailingSlash(getLocationUriString(removeEntityId(requestUri.toString()))))
                 .query(Query.EMPTY);

--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractShardedPersistenceActor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractShardedPersistenceActor.java
@@ -518,7 +518,8 @@ public abstract class AbstractShardedPersistenceActor<
         l.debug("Persisting Event <{}>.", event.getType());
 
         persist(event, persistedEvent -> {
-            l.info("Successfully persisted Event <{}>.", event.getType());
+            l.info("Successfully persisted Event <{}> w/ rev: <{}>.", event.getType(),
+                    getRevisionNumber());
 
             /* the event has to be applied before creating the snapshot, otherwise a snapshot with new
                sequence no (e.g. 2), but old entity revision no (e.g. 1) will be created -> can lead to serious


### PR DESCRIPTION
- MQTT: reduced log level of disconnecting a disconnected client to
  DEBUG.

- AMQP: reduced log level of consumer initialization erros to INFO
  because it can be triggered by incorrect credentials.
  Disabled Qpid JMS Failover log.

- Pub/sub: reduced log level of ddata update failure to WARNING
  before it persists for 3 consecutive clock ticks.

- HTTP: log the entire response on DEBUG level in 1 statement.
  Payload and sensitive headers are hidden automatically.