### PR TITLE
Do not publish SubjectDeletionAnnouncement for modified subjects.

### DIFF
--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfig.java
@@ -34,11 +34,14 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
 
     private final Duration gracePeriod;
     private final Duration maxTimeout;
+    private final boolean enableAnnouncementsWhenDeleted;
     private final ExponentialBackOffConfig exponentialBackOffConfig;
 
     private DefaultPolicyAnnouncementConfig(final ScopedConfig scopedConfig) {
         gracePeriod = scopedConfig.getDuration(ConfigValue.GRACE_PERIOD.getConfigPath());
         maxTimeout = scopedConfig.getDuration(ConfigValue.MAX_TIMEOUT.getConfigPath());
+        enableAnnouncementsWhenDeleted =
+                scopedConfig.getBoolean(ConfigValue.ENABLE_ANNOUNCEMENTS_WHEN_DELETED.getConfigPath());
         exponentialBackOffConfig = DefaultExponentialBackOffConfig.of(scopedConfig);
     }
 
@@ -59,6 +62,11 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
     }
 
     @Override
+    public boolean isEnableAnnouncementsWhenDeleted() {
+        return enableAnnouncementsWhenDeleted;
+    }
+
+    @Override
     public ExponentialBackOffConfig getExponentialBackOffConfig() {
         return exponentialBackOffConfig;
     }
@@ -74,12 +82,13 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
         final DefaultPolicyAnnouncementConfig that = (DefaultPolicyAnnouncementConfig) o;
         return Objects.equals(gracePeriod, that.gracePeriod) &&
                 Objects.equals(maxTimeout, that.maxTimeout) &&
+                enableAnnouncementsWhenDeleted == that.enableAnnouncementsWhenDeleted &&
                 Objects.equals(exponentialBackOffConfig, that.exponentialBackOffConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(gracePeriod, maxTimeout, exponentialBackOffConfig);
+        return Objects.hash(gracePeriod, maxTimeout, enableAnnouncementsWhenDeleted, exponentialBackOffConfig);
     }
 
     @Override
@@ -87,6 +96,7 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
         return getClass().getSimpleName() + " [" +
                 "gracePeriod=" + gracePeriod +
                 ", maxTimeout=" + maxTimeout +
+                ", enableAnnouncementsWhenDeleted=" + enableAnnouncementsWhenDeleted +
                 ", exponentialBackOffConfig" + exponentialBackOffConfig +
                 "]";
     }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyAnnouncementConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyAnnouncementConfig.java
@@ -43,6 +43,13 @@ public interface PolicyAnnouncementConfig {
     Duration getMaxTimeout();
 
     /**
+     * Returns whether announcements are published for subjects upon deletion when requested.
+     *
+     * @return whether announcements-when-deleted are enabled.
+     */
+    boolean isEnableAnnouncementsWhenDeleted();
+
+    /**
      * Returns the config for the exponential back-off strategy of announcement redelivery.
      *
      * @return the config.
@@ -74,7 +81,12 @@ public interface PolicyAnnouncementConfig {
         /**
          * The maximum timeout.
          */
-        MAX_TIMEOUT("max-timeout", Duration.ofMinutes(1L));
+        MAX_TIMEOUT("max-timeout", Duration.ofMinutes(1L)),
+
+        /**
+         * Whether when-deleted announcements are enabled.
+         */
+        ENABLE_ANNOUNCEMENTS_WHEN_DELETED("enable-announcements-when-deleted", true);
 
         private final String path;
         private final Object defaultValue;

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
@@ -27,12 +27,14 @@ import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyLifecycle;
 import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.policies.service.common.config.PolicyAnnouncementConfig;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
+import akka.actor.PoisonPill;
 import akka.actor.Props;
 import akka.actor.Terminated;
 import akka.japi.pf.ReceiveBuilder;
@@ -48,6 +50,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
     private final DistributedPub<PolicyAnnouncement<?>> policyAnnouncementPub;
     private final Map<Subject, ActorRef> subjectExpiryActors;
     private final Map<ActorRef, Subject> activeSubjects;
+    private final Map<SubjectId, Integer> activeSubjectIds;
     private final ActorRef commandForwarder;
     private final PolicyAnnouncementConfig config;
 
@@ -61,6 +64,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
         this.commandForwarder = commandForwarder;
         this.subjectExpiryActors = new HashMap<>();
         this.activeSubjects = new HashMap<>();
+        this.activeSubjectIds = new HashMap<>();
         this.config = config;
     }
 
@@ -99,6 +103,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
             startChild(newSubject);
         }
         for (final var deletedSubject : deletedSubjects) {
+            // precondition: child actors have started for new subjects so that modified subjects can be recognized
             sendSubjectDeleted(deletedSubject);
         }
     }
@@ -112,6 +117,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
         getContext().watch(child);
         subjectExpiryActors.put(subject, child);
         activeSubjects.put(child, subject);
+        addActiveSubjectId(subject);
     }
 
     private void onChildTerminated(final Terminated terminated) {
@@ -119,6 +125,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
         final var removedSubject = activeSubjects.remove(terminatedActor);
         if (removedSubject != null) {
             final var child = subjectExpiryActors.remove(removedSubject);
+            removeActiveSubjectId(removedSubject);
             log.debug("OnChildTerminated: Removed terminated child <{}>", child);
         } else {
             log.debug("OnChildTerminated: Child not found: <{}>", terminatedActor);
@@ -128,9 +135,27 @@ public final class PolicyAnnouncementManager extends AbstractActor {
     private void sendSubjectDeleted(final Subject subject) {
         final var child = subjectExpiryActors.get(subject);
         if (child != null) {
-            child.tell(SubjectExpiryActor.Message.SUBJECT_DELETED, ActorRef.noSender());
+            notifyChildOfSubjectDeletion(subject, child);
         } else {
             log.error("Attempting to notify nonexistent child for deleted subject <{}>", subject);
+        }
+    }
+
+    /**
+     * Notify a child whose subject was deleted from the policy.
+     *
+     * @param subject the subject.
+     * @param child the recipient.
+     */
+    private void notifyChildOfSubjectDeletion(final Subject subject, final ActorRef child) {
+        final var activeSubjectIdCount = activeSubjectIds.getOrDefault(subject.getId(), 0);
+        if (activeSubjectIdCount >= 2) {
+            // another actor took over the responsibility of child; terminate it.
+            log.debug("Terminating child <{}> of updated subject <{}>", child, subject);
+            child.tell(PoisonPill.getInstance(), ActorRef.noSender());
+        } else {
+            log.debug("Notifying child <{}> of deleted subject <{}>", child, subject);
+            child.tell(SubjectExpiryActor.Message.SUBJECT_DELETED, ActorRef.noSender());
         }
     }
 
@@ -144,6 +169,26 @@ public final class PolicyAnnouncementManager extends AbstractActor {
         } else {
             return Set.of();
         }
+    }
+
+    private void addActiveSubjectId(final Subject subject) {
+        activeSubjectIds.compute(subject.getId(), (k, count) -> {
+            if (count == null) {
+                return 1;
+            } else {
+                return count + 1;
+            }
+        });
+    }
+
+    private void removeActiveSubjectId(final Subject subject) {
+        activeSubjectIds.computeIfPresent(subject.getId(), (k, count) -> {
+            if (count <= 1) {
+                return null;
+            } else {
+                return count - 1;
+            }
+        });
     }
 
     private static List<Subject> calculateDifference(final Set<Subject> minuend, final Set<Subject> subtrahend) {

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
@@ -111,7 +111,7 @@ public final class PolicyAnnouncementManager extends AbstractActor {
     private void startChild(final Subject subject) {
         final var props =
                 SubjectExpiryActor.props(policyId, subject, config.getGracePeriod(), policyAnnouncementPub,
-                        config.getMaxTimeout(), commandForwarder, config.getExponentialBackOffConfig());
+                        config.getMaxTimeout(), commandForwarder, config);
 
         final var child = getContext().actorOf(props);
         getContext().watch(child);

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -68,6 +68,9 @@ ditto {
         max-timeout = 60s
         max-timeout = ${?POLICY_ANNOUNCEMENT_MAX_TIMEOUT}
 
+        enable-announcements-when-deleted = true
+        enable-announcements-when-deleted = ${?POLICY_ENABLE_ANNOUNCEMENTS_WHEN_DELETED}
+
         exponential-backoff {
           # minimum backoff for announcement redelivery
           min = 1s

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfigTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfigTest.java
@@ -69,6 +69,10 @@ public final class DefaultPolicyAnnouncementConfigTest {
         softly.assertThat(underTest.getMaxTimeout())
                 .as(PolicyAnnouncementConfig.ConfigValue.MAX_TIMEOUT.getConfigPath())
                 .isEqualTo(Duration.ofMinutes(1L));
+
+        softly.assertThat(underTest.isEnableAnnouncementsWhenDeleted())
+                .as(PolicyAnnouncementConfig.ConfigValue.ENABLE_ANNOUNCEMENTS_WHEN_DELETED.getConfigPath())
+                .isTrue();
     }
 
     @Test
@@ -82,6 +86,10 @@ public final class DefaultPolicyAnnouncementConfigTest {
         softly.assertThat(underTest.getMaxTimeout())
                 .as(PolicyAnnouncementConfig.ConfigValue.MAX_TIMEOUT.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(5678));
+
+        softly.assertThat(underTest.isEnableAnnouncementsWhenDeleted())
+                .as(PolicyAnnouncementConfig.ConfigValue.ENABLE_ANNOUNCEMENTS_WHEN_DELETED.getConfigPath())
+                .isFalse();
 
         softly.assertThat(underTest.getExponentialBackOffConfig().getMin())
                 .as("exponential-backoff.min")

--- a/policies/service/src/test/resources/default-policy-config-test.conf
+++ b/policies/service/src/test/resources/default-policy-config-test.conf
@@ -15,13 +15,5 @@ policy {
     }
   }
 
-  announcement {
-    grace-period = 1234s
-    max-timeout = 5678s
-    exponential-backoff {
-      min = 9s
-      max = 10s
-      random-factor = 11
-    }
-  }
+  include "policy-announcement-config-test.conf"
 }

--- a/policies/service/src/test/resources/policy-announcement-config-test.conf
+++ b/policies/service/src/test/resources/policy-announcement-config-test.conf
@@ -1,6 +1,7 @@
 announcement {
   grace-period = 1234s
   max-timeout = 5678s
+  enable-announcements-when-deleted = false
   exponential-backoff {
     min = 9s
     max = 10s


### PR DESCRIPTION
Do not categorize subject modification as subject deletion in order to avoid triggering cascading policy actions.