### PR TITLE
Fix "search-persited" acknowledgement not working for thing deletion.

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
@@ -29,20 +29,23 @@ import com.typesafe.config.Config;
  */
 @Immutable
 public final class DefaultStreamConfig implements StreamConfig {
+
     private static final String CONFIG_PATH = "stream";
     private static final String RETRIEVAL_CONFIG_PATH = "retrieval";
     private static final String ASK_WITH_RETRY_CONFIG_PATH = "ask-with-retry";
 
     private final int maxArraySize;
     private final Duration writeInterval;
-    private final DefaultStreamStageConfig retrievalConfig;
-    private final DefaultPersistenceStreamConfig persistenceStreamConfig;
-    private final DefaultStreamCacheConfig streamCacheConfig;
-    private final DefaultAskWithRetryConfig askWithRetryConfig;
+    private final boolean deleteImmediately;
+    private final StreamStageConfig retrievalConfig;
+    private final PersistenceStreamConfig persistenceStreamConfig;
+    private final StreamCacheConfig streamCacheConfig;
+    private final AskWithRetryConfig askWithRetryConfig;
 
     private DefaultStreamConfig(final ConfigWithFallback streamScopedConfig) {
         maxArraySize = streamScopedConfig.getNonNegativeIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
         writeInterval = streamScopedConfig.getNonNegativeDurationOrThrow(StreamConfigValue.WRITE_INTERVAL);
+        deleteImmediately = streamScopedConfig.getBoolean(StreamConfigValue.DELETE_IMMEDIATELY.getConfigPath());
         askWithRetryConfig = DefaultAskWithRetryConfig.of(streamScopedConfig, ASK_WITH_RETRY_CONFIG_PATH);
         retrievalConfig = DefaultStreamStageConfig.getInstance(streamScopedConfig, RETRIEVAL_CONFIG_PATH);
         persistenceStreamConfig = DefaultPersistenceStreamConfig.of(streamScopedConfig);
@@ -68,6 +71,11 @@ public final class DefaultStreamConfig implements StreamConfig {
     @Override
     public Duration getWriteInterval() {
         return writeInterval;
+    }
+
+    @Override
+    public boolean isDeleteImmediately() {
+        return deleteImmediately;
     }
 
     @Override
@@ -101,6 +109,7 @@ public final class DefaultStreamConfig implements StreamConfig {
         final DefaultStreamConfig that = (DefaultStreamConfig) o;
         return maxArraySize == that.maxArraySize &&
                 writeInterval.equals(that.writeInterval) &&
+                deleteImmediately == that.deleteImmediately &&
                 askWithRetryConfig.equals(that.askWithRetryConfig) &&
                 retrievalConfig.equals(that.retrievalConfig) &&
                 persistenceStreamConfig.equals(that.persistenceStreamConfig) &&
@@ -109,7 +118,7 @@ public final class DefaultStreamConfig implements StreamConfig {
 
     @Override
     public int hashCode() {
-        return Objects.hash(maxArraySize, writeInterval, askWithRetryConfig, retrievalConfig,
+        return Objects.hash(maxArraySize, writeInterval, deleteImmediately, askWithRetryConfig, retrievalConfig,
                 persistenceStreamConfig, streamCacheConfig);
     }
 
@@ -118,6 +127,7 @@ public final class DefaultStreamConfig implements StreamConfig {
         return getClass().getSimpleName() + " [" +
                 "maxArraySize=" + maxArraySize +
                 ", writeInterval=" + writeInterval +
+                ", deleteImmediately=" + deleteImmediately +
                 ", askWithRetryConfig=" + askWithRetryConfig +
                 ", retrievalConfig=" + retrievalConfig +
                 ", persistenceStreamConfig=" + persistenceStreamConfig +

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamConfig.java
@@ -40,6 +40,13 @@ public interface StreamConfig {
     Duration getWriteInterval();
 
     /**
+     * Returns whether to delete entries from the search index immediately.
+     *
+     * @return whether to delete immediately.
+     */
+    boolean isDeleteImmediately();
+
+    /**
      * Returns the configuration for the used "ask with retry" pattern in the search updater for retrieval of things and
      * policies.
      *
@@ -81,7 +88,12 @@ public interface StreamConfig {
         /**
          * The minimal delay between event dumps.
          */
-        WRITE_INTERVAL("write-interval", Duration.ofSeconds(1L));
+        WRITE_INTERVAL("write-interval", Duration.ofSeconds(1L)),
+
+        /**
+         * Whether to delete entries from the search index immediately.
+         */
+        DELETE_IMMEDIATELY("delete-immediately", true);
 
         private final String configPath;
         private final Object defaultValue;

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
@@ -97,7 +97,7 @@ public final class TestSearchUpdaterStream {
      * @return source of write result.
      */
     private Source<WriteResultAndErrors, NotUsed> delete(final Metadata metadata) {
-        final AbstractWriteModel writeModel = ThingDeleteModel.of(metadata);
+        final AbstractWriteModel writeModel = ThingDeleteModel.of(metadata, false);
         return Source.single(Source.single(writeModel))
                 .via(mongoSearchUpdaterFlow.start(false, 1, 1));
     }

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -119,6 +119,9 @@ ditto {
         write-interval = 1s
         write-interval = ${?THINGS_SEARCH_UPDATER_STREAM_WRITE_INTERVAL}
 
+        delete-immediately = true
+        delete-immediately = ${?THINGS_SEARCH_UPDATER_STREAM_DELETE_IMMEDIATELY}
+
         # configuration for retrieval of policies/things via sharding
         ask-with-retry {
           ask-timeout = 5s

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfigTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import static org.eclipse.ditto.thingsearch.service.common.config.StreamConfig.StreamConfigValue;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import java.time.Duration;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit tests for {@link DefaultStreamConfig}.
+ */
+public final class DefaultStreamConfigTest {
+
+
+    private static Config config;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @BeforeClass
+    public static void initTestFixture() {
+        config = ConfigFactory.load("stream-test");
+    }
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(DefaultStreamConfig.class,
+                areImmutable(),
+                provided(PersistenceStreamConfig.class).isAlsoImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultStreamConfig.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final StreamConfig underTest = DefaultStreamConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.getMaxArraySize())
+                .as(StreamConfigValue.MAX_ARRAY_SIZE.getConfigPath())
+                .isEqualTo(StreamConfigValue.MAX_ARRAY_SIZE.getDefaultValue());
+
+        softly.assertThat(underTest.getWriteInterval())
+                .as(StreamConfigValue.WRITE_INTERVAL.getConfigPath())
+                .isEqualTo(StreamConfigValue.WRITE_INTERVAL.getDefaultValue());
+
+        softly.assertThat(underTest.isDeleteImmediately())
+                .as(StreamConfigValue.DELETE_IMMEDIATELY.getConfigPath())
+                .isEqualTo(StreamConfigValue.DELETE_IMMEDIATELY.getDefaultValue());
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final StreamConfig underTest = DefaultStreamConfig.of(config);
+
+        softly.assertThat(underTest.getMaxArraySize())
+                .as(StreamConfigValue.MAX_ARRAY_SIZE.getConfigPath())
+                .isEqualTo(1);
+
+        softly.assertThat(underTest.getWriteInterval())
+                .as(StreamConfigValue.WRITE_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(2));
+
+        softly.assertThat(underTest.isDeleteImmediately())
+                .as(StreamConfigValue.DELETE_IMMEDIATELY.getConfigPath())
+                .isEqualTo(false);
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
@@ -24,6 +24,8 @@ import org.bson.BsonDocument;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.signals.ShardedMessageEnvelope;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.api.commands.sudo.UpdateThingResponse;
@@ -32,8 +34,6 @@ import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingDeleteModel;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingWriteModel;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.WriteResultAndErrors;
-import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
-import org.eclipse.ditto.base.model.signals.ShardedMessageEnvelope;
 import org.junit.After;
 import org.junit.Test;
 
@@ -201,7 +201,7 @@ public final class BulkWriteResultAckFlowTest {
             final Metadata metadata =
                     Metadata.of(thingId, thingRevision, policyId, policyRevision, null, probes.get(i).ref());
             if (i % 2 == 0) {
-                writeModels.add(ThingDeleteModel.of(metadata));
+                writeModels.add(ThingDeleteModel.of(metadata, false));
             } else {
                 writeModels.add(ThingWriteModel.of(metadata, new Document()));
             }

--- a/thingsearch/service/src/test/resources/stream-test.conf
+++ b/thingsearch/service/src/test/resources/stream-test.conf
@@ -1,0 +1,5 @@
+stream {
+  max-array-size = 1
+  write-interval = 2s
+  delete-immediately = false
+}


### PR DESCRIPTION
- Thing deletion with acknowledgement requests now always result in direct search index deletion.
- Added a feature toggle to immediately delete also for updates without acknowledgement requests.