### PR TITLE
Make fileNamePattern for rolling file appender configurable 

### DIFF
--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -52,8 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/concierge.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-                    <!-- Keep 30 days' worth of history capped at 1GB total size -->
+                    <!-- daily rollover as default-->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -52,7 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/connectivity.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/connectivity.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
+                    <!-- daily rollover as default -->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/connectivity.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -173,6 +173,7 @@ Gathering logs for a running Ditto installation can be achieved by:
 * writing logs to log files: this can be done by setting the environment variable `DITTO_LOGGING_FILE_APPENDER` to `true`
    * configure the amount of log files, and the total amount of space used for logs files via these two environment 
      variables:
+       * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz)
        * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS` (default: 10) 
        * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: 1GB)
    * the format in which logging is done is "LogstashEncoder" format - that way the logfiles may easily be imported into

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -52,8 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/gateway.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/gateway.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-                    <!-- Keep 30 days' worth of history capped at 1GB total size -->
+                    <!-- daily rollover as default-->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/gateway.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default-->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -52,8 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/policies.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/policies.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-                    <!-- Keep 30 days' worth of history capped at 1GB total size -->
+                    <!-- daily rollover as default-->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/policies.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -52,8 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/things.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/things.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-                    <!-- Keep 30 days' worth of history capped at 1GB total size -->
+                    <!-- daily rollover as default-->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/things.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -52,8 +52,9 @@
                 </filter>
                 <file>/var/log/ditto/thing-search.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <fileNamePattern>/var/log/ditto/thing-search.log.%d{yyyy-MM-dd}.gz</fileNamePattern>
-                    <!-- Keep 30 days' worth of history capped at 1GB total size -->
+                    <!-- daily rollover as default-->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/thing-search.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                 </rollingPolicy>


### PR DESCRIPTION
The fileNamePattern used for the TimeBasedRollingPolicy can now be configured via env var DITTO_LOGGING_FILE_NAME_PATTERN.