### PR TITLE
Use CachingSignalEnrichmentFacade for search index update

### DIFF
--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/CachingSignalEnrichmentFacade.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/CachingSignalEnrichmentFacade.java
@@ -12,10 +12,12 @@
  */
 package org.eclipse.ditto.internal.models.signalenrichment;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -30,12 +32,12 @@ import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.protocol.adapter.ProtocolAdapter;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.events.ThingCreated;
 import org.eclipse.ditto.things.model.signals.events.ThingDeleted;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
 import org.eclipse.ditto.things.model.signals.events.ThingMerged;
@@ -45,7 +47,8 @@ import org.eclipse.ditto.things.model.signals.events.ThingMerged;
  * Instantiated once per cluster node so that it builds up a cache across all signal enrichments on a local cluster
  * node.
  */
-public final class CachingSignalEnrichmentFacade implements SignalEnrichmentFacade {
+public final class CachingSignalEnrichmentFacade implements
+        SignalEnrichmentFacade {
 
     private static final ThreadSafeDittoLogger LOGGER = DittoLoggerFactory
             .getThreadSafeLogger(CachingSignalEnrichmentFacade.class);
@@ -88,34 +91,87 @@ public final class CachingSignalEnrichmentFacade implements SignalEnrichmentFaca
             final DittoHeaders dittoHeaders,
             @Nullable final Signal<?> concernedSignal) {
 
-        if (concernedSignal instanceof ThingDeleted && !(ProtocolAdapter.isLiveSignal(concernedSignal))) {
-            // twin deleted events should not be enriched, return empty JsonObject
-            return CompletableFuture.completedFuture(JsonObject.empty());
-        }
-
         // as second step only return what was originally requested as fields:
-        return doRetrievePartialThing(thingId, jsonFieldSelector, dittoHeaders, concernedSignal)
+        final List<Signal<?>> concernedSignals = concernedSignal == null ? List.of() : List.of(concernedSignal);
+        return doRetrievePartialThing(thingId, jsonFieldSelector, dittoHeaders, concernedSignals, true)
                 .thenApply(jsonObject -> jsonObject.get(jsonFieldSelector));
     }
 
-    private CompletionStage<JsonObject> doRetrievePartialThing(final ThingId thingId,
-            final JsonFieldSelector jsonFieldSelector,
-            final DittoHeaders dittoHeaders,
-            @Nullable final Signal<?> concernedSignal) {
+    /**
+     * Retrieve thing given a list of thing events.
+     *
+     * @param thingId the thing to retrieve.
+     * @param events received thing events to reduce traffic. If there are no events, a fresh entry is retrieved.
+     * @return future of the retrieved thing.
+     */
+    public CompletionStage<JsonObject> retrieveThing(final ThingId thingId, final List<ThingEvent<?>> events) {
+        if (events.isEmpty()) {
+            final var cacheKey =
+                    CacheKey.of(thingId, CacheFactory.newCacheLookupContext(DittoHeaders.empty(), null));
+            extraFieldsCache.invalidate(cacheKey);
+            return doCacheLookup(cacheKey, DittoHeaders.empty());
+        } else {
+            return doRetrievePartialThing(thingId, null, DittoHeaders.empty(), events, false);
+        }
+    }
 
-        final JsonFieldSelector enhancedFieldSelector = JsonFactory.newFieldSelectorBuilder()
-                .addPointers(jsonFieldSelector)
-                .addFieldDefinition(Thing.JsonFields.REVISION) // additionally always select the revision
-                .build();
+    private CompletionStage<JsonObject> doRetrievePartialThing(final ThingId thingId,
+            @Nullable final JsonFieldSelector jsonFieldSelector,
+            final DittoHeaders dittoHeaders,
+            final List<? extends Signal<?>> concernedSignals,
+            final boolean invalidateCacheOnPolicyChange) {
+
+        final JsonFieldSelector enhancedFieldSelector;
+        if (jsonFieldSelector == null) {
+            enhancedFieldSelector = null;
+        } else {
+            enhancedFieldSelector = JsonFactory.newFieldSelectorBuilder()
+                    .addPointers(jsonFieldSelector)
+                    .addFieldDefinition(Thing.JsonFields.REVISION) // additionally always select the revision
+                    .build();
+        }
 
         final var idWithResourceType =
                 CacheKey.of(thingId, CacheFactory.newCacheLookupContext(dittoHeaders, enhancedFieldSelector));
 
-        if (concernedSignal instanceof ThingEvent && !(ProtocolAdapter.isLiveSignal(concernedSignal))) {
-            final ThingEvent<?> thingEvent = (ThingEvent<?>) concernedSignal;
-            return smartUpdateCachedObject(enhancedFieldSelector, idWithResourceType, thingEvent);
+        return smartUpdateCachedObject(enhancedFieldSelector, idWithResourceType, concernedSignals,
+                invalidateCacheOnPolicyChange);
+    }
+
+    private Optional<Integer> findLastThingDeletedOrCreated(final List<ThingEvent<?>> thingEvents) {
+        for (int i = thingEvents.size() - 1; i >= 0; --i) {
+            final var event = thingEvents.get(i);
+            if (event instanceof ThingDeleted || event instanceof ThingCreated) {
+                return Optional.of(i);
+            }
         }
-        return doCacheLookup(idWithResourceType, dittoHeaders);
+        return Optional.empty();
+    }
+
+    private Optional<List<ThingEvent<?>>> extractConsecutiveTwinEvents(
+            final List<? extends Signal<?>> concernedSignals) {
+        final List<ThingEvent<?>> thingEvents = concernedSignals.stream()
+                .filter(signal -> (signal instanceof ThingEvent) && !(ProtocolAdapter.isLiveSignal(signal)))
+                .map(signal -> (ThingEvent<?>) signal)
+                .collect(Collectors.toList());
+
+        // ignore events before ThingDeleted or ThingCreated
+        final var events = findLastThingDeletedOrCreated(thingEvents)
+                .map(i -> thingEvents.subList(i, thingEvents.size()))
+                .orElse(thingEvents);
+
+        if (!events.isEmpty()) {
+            // Validate sequence numbers. Discard
+            long lastSeq = -1;
+            for (final ThingEvent<?> event : events) {
+                if (lastSeq >= 0 && event.getRevision() != lastSeq + 1) {
+                    return Optional.empty();
+                } else {
+                    lastSeq = event.getRevision();
+                }
+            }
+        }
+        return Optional.of(events);
     }
 
     private CompletableFuture<JsonObject> doCacheLookup(final CacheKey idWithResourceType,
@@ -128,21 +184,45 @@ public final class CachingSignalEnrichmentFacade implements SignalEnrichmentFaca
     }
 
     private CompletableFuture<JsonObject> smartUpdateCachedObject(
-            final JsonFieldSelector enhancedFieldSelector,
+            @Nullable final JsonFieldSelector enhancedFieldSelector,
             final CacheKey idWithResourceType,
-            final ThingEvent<?> thingEvent) {
+            final List<? extends Signal<?>> concernedSignals,
+            final boolean invalidateCacheOnPolicyChange) {
 
-        final var dittoHeaders = thingEvent.getDittoHeaders();
+        final Optional<List<ThingEvent<?>>> thingEventsOptional = extractConsecutiveTwinEvents(concernedSignals);
+        final var dittoHeaders = getLastDittoHeaders(concernedSignals);
+
+        // there are twin events, but their sequence numbers have gaps
+        if (thingEventsOptional.isEmpty()) {
+            extraFieldsCache.invalidate(idWithResourceType);
+            return doCacheLookup(idWithResourceType, dittoHeaders);
+        }
+
+        // there are no twin event; return the cached thing
+        final var thingEvents = thingEventsOptional.orElseThrow();
+        if (thingEvents.isEmpty()) {
+            return doCacheLookup(idWithResourceType, dittoHeaders);
+        }
+
+        // there are ThingDeleted or ThingCreated events: perform smart update ignoring the cache entry
+        if (thingEvents.get(0) instanceof ThingDeleted || thingEvents.get(0) instanceof ThingCreated) {
+            return handleNextExpectedThingEvents(enhancedFieldSelector, idWithResourceType, thingEvents,
+                    JsonObject.empty(), invalidateCacheOnPolicyChange)
+                    .toCompletableFuture();
+        }
+
+        // there are twin events; perform smart update
         return doCacheLookup(idWithResourceType, dittoHeaders).thenCompose(cachedJsonObject -> {
             final long cachedRevision = cachedJsonObject.getValue(Thing.JsonFields.REVISION).orElse(0L);
-            if (cachedRevision == thingEvent.getRevision()) {
-                // the cache entry was not present before and just loaded
+            final long lastRevision = getLast(thingEvents).getRevision();
+            if (cachedRevision >= lastRevision) {
+                // the cache entry was more up-to-date
                 return CompletableFuture.completedFuture(cachedJsonObject);
-            } else if (cachedRevision + 1 == thingEvent.getRevision()) {
-                // the cache entry was already present and the thingEvent was the next expected revision no
+            } else if (cachedRevision + 1 == getFirst(thingEvents).getRevision()) {
+                // the cache entry was already present and the first thingEvent was the next expected revision no
                 // -> we have all information necessary to calculate it without making another roundtrip
-                return handleNextExpectedThingEvent(enhancedFieldSelector, idWithResourceType, thingEvent,
-                        cachedJsonObject);
+                return handleNextExpectedThingEvents(enhancedFieldSelector, idWithResourceType, thingEvents,
+                        cachedJsonObject, invalidateCacheOnPolicyChange);
             } else {
                 // the cache entry was already present, but we missed sth and need to invalidate the cache
                 // and to another cache lookup (via roundtrip)
@@ -152,52 +232,82 @@ public final class CachingSignalEnrichmentFacade implements SignalEnrichmentFaca
         });
     }
 
-    private CompletionStage<JsonObject> handleNextExpectedThingEvent(final JsonFieldSelector enhancedFieldSelector,
-            final CacheKey idWithResourceType,
-            final ThingEvent<?> thingEvent,
-            final JsonObject cachedJsonObject) {
-
-        final JsonPointer resourcePath = thingEvent.getResourcePath();
-        if (Thing.JsonFields.POLICY_ID.getPointer().equals(resourcePath)) {
-            // invalidate the cache
-            extraFieldsCache.invalidate(idWithResourceType);
-            // and to another cache lookup (via roundtrip):
-            return doCacheLookup(idWithResourceType, thingEvent.getDittoHeaders());
-        }
-
-        final JsonObjectBuilder jsonObjectBuilder;
-        if (thingEvent instanceof ThingMerged) {
-            final var thingMerged = (ThingMerged) thingEvent;
-            final JsonValue mergedValue = thingMerged.getValue();
-
-            // if the policyId was part of a "top level" merge:
-            if (resourcePath.isEmpty() && Optional.of(mergedValue)
-                    .filter(JsonValue::isObject)
-                    .map(JsonValue::asObject)
-                    .filter(obj -> obj.contains(Thing.JsonFields.POLICY_ID.getPointer()))
-                    .isPresent()) {
-                // invalidate the cache
-                extraFieldsCache.invalidate(idWithResourceType);
-                // and to another cache lookup (via roundtrip):
-                return doCacheLookup(idWithResourceType, thingEvent.getDittoHeaders());
-            }
-
-            final JsonObject mergePatch = JsonFactory.newObject(resourcePath, mergedValue);
-            final JsonObject mergedJson = JsonFactory.mergeJsonValues(mergePatch, cachedJsonObject).asObject();
-            jsonObjectBuilder = mergedJson.toBuilder();
+    private DittoHeaders getLastDittoHeaders(final List<? extends Signal<?>> concernedSignals) {
+        if (concernedSignals.isEmpty()) {
+            return DittoHeaders.empty();
         } else {
-            jsonObjectBuilder = cachedJsonObject.toBuilder();
-            final Optional<JsonValue> optEntity = thingEvent.getEntity();
-            if (resourcePath.isEmpty() && optEntity.filter(JsonValue::isObject).isPresent()) {
-                optEntity.map(JsonValue::asObject).ifPresent(jsonObjectBuilder::setAll);
-            } else {
-                optEntity.ifPresent(entity -> jsonObjectBuilder
-                        .set(resourcePath.toString(), entity)
-                );
+            return getLast(concernedSignals).getDittoHeaders();
+        }
+    }
+
+    private <T> T getLast(final List<T> list) {
+        return list.get(list.size() - 1);
+    }
+
+    private <T> T getFirst(final List<T> list) {
+        return list.get(0);
+    }
+
+    private CompletionStage<JsonObject> handleNextExpectedThingEvents(
+            @Nullable final JsonFieldSelector enhancedFieldSelector,
+            final CacheKey idWithResourceType,
+            final List<ThingEvent<?>> thingEvents,
+            final JsonObject cachedJsonObject,
+            final boolean invalidateCacheOnPolicyChange) {
+
+        final Optional<String> cachedPolicyIdOpt = cachedJsonObject.getValue(Thing.JsonFields.POLICY_ID);
+        JsonObject jsonObject = cachedJsonObject;
+        for (final ThingEvent<?> thingEvent : thingEvents) {
+            final JsonPointer resourcePath = thingEvent.getResourcePath();
+
+            switch (thingEvent.getCommandCategory()) {
+                case MERGE:
+                    final var thingMerged = (ThingMerged) thingEvent;
+                    final JsonValue mergedValue = thingMerged.getValue();
+                    final JsonObject mergePatch = JsonFactory.newObject(resourcePath, mergedValue);
+                    jsonObject = JsonFactory.mergeJsonValues(mergePatch, jsonObject).asObject();
+                    break;
+                case DELETE:
+                    if (resourcePath.isEmpty()) {
+                        jsonObject = JsonObject.empty();
+                    } else {
+                        jsonObject = jsonObject.remove(resourcePath);
+                    }
+                    break;
+                case MODIFY:
+                default:
+                    final var jsonObjectBuilder = jsonObject.toBuilder();
+                    final Optional<JsonValue> optEntity = thingEvent.getEntity();
+                    if (resourcePath.isEmpty() && optEntity.filter(JsonValue::isObject).isPresent()) {
+                        optEntity.map(JsonValue::asObject).ifPresent(jsonObjectBuilder::setAll);
+                    } else {
+                        optEntity.ifPresent(entity -> jsonObjectBuilder
+                                .set(resourcePath.toString(), entity)
+                        );
+                    }
+                    jsonObject = jsonObjectBuilder.build();
+            }
+
+            // invalidate cache on policy change if the flag is set
+            if (invalidateCacheOnPolicyChange) {
+                final var currentJsonObject = jsonObject;
+                final boolean shouldInvalidate = cachedPolicyIdOpt.flatMap(cachedPolicyId ->
+                                currentJsonObject.getValue(Thing.JsonFields.POLICY_ID)
+                                        .filter(currentPolicyId -> !cachedPolicyId.equals(currentPolicyId)))
+                        .isPresent();
+                if (shouldInvalidate) {
+                    // invalidate the cache
+                    extraFieldsCache.invalidate(idWithResourceType);
+                    // and to another cache lookup (via roundtrip):
+                    return doCacheLookup(idWithResourceType, thingEvent.getDittoHeaders());
+                }
             }
         }
-        jsonObjectBuilder.set(Thing.JsonFields.REVISION, thingEvent.getRevision());
-        final var enhancedJsonObject = jsonObjectBuilder.build().get(enhancedFieldSelector);
+        final var jsonObjectBuilder = jsonObject.toBuilder()
+                .set(Thing.JsonFields.REVISION, getLast(thingEvents).getRevision());
+        final var enhancedJsonObject = enhancedFieldSelector == null
+                ? jsonObjectBuilder.build()
+                : jsonObjectBuilder.build().get(enhancedFieldSelector);
         // update local cache with enhanced object:
         extraFieldsCache.put(idWithResourceType, enhancedJsonObject);
         return CompletableFuture.completedFuture(enhancedJsonObject);

--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/SignalEnrichmentCacheLoader.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/SignalEnrichmentCacheLoader.java
@@ -53,10 +53,10 @@ final class SignalEnrichmentCacheLoader implements AsyncCacheLoader<CacheKey, Js
         final Optional<CacheLookupContext> contextOptional = key.getCacheLookupContext();
         final Optional<JsonFieldSelector> selectorOptional =
                 contextOptional.flatMap(CacheLookupContext::getJsonFieldSelector);
-        if (contextOptional.isPresent() && selectorOptional.isPresent()) {
+        if (contextOptional.isPresent()) {
             final CacheLookupContext context = contextOptional.get();
             final ThingId thingId = ThingId.of(key.getId());
-            final JsonFieldSelector jsonFieldSelector = selectorOptional.get();
+            final JsonFieldSelector jsonFieldSelector = selectorOptional.orElse(null);
             final DittoHeaders dittoHeaders = context.getDittoHeaders().orElseGet(DittoHeaders::empty);
             return facade.retrievePartialThing(thingId, jsonFieldSelector, dittoHeaders, null)
                     .toCompletableFuture();

--- a/protocol/src/test/java/org/eclipse/ditto/protocol/adapter/things/ThingEventAdapterTest.java
+++ b/protocol/src/test/java/org/eclipse/ditto/protocol/adapter/things/ThingEventAdapterTest.java
@@ -20,26 +20,27 @@ import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonPointer;
-import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.base.model.entity.metadata.Metadata;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
-import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.Event;
+import org.eclipse.ditto.base.model.signals.events.EventsourcedEvent;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.protocol.Adaptable;
-import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
 import org.eclipse.ditto.protocol.EventsTopicPathBuilder;
 import org.eclipse.ditto.protocol.LiveTwinTest;
 import org.eclipse.ditto.protocol.Payload;
-import org.eclipse.ditto.protocol.adapter.ProtocolAdapterTest;
 import org.eclipse.ditto.protocol.TestConstants;
 import org.eclipse.ditto.protocol.TopicPath;
 import org.eclipse.ditto.protocol.TopicPathBuilder;
 import org.eclipse.ditto.protocol.UnknownEventException;
-import org.eclipse.ditto.base.model.signals.events.Event;
-import org.eclipse.ditto.base.model.signals.events.EventsourcedEvent;
+import org.eclipse.ditto.protocol.adapter.DittoProtocolAdapter;
+import org.eclipse.ditto.protocol.adapter.ProtocolAdapterTest;
+import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.events.AttributeCreated;
 import org.eclipse.ditto.things.model.signals.events.AttributeDeleted;
 import org.eclipse.ditto.things.model.signals.events.AttributeModified;
@@ -1638,6 +1639,11 @@ public final class ThingEventAdapterTest extends LiveTwinTest implements Protoco
         @Override
         public UnknownThingEvent setDittoHeaders(final DittoHeaders dittoHeaders) {
             return this;
+        }
+
+        @Override
+        public Command.Category getCommandCategory() {
+            return Command.Category.MODIFY;
         }
 
         @Nonnull

--- a/things/api/src/main/java/org/eclipse/ditto/things/api/commands/sudo/SudoRetrieveThingResponse.java
+++ b/things/api/src/main/java/org/eclipse/ditto/things/api/commands/sudo/SudoRetrieveThingResponse.java
@@ -120,7 +120,7 @@ public final class SudoRetrieveThingResponse extends AbstractCommandResponse<Sud
     }
 
     @Override
-    public JsonValue getEntity(final JsonSchemaVersion schemaVersion) {
+    public JsonObject getEntity(final JsonSchemaVersion schemaVersion) {
         return thing;
     }
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeCreated.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -181,6 +182,11 @@ public final class AttributeCreated extends AbstractThingEvent<AttributeCreated>
     public AttributeCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), attributePointer, attributeValue, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeDeleted.java
@@ -19,6 +19,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -152,6 +153,11 @@ public final class AttributeDeleted extends AbstractThingEvent<AttributeDeleted>
     public AttributeDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), attributePointer, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributeModified.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -181,6 +182,11 @@ public final class AttributeModified extends AbstractThingEvent<AttributeModifie
     public AttributeModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), attributePointer, attributeValue, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesCreated.java
@@ -20,6 +20,13 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -27,15 +34,9 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableEvent;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.Attributes;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 
 /**
  * This event is emitted after all {@code Attribute}s were created at once.
@@ -160,6 +161,11 @@ public final class AttributesCreated extends AbstractThingEvent<AttributesCreate
     public AttributesCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), createdAttributes, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesDeleted.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -127,6 +128,11 @@ public final class AttributesDeleted extends AbstractThingEvent<AttributesDelete
     public AttributesDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/AttributesModified.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -161,6 +162,11 @@ public final class AttributesModified extends AbstractThingEvent<AttributesModif
     public AttributesModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), modifiedAttributes, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -174,6 +175,11 @@ public final class FeatureCreated extends AbstractThingEvent<FeatureCreated> imp
     public FeatureCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), feature, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -181,6 +182,11 @@ public final class FeatureDefinitionCreated extends AbstractThingEvent<FeatureDe
     public FeatureDefinitionCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, definition, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -145,6 +146,11 @@ public final class FeatureDefinitionDeleted extends AbstractThingEvent<FeatureDe
     public FeatureDefinitionDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDefinitionModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -180,6 +181,11 @@ public final class FeatureDefinitionModified extends AbstractThingEvent<FeatureD
     public FeatureDefinitionModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, definition, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -145,6 +146,11 @@ public final class FeatureDeleted extends AbstractThingEvent<FeatureDeleted> imp
     public FeatureDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -48,8 +49,7 @@ import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 @Immutable
 @JsonParsableEvent(name = FeatureDesiredPropertiesCreated.NAME, typePrefix = ThingEvent.TYPE_PREFIX)
 public final class FeatureDesiredPropertiesCreated extends AbstractThingEvent<FeatureDesiredPropertiesCreated>
-        implements
-        ThingModifiedEvent<FeatureDesiredPropertiesCreated>, WithFeatureId {
+        implements ThingModifiedEvent<FeatureDesiredPropertiesCreated>, WithFeatureId {
 
     /**
      * Name of the "Feature Desired Properties Created" event.
@@ -191,6 +191,11 @@ public final class FeatureDesiredPropertiesCreated extends AbstractThingEvent<Fe
         return of(getEntityId(), featureId, desiredProperties, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -42,8 +43,7 @@ import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 @Immutable
 @JsonParsableEvent(name = FeatureDesiredPropertiesDeleted.NAME, typePrefix = ThingEvent.TYPE_PREFIX)
 public final class FeatureDesiredPropertiesDeleted extends AbstractThingEvent<FeatureDesiredPropertiesDeleted>
-        implements
-        ThingModifiedEvent<FeatureDesiredPropertiesDeleted>, WithFeatureId {
+        implements ThingModifiedEvent<FeatureDesiredPropertiesDeleted>, WithFeatureId {
 
     /**
      * Name of the "Feature Desired Properties Deleted" event.
@@ -150,6 +150,11 @@ public final class FeatureDesiredPropertiesDeleted extends AbstractThingEvent<Fe
     public FeatureDesiredPropertiesDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertiesModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -48,8 +49,7 @@ import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 @Immutable
 @JsonParsableEvent(name = FeatureDesiredPropertiesModified.NAME, typePrefix = ThingEvent.TYPE_PREFIX)
 public final class FeatureDesiredPropertiesModified extends AbstractThingEvent<FeatureDesiredPropertiesModified>
-        implements
-        ThingModifiedEvent<FeatureDesiredPropertiesModified>, WithFeatureId {
+        implements ThingModifiedEvent<FeatureDesiredPropertiesModified>, WithFeatureId {
 
     /**
      * Name of the "Feature Desired Properties Modified" event.
@@ -186,6 +186,11 @@ public final class FeatureDesiredPropertiesModified extends AbstractThingEvent<F
         return of(getEntityId(), featureId, desiredProperties, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -195,6 +196,11 @@ public final class FeatureDesiredPropertyCreated extends AbstractThingEvent<Feat
     public FeatureDesiredPropertyCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, desiredPropertyPointer, desiredPropertyValue, getRevision(),
                 getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -170,6 +171,11 @@ public final class FeatureDesiredPropertyDeleted extends AbstractThingEvent<Feat
     public FeatureDesiredPropertyDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, desiredPropertyPointer, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureDesiredPropertyModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -196,6 +197,11 @@ public final class FeatureDesiredPropertyModified extends AbstractThingEvent<Fea
     public FeatureDesiredPropertyModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, desiredPropertyPointer, desiredPropertyValue, getRevision(),
                 getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeatureModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -173,6 +174,11 @@ public final class FeatureModified extends AbstractThingEvent<FeatureModified>
     public FeatureModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), feature, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesCreated.java
@@ -22,6 +22,14 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.WithFeatureId;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -29,16 +37,9 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableEvent;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.base.model.signals.WithFeatureId;
-import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 
 /**
  * This event is emitted after a Feature's {@link org.eclipse.ditto.things.model.FeatureProperties} were created.
@@ -184,6 +185,11 @@ public final class FeaturePropertiesCreated extends AbstractThingEvent<FeaturePr
     public FeaturePropertiesCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, properties, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -145,6 +146,11 @@ public final class FeaturePropertiesDeleted extends AbstractThingEvent<FeaturePr
     public FeaturePropertiesDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertiesModified.java
@@ -22,6 +22,14 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.WithFeatureId;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -29,16 +37,9 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableEvent;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.base.model.signals.WithFeatureId;
-import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 
 /**
  * This event is emitted after a Feature's {@link org.eclipse.ditto.things.model.FeatureProperties} were modified.
@@ -180,6 +181,11 @@ public final class FeaturePropertiesModified extends AbstractThingEvent<FeatureP
     public FeaturePropertiesModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, properties, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -196,6 +197,11 @@ public final class FeaturePropertyCreated extends AbstractThingEvent<FeatureProp
     public FeaturePropertyCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, propertyPointer, propertyValue, getRevision(),
                 getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyDeleted.java
@@ -21,6 +21,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -170,6 +171,11 @@ public final class FeaturePropertyDeleted extends AbstractThingEvent<FeatureProp
     public FeaturePropertyDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, propertyPointer, getRevision(), getTimestamp().orElse(null),
                 dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturePropertyModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -196,6 +197,11 @@ public final class FeaturePropertyModified extends AbstractThingEvent<FeaturePro
     public FeaturePropertyModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), featureId, propertyPointer, propertyValue, getRevision(),
                 getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesCreated.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -167,6 +168,11 @@ public final class FeaturesCreated extends AbstractThingEvent<FeaturesCreated>
     public FeaturesCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), features, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesDeleted.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -128,6 +129,11 @@ public final class FeaturesDeleted extends AbstractThingEvent<FeaturesDeleted>
     public FeaturesDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/FeaturesModified.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -164,6 +165,11 @@ public final class FeaturesModified extends AbstractThingEvent<FeaturesModified>
     public FeaturesModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), features, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/PolicyIdModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/PolicyIdModified.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -161,6 +162,11 @@ public final class PolicyIdModified extends AbstractThingEvent<PolicyIdModified>
     public PolicyIdModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), policyId, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingCreated.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -136,6 +137,11 @@ public final class ThingCreated extends AbstractThingEvent<ThingCreated> impleme
     @Override
     public ThingCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(thing, getRevision(), getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionCreated.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionCreated.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -172,6 +173,11 @@ public final class ThingDefinitionCreated extends AbstractThingEvent<ThingDefini
     public ThingDefinitionCreated setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), definition, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionDeleted.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -127,6 +128,11 @@ public final class ThingDefinitionDeleted extends AbstractThingEvent<ThingDefini
     public ThingDefinitionDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDefinitionModified.java
@@ -20,6 +20,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -174,6 +175,11 @@ public final class ThingDefinitionModified extends AbstractThingEvent<ThingDefin
     public ThingDefinitionModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), definition, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDeleted.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingDeleted.java
@@ -18,6 +18,7 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
@@ -126,6 +127,11 @@ public final class ThingDeleted extends AbstractThingEvent<ThingDeleted> impleme
     public ThingDeleted setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(getEntityId(), getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.DELETE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingEvent.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingEvent.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.things.model.signals.events;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
@@ -48,6 +49,14 @@ public interface ThingEvent<T extends ThingEvent<T>> extends EventsourcedEvent<T
 
     @Override
     T setDittoHeaders(DittoHeaders dittoHeaders);
+
+    /**
+     * Get the category of the command that caused this event.
+     *
+     * @return the command category.
+     * @since 2.1.0
+     */
+    Command.Category getCommandCategory();
 
     /**
      * An enumeration of the known {@link org.eclipse.ditto.json.JsonField}s of an event.

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingMerged.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingMerged.java
@@ -21,6 +21,15 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.FeatureToggle;
+import org.eclipse.ditto.base.model.signals.UnsupportedSchemaVersionException;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -28,15 +37,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableEvent;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.base.model.signals.FeatureToggle;
-import org.eclipse.ditto.base.model.signals.UnsupportedSchemaVersionException;
-import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 
 /**
  * This event is emitted after a {@link org.eclipse.ditto.things.model.Thing} was merged.
@@ -125,6 +126,11 @@ public final class ThingMerged extends AbstractThingEvent<ThingMerged> implement
     public ThingMerged setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(thingId, path, value, getRevision(), getTimestamp().orElse(null), dittoHeaders,
                 getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MERGE;
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingModified.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/events/ThingModified.java
@@ -22,20 +22,21 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.entity.metadata.Metadata;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableEvent;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.Command;
+import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.entity.metadata.Metadata;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableEvent;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.base.model.signals.events.EventJsonDeserializer;
 
 /**
  * This event is emitted after a {@link org.eclipse.ditto.things.model.Thing} was modified.
@@ -152,6 +153,11 @@ public final class ThingModified extends AbstractThingEvent<ThingModified>
     @Override
     public ThingModified setDittoHeaders(final DittoHeaders dittoHeaders) {
         return of(thing, getRevision(), getTimestamp().orElse(null), dittoHeaders, getMetadata().orElse(null));
+    }
+
+    @Override
+    public Command.Category getCommandCategory() {
+        return Command.Category.MODIFY;
     }
 
     @Override

--- a/thingsearch/service/pom.xml
+++ b/thingsearch/service/pom.xml
@@ -45,6 +45,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.ditto</groupId>
+            <artifactId>ditto-internal-models-signalenrichment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.ditto</groupId>
             <artifactId>ditto-internal-utils-akka</artifactId>
         </dependency>
         <dependency>

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.thingsearch.service.persistence.write.mapping;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -104,8 +105,8 @@ public final class EnforcedThingMapper {
         final var nullablePolicyId = thing.getValue(Thing.JsonFields.POLICY_ID).map(PolicyId::of).orElse(null);
         final var metadata = Metadata.of(thingId, thingRevision, nullablePolicyId, policyRevision,
                 Optional.ofNullable(oldMetadata).flatMap(Metadata::getModified).orElse(null),
-                Optional.ofNullable(oldMetadata).map(Metadata::getTimers).orElse(Collections.emptyList()),
-                Optional.ofNullable(oldMetadata).map(Metadata::getSenders).orElse(Collections.emptyList()));
+                Optional.ofNullable(oldMetadata).map(Metadata::getTimers).orElse(List.of()),
+                Optional.ofNullable(oldMetadata).map(Metadata::getSenders).orElse(List.of()));
 
         // hierarchical values for sorting
         final BsonValue thingCopyForSorting = JsonToBson.convert(pruneArrays(thing, maxArraySize));

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SudoSignalEnrichmentFacade.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SudoSignalEnrichmentFacade.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.internal.models.signalenrichment.SignalEnrichmentFacade;
+import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThing;
+import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
+import org.eclipse.ditto.things.model.ThingId;
+
+import akka.actor.ActorSelection;
+import akka.pattern.Patterns;
+
+/**
+ * Sudo-retrieve things by asking an actor.
+ */
+final class SudoSignalEnrichmentFacade implements SignalEnrichmentFacade {
+
+    private final ActorSelection commandHandler;
+    private final Duration askTimeout;
+
+    private SudoSignalEnrichmentFacade(final ActorSelection commandHandler, final Duration askTimeout) {
+        this.commandHandler = checkNotNull(commandHandler, "commandHandler");
+        this.askTimeout = checkNotNull(askTimeout, "askTimeout");
+    }
+
+    static SudoSignalEnrichmentFacade of(final ActorSelection commandHandler, final Duration askTimeout) {
+        return new SudoSignalEnrichmentFacade(commandHandler, askTimeout);
+    }
+
+    @Override
+    public CompletionStage<JsonObject> retrievePartialThing(final ThingId thingId,
+            final JsonFieldSelector jsonFieldSelector,
+            final DittoHeaders dittoHeaders,
+            @Nullable final Signal<?> concernedSignal) {
+
+        final DittoHeaders headersWithCorrelationId = DittoHeaders.newBuilder().randomCorrelationId().build();
+        final SudoRetrieveThing command = SudoRetrieveThing.of(thingId, headersWithCorrelationId);
+        return Patterns.ask(commandHandler, command, askTimeout).thenCompose(SudoSignalEnrichmentFacade::extractThing);
+    }
+
+    private static CompletionStage<JsonObject> extractThing(final Object object) {
+        if (object instanceof SudoRetrieveThingResponse) {
+            final SudoRetrieveThingResponse response = (SudoRetrieveThingResponse) object;
+            return CompletableFuture.completedFuture(response.getEntity(JsonSchemaVersion.LATEST));
+        } else {
+            final CompletableFuture<JsonObject> failedFuture = new CompletableFuture<>();
+            failedFuture.completeExceptionally(toThrowable(object));
+            return failedFuture;
+        }
+    }
+
+    private static Throwable toThrowable(final Object object) {
+        if (object instanceof Throwable) {
+            return (Throwable) object;
+        } else {
+            return new IllegalStateException("Unexpected message: " + object);
+        }
+    }
+
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -120,7 +120,8 @@ final class ThingUpdater extends AbstractActor {
      * @param timer an optional timer measuring the search updater's consistency lag.
      */
     private Metadata exportMetadata(@Nullable final ThingEvent<?> event, @Nullable final StartedTimer timer) {
-        return Metadata.of(thingId, thingRevision, policyId, policyRevision, List.of(event), timer, null);
+        return Metadata.of(thingId, thingRevision, policyId, policyRevision,
+                event == null ? List.of() : List.of(event), timer, null);
     }
 
     private Metadata exportMetadataWithSender(final boolean shouldAcknowledge,

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -17,6 +17,7 @@ import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
+import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nullable;
@@ -118,16 +119,19 @@ final class ThingUpdater extends AbstractActor {
      *
      * @param timer an optional timer measuring the search updater's consistency lag.
      */
-    private Metadata exportMetadata(@Nullable final StartedTimer timer) {
-        return Metadata.of(thingId, thingRevision, policyId, policyRevision, timer);
+    private Metadata exportMetadata(@Nullable final ThingEvent<?> event, @Nullable final StartedTimer timer) {
+        return Metadata.of(thingId, thingRevision, policyId, policyRevision, List.of(event), timer, null);
     }
 
-    private Metadata exportMetadataWithSender(final boolean shouldAcknowledge, final ActorRef sender,
+    private Metadata exportMetadataWithSender(final boolean shouldAcknowledge,
+            final ThingEvent<?> event,
+            final ActorRef sender,
             final StartedTimer consistencyLagTimer) {
         if (shouldAcknowledge) {
-            return Metadata.of(thingId, thingRevision, policyId, policyRevision, consistencyLagTimer, sender);
+            return Metadata.of(thingId, thingRevision, policyId, policyRevision, List.of(event), consistencyLagTimer,
+                    sender);
         } else {
-            return exportMetadata(consistencyLagTimer);
+            return exportMetadata(event, consistencyLagTimer);
         }
     }
 
@@ -135,7 +139,7 @@ final class ThingUpdater extends AbstractActor {
      * Push metadata of this updater to the queue of thing-changes to be streamed into the persistence.
      */
     private void enqueueMetadata() {
-        enqueueMetadata(exportMetadata(null));
+        enqueueMetadata(exportMetadata(null, null));
     }
 
     private void enqueueMetadata(final Metadata metadata) {
@@ -160,12 +164,12 @@ final class ThingUpdater extends AbstractActor {
     private void updateThing(final UpdateThing updateThing) {
         log.withCorrelationId(updateThing)
                 .info("Requested to update search index <{}> by <{}>", updateThing, getSender());
-        enqueueMetadata(exportMetadata(null).invalidateCache());
+        enqueueMetadata(exportMetadata(null, null).invalidateCache());
     }
 
     private void processUpdateThingResponse(final UpdateThingResponse response) {
         if (!response.isSuccess()) {
-            final Metadata metadata = exportMetadata(null);
+            final Metadata metadata = exportMetadata(null, null).invalidateCache();
             log.warning("Got negative acknowledgement for <{}>; updating to <{}>.",
                     Metadata.fromResponse(response),
                     metadata);
@@ -213,7 +217,7 @@ final class ThingUpdater extends AbstractActor {
                             l.warning("Timer measuring consistency lag timed out for event <{}>", thingEvent))
                     .start();
             ConsistencyLag.startS0InUpdater(timer);
-            enqueueMetadata(exportMetadataWithSender(shouldAcknowledge, getSender(), timer));
+            enqueueMetadata(exportMetadataWithSender(shouldAcknowledge, thingEvent, getSender(), timer));
         }
     }
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -84,7 +85,7 @@ public final class BulkWriteResultAckFlowTest {
     @Test
     public void partialSuccess() {
         final List<AbstractWriteModel> writeModels = generate5WriteModels();
-        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of());
+        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of(), List.of());
         final List<BulkWriteError> updateFailure = List.of(
                 new BulkWriteError(11000, "E11000 duplicate key error", new BsonDocument(), 3),
                 new BulkWriteError(50, "E50 operation timed out", new BsonDocument(), 4)
@@ -92,7 +93,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with errors, one of which is not duplicate key
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: the non-duplicate-key error triggers a failure acknowledgement
@@ -128,7 +129,7 @@ public final class BulkWriteResultAckFlowTest {
     @Test
     public void errorIndexOutOfBoundError() {
         final List<AbstractWriteModel> writeModels = generate5WriteModels();
-        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of());
+        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of(), List.of());
         final List<BulkWriteError> updateFailure = List.of(
                 new BulkWriteError(11000, "E11000 duplicate key error", new BsonDocument(), 0),
                 new BulkWriteError(50, "E50 operation timed out", new BsonDocument(), 5)
@@ -136,7 +137,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with at least 1 error with out-of-bound index
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: All updates are considered failures
@@ -153,7 +154,7 @@ public final class BulkWriteResultAckFlowTest {
         final List<TestProbe> probes =
                 IntStream.range(0, 5).mapToObj(i -> TestProbe.apply(actorSystem)).collect(Collectors.toList());
         final List<AbstractWriteModel> writeModels = generateWriteModels(probes);
-        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of());
+        final BulkWriteResult result = BulkWriteResult.acknowledged(1, 2, 1, 2, List.of(), List.of());
         final List<BulkWriteError> updateFailure = List.of(
                 new BulkWriteError(11000, "E11000 duplicate key error", new BsonDocument(), 3),
                 new BulkWriteError(50, "E50 operation timed out", new BsonDocument(), 4)
@@ -161,7 +162,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with errors, one of which is not duplicate key
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
         runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: only the non-duplicate-key sender receives negative acknowledgement
@@ -199,7 +200,7 @@ public final class BulkWriteResultAckFlowTest {
             final PolicyId policyId = i % 4 < 2 ? null : PolicyId.of("policy", String.valueOf(i));
             final long policyRevision = i * 100;
             final Metadata metadata =
-                    Metadata.of(thingId, thingRevision, policyId, policyRevision, null, probes.get(i).ref());
+                    Metadata.of(thingId, thingRevision, policyId, policyRevision, List.of(), null, probes.get(i).ref());
             if (i % 2 == 0) {
                 writeModels.add(ThingDeleteModel.of(metadata, false));
             } else {

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ChangeQueueActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ChangeQueueActorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.events.ThingEvent;
+import org.eclipse.ditto.things.model.signals.events.ThingMerged;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
+import org.junit.After;
+import org.junit.Test;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Tests {@link ChangeQueueActor};
+ */
+public final class ChangeQueueActorTest {
+
+    private static final ThingId THING_ID = ThingId.of("thing:id");
+
+    private final ActorSystem system = ActorSystem.create();
+
+    @After
+    public void shutdown() {
+        TestKit.shutdownActorSystem(system);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void aggregateThingEvents() {
+        new TestKit(system) {{
+            final ActorRef underTest = system.actorOf(ChangeQueueActor.props());
+            final long start = 1;
+            final long end = 5;
+            for (long i = start; i <= end; ++i) {
+                underTest.tell(metadataWithEvent(i), getRef());
+            }
+            underTest.tell(ChangeQueueActor.Control.DUMP, getRef());
+            final Map<ThingId, Metadata> map = expectMsgClass(Map.class);
+            final Metadata metadata = Objects.requireNonNull(map.get(THING_ID));
+            assertThat(metadata.getThingRevision()).isEqualTo(end);
+            assertThat(metadata.getEvents().stream().map(ThingEvent::getRevision).collect(Collectors.toList()))
+                    .isEqualTo(LongStream.rangeClosed(start, end).boxed().collect(Collectors.toList()));
+        }};
+    }
+
+    private static Metadata metadataWithEvent(final long seqNr) {
+        return Metadata.of(THING_ID, seqNr, null, null,
+                List.of(ThingMerged.of(THING_ID, JsonPointer.of("attributes/seqNr"), JsonValue.of(seqNr), seqNr, null,
+                        DittoHeaders.empty(), null)),
+                null, null);
+    }
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -16,10 +16,12 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
@@ -29,6 +31,13 @@ import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThing;
 import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.events.AttributeDeleted;
+import org.eclipse.ditto.things.model.signals.events.AttributeModified;
+import org.eclipse.ditto.things.model.signals.events.ThingCreated;
+import org.eclipse.ditto.things.model.signals.events.ThingDeleted;
+import org.eclipse.ditto.things.model.signals.events.ThingEvent;
+import org.eclipse.ditto.things.model.signals.events.ThingMerged;
+import org.eclipse.ditto.things.model.signals.events.ThingModified;
 import org.eclipse.ditto.thingsearch.service.common.config.DefaultStreamConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.StreamConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
@@ -53,6 +62,7 @@ import akka.stream.testkit.javadsl.TestSink;
 import akka.stream.testkit.javadsl.TestSource;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
+import scala.concurrent.duration.FiniteDuration;
 
 /**
  * Unit tests for {@link EnforcementFlow}.
@@ -107,7 +117,7 @@ public final class EnforcementFlowTest {
             sourceProbe.sendComplete();
 
             // WHEN: thing and policy are retrieved with up-to-date revisions
-            thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+            thingsProbe.expectMsgClass(FiniteDuration.apply(10, TimeUnit.SECONDS), SudoRetrieveThing.class);
             final var thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).setRevision(thingRev2).build();
             final var thingJson = thing.toJson(FieldType.regularOrSpecial());
             assertThat(thingJson.getValue(Thing.JsonFields.REVISION)).contains(thingRev2);
@@ -190,6 +200,332 @@ public final class EnforcementFlowTest {
         final var document2 = JsonObject.of(((ThingWriteModel) writeModel2).getThingDocument().toJson());
         assertThat(document2.getValue("_revision")).contains(JsonValue.of(thingRev2));
         assertThat(document2.getValue("__policyRev")).contains(JsonValue.of(policyRev2));
+    }
+
+    @Test
+    public void computeThingCacheValueFromThingEvents() {
+        new TestKit(system) {{
+            // GIVEN: enqueued metadata contains events sufficient to determine the thing state
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    ThingModified.of(thing, 1, null, headers, null),
+                    ThingDeleted.of(thingId, 2, null, headers, null),
+                    ThingCreated.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/y"), JsonValue.of(6), 4, null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 5L, policyId, 1L, events, null, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            // WHEN: policy is retrieved with up-to-date revisions
+            policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+            final var policy = Policy.newBuilder(policyId).setRevision(1).build();
+            policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy, DittoHeaders.empty()));
+
+            // THEN: the write model contains up-to-date revisions
+            final AbstractWriteModel writeModel = sinkProbe.expectNext().get(0);
+            sinkProbe.expectComplete();
+            assertThat(writeModel).isInstanceOf(ThingWriteModel.class);
+            final var document = JsonObject.of(((ThingWriteModel) writeModel).getThingDocument().toJson());
+            assertThat(document.getValue("_id")).contains(JsonValue.of(thingId));
+            assertThat(document.getValue("policyId")).contains(JsonValue.of(policyId));
+            assertThat(document.getValue("_revision")).contains(JsonValue.of(6));
+            assertThat(document.getValue("__policyRev")).contains(JsonValue.of(1));
+            assertThat(document.getValue("s/attributes")).contains(JsonObject.of("{\"x\":5,\"y\":6,\"z\":7}"));
+
+            // THEN: thing is computed in the cache
+            thingsProbe.expectNoMessage(FiniteDuration.Zero());
+        }};
+    }
+
+    @Test
+    public void forceRetrieveThing() {
+        new TestKit(system) {{
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    ThingModified.of(thing, 1, null, headers, null),
+                    ThingDeleted.of(thingId, 2, null, headers, null),
+                    ThingCreated.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/y"), JsonValue.of(6), 4, null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 6L, policyId, 1L, events, null, null).invalidateCache();
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            assertThat((CharSequence) thingsProbe.expectMsgClass(SudoRetrieveThing.class).getEntityId())
+                    .isEqualTo(thingId);
+        }};
+    }
+
+    @Test
+    public void eventSequenceNumberTooLow() {
+        new TestKit(system) {{
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    ThingModified.of(thing, 1, null, headers, null),
+                    ThingDeleted.of(thingId, 2, null, headers, null),
+                    ThingCreated.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/y"), JsonValue.of(6), 4, null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 7L, policyId, 1L, events, null, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            assertThat((CharSequence) thingsProbe.expectMsgClass(SudoRetrieveThing.class).getEntityId())
+                    .isEqualTo(thingId);
+        }};
+    }
+
+    @Test
+    public void eventMissed() {
+        new TestKit(system) {{
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    ThingModified.of(thing, 1, null, headers, null),
+                    ThingDeleted.of(thingId, 2, null, headers, null),
+                    ThingCreated.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 6L, policyId, 1L, events, null, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            assertThat((CharSequence) thingsProbe.expectMsgClass(SudoRetrieveThing.class).getEntityId())
+                    .isEqualTo(thingId);
+        }};
+    }
+
+    @Test
+    public void noInitialCreatedOrDeletedEvent() {
+        new TestKit(system) {{
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    ThingModified.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/y"), JsonValue.of(6), 4, null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 6L, policyId, 1L, events, null, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            // WHEN: thing and policy caches are loaded
+            final var sudoRetrieveThing = thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+            thingsProbe.reply(SudoRetrieveThingResponse.of(
+                    thing.toBuilder().setRevision(2).build().toJson(FieldType.all()),
+                    sudoRetrieveThing.getDittoHeaders()));
+            policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+            final var policy = Policy.newBuilder(policyId).setRevision(1).build();
+            policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy, DittoHeaders.empty()));
+
+            // THEN: the write model contains up-to-date revisions
+            final AbstractWriteModel writeModel = sinkProbe.expectNext().get(0);
+            sinkProbe.expectComplete();
+            assertThat(writeModel).isInstanceOf(ThingWriteModel.class);
+            final var document = JsonObject.of(((ThingWriteModel) writeModel).getThingDocument().toJson());
+            assertThat(document.getValue("_id")).contains(JsonValue.of(thingId));
+            assertThat(document.getValue("policyId")).contains(JsonValue.of(policyId));
+            assertThat(document.getValue("_revision")).contains(JsonValue.of(6));
+            assertThat(document.getValue("__policyRev")).contains(JsonValue.of(1));
+            assertThat(document.getValue("s/attributes")).contains(JsonObject.of("{\"x\":5,\"y\":6,\"z\":7}"));
+
+            // THEN: thing is computed in the cache
+            thingsProbe.expectNoMessage(FiniteDuration.Zero());
+        }};
+    }
+
+    @Test
+    public void onlyApplyRelevantEvents() {
+        new TestKit(system) {{
+            final DittoHeaders headers = DittoHeaders.empty();
+            final ThingId thingId = ThingId.of("thing:id");
+            final PolicyId policyId = PolicyId.of("policy:id");
+            final Thing thing = Thing.newBuilder().setId(thingId).setPolicyId(policyId).build();
+            final List<ThingEvent<?>> events = List.of(
+                    // this event should be skipped because cache loader returns revision 2
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/v"), JsonValue.of(3), 2, null, headers, null),
+
+                    // these events should be applied
+                    ThingModified.of(thing.toBuilder()
+                                    .setAttribute(JsonPointer.of("w"), JsonValue.of(4))
+                                    .setAttribute(JsonPointer.of("x"), JsonValue.of(5))
+                                    .build(), 3,
+                            null, headers, null),
+                    ThingMerged.of(thingId, JsonPointer.of("attributes/y"), JsonValue.of(6), 4, null, headers, null),
+                    AttributeModified.of(thingId, JsonPointer.of("z"), JsonValue.of(7), 5, null, headers, null),
+                    AttributeDeleted.of(thingId, JsonPointer.of("w"), 6, null, headers, null)
+            );
+
+            final Metadata metadata = Metadata.of(thingId, 6L, policyId, 1L, events, null, null);
+            final Map<ThingId, Metadata> inputMap = Map.of(thingId, metadata);
+
+            final TestProbe thingsProbe = TestProbe.apply(system);
+            final TestProbe policiesProbe = TestProbe.apply(system);
+
+            final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
+            final EnforcementFlow underTest =
+                    EnforcementFlow.of(streamConfig, thingsProbe.ref(), policiesProbe.ref(),
+                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+
+            materializeTestProbes(underTest.create(false, 1));
+
+            sinkProbe.ensureSubscription();
+            sourceProbe.ensureSubscription();
+            sinkProbe.request(1);
+            assertThat(sourceProbe.expectRequest()).isEqualTo(1);
+            sourceProbe.sendNext(inputMap);
+            sourceProbe.sendComplete();
+
+            // WHEN: thing and policy caches are loaded
+            final var sudoRetrieveThing = thingsProbe.expectMsgClass(SudoRetrieveThing.class);
+            thingsProbe.reply(SudoRetrieveThingResponse.of(
+                    thing.toBuilder().setRevision(2).build().toJson(FieldType.all()),
+                    sudoRetrieveThing.getDittoHeaders()));
+            policiesProbe.expectMsgClass(SudoRetrievePolicy.class);
+            final var policy = Policy.newBuilder(policyId).setRevision(1).build();
+            policiesProbe.reply(SudoRetrievePolicyResponse.of(policyId, policy, DittoHeaders.empty()));
+
+            // THEN: the write model contains up-to-date revisions
+            final AbstractWriteModel writeModel = sinkProbe.expectNext().get(0);
+            sinkProbe.expectComplete();
+            assertThat(writeModel).isInstanceOf(ThingWriteModel.class);
+            final var document = JsonObject.of(((ThingWriteModel) writeModel).getThingDocument().toJson());
+            assertThat(document.getValue("_id")).contains(JsonValue.of(thingId));
+            assertThat(document.getValue("policyId")).contains(JsonValue.of(policyId));
+            assertThat(document.getValue("_revision")).contains(JsonValue.of(6));
+            assertThat(document.getValue("__policyRev")).contains(JsonValue.of(1));
+            assertThat(document.getValue("s/attributes")).contains(JsonObject.of("{\"x\":5,\"y\":6,\"z\":7}"));
+
+            // THEN: thing is computed in the cache
+            thingsProbe.expectNoMessage(FiniteDuration.Zero());
+        }};
     }
 
     private void materializeTestProbes(

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingSearchServiceGlobalErrorRegistryTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingSearchServiceGlobalErrorRegistryTest.java
@@ -24,10 +24,14 @@ import org.eclipse.ditto.base.model.signals.acks.AcknowledgementCorrelationIdMis
 import org.eclipse.ditto.base.model.signals.commands.CommandNotSupportedException;
 import org.eclipse.ditto.base.model.signals.commands.exceptions.GatewayAuthenticationFailedException;
 import org.eclipse.ditto.base.model.signals.commands.exceptions.PathUnknownException;
+import org.eclipse.ditto.connectivity.model.ConnectionIdInvalidException;
+import org.eclipse.ditto.connectivity.model.signals.commands.exceptions.ConnectionConflictException;
 import org.eclipse.ditto.internal.utils.test.GlobalErrorRegistryTestCases;
 import org.eclipse.ditto.messages.model.AuthorizationSubjectBlockedException;
 import org.eclipse.ditto.policies.model.PolicyEntryInvalidException;
 import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyConflictException;
+import org.eclipse.ditto.protocol.UnknownSignalException;
+import org.eclipse.ditto.protocol.adapter.UnknownTopicPathException;
 import org.eclipse.ditto.things.model.FeatureDefinitionEmptyException;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.AttributePointerInvalidException;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingNotAccessibleException;
@@ -54,7 +58,11 @@ public final class ThingSearchServiceGlobalErrorRegistryTest extends GlobalError
                 AcknowledgementLabelInvalidException.class,
                 AcknowledgementCorrelationIdMissingException.class,
                 PathUnknownException.class,
-                AskException.class);
+                AskException.class,
+                ConnectionIdInvalidException.class,
+                ConnectionConflictException.class,
+                UnknownTopicPathException.class,
+                UnknownSignalException.class);
     }
 
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalCommandRegistryTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalCommandRegistryTest.java
@@ -13,6 +13,8 @@
 package org.eclipse.ditto.thingsearch.service.starter;
 
 import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistence;
+import org.eclipse.ditto.connectivity.model.signals.commands.modify.ModifyConnection;
+import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnection;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.internal.models.streaming.SudoStreamPids;
 import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThing;
@@ -54,7 +56,9 @@ public final class ThingsSearchServiceGlobalCommandRegistryTest extends GlobalCo
                 RetrieveHealth.class,
                 PurgeEntities.class,
                 PublishSignal.class,
-                CleanupPersistence.class
+                CleanupPersistence.class,
+                ModifyConnection.class,
+                RetrieveConnection.class
         );
     }
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalCommandResponseRegistryTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalCommandResponseRegistryTest.java
@@ -12,25 +12,28 @@
  */
 package org.eclipse.ditto.thingsearch.service.starter;
 
-import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistenceResponse;
-import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
-import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
-import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
-import org.eclipse.ditto.thingsearch.api.commands.sudo.SudoRetrieveNamespaceReportResponse;
-import org.eclipse.ditto.internal.utils.health.RetrieveHealthResponse;
-import org.eclipse.ditto.internal.utils.test.GlobalCommandResponseRegistryTestCases;
 import org.eclipse.ditto.base.api.common.RetrieveConfigResponse;
 import org.eclipse.ditto.base.api.common.purge.PurgeEntitiesResponse;
 import org.eclipse.ditto.base.api.devops.signals.commands.RetrieveLoggerConfigResponse;
-import org.eclipse.ditto.messages.model.signals.commands.SendClaimMessageResponse;
+import org.eclipse.ditto.base.api.persistence.cleanup.CleanupPersistenceResponse;
 import org.eclipse.ditto.base.model.namespaces.signals.commands.PurgeNamespaceResponse;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
+import org.eclipse.ditto.connectivity.model.signals.commands.ConnectivityErrorResponse;
+import org.eclipse.ditto.connectivity.model.signals.commands.modify.ModifyConnectionResponse;
+import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnectionResponse;
+import org.eclipse.ditto.internal.utils.health.RetrieveHealthResponse;
+import org.eclipse.ditto.internal.utils.test.GlobalCommandResponseRegistryTestCases;
+import org.eclipse.ditto.messages.model.signals.commands.SendClaimMessageResponse;
+import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyErrorResponse;
 import org.eclipse.ditto.policies.model.signals.commands.actions.ActivateTokenIntegrationResponse;
 import org.eclipse.ditto.policies.model.signals.commands.modify.DeleteSubjectResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResourceResponse;
+import org.eclipse.ditto.things.api.commands.sudo.SudoRetrieveThingResponse;
 import org.eclipse.ditto.things.model.signals.commands.ThingErrorResponse;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeaturePropertyResponse;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeatureResponse;
+import org.eclipse.ditto.thingsearch.api.commands.sudo.SudoRetrieveNamespaceReportResponse;
 import org.eclipse.ditto.thingsearch.model.signals.commands.SearchErrorResponse;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.QueryThingsResponse;
 
@@ -58,7 +61,10 @@ public final class ThingsSearchServiceGlobalCommandResponseRegistryTest extends 
                 PurgeEntitiesResponse.class,
                 SudoRetrieveNamespaceReportResponse.class,
                 Acknowledgement.class,
-                CleanupPersistenceResponse.class
+                CleanupPersistenceResponse.class,
+                ModifyConnectionResponse.class,
+                RetrieveConnectionResponse.class,
+                ConnectivityErrorResponse.class
         );
     }
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalEventRegistryTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/ThingsSearchServiceGlobalEventRegistryTest.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.thingsearch.service.starter;
 
+import org.eclipse.ditto.connectivity.model.signals.events.ConnectionModified;
 import org.eclipse.ditto.things.api.ThingSnapshotTaken;
 import org.eclipse.ditto.internal.utils.test.GlobalEventRegistryTestCases;
 import org.eclipse.ditto.policies.model.signals.events.ResourceDeleted;
@@ -21,7 +22,8 @@ import org.eclipse.ditto.thingsearch.model.signals.events.ThingsOutOfSync;
 public final class ThingsSearchServiceGlobalEventRegistryTest extends GlobalEventRegistryTestCases {
 
     public ThingsSearchServiceGlobalEventRegistryTest() {
-        super(ResourceDeleted.class, FeatureDeleted.class, ThingsOutOfSync.class, ThingSnapshotTaken.class);
+        super(ResourceDeleted.class, FeatureDeleted.class, ThingsOutOfSync.class, ThingSnapshotTaken.class,
+                ConnectionModified.class);
     }
 
 }


### PR DESCRIPTION
Reuse the caching and incremental update logic of `CachingSignalEnrichmentFacade` to reduce network traffic due to search index update.

Added the `getCommandCategory` method to thing events.

Fixed the following bugs:
- `CachingSignalEnrichmentFacade` did not handle sub-resource deletions such as `FeatureDeleted` correctly.
- `ChangeQueueActor` gave control messages priority so that pending changes spend more time in the updater stream buffer than the change queue, where updates for the same thing are aggregated to reduce load.