### PR TITLE
Feature/devops command

### DIFF
--- a/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/AggregatedDevOpsCommandResponse.java
+++ b/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/AggregatedDevOpsCommandResponse.java
@@ -19,12 +19,6 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonFieldDefinition;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonObjectBuilder;
-import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.FieldType;
@@ -33,6 +27,12 @@ import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
 import org.eclipse.ditto.base.model.signals.commands.CommandResponseJsonDeserializer;
 import org.eclipse.ditto.base.model.signals.commands.WithEntity;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonValue;
 
 /**
  * A {@link DevOpsCommandResponse} aggregating multiple {@link org.eclipse.ditto.base.model.signals.commands.CommandResponse}s.
@@ -184,7 +184,12 @@ public final class AggregatedDevOpsCommandResponse
         for (final CommandResponse<?> cmdR : commandResponses) {
             final String key = String.format("/%s/%s", calculateServiceName(cmdR), calculateInstance(cmdR, i++));
             // include both regular and special fields for devops command responses
-            final JsonObject responseJson = cmdR.toJson(schemaVersion, FieldType.regularOrSpecial());
+            final JsonValue responseJson;
+            if (cmdR instanceof ExecutePiggybackCommandResponse) {
+                responseJson = ((ExecutePiggybackCommandResponse) cmdR).getResponse();
+            } else {
+                responseJson = cmdR.toJson(schemaVersion, FieldType.regularOrSpecial());
+            }
             builder.set(key, responseJson);
         }
 

--- a/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/ExecutePiggybackCommandResponse.java
+++ b/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/ExecutePiggybackCommandResponse.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.api.devops.signals.commands;
+
+import java.util.Objects;
+import java.util.function.Predicate;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommandResponse;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.CommandResponseJsonDeserializer;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldDefinition;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonValue;
+
+/**
+ * Response to the {@link ExecutePiggybackCommand}.
+ */
+@Immutable
+@JsonParsableCommandResponse(type = ExecutePiggybackCommandResponse.TYPE)
+public final class ExecutePiggybackCommandResponse
+        extends AbstractDevOpsCommandResponse<ExecutePiggybackCommandResponse> {
+
+    /**
+     * Type of this response.
+     */
+    public static final String TYPE = TYPE_PREFIX + ExecutePiggybackCommand.NAME;
+
+    private static final JsonFieldDefinition<JsonValue> JSON_RESPONSE =
+            JsonFactory.newJsonValueFieldDefinition("response", FieldType.REGULAR, JsonSchemaVersion.V_2);
+
+    private final JsonValue response;
+
+    private ExecutePiggybackCommandResponse(@Nullable final String serviceName,
+            @Nullable final String instance,
+            final HttpStatus status,
+            final JsonValue response,
+            final DittoHeaders dittoHeaders) {
+
+        super(TYPE, serviceName, instance, status, dittoHeaders);
+        this.response = response;
+    }
+
+    /**
+     * Creates a new ExecutePiggybackCommandResponse instance.
+     *
+     * @param serviceName the service name from which the DevOpsCommandResponse originated.
+     * @param instance the instance identifier of the serviceName from which the DevOpsCommandResponse originated.
+     * @param status http status of the response.
+     * @param response JSON value of the response.
+     * @param dittoHeaders the DittoHeaders of the response.
+     * @return the new instance.
+     */
+    public static ExecutePiggybackCommandResponse of(@Nullable final String serviceName,
+            @Nullable final String instance,
+            final HttpStatus status,
+            final JsonValue response,
+            final DittoHeaders dittoHeaders) {
+
+        return new ExecutePiggybackCommandResponse(serviceName, instance, status, response, dittoHeaders);
+    }
+
+    /**
+     * Creates a response to a ExecutePiggybackCommand from a JSON string.
+     *
+     * @param jsonString contains the data of the ExecutePiggybackCommandResponse.
+     * @param dittoHeaders the headers of the request.
+     * @return the ChangeLogLevelResponse command which is based on the dta of {@code jsonString}.
+     * @throws NullPointerException if {@code jsonString} is {@code null}.
+     * @throws IllegalArgumentException if {@code jsonString} is empty.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonString} was not in the expected
+     * format.
+     */
+    public static ExecutePiggybackCommandResponse fromJson(final String jsonString, final DittoHeaders dittoHeaders) {
+        return fromJson(JsonFactory.newObject(jsonString), dittoHeaders);
+    }
+
+    /**
+     * Creates an ExecutePiggybackCommandResponse from a JSON object.
+     *
+     * @param jsonObject the JSON object of which the response is to be created.
+     * @param dittoHeaders the headers of the response.
+     * @return the response.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static ExecutePiggybackCommandResponse fromJson(final JsonObject jsonObject,
+            final DittoHeaders dittoHeaders) {
+        return new CommandResponseJsonDeserializer<ExecutePiggybackCommandResponse>(TYPE, jsonObject).deserialize(
+                status -> {
+                    final String serviceName =
+                            jsonObject.getValue(DevOpsCommandResponse.JsonFields.JSON_SERVICE_NAME)
+                                    .orElse(null);
+                    final String instance = jsonObject.getValue(DevOpsCommandResponse.JsonFields.JSON_INSTANCE)
+                            .orElse(null);
+                    final JsonValue response = jsonObject.getValueOrThrow(JSON_RESPONSE);
+                    return ExecutePiggybackCommandResponse.of(serviceName, instance, status, response, dittoHeaders);
+                });
+    }
+
+    /**
+     * Returns the original response as JSON.
+     *
+     * @return the original response.
+     */
+    public JsonValue getResponse() {
+        return response;
+    }
+
+    @Override
+    public ExecutePiggybackCommandResponse setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return of(getServiceName().orElse(null), getInstance().orElse(null), getHttpStatus(), response, dittoHeaders);
+    }
+
+    @Override
+    protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
+            final Predicate<JsonField> thePredicate) {
+
+        super.appendPayload(jsonObjectBuilder, schemaVersion, thePredicate);
+
+        final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
+        jsonObjectBuilder.set(JSON_RESPONSE, response, predicate);
+    }
+
+    @SuppressWarnings("squid:MethodCyclomaticComplexity")
+    @Override
+    public boolean equals(@Nullable final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ExecutePiggybackCommandResponse that = (ExecutePiggybackCommandResponse) o;
+        return that.canEqual(this) && Objects.equals(response, that.response) && super.equals(that);
+    }
+
+    @Override
+    protected boolean canEqual(@Nullable final Object other) {
+        return other instanceof ExecutePiggybackCommandResponse;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), response);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" + super.toString() + ", successful=" + response + "]";
+    }
+}

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -389,8 +389,8 @@ variables. Response example:
 
 ```json
 {
-  "?": {
-    "?": {
+  "gateway": {
+    "1": {
       "type": "common.responses:retrieveConfig",
       "status": 200,
       "config": {
@@ -405,8 +405,10 @@ variables. Response example:
           "-Dfile.encoding=UTF-8"
         ]
       }
-    },
-    "?1": {
+    }
+  },
+  "connectivity": {
+    "1": {
       "type": "common.responses:retrieveConfig",
       "status": 200,
       "config": {
@@ -440,8 +442,8 @@ Response example:
 
 ```json
 {
-  "?": {
-    "?": {
+  "gateway": {
+    "1": {
       "type": "common.responses:retrieveConfig",
       "status": 200,
       "config": {
@@ -529,8 +531,8 @@ The response has the following details:
 
 ```json
 {
-  "?": {
-    "?": {
+  "concierge": {
+    "1": {
       "type": "status.responses:retrieveHealth",
       "status": 200,
       "statusInfo": {
@@ -579,8 +581,8 @@ Response example:
 
 ```json
 {
-  "?": {
-    "?": {
+  "concierge": {
+    "1": {
       "type": "common.responses:retrieveConfig",
       "status": 200,
       "config": {
@@ -638,8 +640,8 @@ piggyback command contains any error, then an error is logged and the actor's co
 
 ```json
 {
-  "?": {
-    "?": {
+  "concierge": {
+    "1": {
       "type": "common.responses:modifyConfig",
       "status": 200,
       "config": {
@@ -693,8 +695,8 @@ Response example:
 
 ```json
 {
-  "?": {
-    "?": {
+  "concierge": {
+    "1": {
       "type": "common.responses:shutdown",
       "status": 200,
       "message": "Restarting stream in <PT5760H30M5S>."
@@ -729,8 +731,8 @@ Response example:
 
 ```json
 {
-  "?": {
-    "?": {
+  "things": {
+    "1": {
       "type": "cleanup.responses:cleanupPersistence",
       "status": 200,
       "entityId": "thing:ditto:thing1"
@@ -886,7 +888,8 @@ slow. Set the timeout to a safe margin above the estimated erasure time in milli
 {
   "targetActorSelection": "/system/distributedPubSubMediator",
   "headers": {
-    "aggregate": true
+    "aggregate": true,
+    "is-group-topic": true
   },
   "piggybackCommand": {
     "type": "namespaces.commands:purgeNamespace",


### PR DESCRIPTION
Enhance piggyback command responses with service and instance info.

- Add `ExecutePiggybackCommandResponse` in order to relay service
  and instance information back to Gateway.

- Read the expected number of responses from cluster state in order
  to reduce wait time for DevOps commands.