### PR TITLE
Remove Java serialization

### DIFF
--- a/base/model/pom.xml
+++ b/base/model/pom.xml
@@ -131,6 +131,9 @@
                         <excludes>
                             <!-- Don't add excludes here before checking with the whole Ditto team -->
                             <!--<exclude></exclude>-->
+
+                            <!-- Excluded because Java serialization was already turned off -->
+                            <exclude>org.eclipse.ditto.base.model.common.HttpStatus</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/common/HttpStatus.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/common/HttpStatus.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.base.model.common;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -30,9 +29,7 @@ import javax.annotation.concurrent.Immutable;
  * @since 2.0.0
  */
 @Immutable
-public final class HttpStatus implements Serializable {
-
-    private static final long serialVersionUID = -8885963617558010628L;
+public final class HttpStatus {
 
     private static final Map<Integer, HttpStatus> ASSIGNED = new HashMap<>();
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -219,7 +219,7 @@
             <!-- MongoDB client -->
             <dependency>
                 <groupId>org.mongodb</groupId>
-                <artifactId>mongodb-bson</artifactId>
+                <artifactId>bson</artifactId>
                 <version>${mongo-java-driver.version}</version>
             </dependency>
             <dependency>

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/DefaultClientActorPropsFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/DefaultClientActorPropsFactory.java
@@ -20,7 +20,6 @@ import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.ConnectionType;
 import org.eclipse.ditto.connectivity.service.messaging.amqp.AmqpClientActor;
 import org.eclipse.ditto.connectivity.service.messaging.httppush.HttpPushClientActor;
-import org.eclipse.ditto.connectivity.service.messaging.kafka.DefaultKafkaPublisherActorFactory;
 import org.eclipse.ditto.connectivity.service.messaging.kafka.KafkaClientActor;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq.HiveMqtt3ClientActor;
 import org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq.HiveMqtt5ClientActor;
@@ -69,8 +68,7 @@ public final class DefaultClientActorPropsFactory implements ClientActorPropsFac
                 result = HiveMqtt5ClientActor.props(connection, proxyActor, connectionActor, dittoHeaders);
                 break;
             case KAFKA:
-                result = KafkaClientActor.props(connection, proxyActor, connectionActor,
-                        DefaultKafkaPublisherActorFactory.getInstance(), dittoHeaders);
+                result = KafkaClientActor.props(connection, proxyActor, connectionActor, dittoHeaders);
                 break;
             case HTTP_PUSH:
                 result = HttpPushClientActor.props(connection, connectionActor, dittoHeaders);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultKafkaPublisherActorFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultKafkaPublisherActorFactory.java
@@ -29,8 +29,6 @@ public final class DefaultKafkaPublisherActorFactory implements KafkaPublisherAc
 
     @Nullable private static DefaultKafkaPublisherActorFactory instance;
 
-    private static final long serialVersionUID = 5200344820825330940L;
-
     private DefaultKafkaPublisherActorFactory() {
         super();
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActor.java
@@ -60,7 +60,6 @@ public final class KafkaClientActor extends BaseClientActor {
     private final List<ActorRef> kafkaConsumerActors;
     private final KafkaConfig kafkaConfig;
 
-    @SuppressWarnings("unused") // used by `props` via reflection
     private KafkaClientActor(final Connection connection,
             @Nullable final ActorRef proxyActor,
             final ActorRef connectionActor,
@@ -76,17 +75,34 @@ public final class KafkaClientActor extends BaseClientActor {
         pendingStatusReportsFromStreams = new HashSet<>();
     }
 
+    @SuppressWarnings("unused") // used by `props` via reflection
+    private KafkaClientActor(final Connection connection,
+            @Nullable final ActorRef proxyActor,
+            final ActorRef connectionActor,
+            final DittoHeaders dittoHeaders) {
+
+        this(connection, proxyActor, connectionActor, DefaultKafkaPublisherActorFactory.getInstance(), dittoHeaders);
+    }
+
     /**
      * Creates Akka configuration object for this actor.
      *
      * @param connection the connection.
      * @param proxyActor the actor used to send signals into the ditto cluster.
      * @param connectionActor the connectionPersistenceActor which created this client.
-     * @param factory factory for creating a kafka publisher actor.
      * @param dittoHeaders headers of the command that caused this actor to be created.
      * @return the Akka configuration Props object.
      */
     public static Props props(final Connection connection,
+            @Nullable final ActorRef proxyActor,
+            final ActorRef connectionActor,
+            final DittoHeaders dittoHeaders) {
+
+        return Props.create(KafkaClientActor.class, validateConnection(connection), proxyActor, connectionActor,
+                dittoHeaders);
+    }
+
+    static Props propsForTests(final Connection connection,
             @Nullable final ActorRef proxyActor,
             final ActorRef connectionActor,
             final KafkaPublisherActorFactory factory,

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorFactory.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
-import java.io.Serializable;
-
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.service.config.KafkaProducerConfig;
 
@@ -22,7 +20,7 @@ import akka.actor.Props;
 /**
  * Factory for creating {@link KafkaPublisherActor}s.
  */
-public interface KafkaPublisherActorFactory extends Serializable {
+public interface KafkaPublisherActorFactory {
 
     /**
      * Get the name that should be used for the actor that is created with {@code props}.

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActorTest.java
@@ -223,7 +223,7 @@ public final class KafkaClientActorTest extends AbstractBaseClientActorTest {
 
     private Props getKafkaClientActorProps(final ActorRef ref, final Status.Status status,
             final Connection connection) {
-        return KafkaClientActor.props(connection, ref, ref,
+        return KafkaClientActor.propsForTests(connection, ref, ref,
                 new KafkaPublisherActorFactory() {
                     @Override
                     public String getActorName() {

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -263,8 +263,6 @@ akka {
     serialize-messages = off
     serialize-creators = off
 
-    allow-java-serialization = on
-
     debug {
       lifecycle = on
     }
@@ -279,6 +277,7 @@ akka {
     }
 
     serializers {
+      bson = "org.eclipse.ditto.internal.utils.test.mongo.BsonDocumentSerializer"
       json = "org.eclipse.ditto.internal.utils.cluster.JsonJsonifiableSerializer"
       cbor = "org.eclipse.ditto.internal.utils.cluster.CborJsonifiableSerializer"
       cbor-json-value = "org.eclipse.ditto.internal.utils.cluster.CborJsonValueSerializer"
@@ -286,7 +285,7 @@ akka {
     }
 
     serialization-bindings {
-      # "java.io.Serializable" = none
+      "org.bson.BsonDocument" = bson
       # Serialize Jsonifiable events with custom JSON serializer:
       "org.eclipse.ditto.base.model.json.Jsonifiable" = cbor
       "org.eclipse.ditto.base.model.exceptions.DittoRuntimeException" = cbor

--- a/internal/utils/test/pom.xml
+++ b/internal/utils/test/pom.xml
@@ -27,7 +27,7 @@
     <dependencies>
         <dependency>
             <groupId>com.typesafe.akka</groupId>
-            <artifactId>akka-actor_2.13</artifactId>
+            <artifactId>akka-actor_${scala.version}</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>

--- a/internal/utils/test/pom.xml
+++ b/internal/utils/test/pom.xml
@@ -25,6 +25,15 @@
     <name>Eclipse Ditto :: Internal :: Utils :: Test</name>
 
     <dependencies>
+        <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-actor_2.13</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>bson</artifactId>
+        </dependency>
+
         <!-- Required for GlobalErrorRegistryTestCases -->
         <dependency>
             <groupId>org.eclipse.ditto</groupId>

--- a/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/BsonDocumentSerializer.java
+++ b/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/BsonDocumentSerializer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.test.mongo;
+
+import java.nio.charset.StandardCharsets;
+
+import org.bson.BsonDocument;
+
+import akka.serialization.JSerializer;
+
+/**
+ * Serializer for BsonDocument for unit tests using the in-memory persistence plugin.
+ */
+public final class BsonDocumentSerializer extends JSerializer {
+
+    @Override
+    public Object fromBinaryJava(final byte[] bytes, final Class<?> manifest) {
+        return BsonDocument.parse(new String(bytes, StandardCharsets.UTF_8));
+    }
+
+    @Override
+    public int identifier() {
+        return 2114006166;
+    }
+
+    @Override
+    public byte[] toBinary(final Object o) {
+        final var bsonDocument = (BsonDocument) o;
+        return bsonDocument.toJson().getBytes(StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public boolean includeManifest() {
+        return false;
+    }
+}

--- a/policies/service/src/test/resources/test.conf
+++ b/policies/service/src/test/resources/test.conf
@@ -20,8 +20,15 @@ akka {
 
   log-config-on-start = off
 
-  actor.allow-java-serialization = on
   actor.provider = cluster
+  actor {
+    serializers {
+      bson = "org.eclipse.ditto.internal.utils.test.mongo.BsonDocumentSerializer"
+    }
+    serialization-bindings {
+      "org.bson.BsonDocument" = bson
+    }
+  }
 
   test {
     # factor by which to scale timeouts during tests, e.g. to account for shared

--- a/things/service/src/test/resources/test.conf
+++ b/things/service/src/test/resources/test.conf
@@ -21,7 +21,14 @@ akka {
 
   log-config-on-start = off
 
-  actor.allow-java-serialization = on
+  actor {
+    serializers {
+      bson = "org.eclipse.ditto.internal.utils.test.mongo.BsonDocumentSerializer"
+    }
+    serialization-bindings {
+      "org.bson.BsonDocument" = bson
+    }
+  }
 
   test {
     # factor by which to scale timeouts during tests, e.g. to account for shared


### PR DESCRIPTION
Remove all uses of Java serialization in tests and the `Serializable` interface.

Breaks the binary API, but it should not impact existing Ditto clusters because Java serialization is disabled outside of tests.