### PR TITLE
Fix that connection status was "failed" after reconnect backoff of misconfigured connection

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -40,7 +40,7 @@
         <akka-bom.version>2.6.16</akka-bom.version>
         <akka-persistence-mongo.version>3.0.6</akka-persistence-mongo.version>
         <akka-http-bom.version>10.2.5</akka-http-bom.version>
-        <akka-management.version>1.1.1</akka-management.version>
+        <akka-management.version>1.0.10</akka-management.version>
         <akka-stream-kafka.version>2.1.1</akka-stream-kafka.version>
         <hivemq-mqtt-client.version>1.2.2</hivemq-mqtt-client.version>
         <sshd.version>2.7.0</sshd.version>

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponse.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponse.java
@@ -46,6 +46,7 @@ import org.eclipse.ditto.connectivity.model.ResourceStatus;
 import org.eclipse.ditto.connectivity.model.WithConnectionId;
 import org.eclipse.ditto.connectivity.model.signals.commands.ConnectivityCommandResponse;
 import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonArrayBuilder;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
@@ -443,72 +444,84 @@ public final class RetrieveConnectionStatusResponse extends AbstractCommandRespo
                 jsonObjectBuilder.set(JsonFields.CONNECTED_SINCE, connectedSince.toString());
             }
 
+            JsonArray clientStatusJsonArray = JsonArray.empty();
             if (clientStatus != null) {
-                final JsonArray jsonArray = clientStatus.stream()
+                clientStatusJsonArray = clientStatus.stream()
                         .map(ResourceStatus::toJson)
                         .collect(JsonCollectors.valuesToArray());
-                addTimeoutsToResourcesArray(ResourceStatus.ResourceType.CLIENT, jsonArray, () ->
-                        ConnectivityModelFactory.newClientStatus(UNKNOWN_CLIENT,
-                                ConnectivityStatus.FAILED,
-                                "Client failed to report its status within the timeout.",
-                                now
-                        ));
-                jsonObjectBuilder.set(JsonFields.CLIENT_STATUS, jsonArray);
             }
+            clientStatusJsonArray =
+                    addTimeoutsToResourcesArray(ResourceStatus.ResourceType.CLIENT, clientStatusJsonArray, () ->
+                            ConnectivityModelFactory.newClientStatus(UNKNOWN_CLIENT,
+                                    ConnectivityStatus.FAILED,
+                                    "Client failed to report its status within the timeout.",
+                                    now
+                            ));
+            jsonObjectBuilder.set(JsonFields.CLIENT_STATUS, clientStatusJsonArray);
 
+            JsonArray sourceStatusJsonArray = JsonArray.empty();
             if (sourceStatus != null) {
-                final JsonArray jsonArray = sourceStatus.stream()
+                sourceStatusJsonArray = sourceStatus.stream()
                         .map(ResourceStatus::toJson)
                         .collect(JsonCollectors.valuesToArray());
-                addTimeoutsToResourcesArray(ResourceStatus.ResourceType.SOURCE, jsonArray, () ->
-                        ConnectivityModelFactory.newSourceStatus(UNKNOWN_CLIENT,
-                                ConnectivityStatus.FAILED,
-                                null,
-                                "Source failed to report its status within the timeout."
-                        ));
-                jsonObjectBuilder.set(JsonFields.SOURCE_STATUS, jsonArray);
             }
+            sourceStatusJsonArray =
+                    addTimeoutsToResourcesArray(ResourceStatus.ResourceType.SOURCE, sourceStatusJsonArray, () ->
+                            ConnectivityModelFactory.newSourceStatus(UNKNOWN_CLIENT,
+                                    ConnectivityStatus.FAILED,
+                                    null,
+                                    "Source failed to report its status within the timeout."
+                            ));
+            jsonObjectBuilder.set(JsonFields.SOURCE_STATUS, sourceStatusJsonArray);
 
+            JsonArray targetStatusJsonArray = JsonArray.empty();
             if (targetStatus != null) {
-                final JsonArray jsonArray = targetStatus.stream()
+                targetStatusJsonArray = targetStatus.stream()
                         .map(ResourceStatus::toJson)
                         .collect(JsonCollectors.valuesToArray());
-                addTimeoutsToResourcesArray(ResourceStatus.ResourceType.TARGET, jsonArray, () ->
-                        ConnectivityModelFactory.newTargetStatus(UNKNOWN_CLIENT,
-                                ConnectivityStatus.FAILED,
-                                null,
-                                "Target failed to report its status within the timeout."
-                        ));
-                jsonObjectBuilder.set(JsonFields.TARGET_STATUS, jsonArray);
             }
+            targetStatusJsonArray =
+                    addTimeoutsToResourcesArray(ResourceStatus.ResourceType.TARGET, targetStatusJsonArray, () ->
+                            ConnectivityModelFactory.newTargetStatus(UNKNOWN_CLIENT,
+                                    ConnectivityStatus.FAILED,
+                                    null,
+                                    "Target failed to report its status within the timeout."
+                            ));
+            jsonObjectBuilder.set(JsonFields.TARGET_STATUS, targetStatusJsonArray);
 
+            JsonArray sshTunnelStatusJsonArray = JsonArray.empty();
             if (sshTunnelStatus != null) {
-                final JsonArray jsonArray = sshTunnelStatus.stream()
+                sshTunnelStatusJsonArray = sshTunnelStatus.stream()
                         .map(ResourceStatus::toJson)
                         .collect(JsonCollectors.valuesToArray());
-                addTimeoutsToResourcesArray(ResourceStatus.ResourceType.SSH_TUNNEL, jsonArray, () ->
-                        ConnectivityModelFactory.newSshTunnelStatus(UNKNOWN_CLIENT,
-                                ConnectivityStatus.FAILED,
-                                "SSH Tunnel failed to report its status within the timeout.",
-                                now
-                        ));
-                jsonObjectBuilder.set(JsonFields.SSH_TUNNEL_STATUS, jsonArray);
             }
+            sshTunnelStatusJsonArray =
+                    addTimeoutsToResourcesArray(ResourceStatus.ResourceType.SSH_TUNNEL, sshTunnelStatusJsonArray, () ->
+                            ConnectivityModelFactory.newSshTunnelStatus(UNKNOWN_CLIENT,
+                                    ConnectivityStatus.FAILED,
+                                    "SSH Tunnel failed to report its status within the timeout.",
+                                    now
+                            ));
+            jsonObjectBuilder.set(JsonFields.SSH_TUNNEL_STATUS, sshTunnelStatusJsonArray);
 
             return new RetrieveConnectionStatusResponse(connectionId, jsonObjectBuilder.build(), dittoHeaders);
         }
 
-        private void addTimeoutsToResourcesArray(final ResourceStatus.ResourceType resourceType,
+        private JsonArray addTimeoutsToResourcesArray(final ResourceStatus.ResourceType resourceType,
                 final JsonArray jsonArray,
                 final Supplier<ResourceStatus> resourceStatusSupplier) {
 
             if (null == missingResources) {
-                return;
+                return jsonArray;
             }
             final int missingCount = missingResources.getOrDefault(resourceType, 0);
+            if (missingCount < 1) {
+                return jsonArray;
+            }
+            final JsonArrayBuilder jsonArrayBuilder = jsonArray.toBuilder();
             IntStream.range(0, missingCount)
-                    .forEach(i -> jsonArray.add(resourceStatusSupplier.get().toJson()));
-
+                    .forEach(i -> jsonArrayBuilder.add(resourceStatusSupplier.get().toJson()));
+            return jsonArrayBuilder.build();
         }
     }
 

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponse.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponse.java
@@ -457,7 +457,9 @@ public final class RetrieveConnectionStatusResponse extends AbstractCommandRespo
                                     "Client failed to report its status within the timeout.",
                                     now
                             ));
-            jsonObjectBuilder.set(JsonFields.CLIENT_STATUS, clientStatusJsonArray);
+            if (!clientStatusJsonArray.isEmpty()) {
+                jsonObjectBuilder.set(JsonFields.CLIENT_STATUS, clientStatusJsonArray);
+            }
 
             JsonArray sourceStatusJsonArray = JsonArray.empty();
             if (sourceStatus != null) {
@@ -472,7 +474,9 @@ public final class RetrieveConnectionStatusResponse extends AbstractCommandRespo
                                     null,
                                     "Source failed to report its status within the timeout."
                             ));
-            jsonObjectBuilder.set(JsonFields.SOURCE_STATUS, sourceStatusJsonArray);
+            if (!sourceStatusJsonArray.isEmpty()) {
+                jsonObjectBuilder.set(JsonFields.SOURCE_STATUS, sourceStatusJsonArray);
+            }
 
             JsonArray targetStatusJsonArray = JsonArray.empty();
             if (targetStatus != null) {
@@ -487,7 +491,9 @@ public final class RetrieveConnectionStatusResponse extends AbstractCommandRespo
                                     null,
                                     "Target failed to report its status within the timeout."
                             ));
-            jsonObjectBuilder.set(JsonFields.TARGET_STATUS, targetStatusJsonArray);
+            if (!targetStatusJsonArray.isEmpty()) {
+                jsonObjectBuilder.set(JsonFields.TARGET_STATUS, targetStatusJsonArray);
+            }
 
             JsonArray sshTunnelStatusJsonArray = JsonArray.empty();
             if (sshTunnelStatus != null) {
@@ -502,7 +508,9 @@ public final class RetrieveConnectionStatusResponse extends AbstractCommandRespo
                                     "SSH Tunnel failed to report its status within the timeout.",
                                     now
                             ));
-            jsonObjectBuilder.set(JsonFields.SSH_TUNNEL_STATUS, sshTunnelStatusJsonArray);
+            if (!sshTunnelStatusJsonArray.isEmpty()) {
+                jsonObjectBuilder.set(JsonFields.SSH_TUNNEL_STATUS, sshTunnelStatusJsonArray);
+            }
 
             return new RetrieveConnectionStatusResponse(connectionId, jsonObjectBuilder.build(), dittoHeaders);
         }

--- a/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponseTest.java
+++ b/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/signals/commands/query/RetrieveConnectionStatusResponseTest.java
@@ -148,8 +148,6 @@ public final class RetrieveConnectionStatusResponseTest {
                                             .set(ResourceStatus.JsonFields.STATUS_DETAILS, "closed since 123")
                                             .build()
                             ).build())
-            .set(RetrieveConnectionStatusResponse.JsonFields.SSH_TUNNEL_STATUS,
-                    JsonFactory.newArrayBuilder().build())
             .build();
 
     @Test

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -1080,7 +1080,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                 } else {
                     try {
                         reconnect();
-                    } catch (final ConnectionFailedException e){
+                    } catch (final ConnectionFailedException e) {
                         return goToConnecting(reconnectTimeoutStrategy.getNextTimeout())
                                 .using(data.setConnectionStatus(ConnectivityStatus.MISCONFIGURED)
                                         .setConnectionStatusDetails(
@@ -1088,27 +1088,33 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                                         .resetSession());
                     }
                 }
-                return goToConnecting(reconnectTimeoutStrategy.getNextTimeout()).using(data.resetSession()
-                        .setConnectionStatus(ConnectivityStatus.FAILED)
-                        .setConnectionStatusDetails(timeoutMessage + " Will try to reconnect."));
+                return goToConnecting(reconnectTimeoutStrategy.getNextTimeout())
+                        .using(data.resetSession()
+                                .setConnectionStatus(ConnectivityStatus.FAILED)
+                                .setConnectionStatusDetails(timeoutMessage + " Will try to reconnect."));
             } else {
                 connectionLogger.failure(
                         "Connection timed out. Reached maximum tries and thus will no longer try to reconnect.");
                 logger.info(
-                        "Connection <{}> reached maximum retries for reconnecting and thus will no longer try to reconnect.",
+                        "Connection <{}> - connection timed out - " +
+                                "reached maximum retries for reconnecting and thus will no longer try to reconnect.",
                         connectionId());
 
-                return goTo(INITIALIZED).using(data.resetSession()
-                        .setConnectionStatus(ConnectivityStatus.FAILED)
-                        .setConnectionStatusDetails(timeoutMessage +
-                                " Reached maximum retries and thus will not try to reconnect any longer."));
+                return goTo(INITIALIZED)
+                        .using(data.resetSession() // don't set the state, preserve the old one (e.g. MISCONFIGURED)
+                                .setConnectionStatusDetails(
+                                        data.getConnectionStatusDetails().orElse(timeoutMessage) // Preserve old status details
+                                                 + " Reached maximum retries and thus will not try to reconnect any longer.")
+                        );
             }
         }
 
         connectionLogger.failure("Connection timed out.");
-        return goTo(INITIALIZED).using(data.resetSession()
-                .setConnectionStatus(ConnectivityStatus.FAILED)
-                .setConnectionStatusDetails(timeoutMessage));
+        return goTo(INITIALIZED)
+                .using(data.resetSession()
+                        .setConnectionStatus(ConnectivityStatus.FAILED)
+                        .setConnectionStatusDetails(timeoutMessage)
+                );
     }
 
     private State<BaseClientState, BaseClientData> tunnelStarted(final SshTunnelActor.TunnelStarted tunnelStarted,
@@ -1357,14 +1363,18 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                         "Connection failed due to: {0}. Reached maximum tries and thus will no longer try to reconnect.",
                         event.getFailureDescription());
                 logger.info(
-                        "Connection <{}> reached maximum retries for reconnecting and thus will no longer try to reconnect.",
+                        "Connection <{}> - backoff after failure - " +
+                                "reached maximum retries for reconnecting and thus will no longer try to reconnect.",
                         connectionId());
 
-                // stay in UNKNOWN state until re-opened manually
-                return goTo(INITIALIZED).using(data.resetSession()
-                        .setConnectionStatus(connectivityStatusResolver.resolve(event))
-                        .setConnectionStatusDetails(event.getFailureDescription()
-                                + " Reached maximum retries and thus will not try to reconnect any longer."));
+                // stay in INITIALIZED state until re-opened manually
+                return goTo(INITIALIZED)
+                        .using(data.resetSession()
+                                .setConnectionStatus(connectivityStatusResolver.resolve(event))
+                                .setConnectionStatusDetails(event.getFailureDescription()
+                                        + " Reached maximum retries after backing off after failure and thus will " +
+                                        "not try to reconnect any longer.")
+                        );
             }
         }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MockClientActor.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MockClientActor.java
@@ -18,7 +18,6 @@ import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.connectivity.model.ConnectionIdInvalidException;
 import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
 import org.eclipse.ditto.connectivity.model.ConnectivityStatus;
-import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
 import org.eclipse.ditto.connectivity.model.signals.commands.modify.CheckConnectionLogsActive;
 import org.eclipse.ditto.connectivity.model.signals.commands.modify.CloseConnection;
 import org.eclipse.ditto.connectivity.model.signals.commands.modify.CreateConnection;
@@ -29,6 +28,7 @@ import org.eclipse.ditto.connectivity.model.signals.commands.modify.OpenConnecti
 import org.eclipse.ditto.connectivity.model.signals.commands.modify.TestConnection;
 import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnectionLogs;
 import org.eclipse.ditto.connectivity.model.signals.commands.query.RetrieveConnectionStatus;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
 
 import akka.actor.AbstractActor;
 import akka.actor.ActorRef;
@@ -126,6 +126,12 @@ public class MockClientActor extends AbstractActor {
                             getSelf());
                     sender().tell(ConnectivityModelFactory.newTargetStatus("client1",
                             ConnectivityStatus.OPEN, "target1", "publisher started"),
+                            getSelf());
+                    sender().tell(ConnectivityModelFactory.newTargetStatus("client1",
+                            ConnectivityStatus.OPEN, "target2", "publisher started"),
+                            getSelf());
+                    sender().tell(ConnectivityModelFactory.newTargetStatus("client1",
+                            ConnectivityStatus.OPEN, "target3", "publisher started"),
                             getSelf());
                 })
                 .match(RetrieveConnectionLogs.class, rcl -> {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActorTest.java
@@ -204,7 +204,11 @@ public final class ConnectionPersistenceActorTest extends WithMockServers {
                                 ))
                         .targetStatus(
                                 List.of(ConnectivityModelFactory.newTargetStatus("client1", ConnectivityStatus.OPEN,
-                                        "target1", "publisher started")))
+                                        "target1", "publisher started"),
+                                        ConnectivityModelFactory.newTargetStatus("client1", ConnectivityStatus.OPEN,
+                                                "target2", "publisher started"),
+                                        ConnectivityModelFactory.newTargetStatus("client1", ConnectivityStatus.OPEN,
+                                                "target3", "publisher started")))
                         .sshTunnelStatus(List.of())
                         .build();
         connectionNotAccessibleException = ConnectionNotAccessibleException.newBuilder(connectionId).build();


### PR DESCRIPTION
Additionally fix that `RetrieveConnectionStatusResponse` did not include timed out resources in the built JsonObject.