### PR TITLE
Minor fixes in connectivity to reduce error logs

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -1400,7 +1400,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                                 " Forwarding to consumers and publishers.", command.getEntityId(),
                         sender);
 
-        final int numberOfProducers = connection.getTargets().size();
+        final int numberOfProducers = connection.getTargets().isEmpty() ? 0 : 1;
         final int numberOfConsumers = connection.getSources()
                 .stream()
                 .mapToInt(source -> source.getConsumerCount() * source.getAddresses().size())
@@ -1420,17 +1420,13 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                     .map(sourceAddress -> ConnectivityModelFactory.newSourceStatus(getInstanceIdentifier(),
                             ConnectivityStatus.CLOSED,
                             sourceAddress, "Closed because of failure in client"))
-                    .forEach(resourceStatus -> {
-                        sender.tell(resourceStatus, ActorRef.noSender());
-                    });
+                    .forEach(resourceStatus -> sender.tell(resourceStatus, ActorRef.noSender()));
             connection.getTargets().stream()
                     .map(Target::getAddress)
                     .map(targetAddress -> ConnectivityModelFactory.newTargetStatus(getInstanceIdentifier(),
                             ConnectivityStatus.CLOSED,
                             targetAddress, "Closed because of failure in client"))
-                    .forEach(resourceStatus -> {
-                        sender.tell(resourceStatus, ActorRef.noSender());
-                    });
+                    .forEach(resourceStatus -> sender.tell(resourceStatus, ActorRef.noSender()));
         } else {
             childrenToAsk.forEach(child -> {
                 logger.withCorrelationId(command)

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -112,6 +112,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
     protected final Sink<AcknowledgeableMessage, NotUsed> getMessageMappingSink() {
         return Flow.fromFunction(this::withSender)
                 .map(Object.class::cast)
+                .recoverWithRetries(-1, Throwable.class, akka.stream.javadsl.Source::empty)
                 .to(inboundMappingSink);
     }
 
@@ -216,6 +217,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
                     inboundMonitor.failure(value.getDittoHeaders(), value);
                     return value;
                 }))
+                .recoverWithRetries(-1, Throwable.class, akka.stream.javadsl.Source::empty)
                 .to(inboundMappingSink);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -638,6 +638,12 @@ public final class ConnectionPersistenceActor
                 .orElse(super.matchAnyWhenDeleted());
     }
 
+    @Override
+    protected void becomeDeletedHandler() {
+        this.cancelPeriodicPriorityUpdate();
+        super.becomeDeletedHandler();
+    }
+
     /**
      * Route search commands according to subscription ID prefix. This is necessary so that for connections with
      * client count > 1, all commands related to 1 search session are routed to the same client actor. This is achieved
@@ -855,6 +861,10 @@ public final class ConnectionPersistenceActor
         log.info("Schedule update of priority periodically in an interval of <{}>", priorityUpdateInterval);
         timers().startTimerWithFixedDelay(Control.TRIGGER_UPDATE_PRIORITY, Control.TRIGGER_UPDATE_PRIORITY,
                 priorityUpdateInterval);
+    }
+
+    private void cancelPeriodicPriorityUpdate() {
+        timers().cancel(Control.TRIGGER_UPDATE_PRIORITY);
     }
 
     private void respondWithEmptyLogs(final RetrieveConnectionLogs command, final ActorRef origin) {


### PR DESCRIPTION
This PR:
* Cancels the periodic update of a connection priority when it gets deleted
* Prevents the MergeHub in front of the inboundMappingSink to log errors (They are already handled by the completion stage, when the stream terminates)
* Sends a static ResourceStatus as response for all sources and targets in case the client actor is in a failed state and not all consumer and publisher actor children could be started