### PR TITLE
Fix double slashes in location header

### DIFF
--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/UriForLocationHeaderSupplierTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/UriForLocationHeaderSupplierTest.java
@@ -70,6 +70,13 @@ public final class UriForLocationHeaderSupplierTest {
     }
 
     @Test
+    public void getUriWithTrailingSlash() {
+        final Uri uri = Uri.create("https://example.com/things/");
+        final Uri locationUri = Uri.create("https://example.com/things");
+        checkUriForNonIdempotentRequestWithoutEntityIdInUri(locationUri, uri);
+    }
+
+    @Test
     public void getUriForNonIdempotentRequestWithoutEntityIdInUriWithQueryParam() {
         final Uri expectedBaseUri = Uri.create("https://example.com/things");
         final Uri uri = Uri.create("https://example.com/things?timeout=42&response-required=false");


### PR DESCRIPTION
Currently requests ending with slash lead to duplicate slashes in location header (i.e. POST /things/ leads to /things//entityId).
Fixed by removing trailing slashes from base URI if present.