### PR TITLE
allow to use an URL as "definition" for Thing + Feature definitions

### DIFF
--- a/documentation/src/main/resources/jsonschema/feature_v2.json
+++ b/documentation/src/main/resources/jsonschema/feature_v2.json
@@ -7,12 +7,12 @@
     "definition": {
       "title": "Definition",
       "type": "array",
-      "description": "The Definition of the Feature, a list of Identifiers containing at least 1 Identifier in the form 'namespace:name:version'.",
+      "description": "The Definition of the Feature, a list of Identifiers containing at least 1 Identifier in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL.",
       "minItems": 1,
       "uniqueItems": true,
       "items": {
         "type": "string",
-        "description": "A single fully qualified Identifier of a Feature Definition in the form 'namespace:name:version'.",
+        "description": "A single fully qualified Identifier of a Feature Definition in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL.",
         "pattern": "(?<namespace>[_a-zA-Z0-9\\-.]+):(?<name>[_a-zA-Z0-9\\-.]+):(?<version>[_a-zA-Z0-9\\-.]+)"
       }
     },

--- a/documentation/src/main/resources/jsonschema/thing_v2.json
+++ b/documentation/src/main/resources/jsonschema/thing_v2.json
@@ -15,7 +15,7 @@
     "definition": {
       "title": "Definition",
       "type": "string",
-      "description": "The definition of this Thing declaring its model in the form 'namespace:name:version'.",
+      "description": "The definition of this Thing declaring its model in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL.",
       "pattern": "([_a-zA-Z0-9\\-.]+):([_a-zA-Z0-9\\-.]+):([_a-zA-Z0-9\\-.]+)"
     },
     "attributes": {
@@ -38,12 +38,12 @@
             "definition": {
               "title": "Definition",
               "type": "array",
-              "description": "The definition of the Feature declaring its model, a list of Identifiers containing at least 1 Identifier in the form 'namespace:name:version'.",
+              "description": "The definition of the Feature declaring its model, a list of Identifiers containing at least 1 Identifier in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL.",
               "minItems": 1,
               "uniqueItems": true,
               "items": {
                 "type": "string",
-                "description": "A single fully qualified Identifier of a Feature definition in the form 'namespace:name:version'.",
+                "description": "A single fully qualified Identifier of a Feature definition in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL.",
                 "pattern": "([_a-zA-Z0-9\\-.]+):([_a-zA-Z0-9\\-.]+):([_a-zA-Z0-9\\-.]+)"
               }
             },

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -2635,7 +2635,7 @@ paths:
 
           Consider that the value has to be a JSON array or `null`.
 
-          The content of the JSON array are strings in the format `"namespace:name:version"` which is enforced.
+          The content of the JSON array are strings in the format `"<namespace>:<name>:<version>"` or a valid HTTP(s) URL, which is enforced.
         required: true
     patch:
       summary: Patch the definition of a feature
@@ -2713,7 +2713,7 @@ paths:
         description: |-
           JSON array of the complete definition to be patched. Consider that the value has to be a JSON array.
 
-          The content of the JSON array are strings in the format `"namespace:name:version"` which is enforced.
+          The content of the JSON array are strings in the format `"<namespace>:<name>:<version>"` or a valid HTTP(s) URL, which is enforced.
           To delete the definition use `null` as content in the request body.
         required: true
     delete:
@@ -6972,14 +6972,14 @@ components:
       description: An arbitrary JSON object describing the attributes of a thing.
     Definition:
       type: string
-      description: 'A single fully qualified identifier of a definition in the form ''namespace:name:version'''
+      description: 'A single fully qualified identifier of a definition in the form ''<namespace>:<name>:<version>'' or a valid HTTP(s) URL'
       pattern: '([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)'
     FeatureDefinition:
       type: array
       description: The definitions of a feature.
       items:
         type: string
-        description: 'A single fully qualified identifier of a feature definition in the form ''namespace:name:version'''
+        description: 'A single fully qualified identifier of a feature definition in the form ''<namespace>:<name>:<version>'' or a valid HTTP(s) URL'
         pattern: '([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)'
     FeatureProperties:
       type: object

--- a/documentation/src/main/resources/openapi/sources/paths/features/definition.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/features/definition.yml
@@ -153,7 +153,7 @@ put:
 
       Consider that the value has to be a JSON array or `null`.
 
-      The content of the JSON array are strings in the format `"namespace:name:version"` which is enforced.
+      The content of the JSON array are strings in the format `"<namespace>:<name>:<version>"` or a valid HTTP(s) URL, which is enforced.
     required: true
 patch:
   summary: Patch the definition of a feature
@@ -232,7 +232,7 @@ patch:
     description: |-
       JSON array of the complete definition to be patched. Consider that the value has to be a JSON array.
 
-      The content of the JSON array are strings in the format `"namespace:name:version"` which is enforced.
+      The content of the JSON array are strings in the format `"<namespace>:<name>:<version>"` or a valid HTTP(s) URL, which is enforced.
       To delete the definition use `null` as content in the request body.
     required: true
 delete:

--- a/documentation/src/main/resources/openapi/sources/schemas/features/featureDefinition.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/features/featureDefinition.yml
@@ -12,5 +12,5 @@ type: array
 description: The definitions of a feature.
 items:
   type: string
-  description: "A single fully qualified identifier of a feature definition in the form 'namespace:name:version'"
+  description: "A single fully qualified identifier of a feature definition in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL"
   pattern: ([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)

--- a/documentation/src/main/resources/openapi/sources/schemas/things/definition.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/things/definition.yml
@@ -9,5 +9,5 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 type: string
-description: "A single fully qualified identifier of a definition in the form 'namespace:name:version'"
+description: "A single fully qualified identifier of a definition in the form '<namespace>:<name>:<version>' or a valid HTTP(s) URL"
 pattern: ([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+):([_a-zA-Z0-9\-.]+)

--- a/documentation/src/main/resources/pages/ditto/basic-feature.md
+++ b/documentation/src/main/resources/pages/ditto/basic-feature.md
@@ -14,8 +14,7 @@ and do not exist without this Thing.
 ## Feature ID
 Within a Thing each Feature is identified by a unique string - the so called Feature ID.
 A Feature ID often needs to be set in the path of a HTTP request. Due to this fact we strongly recommend to use a
-restricted set of characters (e.g. those for
-[Uniform Resource Identifiers (URI)](https://www.ietf.org/rfc/rfc3986.txt)).
+restricted set of characters (e.g. those for [Uniform Resource Identifiers (URI)](https://www.ietf.org/rfc/rfc3986.txt)).
 
 ## Feature properties
 

--- a/documentation/src/main/resources/pages/ditto/basic-feature.md
+++ b/documentation/src/main/resources/pages/ditto/basic-feature.md
@@ -5,21 +5,19 @@ tags: [model]
 permalink: basic-feature.html
 ---
 
-## Feature
-
 A Feature is used to manage all data and functionality of a Thing that can be clustered in an outlined technical
 context.
 
 For different contexts or aspects of a Thing different Features can be used which are all belonging to the same Thing
 and do not exist without this Thing.
 
-### Feature ID
+## Feature ID
 Within a Thing each Feature is identified by a unique string - the so called Feature ID.
 A Feature ID often needs to be set in the path of a HTTP request. Due to this fact we strongly recommend to use a
 restricted set of characters (e.g. those for
 [Uniform Resource Identifiers (URI)](https://www.ietf.org/rfc/rfc3986.txt)).
 
-### Feature properties
+## Feature properties
 
 The **data** related to Features is managed in form of a **list of properties**. These properties can be categorized,
 e.g. to manage the status, the configuration or any fault information.
@@ -27,7 +25,7 @@ Feature properties are represented as one JSON object.
 
 Each property itself can be either a simple/scalar value or a complex object; allowed is any JSON value.
 
-### Feature desired properties
+## Feature desired properties
 
 Desired properties represent the desired state of the properties. They are a tool to represent the desired target state 
 of the properties. 
@@ -40,70 +38,41 @@ Each desired property itself can be either a simple/scalar value or a complex ob
 Please note however, that besides persisting the desired properties, and indexing the fields for search requests, filtering 
 etc. for the time being, Ditto does not implement their further processing. Such functionality will come with future releases.
 
-### Feature definition
+## Feature definition
 
 Ditto supports specifying a definition for a feature in order to document how a feature's state is structured
 (in [properties](#feature-properties)), and which behavior/capabilities
-([messages related to features](basic-messages.html)) can be expected from such a feature.<br/>
+([messages related to features](basic-messages.html)) can be expected from such a feature.
 
-A feature's definition is a list of definition identifiers containing a *namespace*, *name* and *version* separated 
-by colons: `namespace:name:version`. Thus the *definition* element can hold even multiple identifiers.
+A feature's definition is a list of definition identifiers containing 
+* either a *namespace*, *name* and *version* separated by colons: `<namespace>:<name>:<version>`
+* or valid HTTP(s) URLs
 
 A Definition can be seen as some kind of type for features. The [properties](#feature-properties) of a 
 feature containing a definition identifier `"org.eclipse.ditto:lamp:1.0.0"` can be expected to follow the structure
 described in the `lamp` type of namespace `org.eclipse.ditto` semantically versioned with version `1.0.0`.
 
 {% include note.html content="Ditto does not contain a type system on its own and does not specify how to describe types. 
-   Tooling for editing such structures and type descriptors is provided by [Eclipse Vorto](#the-link-to-eclipse-vorto)." %}
-
-Ditto aims to support contract-based development - by using feature definitions  - to ensure validity and 
-integrity of **digital twins**.
+   You may either use [Eclipse Vorto](#the-link-to-eclipse-vorto) or [W3C Web of Things](#the-link-to-w3c-web-of-things)
+   to describe data structures and supported messages of Ditto features." %}
 
 {% include warning.html content="Currently Ditto **does not** ensure that the `properties` or 
- `desiredProperties` of a feature or its supported
-   messages follow the type defined in the definition." %}
+ `desiredProperties` of a feature or its supported messages follow the type defined in the definition." %}
 
-## Example
+### The link to Eclipse Vorto
 
-The following snippet shows a Feature with the ID "arbitrary-feature" and a definition with the sole identifier
-"org.eclipse.ditto:complex-type:1.0.0":
+If a [feature definition](#feature-definition) has the form `<namespace>:<name>:<version>`, those 3 values may be
+interpreted as the link to an Eclipse Vorto "function block" model.
 
-```json
-{
-  "arbitrary-feature": {
-    "definition": [ "org.eclipse.ditto:complex-type:1.0.0" ],
-    "properties": {
-      "status": {
-        "connected": true,
-        "complexProperty": {
-          "street": "my street",
-          "house no": 42
-        }
-      }
-    },
-    "desiredProperties": {
-      "status": {
-        "connected": false
-      }
-    }
-  }
-}
-```
+{% include warning.html content="Ditto does not enforce structures and data types based on Eclipse Vorto models -
+a referenced Vorto model may be used in order to find out which data structures and messages a Ditto feature
+supports. Validation - if needed - must be done in another place." %}
 
-## Model specification
-
-The feature model API version 2:
-
-### V2
-{% include docson.html schema="jsonschema/feature_v2.json" %}
-
-## The link to Eclipse Vorto
-
-> Vorto is an open source tool that allows to create and manage technology agnostic, abstract device descriptions, 
+> Vorto is an open source tool that allows to create and manage technology agnostic, abstract device descriptions,
 so called information models. Information models describe the attributes and the capabilities of real world devices.
 Source: [http://www.eclipse.org/vorto/](http://www.eclipse.org/vorto/)
 
-Ditto's feature definition may be mapped to the Vorto type system which is defined by so called "information models" 
+Ditto's feature definition may be mapped to the Vorto type system which is defined by so called "information models"
 and "function blocks":
 > Information models represent the capabilities of a particular type of device entirely.
 An information model contains one or more function blocks.
@@ -112,20 +81,20 @@ An information model contains one or more function blocks.
 Thus, it is a consistent, self-contained set of (potentially re-usable) properties and capabilities.
 
 {% include image.html file="pages/basic/ditto-thing-feature-definition-model.png" alt="Feature Definition Model"
-   caption="One Thing can have many features. A feature may conform to a definition" max-width=250 %}
+caption="One Thing can have many features. A feature may conform to a definition" max-width=250 %}
 
-### Mapping Vorto function block elements
+#### Mapping Vorto function block elements
 
-A Vorto function block consists of different sections defining state and capabilities 
-(see also [Eclipse Vorto's documentation](https://www.eclipse.org/vorto/)) of a device 
+A Vorto function block consists of different sections defining state and capabilities
+(see also [Eclipse Vorto's documentation](https://www.eclipse.org/vorto/)) of a device
 (in our case of a feature):
-* `configuration`: Contains one or many configuration properties for the function block. 
-* `status`: Contains one or many status properties for the function block. 
-* `fault`: Contains one or many fault properties for the function block. 
-* `operations`: Contains one or many operations for the function block. 
-* `events`: Contains one or many events for the function block. 
+* `configuration`: Contains one or many configuration properties for the function block.
+* `status`: Contains one or many status properties for the function block.
+* `fault`: Contains one or many fault properties for the function block.
+* `operations`: Contains one or many operations for the function block.
+* `events`: Contains one or many events for the function block.
 
-#### Function block state
+##### Function block state
 
 The `configuration`, `status` and `fault` sections of a function block define the state of a feature in Ditto.
 
@@ -135,7 +104,7 @@ following JSON structure of a Ditto feature:
 ```json
 {
     "feature-id": {
-        "definition": [ "namespace:name:version" ],
+        "definition": [ "<namespace>:<name>:<version>" ],
         "properties": {
             "configuration": {
             },
@@ -148,10 +117,10 @@ following JSON structure of a Ditto feature:
 }
 ```
 
-The structure below `configuration, status, fault` is defined by the custom types of the Vorto function block. As these 
+The structure below `configuration, status, fault` is defined by the custom types of the Vorto function block. As these
 can be simple types as well as complex types, the JSON structure follows the structure of the types.
 
-#### Function block capabilities
+##### Function block capabilities
 
 The `operations` and `events` sections of a function block define the capabilities or behavior of a Ditto feature.
 
@@ -159,10 +128,7 @@ Both are mapped to feature [messages](basic-messages.html) sent "to" or "from" a
 * A message sent **to** a feature is mapped to an `operation`.
 * A messages sent **from** a feature is mapped to an `event`.
 
-### Vorto example
-
-{% include warning.html content="Ditto has not yet included Eclipse Vorto in order to enforce types - the following
-   section can be seen as an **outlook** how Ditto would map Vorto concepts to features." %}
+#### Vorto example
 
 Here an example for a Vorto Function Block (in Vorto's custom DSL) with the name `Lamp`.
 For the sake of giving an example for events this lamp has some additional capabilities like detecting movement and
@@ -236,11 +202,67 @@ A feature containing a definition pointing to such a Vorto function block would 
 ```
 
 The capabilities or behavior of this "lamp" feature would be defined as [messages](basic-messages.html):
-* Message with subject `smokeDetected` which is sent `FROM` a feature containing a JSON payload with an 
-    `intensity` and whether the detected smoke has reached a `critical` mass or not.
+* Message with subject `smokeDetected` which is sent `FROM` a feature containing a JSON payload with an
+  `intensity` and whether the detected smoke has reached a `critical` mass or not.
 * Message with subject `movementAlarm` which is sent `FROM` a feature with no payload.
-* Message with subject `blink` which is sent `TO` a feature containing a JSON payload of an `interval` 
-    (as JSON number) and a duration (also as JSON number) returning a JSON boolean.
+* Message with subject `blink` which is sent `TO` a feature containing a JSON payload of an `interval`
+  (as JSON number) and a duration (also as JSON number) returning a JSON boolean.
 * Message with subject `stopBlinking` which is sent `TO` a feature with no payload returning a JSON boolean.
-* Message with subject `changeColor` which is sent `TO` a feature containing a JSON payload which follows the type 
-    `Color` defined in another Vorto function block.
+* Message with subject `changeColor` which is sent `TO` a feature containing a JSON payload which follows the type
+  `Color` defined in another Vorto function block.
+
+### The link to W3C Web of Things
+
+If a [feature definition](#feature-definition) has the form of an HTTP(s) URL, this URL pointing to a resource may be
+interpreted as the link to a [W3C WoT (Web of Things)](https://www.w3.org/TR/wot-thing-description11/) 
+[Thing Model](https://www.w3.org/TR/wot-thing-description11/#thing-model) in [JSON-LD](https://www.w3.org/TR/json-ld11/) 
+format.
+
+#### Mapping WoT Thing Model elements
+
+A WoT Thing Model describes the following elements a "thing" supports:
+* properties
+* actions
+* events
+
+The following table shows an overview of how those elements map to Ditto concepts:
+
+| WoT element           | Ditto concept  |
+| [Thing](https://www.w3.org/TR/wot-thing-description11/#thing) | Feature.<br/>In Ditto, a Feature is an aspect of a [Ditto Thing](basic-thing.html). As the feature is defined by its properties and messages it supports, it maps to a WoT Thing. |
+| [Properties](https://www.w3.org/TR/wot-thing-description11/#propertyaffordance) | Feature [properties](#feature-properties) and [desired properties](#feature-desired-properties) |
+| [Actions](https://www.w3.org/TR/wot-thing-description11/#actionaffordance) | [Messages](basic-messages.html#elements) with **Direction** *to* ("inbox") of a Thing ID + Feature ID combination |
+| [Events](https://www.w3.org/TR/wot-thing-description11/#eventaffordance) | [Messages](basic-messages.html#elements) with **Direction** *from* ("outbox") of a Thing ID + Feature ID combination  |
+
+# Example
+
+The following snippet shows a Feature with the ID "arbitrary-feature" and a definition with the sole identifier
+"org.eclipse.ditto:complex-type:1.0.0":
+
+```json
+{
+  "arbitrary-feature": {
+    "definition": [ "org.eclipse.ditto:complex-type:1.0.0" ],
+    "properties": {
+      "status": {
+        "connected": true,
+        "complexProperty": {
+          "street": "my street",
+          "house no": 42
+        }
+      }
+    },
+    "desiredProperties": {
+      "status": {
+        "connected": false
+      }
+    }
+  }
+}
+```
+
+## Model specification
+
+The feature model API version 2:
+
+### V2
+{% include docson.html schema="jsonschema/feature_v2.json" %}

--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -143,22 +143,22 @@ A user is authorized to inject the token integration subject when granted the `E
 The `WRITE` permission is not necessary. To activate or deactivate a token integration subject, send a `POST` 
 request to the following HTTP routes:
 
-- [POST /api/2/policies/{policyId}/actions/activateTokenIntegration](/http-api-doc.html#/Policies/post_policies__policyId__actions_activateTokenIntegration)<br/>
+- [POST /api/2/policies/{policyId}/actions/activateTokenIntegration](http-api-doc.html#/Policies/post_policies__policyId__actions_activateTokenIntegration)<br/>
   Injects a new subject **into all matched policy entries** calculated with information extracted from the authenticated 
   JWT. 
    - the authenticated token must be granted the `EXECUTE` permission to perform the `activateTokenIntegration` action
    - one of the subject IDs must be contained in the authenticated token
    - at least one `READ` permission to a `thing:/` resource path must be granted
-- [POST /api/2/policies/{policyId}/actions/deactivateTokenIntegration](/http-api-doc.html#/Policies/post_policies__policyId__actions_deactivateTokenIntegration)<br/>
+- [POST /api/2/policies/{policyId}/actions/deactivateTokenIntegration](http-api-doc.html#/Policies/post_policies__policyId__actions_deactivateTokenIntegration)<br/>
   Removes the calculated subject with information extracted from the authenticated JWT **from all matched policy entries**. 
    - the authenticated token must be granted the `EXECUTE` permission to perform the `deactivateTokenIntegration` action
    - one of the subject IDs must be contained in the authenticated token 
-- [POST /api/2/policies/{policyId}/entries/{label}/actions/activateTokenIntegration](/http-api-doc.html#/Policies/post_policies__policyId__entries__label__actions_activateTokenIntegration)<br/>
+- [POST /api/2/policies/{policyId}/entries/{label}/actions/activateTokenIntegration](http-api-doc.html#/Policies/post_policies__policyId__entries__label__actions_activateTokenIntegration)<br/>
   Injects the calculated subject **into the policy entry** calculated with information extracted from the authenticated JWT.
    - the authenticated token must be granted the `EXECUTE` permission to perform the `activateTokenIntegration` action
    - one of the subject IDs must be contained in the authenticated token
    - at least one `READ` permission to a `thing:/` resource path must be granted
-- [POST /api/2/policies/{policyId}/entries/{label}/actions/deactivateTokenIntegration](/http-api-doc.html#/Policies/post_policies__policyId__entries__label__actions_deactivateTokenIntegration)<br/>
+- [POST /api/2/policies/{policyId}/entries/{label}/actions/deactivateTokenIntegration](http-api-doc.html#/Policies/post_policies__policyId__entries__label__actions_deactivateTokenIntegration)<br/>
   Removes the calculated subject with information extracted from the authenticated JWT **from the policy entry**.
    - the authenticated token must be granted the `EXECUTE` permission to perform the `deactivateTokenIntegration` action
    - one of the subject IDs must be contained in the authenticated token

--- a/documentation/src/main/resources/pages/ditto/basic-thing.md
+++ b/documentation/src/main/resources/pages/ditto/basic-thing.md
@@ -37,8 +37,11 @@ authenticated subjects may READ and WRITE the Thing or even parts of it (hierarc
 ### Definition
 
 A Thing may contain a definition. The definition can also be used to find Things. The definition is used to link a thing
-to a corresponding model defining the capabilities/features of it, e.g. via an 
-[Eclipse Vorto](https://www.eclipse.org/vorto/) "information model".
+to a corresponding model defining the capabilities/features of it.  
+The definition can for example point to a:  
+* [Eclipse Vorto](https://www.eclipse.org/vorto/) "information model" using the syntax `<namespace>:<name>:<version>`
+* [WoT Thing Model](https://w3c.github.io/wot-thing-description/#thing-model) - "Web of Things" Thing Model in form of
+  a URL to the thing model in JSON-LD format
 
 
 ### Attributes

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRouteTest.java
@@ -18,14 +18,14 @@ import static org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants.
 import static org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants.UNKNOWN_PATH;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
+import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
+import org.eclipse.ditto.internal.utils.protocol.ProtocolAdapterProvider;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.FeatureDefinition;
 import org.eclipse.ditto.things.model.FeatureProperties;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.gateway.service.endpoints.EndpointTestBase;
-import org.eclipse.ditto.gateway.service.endpoints.EndpointTestConstants;
-import org.eclipse.ditto.internal.utils.protocol.ProtocolAdapterProvider;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeatureProperties;
 import org.junit.Before;
 import org.junit.Rule;
@@ -168,7 +168,7 @@ public final class FeaturesRouteTest extends EndpointTestBase {
 
     @Test
     public void putFeatureEntryDefinition() {
-        final FeatureDefinition featureDefinition = FeatureDefinition.fromIdentifier("org.eclipse.ditto:vorto:0.1.0");
+        final FeatureDefinition featureDefinition = FeatureDefinition.fromIdentifier("org.eclipse.ditto:example:0.1.0");
         final TestRouteResult result = underTest.run(
                 HttpRequest.PUT(FEATURE_ENTRY_DEFINITION_PATH)
                         .withEntity(ContentTypes.APPLICATION_JSON, featureDefinition.toJsonString()));
@@ -498,7 +498,7 @@ public final class FeaturesRouteTest extends EndpointTestBase {
 
     @Test
     public void patchFeatureEntryDefinitionSuccessfully() {
-        final String featureDefinition = "[\"org.eclipse.ditto:vorto:0.1.0\"]";
+        final String featureDefinition = "[\"org.eclipse.ditto:example:0.1.0\"]";
         final TestRouteResult result = underTest.run(HttpRequest.PATCH(FEATURE_ENTRY_DEFINITION_PATH)
                 .withEntity(MediaTypes.APPLICATION_MERGE_PATCH_JSON.toContentType(), featureDefinition));
         result.assertStatusCode(EndpointTestConstants.DUMMY_COMMAND_SUCCESS);
@@ -506,7 +506,7 @@ public final class FeaturesRouteTest extends EndpointTestBase {
 
     @Test
     public void patchFeatureEntryDefinitionWithJsonException() {
-        final String featureDefinition = "org.eclipse.ditto:vorto:0.1.0";
+        final String featureDefinition = "org.eclipse.ditto:example:0.1.0";
         final TestRouteResult result = underTest.run(HttpRequest.PATCH(FEATURE_ENTRY_DEFINITION_PATH)
                 .withEntity(MediaTypes.APPLICATION_MERGE_PATCH_JSON.toContentType(), featureDefinition));
         result.assertStatusCode(StatusCodes.BAD_REQUEST);

--- a/internal/utils/persistent-actors/src/test/java/org/eclipse/ditto/internal/utils/persistentactors/MockSnapshotStorePlugin.java
+++ b/internal/utils/persistent-actors/src/test/java/org/eclipse/ditto/internal/utils/persistentactors/MockSnapshotStorePlugin.java
@@ -83,7 +83,8 @@ public class MockSnapshotStorePlugin extends SnapshotStore {
     }
 
     static void verify(final String persistenceId, final int toSequenceNr) {
-        Mockito.verify(snapshotStore).doDeleteAsync(eq(persistenceId), argThat(matchesCriteria(toSequenceNr)));
+        Mockito.verify(snapshotStore, Mockito.timeout(10000L).times(1))
+                .doDeleteAsync(eq(persistenceId), argThat(matchesCriteria(toSequenceNr)));
     }
 
     static void reset() {

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableSubjectAnnouncement.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/ImmutableSubjectAnnouncement.java
@@ -150,7 +150,7 @@ final class ImmutableSubjectAnnouncement implements SubjectAnnouncement {
                 "[beforeExpiry=" + beforeExpiry +
                 ", whenDeleted=" + whenDeleted +
                 ", requestedAcksLabels=" + requestedAcksLabels +
-                ", requestedAcksTimeout" + requestedAcksTimeout +
+                ", requestedAcksTimeout=" + requestedAcksTimeout +
                 "]";
     }
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifier.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifier.java
@@ -12,6 +12,9 @@
  */
 package org.eclipse.ditto.things.model;
 
+import java.net.URL;
+import java.util.Optional;
+
 /**
  * This interface represents a single fully qualified Identifier of a {@code Definition} both used for
  * {@code Thing} and {@code Feature}.
@@ -20,6 +23,7 @@ public interface DefinitionIdentifier extends CharSequence {
 
     /**
      * Returns the namespace of ths Identifier.
+     * Might be an empty string when the Identifier contains an {@code url} instead.
      *
      * @return the namespace.
      */
@@ -27,6 +31,7 @@ public interface DefinitionIdentifier extends CharSequence {
 
     /**
      * Returns the name of this Identifier.
+     * Might be an empty string when the Identifier contains an {@code url} instead.
      *
      * @return the name.
      */
@@ -34,14 +39,26 @@ public interface DefinitionIdentifier extends CharSequence {
 
     /**
      * Returns the version of this Identifier.
+     * Might be an empty string when the Identifier contains an {@code url} instead.
      *
      * @return the version.
      */
     String getVersion();
 
     /**
+     * Returns the optional URL of this Identifier - if this is present, the {@code namespace}, {@code name} and
+     * {@code version} strings of the definition are empty.
+     * @return
+     * @since 2.1.0
+     */
+    Optional<URL> getUrl();
+
+    /**
      * Returns the string representation of this Identifier with the following structure:
-     * {@code "namespace:name:version"}
+     * <ul>
+     * <li>either {@code "namespace:name:version"}</li>
+     * <li>or {@code "http(s)://some.url:80/some/resource.json"}</li>
+     * </ul>
      *
      * @return the string representation.
      */

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifier.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifier.java
@@ -48,7 +48,7 @@ public interface DefinitionIdentifier extends CharSequence {
     /**
      * Returns the optional URL of this Identifier - if this is present, the {@code namespace}, {@code name} and
      * {@code version} strings of the definition are empty.
-     * @return
+     * @return the optional URL.
      * @since 2.1.0
      */
     Optional<URL> getUrl();

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifierInvalidException.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifierInvalidException.java
@@ -39,8 +39,8 @@ public final class DefinitionIdentifierInvalidException extends DittoRuntimeExce
     private static final String MESSAGE_TEMPLATE = "Definition identifier <{0}> is invalid!";
 
     private static final String DEFAULT_DESCRIPTION = "An identifier string is expected to have the structure " +
-            "'namespace:name:version' where each segment must contain at least one char of [_a-zA-Z0-9\\-.] OR is " +
-            "must be a valid HTTP(s) URL.";
+            "'namespace:name:version' where each segment must contain at least one char of [_a-zA-Z0-9\\-.] " +
+            "OR it must be a valid HTTP(s) URL.";
 
     private static final long serialVersionUID = -5652551484675928573L;
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifierInvalidException.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/DefinitionIdentifierInvalidException.java
@@ -18,12 +18,12 @@ import java.text.MessageFormat;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeExceptionBuilder;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.JsonParsableException;
+import org.eclipse.ditto.json.JsonObject;
 
 /**
  * This exception is thrown if an Identifier of a Feature Definition has an invalid structure.
@@ -39,7 +39,8 @@ public final class DefinitionIdentifierInvalidException extends DittoRuntimeExce
     private static final String MESSAGE_TEMPLATE = "Definition identifier <{0}> is invalid!";
 
     private static final String DEFAULT_DESCRIPTION = "An identifier string is expected to have the structure " +
-            "'namespace:name:version'. Each segment must contain at least one char of [_a-zA-Z0-9\\-.]";
+            "'namespace:name:version' where each segment must contain at least one char of [_a-zA-Z0-9\\-.] OR is " +
+            "must be a valid HTTP(s) URL.";
 
     private static final long serialVersionUID = -5652551484675928573L;
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionIdentifier.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionIdentifier.java
@@ -14,7 +14,9 @@ package org.eclipse.ditto.things.model;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
+import java.net.URL;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -83,6 +85,11 @@ final class ImmutableFeatureDefinitionIdentifier implements DefinitionIdentifier
     @Override
     public String getVersion() {
         return delegate.getVersion();
+    }
+
+    @Override
+    public Optional<URL> getUrl() {
+        return delegate.getUrl();
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableThingDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableThingDefinition.java
@@ -133,4 +133,5 @@ final class ImmutableThingDefinition implements ThingDefinition {
     public String toString() {
         return delegate.toString();
     }
+
 }

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableThingDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableThingDefinition.java
@@ -15,7 +15,9 @@ package org.eclipse.ditto.things.model;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
+import java.net.URL;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.eclipse.ditto.json.JsonValue;
 
@@ -83,6 +85,11 @@ final class ImmutableThingDefinition implements ThingDefinition {
     @Override
     public String getVersion() {
         return delegate.getVersion();
+    }
+
+    @Override
+    public Optional<URL> getUrl() {
+        return delegate.getUrl();
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/NullFeatureDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/NullFeatureDefinition.java
@@ -12,10 +12,12 @@
  */
 package org.eclipse.ditto.things.model;
 
+import java.net.URL;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.annotation.concurrent.Immutable;
@@ -112,6 +114,11 @@ final class NullFeatureDefinition implements FeatureDefinition {
         @Override
         public String getVersion() {
             return "";
+        }
+
+        @Override
+        public Optional<URL> getUrl() {
+            return Optional.empty();
         }
 
         @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/NullThingDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/NullThingDefinition.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.things.model;
 
+import java.net.URL;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -51,6 +53,11 @@ final class NullThingDefinition implements ThingDefinition {
     @Override
     public String getVersion() {
         return "";
+    }
+
+    @Override
+    public Optional<URL> getUrl() {
+        return Optional.empty();
     }
 
     @Override

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/NullThingDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/NullThingDefinition.java
@@ -97,4 +97,5 @@ final class NullThingDefinition implements ThingDefinition {
         }
         return obj != null && getClass() == obj.getClass();
     }
+
 }

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionIdentifierTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionIdentifierTest.java
@@ -30,7 +30,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class ImmutableFeatureDefinitionIdentifierTest {
 
     private static final String NAMESPACE = "org.eclipse.ditto";
-    private static final String NAME = "vorto";
+    private static final String NAME = "example";
     private static final String VERSION = "0.1.0";
     private static final String VALID_IDENTIFIER_STRING = NAMESPACE + ":" + NAME + ":" + VERSION;
 

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionTest.java
@@ -34,10 +34,10 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 public final class ImmutableFeatureDefinitionTest {
 
     private static final DefinitionIdentifier FIRST_IDENTIFIER =
-            ThingsModelFactory.newFeatureDefinitionIdentifier("org.eclipse.ditto:vorto:0.1.0");
+            ThingsModelFactory.newFeatureDefinitionIdentifier("org.eclipse.ditto:example:0.1.0");
 
     private static final DefinitionIdentifier SECOND_IDENTIFIER =
-            ThingsModelFactory.newFeatureDefinitionIdentifier("org.eclipse.ditto:vorto:1.0.0");
+            ThingsModelFactory.newFeatureDefinitionIdentifier("org.eclipse.ditto:example:1.0.0");
 
     private static final DefinitionIdentifier THIRD_IDENTIFIER =
             ThingsModelFactory.newFeatureDefinitionIdentifier("foo:bar:2.0.0");


### PR DESCRIPTION
in addition to the namespace:name:version

* by that, support linking to e.g. WoT Thing Models (links to JSON-LD documents) in definitions
* described in the documentation how WoT elements roughly map to Ditto concepts

Fixes: #1177 