### PR TITLE
Apply e2e backpressure by using requested acks

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaCompletableMessage.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaCompletableMessage.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.kafka;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.connectivity.api.ExternalMessage;
+import org.eclipse.ditto.connectivity.service.messaging.AcknowledgeableMessage;
+
+import akka.Done;
+
+/**
+ * Wraps an {@link org.eclipse.ditto.connectivity.service.messaging.AcknowledgeableMessage} and provides a future of {@link akka.Done}
+ * which is completed successfully in all cases:
+ * <ul>
+ * <li>once the requested acknowledgement was issued/settled</li>
+ * <li>once the requested acknowledgement was rejected but not with redelivery request</li>
+ * <li>once the requested acknowledgement was rejected with redelivery request</li>
+ * </ul>
+ * Its purpose is to know when a message has been fully processed.
+ */
+@Immutable
+final class KafkaCompletableMessage {
+
+    private final AcknowledgeableMessage acknowledgeableMessage;
+    private final CompletableFuture<Done> acknowledgementFuture;
+
+    KafkaCompletableMessage(final ExternalMessage message) {
+        this.acknowledgementFuture = new CompletableFuture<>();
+        this.acknowledgeableMessage = AcknowledgeableMessage.of(message,
+                () -> acknowledgementFuture.complete(Done.getInstance()),
+                shouldRedeliver -> acknowledgementFuture.complete(Done.getInstance()));
+    }
+
+    AcknowledgeableMessage getAcknowledgeableMessage() {
+        return acknowledgeableMessage;
+    }
+
+    CompletableFuture<Done> getAcknowledgementFuture() {
+        return acknowledgementFuture;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final KafkaCompletableMessage that = (KafkaCompletableMessage) o;
+        return Objects.equals(acknowledgeableMessage, that.acknowledgeableMessage) &&
+                Objects.equals(acknowledgementFuture, that.acknowledgementFuture);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(acknowledgeableMessage, acknowledgementFuture);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "acknowledgeableMessage=" + acknowledgeableMessage +
+                ", acknowledgementFuture=" + acknowledgementFuture +
+                "]";
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaConsumerStreamFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaConsumerStreamFactory.java
@@ -86,6 +86,7 @@ final class KafkaConsumerStreamFactory {
 
         final KafkaMessageTransformer kafkaMessageTransformer = buildKafkaMessageTransformer(inboundMonitor);
         return new AtMostOnceConsumerStream(atMostOnceKafkaConsumerSourceSupplier,
+                throttlingConfig.getMaxInFlight(),
                 kafkaMessageTransformer,
                 dryRun,
                 materializer,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
@@ -12,23 +12,137 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import static org.apache.kafka.clients.consumer.ConsumerRecord.NULL_SIZE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
-import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
-import org.junit.Test;
+import java.time.Instant;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.connectivity.api.ExternalMessage;
+import org.eclipse.ditto.connectivity.service.messaging.AcknowledgeableMessage;
+import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import akka.NotUsed;
+import akka.actor.ActorSystem;
 import akka.kafka.javadsl.Consumer;
+import akka.stream.BoundedSourceQueue;
 import akka.stream.Materializer;
+import akka.stream.QueueOfferResult;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.stream.testkit.TestSubscriber;
+import akka.stream.testkit.javadsl.TestSink;
+import akka.testkit.javadsl.TestKit;
 
 public final class AtMostOnceConsumerStreamTest {
+
+    private ActorSystem actorSystem;
+    private Source<ConsumerRecord<String, String>, Consumer.Control> source;
+    private Sink<AcknowledgeableMessage, NotUsed> inboundMappingSink;
+    private final AtomicReference<BoundedSourceQueue<ConsumerRecord<String, String>>> sourceQueue =
+            new AtomicReference<>();
+    private final AtomicReference<TestSubscriber.Probe<AcknowledgeableMessage>> inboundSinkProbe =
+            new AtomicReference<>();
+
+    @Before
+    public void setUp() {
+        actorSystem = ActorSystem.create("AkkaTestSystem");
+        final Consumer.Control control = mock(Consumer.Control.class);
+        source = Source.<ConsumerRecord<String, String>>queue(1)
+                .mapMaterializedValue(queue -> {
+                    sourceQueue.set(queue);
+                    return control;
+                });
+        inboundMappingSink = TestSink.<AcknowledgeableMessage>create(actorSystem).mapMaterializedValue(probe -> {
+            // Will be set on each consumed message.
+            inboundSinkProbe.set(probe);
+            return NotUsed.getInstance();
+        });
+    }
+
+    @After
+    public void tearDown() {
+        actorSystem.terminate();
+    }
 
     @Test
     public void isImmutable() {
         assertInstancesOf(AtMostOnceConsumerStream.class,
                 areImmutable(),
-                provided(ConnectionMonitor.class, Materializer.class, Consumer.DrainingControl.class)
+                provided(ConnectionMonitor.class, Sink.class, Materializer.class, Consumer.DrainingControl.class)
                         .areAlsoImmutable());
     }
+
+    @Test
+    public void appliesBackPressureWhenMessagesAreNotAcknowledged() throws InterruptedException {
+        new TestKit(actorSystem) {{
+            /*
+             * Given we have a kafka source which emits records that are all transformed to External messages.
+             */
+            final ConsumerRecord<String, String> consumerRecord =
+                    new ConsumerRecord<>("topic", 1, 1, Instant.now().toEpochMilli(), TimestampType.LOG_APPEND_TIME,
+                            -1L, NULL_SIZE, NULL_SIZE, "Key", "Value", new RecordHeaders());
+            final AtMostOnceKafkaConsumerSourceSupplier sourceSupplier =
+                    mock(AtMostOnceKafkaConsumerSourceSupplier.class);
+            when(sourceSupplier.get()).thenReturn(source);
+            final KafkaMessageTransformer messageTransformer = mock(KafkaMessageTransformer.class);
+            final TransformationResult result = TransformationResult.successful(mock(ExternalMessage.class));
+            when(messageTransformer.transform(ArgumentMatchers.<ConsumerRecord<String, String>>any())).thenReturn(
+                    result);
+            final ConnectionMonitor connectionMonitor = mock(ConnectionMonitor.class);
+            final int maxInflight = 3;
+            final Materializer materializer = Materializer.createMaterializer(actorSystem);
+            final Sink<DittoRuntimeException, TestSubscriber.Probe<DittoRuntimeException>> dreSink =
+                    TestSink.create(actorSystem);
+
+            // When starting the stream
+            new AtMostOnceConsumerStream(sourceSupplier, maxInflight, messageTransformer, false, materializer,
+                    connectionMonitor, inboundMappingSink, dreSink);
+
+            // Then we can offer those records and they are processed in parallel to the maximum of 'maxInflight' + 1
+            for (int i = 0; i < maxInflight + 1; i++) { // +1 because one message goes to the buffer
+                assertThat(sourceQueue.get().offer(consumerRecord)).isEqualTo(QueueOfferResult.enqueued());
+                final TestSubscriber.Probe<AcknowledgeableMessage> inboundMappingSinkProbe =
+                        getInboundMappingSinkPropeAfterSleep();
+                inboundMappingSinkProbe.ensureSubscription();
+                inboundMappingSinkProbe.requestNext();
+                inboundMappingSinkProbe.expectComplete();
+            }
+
+            // Further messages are going to the buffer but are not forwarded to the mapping sink.
+            final int bufferSize = 4; // SourceQueue creates a source with buffer size 4.
+            for (int i = 0; i < bufferSize - 1; i++) { // -1 because one message already went to the buffer before
+                assertThat(sourceQueue.get().offer(consumerRecord)).isEqualTo(QueueOfferResult.enqueued());
+                final TestSubscriber.Probe<AcknowledgeableMessage> inboundMappingSinkProbe =
+                        getInboundMappingSinkPropeAfterSleep();
+                inboundMappingSinkProbe.ensureSubscription();
+                inboundMappingSinkProbe.request(1);
+                inboundMappingSinkProbe.expectNoMessage();
+            }
+
+            // Buffer is full. No messages can be offered anymore. Backpressure applies.
+            assertThat(sourceQueue.get().offer(consumerRecord)).isEqualTo(QueueOfferResult.dropped());
+        }};
+    }
+
+    private TestSubscriber.Probe<AcknowledgeableMessage> getInboundMappingSinkPropeAfterSleep()
+            throws InterruptedException {
+        TimeUnit.SECONDS.sleep(1);
+        return inboundSinkProbe.get();
+    }
+
 }

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-kafka2.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-kafka2.md
@@ -116,6 +116,25 @@ When Ditto consumes such a message it checks whether the amount of milliseconds 
 If so, the message will be ignored.
 If this is not the case or the headers are not specified at all, the message will be processed normally.
 
+#### Backpressure by using acknowledgements
+
+For Kafka Sources one can use [acknowledements](basic-acknowledgements.html) to achieve backpressure from the event/message consuming application down to the Kafka consumer in Ditto.
+So if for example [live messages](basic-messages.html) should be consumed via the Kafka connection, you could want that the consume rate adapts to the performance of the message consuming and responding application.
+
+For this scenario there is nothing that needs to be configured explicitly. Since the `live-response` is a built in acknowledgement, it is requested by default.
+The same applies for [twin modify commands](basic-signals-command.html#modify-commands). 
+For those type of commands the `twin-persisted` acknowledgement is requested automatically which would cause backpressure from the persistence to the Kafka consumer.
+
+If for some reason you don't want to have this backpressure, because losing some messages due to for example overflowing buffers is not a problem for you, you can disable requesting acknowledgements for the Kafka source.
+This can be done by configuring the following for your source:
+```json
+"acknowledgementRequests": {
+  "includes": [],
+  "filter": "fn:delete()"
+}
+```
+If you however want to achieve backpressure from an event consuming application to the Kafka consumer, you could use custom [acknowledgement requests](basic-acknowledgements.html#requesting-acks).
+
 ### Target format
 
 A Kafka 2.x connection requires the protocol configuration target object to have an `address` property.

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-kafka2.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-kafka2.md
@@ -127,12 +127,14 @@ For those type of commands the `twin-persisted` acknowledgement is requested aut
 
 If for some reason you don't want to have this backpressure, because losing some messages due to for example overflowing buffers is not a problem for you, you can disable requesting acknowledgements for the Kafka source.
 This can be done by configuring the following for your source:
+
 ```json
 "acknowledgementRequests": {
   "includes": [],
   "filter": "fn:delete()"
 }
 ```
+
 If you however want to achieve backpressure from an event consuming application to the Kafka consumer, you could use custom [acknowledgement requests](basic-acknowledgements.html#requesting-acks).
 
 ### Target format


### PR DESCRIPTION
* This makes it possible to apply backpressure even from the event/message
  consuming application back down to the kafka consumer