### PR TITLE
make readConcern and readPreference to use for MongoThingsSearchUpdaterPersistence configurable

### DIFF
--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadConcern.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadConcern.java
@@ -49,7 +49,7 @@ public enum ReadConcern {
      * @return An optional of the ReadConcern matching to the given read preference string. Empty if no matching
      * ReadConcern exists.
      */
-    static Optional<ReadConcern> ofReadConcern(final String readConcern) {
+    public static Optional<ReadConcern> ofReadConcern(final String readConcern) {
         checkNotNull(readConcern, "readConcern");
         return Arrays.stream(values())
                 .filter(c -> c.name.contentEquals(readConcern))

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadPreference.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/ReadPreference.java
@@ -47,7 +47,7 @@ public enum ReadPreference {
      * @return An optional of the ReadPreference matching to the given read preference string. Empty if no matching
      * ReadPreference exists.
      */
-    static Optional<ReadPreference> ofReadPreference(final String readPreference) {
+    public static Optional<ReadPreference> ofReadPreference(final String readPreference) {
         checkNotNull(readPreference, "readPreference");
         return Arrays.stream(values())
                 .filter(c -> c.name.contentEquals(readPreference))

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfig.java
@@ -38,6 +38,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     private final double forceUpdateProbability;
     private final BackgroundSyncConfig backgroundSyncConfig;
     private final StreamConfig streamConfig;
+    private final UpdaterPersistenceConfig updaterPersistenceConfig;
 
     private DefaultUpdaterConfig(final ConfigWithFallback updaterScopedConfig) {
         maxIdleTime = updaterScopedConfig.getNonNegativeDurationOrThrow(UpdaterConfigValue.MAX_IDLE_TIME);
@@ -49,6 +50,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
                 updaterScopedConfig.getDouble(UpdaterConfigValue.FORCE_UPDATE_PROBABILITY.getConfigPath());
         backgroundSyncConfig = DefaultBackgroundSyncConfig.fromUpdaterConfig(updaterScopedConfig);
         streamConfig = DefaultStreamConfig.of(updaterScopedConfig);
+        updaterPersistenceConfig = DefaultUpdaterPersistenceConfig.of(updaterScopedConfig);
     }
 
     /**
@@ -94,6 +96,11 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
     }
 
     @Override
+    public UpdaterPersistenceConfig getUpdaterPersistenceConfig() {
+        return updaterPersistenceConfig;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -107,13 +114,14 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
                 Objects.equals(shardingStatePollInterval, that.shardingStatePollInterval) &&
                 Double.compare(forceUpdateProbability, that.forceUpdateProbability) == 0 &&
                 Objects.equals(backgroundSyncConfig, that.backgroundSyncConfig) &&
-                Objects.equals(streamConfig, that.streamConfig);
+                Objects.equals(streamConfig, that.streamConfig) &&
+                Objects.equals(updaterPersistenceConfig, that.updaterPersistenceConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(maxIdleTime, shardingStatePollInterval, eventProcessingActive, forceUpdateProbability,
-                backgroundSyncConfig, streamConfig);
+                backgroundSyncConfig, streamConfig, updaterPersistenceConfig);
     }
 
     @Override
@@ -125,6 +133,7 @@ public final class DefaultUpdaterConfig implements UpdaterConfig {
                 ", forceUpdateProbability=" + forceUpdateProbability +
                 ", backgroundSyncConfig=" + backgroundSyncConfig +
                 ", streamConfig=" + streamConfig +
+                ", updaterPersistenceConfig=" + updaterPersistenceConfig +
                 "]";
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterPersistenceConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterPersistenceConfig.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.text.MessageFormat;
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+import org.eclipse.ditto.internal.utils.config.DittoConfigError;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.MongoDbConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class is the default implementation of {@link UpdaterPersistenceConfig}.
+ */
+@Immutable
+public final class DefaultUpdaterPersistenceConfig implements UpdaterPersistenceConfig {
+
+    private static final String CONFIG_PATH = "persistence";
+
+    private final ReadPreference readPreference;
+    private final ReadConcern readConcern;
+
+
+    private DefaultUpdaterPersistenceConfig(final ConfigWithFallback config) {
+        final var readPreferenceString =
+                config.getString(MongoDbConfig.OptionsConfig.OptionsConfigValue.READ_PREFERENCE.getConfigPath());
+        readPreference = ReadPreference.ofReadPreference(readPreferenceString)
+                .orElseThrow(() -> {
+                    final String msg =
+                            MessageFormat.format("Could not parse a ReadPreference from configured string <{0}>",
+                                    readPreferenceString);
+                    return new DittoConfigError(msg);
+                });
+        final var readConcernString =
+                config.getString(MongoDbConfig.OptionsConfig.OptionsConfigValue.READ_CONCERN.getConfigPath());
+        readConcern = ReadConcern.ofReadConcern(readConcernString)
+                .orElseThrow(() -> {
+                    final String msg =
+                            MessageFormat.format("Could not parse a ReadConcern from configured string <{0}>",
+                                    readConcernString);
+                    return new DittoConfigError(msg);
+                });
+    }
+
+    /**
+     * Returns an instance of DefaultUpdaterPersistenceConfig based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the stream config at {@value CONFIG_PATH}.
+     * @return the instance.
+     * @throws DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultUpdaterPersistenceConfig of(final Config config) {
+        return new DefaultUpdaterPersistenceConfig(ConfigWithFallback.newInstance(config, CONFIG_PATH, ConfigValue.values()));
+    }
+
+
+    @Override
+    public ReadPreference readPreference() {
+        return readPreference;
+    }
+
+    @Override
+    public ReadConcern readConcern() {
+        return readConcern;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultUpdaterPersistenceConfig that = (DefaultUpdaterPersistenceConfig) o;
+        return readPreference == that.readPreference && readConcern == that.readConcern;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(readPreference, readConcern);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "readPreference=" + readPreference +
+                ", readConcern=" + readConcern +
+                "]";
+    }
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterConfig.java
@@ -69,6 +69,13 @@ public interface UpdaterConfig {
     StreamConfig getStreamConfig();
 
     /**
+     * Returns the updater persistence config.
+     *
+     * @return the config.
+     */
+    UpdaterPersistenceConfig getUpdaterPersistenceConfig();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * UpdaterConfig.
      */

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterPersistenceConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/UpdaterPersistenceConfig.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
+
+/**
+ * Provides configuration settings of the Search updater persistence.
+ */
+@Immutable
+public interface UpdaterPersistenceConfig {
+
+    /**
+     * Gets the desired read preference that should be used for queries done in the updater persistence.
+     *
+     * @return the desired read preference.
+     */
+    ReadPreference readPreference();
+
+    /**
+     * Gets the desired read concern that should be used for queries done in the updater persistence.
+     *
+     * @return the desired read concern.
+     */
+    ReadConcern readConcern();
+
+    /**
+     * An enumeration of known config path expressions and their associated default values for {@code UpdaterPersistenceConfig}.
+     */
+    enum ConfigValue implements KnownConfigValue {
+
+        /**
+         * Determines the read preference used for MongoDB connections. See {@link ReadPreference} for available options.
+         */
+        READ_PREFERENCE("readPreference", "primaryPreferred"),
+
+        /**
+         * Determines the read concern used for MongoDB connections. See {@link ReadConcern} for available options.
+         */
+        READ_CONCERN("readConcern", "default");
+
+        private final String configPath;
+        private final Object defaultValue;
+
+        ConfigValue(final String configPath, final Object defaultValue) {
+            this.configPath = configPath;
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return configPath;
+        }
+
+    }
+
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/impl/MongoThingsSearchUpdaterPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/impl/MongoThingsSearchUpdaterPersistence.java
@@ -28,10 +28,11 @@ import org.bson.BsonInt32;
 import org.bson.BsonString;
 import org.bson.Document;
 import org.bson.conversions.Bson;
-import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.policies.api.PolicyReferenceTag;
 import org.eclipse.ditto.policies.api.PolicyTag;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.thingsearch.service.common.config.UpdaterPersistenceConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
 import org.eclipse.ditto.thingsearch.service.persistence.write.ThingsSearchUpdaterPersistence;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
@@ -54,17 +55,23 @@ public final class MongoThingsSearchUpdaterPersistence implements ThingsSearchUp
 
     private final MongoCollection<Document> collection;
 
-    private MongoThingsSearchUpdaterPersistence(final MongoDatabase database) {
-        collection = database.getCollection(PersistenceConstants.THINGS_COLLECTION_NAME);
+    private MongoThingsSearchUpdaterPersistence(final MongoDatabase database,
+            final UpdaterPersistenceConfig updaterPersistenceConfig) {
+
+        collection = database.getCollection(PersistenceConstants.THINGS_COLLECTION_NAME)
+                .withReadConcern(updaterPersistenceConfig.readConcern().getMongoReadConcern())
+                .withReadPreference(updaterPersistenceConfig.readPreference().getMongoReadPreference());
     }
 
     /**
      * Constructor.
      *
      * @param database the database.
+     * @param updaterPersistenceConfig the updater persistence config to use.
      */
-    public static ThingsSearchUpdaterPersistence of(final MongoDatabase database) {
-        return new MongoThingsSearchUpdaterPersistence(database);
+    public static ThingsSearchUpdaterPersistence of(final MongoDatabase database,
+            final UpdaterPersistenceConfig updaterPersistenceConfig) {
+        return new MongoThingsSearchUpdaterPersistence(database, updaterPersistenceConfig);
     }
 
     @Override

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
@@ -121,7 +121,8 @@ public final class SearchUpdaterRootActor extends AbstractActor {
         updaterStreamWithAcknowledgementsKillSwitch = searchUpdaterStream.start(getContext(), true);
 
         final var searchUpdaterPersistence =
-                MongoThingsSearchUpdaterPersistence.of(dittoMongoClient.getDefaultDatabase());
+                MongoThingsSearchUpdaterPersistence.of(dittoMongoClient.getDefaultDatabase(),
+                        updaterConfig.getUpdaterPersistenceConfig());
 
         pubSubMediator.tell(DistPubSubAccess.put(getSelf()), getSelf());
 

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -207,6 +207,16 @@ ditto {
         }
 
       }
+
+      persistence {
+        # read preference is one of: primary, primaryPreferred, secondary, secondaryPreferred, nearest
+        readPreference = ${ditto.mongodb.options.readPreference}
+        readPreference = ${?UPDATER_PERSISTENCE_MONGO_DB_READ_PREFERENCE}
+
+        # read concern is one of: default, local, majority, linearizable, snapshot, available
+        readConcern = ${ditto.mongodb.options.readConcern}
+        readConcern = ${?UPDATER_PERSISTENCE_MONGO_DB_READ_CONCERN}
+      }
     }
   }
 }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterConfigTest.java
@@ -45,7 +45,8 @@ public final class DefaultUpdaterConfigTest {
     @Test
     public void assertImmutability() {
         assertInstancesOf(DefaultUpdaterConfig.class, areImmutable(),
-                provided(BackgroundSyncConfig.class, DefaultStreamConfig.class).isAlsoImmutable());
+                provided(BackgroundSyncConfig.class, DefaultStreamConfig.class, DefaultUpdaterPersistenceConfig.class)
+                        .isAlsoImmutable());
     }
 
     @Test

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterPersistenceConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultUpdaterPersistenceConfigTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
+import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
+import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadConcern;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.ReadPreference;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit tests for {@link DefaultUpdaterPersistenceConfig}.
+ */
+public final class DefaultUpdaterPersistenceConfigTest {
+
+
+    private static Config config;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @BeforeClass
+    public static void initTestFixture() {
+        config = ConfigFactory.load("updater-persistence-test");
+    }
+
+    @Test
+    public void assertImmutability() {
+        assertInstancesOf(DefaultUpdaterPersistenceConfig.class,
+                areImmutable(),
+                provided(ReadPreference.class).isAlsoImmutable());
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultUpdaterPersistenceConfig.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final UpdaterPersistenceConfig underTest = DefaultUpdaterPersistenceConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.readConcern())
+                .as(UpdaterPersistenceConfig.ConfigValue.READ_CONCERN.getConfigPath())
+                .isEqualTo(ReadConcern.ofReadConcern(
+                        (String) UpdaterPersistenceConfig.ConfigValue.READ_CONCERN.getDefaultValue())
+                        .orElseThrow());
+
+        softly.assertThat(underTest.readPreference())
+                .as(UpdaterPersistenceConfig.ConfigValue.READ_PREFERENCE.getConfigPath())
+                .isEqualTo(ReadPreference.ofReadPreference(
+                        (String) UpdaterPersistenceConfig.ConfigValue.READ_PREFERENCE.getDefaultValue())
+                        .orElseThrow());
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final UpdaterPersistenceConfig underTest = DefaultUpdaterPersistenceConfig.of(config);
+
+        softly.assertThat(underTest.readConcern())
+                .as(UpdaterPersistenceConfig.ConfigValue.READ_CONCERN.getConfigPath())
+                .isEqualTo(ReadConcern.AVAILABLE);
+
+        softly.assertThat(underTest.readPreference())
+                .as(UpdaterPersistenceConfig.ConfigValue.READ_PREFERENCE.getConfigPath())
+                .isEqualTo(ReadPreference.SECONDARY_PREFERRED);
+    }
+
+}

--- a/thingsearch/service/src/test/resources/updater-persistence-test.conf
+++ b/thingsearch/service/src/test/resources/updater-persistence-test.conf
@@ -1,0 +1,6 @@
+persistence {
+  # read preference is one of: primary, primaryPreferred, secondary, secondaryPreferred, nearest
+  readPreference = secondaryPreferred
+  # read concern is one of: default, local, majority, linearizable, snapshot, available
+  readConcern = available
+}


### PR DESCRIPTION
* in order to have more fine-grained options for those very often executed queries
* defaulting to default mongoDB settings of ditto search