### PR TITLE
Revert "use classloader of EntityId to find annotated classes"

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/entity/id/BaseEntityIdFactory.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/entity/id/BaseEntityIdFactory.java
@@ -37,6 +37,7 @@ import org.eclipse.ditto.base.model.entity.type.EntityType;
  * itself.
  *
  * @param <T> the base type of the {@code EntityId}s this factory provides.
+ *
  * @since 2.1.0
  */
 abstract class BaseEntityIdFactory<T extends EntityId> {
@@ -65,8 +66,7 @@ abstract class BaseEntityIdFactory<T extends EntityId> {
     }
 
     private static Stream<Class<?>> typedEntityIdAnnotatedClasses() {
-        final Iterable<Class<?>> classIterable =
-                ClassIndex.getAnnotated(TypedEntityId.class, EntityId.class.getClassLoader());
+        final Iterable<Class<?>> classIterable = ClassIndex.getAnnotated(TypedEntityId.class);
         return StreamSupport.stream(classIterable.spliterator(), false);
     }
 


### PR DESCRIPTION
We want to revert this because of security concerns in OSGi environments where it could be problematic to switch classloaders.