### PR TITLE
Fix event publishing policy enforcement

### DIFF
--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/AbstractEnforcement.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/AbstractEnforcement.java
@@ -173,10 +173,9 @@ public abstract class AbstractEnforcement<C extends Signal<?>> {
             final Enforcer enforcer) {
 
         final var resourceKey = ResourceKey.newInstance(ThingConstants.ENTITY_TYPE, signal.getResourcePath());
-        final var effectedSubjects = enforcer.getSubjectsWithPermission(resourceKey, Permission.READ);
+        final var authorizationSubjects = enforcer.getSubjectsWithUnrestrictedPermission(resourceKey, Permission.READ);
         final var newHeaders = DittoHeaders.newBuilder(signal.getDittoHeaders())
-                .readGrantedSubjects(effectedSubjects.getGranted())
-                .readRevokedSubjects(effectedSubjects.getRevoked())
+                .readGrantedSubjects(authorizationSubjects)
                 .build();
 
         return signal.setDittoHeaders(newHeaders);

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/AuthorizedSubjectsEnforcer.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/AuthorizedSubjectsEnforcer.java
@@ -67,6 +67,12 @@ final class AuthorizedSubjectsEnforcer implements Enforcer {
     }
 
     @Override
+    public Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(final ResourceKey resourceKey,
+            final Permissions permissions) {
+        return new HashSet<>(authorizationContext.getAuthorizationSubjects());
+    }
+
+    @Override
     public JsonObject buildJsonView(final ResourceKey resourceKey,
             final Iterable<JsonField> jsonFields,
             final AuthorizationContext authorizationContext,

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/Enforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/Enforcer.java
@@ -176,6 +176,41 @@ public interface Enforcer {
             Permissions permissions);
 
     /**
+     * Returns a set of authorization subjects each of which has all the given permissions granted on the given resource
+     * or on any sub resource down in the hierarchy.
+     * Revoked permissions are taken into account.
+     *
+     * @param resourceKey the ResourceKey (containing Resource type and path) to use as starting point to check the
+     * partial permission(s) in the hierarchy for.
+     * @param permission the permission to check.
+     * @param furtherPermissions further permissions to check.
+     * @return the authorization subjects with unrestricted permissions on the passed resourceKey or any other
+     * resources in the hierarchy below.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @since 2.2.0
+     */
+    default Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(ResourceKey resourceKey,
+            final String permission, final String... furtherPermissions) {
+        return getSubjectsWithUnrestrictedPermission(resourceKey,
+                Permissions.newInstance(permission, furtherPermissions));
+    }
+
+    /**
+     * Returns a set of authorization subjects each of which has all the given permissions granted on the given resource
+     * or on any sub resource down in the hierarchy.
+     * Revoked permissions are taken into account.
+     *
+     * @param resourceKey the ResourceKey (containing Resource type and path) to use as starting point to check the
+     * partial permission(s) in the hierarchy for.
+     * @param permissions the permissions to be checked.
+     * @return the authorization subjects with unrestricted permissions on the passed resourceKey or any other
+     * resources in the hierarchy below.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @since 2.2.0
+     */
+    Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(ResourceKey resourceKey, Permissions permissions);
+
+    /**
      * Builds a view of the passed {@code jsonFields} (e.g. a {@link org.eclipse.ditto.json.JsonObject} or a {@link
      * org.eclipse.ditto.json.JsonObjectBuilder}) {@code authorizationContext} and {@code permissions}. The resulting
      * {@code JsonObject} only contains {@code JsonFields} for which the {@code authorizationContext} has the required

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonKey;
@@ -37,15 +39,6 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.auth.AuthorizationContext;
-import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
-import org.eclipse.ditto.policies.model.enforcers.tree.EffectedResources;
-import org.eclipse.ditto.policies.model.enforcers.tree.PolicyTreeNode;
-import org.eclipse.ditto.policies.model.enforcers.tree.ResourceNode;
-import org.eclipse.ditto.policies.model.enforcers.tree.SubjectNode;
-import org.eclipse.ditto.policies.model.enforcers.tree.Visitor;
-import org.eclipse.ditto.policies.model.enforcers.EffectedSubjects;
-import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.Policy;
@@ -55,6 +48,8 @@ import org.eclipse.ditto.policies.model.ResourceKey;
 import org.eclipse.ditto.policies.model.Resources;
 import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.Subjects;
+import org.eclipse.ditto.policies.model.enforcers.EffectedSubjects;
+import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 
 /**
  * Holds Algorithms to create a policy tree and to perform different policy checks on this tree.
@@ -222,6 +217,16 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         final Collection<String> authSubjectIds = getAuthorizationSubjectIds(authorizationContext);
         final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
         return visitTree(new CheckPartialPermissionsVisitor(resourcePointer, authSubjectIds, permissions));
+    }
+
+    @Override
+    public Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(final ResourceKey resourceKey,
+            final Permissions permissions) {
+
+        checkResourceKey(resourceKey);
+        checkPermissions(permissions);
+        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        return visitTree(new CollectUnrestrictedSubjectsVisitor(resourcePointer, permissions));
     }
 
     @Override

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/trie/TrieBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/trie/TrieBasedPolicyEnforcer.java
@@ -172,6 +172,20 @@ public final class TrieBasedPolicyEnforcer implements Enforcer {
     }
 
     @Override
+    public Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(final ResourceKey resourceKey,
+            final Permissions permissions) {
+        checkResourceKey(resourceKey);
+        checkPermissions(permissions);
+
+        final PolicyTrie policyTrie = seekWithFallback(resourceKey, bottomUpRevokeTrie, inheritedTrie);
+        final GrantRevokeIndex grantRevokeIndex = policyTrie.getGrantRevokeIndex();
+        final Set<AuthorizationSubject> grantedSubjects = grantRevokeIndex.getGrantedSubjects(permissions);
+        grantedSubjects.removeAll(grantRevokeIndex.getRevokedSubjects(permissions));
+
+        return grantedSubjects;
+    }
+
+    @Override
     public JsonObject buildJsonView(final ResourceKey resourceKey,
             final Iterable<JsonField> jsonFields,
             final AuthorizationContext authorizationContext,

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/testbench/algorithms/TreeBasedPolicyAlgorithm.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/testbench/algorithms/TreeBasedPolicyAlgorithm.java
@@ -59,6 +59,12 @@ public final class TreeBasedPolicyAlgorithm implements PolicyAlgorithm {
     }
 
     @Override
+    public Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(final ResourceKey resourceKey,
+            final Permissions permissions) {
+        return treeBasedPolicyEvaluator.getSubjectsWithUnrestrictedPermission(resourceKey, permissions);
+    }
+
+    @Override
     public JsonObject buildJsonView(final ResourceKey resourceKey, final Iterable<JsonField> jsonFields,
             final AuthorizationContext authorizationContext, final Permissions permissions) {
         return treeBasedPolicyEvaluator.buildJsonView(resourceKey, jsonFields, authorizationContext, permissions);

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/testbench/algorithms/TrieBasedPolicyAlgorithm.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/testbench/algorithms/TrieBasedPolicyAlgorithm.java
@@ -60,6 +60,12 @@ public final class TrieBasedPolicyAlgorithm implements PolicyAlgorithm {
     }
 
     @Override
+    public Set<AuthorizationSubject> getSubjectsWithUnrestrictedPermission(final ResourceKey resourceKey,
+            final Permissions permissions) {
+        return trieBasedPolicyEvaluator.getSubjectsWithUnrestrictedPermission(resourceKey, permissions);
+    }
+
+    @Override
     public JsonObject buildJsonView(final ResourceKey resourceKey, final Iterable<JsonField> jsonFields,
             final AuthorizationContext authorizationContext, final Permissions permissions) {
         return trieBasedPolicyEvaluator.buildJsonView(resourceKey, jsonFields, authorizationContext, permissions);

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/trie/TrieBasedPolicyEnforcerTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/trie/TrieBasedPolicyEnforcerTest.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.policies.model.enforcers.trie;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Set;
+
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonPointer;
@@ -22,6 +24,7 @@ import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
 import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.ResourceKey;
@@ -45,6 +48,37 @@ public class TrieBasedPolicyEnforcerTest {
         final JsonObject expectedJsonView = JsonFactory.nullObject();
 
         assertThat(createdJsonView).isEqualTo(expectedJsonView);
+    }
+
+    @Test
+    public void getSubjectsWithUnrestrictedPermissionDoesNotIncludeRevoked() {
+        final String featureId = "Lamp";
+
+        final AuthorizationSubject allGrantedSubject = AuthorizationSubject.newInstance("dummy:all-granted");
+        final AuthorizationSubject someRevokedSubject = AuthorizationSubject.newInstance("dummy:some-revoked");
+
+        final Permissions permissions = Permissions.newInstance("READ", "WRITE");
+        final PolicyId policyId = PolicyId.of("namespace", "id");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("connections-grant")
+                .setSubject(allGrantedSubject.getId(), SubjectType.GENERATED)
+                .setSubject(someRevokedSubject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), permissions)
+                .setGrantedPermissions(PoliciesResourceType.policyResource("/"), permissions)
+                .setGrantedPermissions(PoliciesResourceType.messageResource("/"), permissions)
+                .forLabel("connections-revoke")
+                .setSubject(someRevokedSubject.getId(), SubjectType.GENERATED)
+                .setRevokedPermissions(PoliciesResourceType.thingResource("/features/" + featureId), permissions)
+                .build();
+
+        final TrieBasedPolicyEnforcer underTest = TrieBasedPolicyEnforcer.newInstance(policy);
+
+        final Set<AuthorizationSubject> subjects =
+                underTest.getSubjectsWithUnrestrictedPermission(ResourceKey.newInstance("thing", "/"), "READ");
+
+        assertThat(subjects)
+                .isNotEmpty()
+                .doesNotContain(someRevokedSubject);
     }
 
     private static Policy defaultPolicy(final PolicyId policyId) {


### PR DESCRIPTION
The internal ditto header "read-subjects" is not calculated correctly according to the thing's policy. A revoke in the hierarchy is not treated properly. This PR fixes that issue.