### PR TITLE
explicitly configure MongoDB query batchSize same as the limit

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/MongoThingsSearchPersistence.java
@@ -233,9 +233,15 @@ public class MongoThingsSearchPersistence implements ThingsSearchPersistence {
                         .sort(sortOptions)
                         .skip(skip)
                         .projection(projection);
-        final FindPublisher<Document> findPublisherWithLimit = limit != null
-                ? findPublisher.limit(limit)
-                : findPublisher;
+
+        final FindPublisher<Document> findPublisherWithLimit;
+        if (null != limit) {
+            findPublisherWithLimit = findPublisher
+                    .limit(limit)
+                    .batchSize(limit);
+        } else {
+            findPublisherWithLimit = findPublisher;
+        }
         final FindPublisher<Document> findPublisherWithMaxQueryTime = maxQueryTime != null
                 ? findPublisherWithLimit.maxTime(maxQueryTime.getSeconds(), TimeUnit.SECONDS)
                 : findPublisherWithLimit;


### PR DESCRIPTION
in order to improve query performance