### PR TITLE
Improve kafka consumer performance

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -390,6 +390,8 @@ ditto {
             # can be defined in this configuration section.
             kafka-clients {
               enable.auto.commit = true
+              fetch.max.wait.ms = 10000
+              fetch.max.wait.ms = ${?KAFKA_CONSUMER_FETCH_MAX_WAIT_MS}
             }
           }
         }


### PR DESCRIPTION
This PR addresses two points in kafka consumer performance

1. Should reduce the CPU load in the connectivity service and number of requests/second to the kafka broker by increasing fetch.max.wait.ms to 10 seconds
2. Should reduce the consumer lag due to a lack of threads when there are a lot of consumers running