### PR TITLE
Fix search updater cache inconsistencies

### DIFF
--- a/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
+++ b/internal/models/signalenrichment/src/main/java/org/eclipse/ditto/internal/models/signalenrichment/DittoCachingSignalEnrichmentFacade.java
@@ -358,13 +358,8 @@ public final class DittoCachingSignalEnrichmentFacade implements CachingSignalEn
             }
         }
         final var enhancedJsonObject = enhanceJsonObject(jsonObject, concernedSignals, enhancedFieldSelector);
-        final ThingEvent<?> last = getLast(concernedSignals);
-        if (last instanceof ThingDeleted) {
-            extraFieldsCache.invalidate(cacheKey);
-        } else {
-            // update local cache with enhanced object:
-            extraFieldsCache.put(cacheKey, enhancedJsonObject);
-        }
+        // update local cache with enhanced object:
+        extraFieldsCache.put(cacheKey, enhancedJsonObject);
         return CompletableFuture.completedFuture(enhancedJsonObject);
     }
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyThingStrategy.java
@@ -120,7 +120,10 @@ final class ModifyThingStrategy extends AbstractThingCommandStrategy<ModifyThing
 
         final ThingBuilder.FromCopy builder = existingThing.toBuilder()
                 .setModified(eventTs)
-                .setRevision(nextRevision);
+                .setRevision(nextRevision)
+                .removeAllAttributes()
+                .removeAllFeatures()
+                .removeDefinition();
 
         thingWithModifications.getPolicyEntityId().ifPresent(builder::setPolicyId);
         thingWithModifications.getDefinition().ifPresent(builder::setDefinition);

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/ThingModifiedStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/events/ThingModifiedStrategy.java
@@ -40,7 +40,10 @@ final class ThingModifiedStrategy extends AbstractThingEventStrategy<ThingModifi
     protected ThingBuilder.FromCopy applyEvent(final ThingModified event, final ThingBuilder.FromCopy thingBuilder) {
 
         // we need to use the current thing as base otherwise we would loose its state
-        thingBuilder.setLifecycle(ThingLifecycle.ACTIVE);
+        thingBuilder.setLifecycle(ThingLifecycle.ACTIVE)
+                .removeAllAttributes()
+                .removeAllFeatures()
+                .removeDefinition();
 
         final Thing thingWithModifications = event.getThing();
         thingWithModifications.getPolicyEntityId().ifPresent(thingBuilder::setPolicyId);


### PR DESCRIPTION
Introduced by smart caching approach in search.
E.g. the "_created" field was not indexed correctly for ThingCreated events.