### PR TITLE
Reduce defaut fetch.max.wait.ms for kafka consumers to 5 seconds

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -390,7 +390,7 @@ ditto {
             # can be defined in this configuration section.
             kafka-clients {
               enable.auto.commit = true
-              fetch.max.wait.ms = 10000
+              fetch.max.wait.ms = 5000
               fetch.max.wait.ms = ${?KAFKA_CONSUMER_FETCH_MAX_WAIT_MS}
             }
           }


### PR DESCRIPTION
* We observed issues with our consumers getting rebalanced with the 10
  seconds timeout

Signed-off-by: Yannic Klem <yannic.klem@bosch.io>