### PR TITLE
Allow to configure connection.max.idle.ms via environment variable

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -406,8 +406,12 @@ ditto {
             # can be defined in this configuration section.
             kafka-clients {
               enable.auto.commit = true
-              fetch.max.wait.ms = 5000
+              fetch.max.wait.ms = 2500
               fetch.max.wait.ms = ${?KAFKA_CONSUMER_FETCH_MAX_WAIT_MS}
+              metadata.max.age.ms = 180000
+              metadata.max.age.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
+              connections.max.idle.ms = 180000
+              connections.max.idle.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
             }
           }
           metric-collecting-interval = 10s
@@ -464,7 +468,11 @@ ditto {
               # Close idle connections after the number of milliseconds specified by this config.
               # When a message should be produced after a connection was closed because of this timeout, the client
               # simply opens the connection again, so for producers there is no need to increase this value:
-              connections.max.idle.ms = 540000 # default: 540000 (9min)
+              connections.max.idle.ms = 180000
+              connections.max.idle.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
+
+              metadata.max.age.ms = 180000
+              metadata.max.age.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
 
               # The maximum amount of time in milliseconds to wait when reconnecting to a broker that has repeatedly failed to connect.
               # If provided, the backoff per host will increase exponentially for each consecutive connection failure, up to this maximum.


### PR DESCRIPTION
* Also lower fetch.max.wait.ms to 2500 to be less then hearbeat.interval.ms

Signed-off-by: Yannic Klem <yannic.klem@bosch.io>