### PR TITLE
Switch to ByteSerializer and ByteDeserializer for Kafka Consumer and Publisher

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
@@ -54,6 +54,7 @@ public final class ByteBufferUtils {
 
     /**
      * Creates an empty ByteBuffer of size 0.
+     *
      * @return an empty ByteBuffer.
      */
     public static ByteBuffer empty() {
@@ -62,6 +63,7 @@ public final class ByteBufferUtils {
 
     /**
      * Creates a string from the ByteBuffer.
+     *
      * @param byteBuffer the ByteBuffer to decode.
      * @return the ByteBuffer in UTF-8 representation or {@code null} if it was null.
      */
@@ -71,6 +73,13 @@ public final class ByteBufferUtils {
             return null;
         }
         return StandardCharsets.UTF_8.decode(byteBuffer.asReadOnlyBuffer()).toString();
+    }
+
+    public static ByteBuffer fromUtf8String(@Nullable final String string) {
+        if (null == string) {
+            return null;
+        }
+        return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.base.model.common;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 
 import javax.annotation.Nullable;
@@ -61,25 +62,46 @@ public final class ByteBufferUtils {
         return ByteBuffer.allocate(0);
     }
 
+
     /**
-     * Creates a string from the ByteBuffer.
+     * Transforms the given String to a ByteBuffer assuming UTF-8 charset.
+     *
+     * @param string the string to transform.
+     * @return the bytebuffer.
+     */
+    @Nullable
+    public static ByteBuffer fromUtf8String(@Nullable final String string) {
+        if (null == string) {
+            return null;
+        }
+        return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    /**
+     * Creates a string from the ByteBuffer assuming UTF-8 charset.
      *
      * @param byteBuffer the ByteBuffer to decode.
      * @return the ByteBuffer in UTF-8 representation or {@code null} if it was null.
      */
     @Nullable
     public static String toUtf8String(@Nullable final ByteBuffer byteBuffer) {
-        if (null == byteBuffer) {
-            return null;
-        }
-        return StandardCharsets.UTF_8.decode(byteBuffer.asReadOnlyBuffer()).toString();
+        return toString(byteBuffer, StandardCharsets.UTF_8);
     }
 
-    public static ByteBuffer fromUtf8String(@Nullable final String string) {
-        if (null == string) {
+
+    /**
+     * Creates a string from the ByteBuffer using the given charset.
+     *
+     * @param value the ByteBuffer to decode.
+     * @return the ByteBuffer or {@code null} if it was null.
+     */
+    @Nullable
+    public static String toString(final ByteBuffer value, final Charset charset) {
+        if (null == value) {
             return null;
         }
-        return ByteBuffer.wrap(string.getBytes(StandardCharsets.UTF_8));
+        return charset.decode(value.asReadOnlyBuffer()).toString();
     }
 
 }

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/common/ByteBufferUtils.java
@@ -94,7 +94,8 @@ public final class ByteBufferUtils {
      * Creates a string from the ByteBuffer using the given charset.
      *
      * @param value the ByteBuffer to decode.
-     * @return the ByteBuffer or {@code null} if it was null.
+     * @param charset the charset to use for decoding.
+     * @return the string or {@code null} if {@code value} was null.
      */
     @Nullable
     public static String toString(final ByteBuffer value, final Charset charset) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
@@ -162,7 +162,7 @@ final class AtLeastOnceConsumerStream implements KafkaConsumerStream {
         return new KafkaAcknowledgableMessage(externalMessage, committableOffset, ackMonitor);
     }
 
-    private static boolean isNotDryRun(final ConsumerRecord<String, String> cRecord, final boolean dryRun) {
+    private static boolean isNotDryRun(final ConsumerRecord<String, byte[]> cRecord, final boolean dryRun) {
         if (dryRun && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Dropping record (key: {}, topic: {}, partition: {}, offset: {}) in dry run mode.",
                     cRecord.key(), cRecord.topic(), cRecord.partition(), cRecord.offset());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -162,7 +163,7 @@ final class AtLeastOnceConsumerStream implements KafkaConsumerStream {
         return new KafkaAcknowledgableMessage(externalMessage, committableOffset, ackMonitor);
     }
 
-    private static boolean isNotDryRun(final ConsumerRecord<String, byte[]> cRecord, final boolean dryRun) {
+    private static boolean isNotDryRun(final ConsumerRecord<String, ByteBuffer> cRecord, final boolean dryRun) {
         if (dryRun && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Dropping record (key: {}, topic: {}, partition: {}, offset: {}) in dry run mode.",
                     cRecord.key(), cRecord.topic(), cRecord.partition(), cRecord.offset());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceKafkaConsumerSourceSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceKafkaConsumerSourceSupplier.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -28,7 +29,7 @@ import akka.stream.javadsl.Source;
  * {@link akka.kafka.javadsl.Consumer.Control} in order to be able to shutdown/terminate Kafka consumption.
  */
 class AtLeastOnceKafkaConsumerSourceSupplier
-        implements Supplier<Source<ConsumerMessage.CommittableMessage<String, byte[]>, Consumer.Control>> {
+        implements Supplier<Source<ConsumerMessage.CommittableMessage<String, ByteBuffer>, Consumer.Control>> {
 
     private final PropertiesFactory propertiesFactory;
     private final String sourceAddress;
@@ -42,8 +43,8 @@ class AtLeastOnceKafkaConsumerSourceSupplier
     }
 
     @Override
-    public Source<ConsumerMessage.CommittableMessage<String, byte[]>, Consumer.Control> get() {
-        final ConsumerSettings<String, byte[]> consumerSettings = propertiesFactory.getConsumerSettings(dryRun)
+    public Source<ConsumerMessage.CommittableMessage<String, ByteBuffer>, Consumer.Control> get() {
+        final ConsumerSettings<String, ByteBuffer> consumerSettings = propertiesFactory.getConsumerSettings(dryRun)
                 .withProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         final AutoSubscription subscription = Subscriptions.topics(sourceAddress);
         return Consumer.committableSource(consumerSettings, subscription);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceKafkaConsumerSourceSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceKafkaConsumerSourceSupplier.java
@@ -28,7 +28,7 @@ import akka.stream.javadsl.Source;
  * {@link akka.kafka.javadsl.Consumer.Control} in order to be able to shutdown/terminate Kafka consumption.
  */
 class AtLeastOnceKafkaConsumerSourceSupplier
-        implements Supplier<Source<ConsumerMessage.CommittableMessage<String, String>, Consumer.Control>> {
+        implements Supplier<Source<ConsumerMessage.CommittableMessage<String, byte[]>, Consumer.Control>> {
 
     private final PropertiesFactory propertiesFactory;
     private final String sourceAddress;
@@ -42,8 +42,8 @@ class AtLeastOnceKafkaConsumerSourceSupplier
     }
 
     @Override
-    public Source<ConsumerMessage.CommittableMessage<String, String>, Consumer.Control> get() {
-        final ConsumerSettings<String, String> consumerSettings = propertiesFactory.getConsumerSettings(dryRun)
+    public Source<ConsumerMessage.CommittableMessage<String, byte[]>, Consumer.Control> get() {
+        final ConsumerSettings<String, byte[]> consumerSettings = propertiesFactory.getConsumerSettings(dryRun)
                 .withProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
         final AutoSubscription subscription = Subscriptions.topics(sourceAddress);
         return Consumer.committableSource(consumerSettings, subscription);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -143,7 +144,7 @@ final class AtMostOnceConsumerStream implements KafkaConsumerStream {
         return value.getExternalMessage().isPresent();
     }
 
-    private static boolean isNotDryRun(final ConsumerRecord<String, byte[]> cRecord, final boolean dryRun) {
+    private static boolean isNotDryRun(final ConsumerRecord<String, ByteBuffer> cRecord, final boolean dryRun) {
         if (dryRun && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Dropping record (key: {}, topic: {}, partition: {}, offset: {}) in dry run mode.",
                     cRecord.key(), cRecord.topic(), cRecord.partition(), cRecord.offset());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
@@ -143,7 +143,7 @@ final class AtMostOnceConsumerStream implements KafkaConsumerStream {
         return value.getExternalMessage().isPresent();
     }
 
-    private static boolean isNotDryRun(final ConsumerRecord<String, String> cRecord, final boolean dryRun) {
+    private static boolean isNotDryRun(final ConsumerRecord<String, byte[]> cRecord, final boolean dryRun) {
         if (dryRun && LOGGER.isDebugEnabled()) {
             LOGGER.debug("Dropping record (key: {}, topic: {}, partition: {}, offset: {}) in dry run mode.",
                     cRecord.key(), cRecord.topic(), cRecord.partition(), cRecord.offset());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceKafkaConsumerSourceSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceKafkaConsumerSourceSupplier.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -27,7 +28,7 @@ import akka.stream.javadsl.Source;
  * {@link akka.kafka.javadsl.Consumer.Control} in order to be able to shutdown/terminate Kafka consumption.
  */
 class AtMostOnceKafkaConsumerSourceSupplier
-        implements Supplier<Source<ConsumerRecord<String, byte[]>, Consumer.Control>> {
+        implements Supplier<Source<ConsumerRecord<String, ByteBuffer>, Consumer.Control>> {
 
     private final PropertiesFactory propertiesFactory;
     private final String sourceAddress;
@@ -41,8 +42,8 @@ class AtMostOnceKafkaConsumerSourceSupplier
     }
 
     @Override
-    public Source<ConsumerRecord<String, byte[]>, Consumer.Control> get() {
-        final ConsumerSettings<String, byte[]> consumerSettings = propertiesFactory.getConsumerSettings(dryRun);
+    public Source<ConsumerRecord<String, ByteBuffer>, Consumer.Control> get() {
+        final ConsumerSettings<String, ByteBuffer> consumerSettings = propertiesFactory.getConsumerSettings(dryRun);
         final AutoSubscription subscription = Subscriptions.topics(sourceAddress);
         return Consumer.plainSource(consumerSettings, subscription);
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceKafkaConsumerSourceSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceKafkaConsumerSourceSupplier.java
@@ -27,7 +27,7 @@ import akka.stream.javadsl.Source;
  * {@link akka.kafka.javadsl.Consumer.Control} in order to be able to shutdown/terminate Kafka consumption.
  */
 class AtMostOnceKafkaConsumerSourceSupplier
-        implements Supplier<Source<ConsumerRecord<String, String>, Consumer.Control>> {
+        implements Supplier<Source<ConsumerRecord<String, byte[]>, Consumer.Control>> {
 
     private final PropertiesFactory propertiesFactory;
     private final String sourceAddress;
@@ -41,8 +41,8 @@ class AtMostOnceKafkaConsumerSourceSupplier
     }
 
     @Override
-    public Source<ConsumerRecord<String, String>, Consumer.Control> get() {
-        final ConsumerSettings<String, String> consumerSettings = propertiesFactory.getConsumerSettings(dryRun);
+    public Source<ConsumerRecord<String, byte[]>, Consumer.Control> get() {
+        final ConsumerSettings<String, byte[]> consumerSettings = propertiesFactory.getConsumerSettings(dryRun);
         final AutoSubscription subscription = Subscriptions.topics(sourceAddress);
         return Consumer.plainSource(consumerSettings, subscription);
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultSendProducerFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultSendProducerFactory.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
+
 import akka.actor.ActorSystem;
 import akka.kafka.ProducerSettings;
 import akka.kafka.javadsl.SendProducer;
@@ -21,10 +23,10 @@ import akka.kafka.javadsl.SendProducer;
  */
 final class DefaultSendProducerFactory implements SendProducerFactory {
 
-    private final ProducerSettings<String, byte[]> producerSettings;
+    private final ProducerSettings<String, ByteBuffer> producerSettings;
     private final ActorSystem actorSystem;
 
-    private DefaultSendProducerFactory(final ProducerSettings<String, byte[]> producerSettings,
+    private DefaultSendProducerFactory(final ProducerSettings<String, ByteBuffer> producerSettings,
             final ActorSystem actorSystem) {
 
         this.producerSettings = producerSettings;
@@ -38,14 +40,14 @@ final class DefaultSendProducerFactory implements SendProducerFactory {
      * @param actorSystem the actor system
      * @return a Kafka SendProducerFactory.
      */
-    static DefaultSendProducerFactory getInstance(final ProducerSettings<String, byte[]> producerSettings,
+    static DefaultSendProducerFactory getInstance(final ProducerSettings<String, ByteBuffer> producerSettings,
             final ActorSystem actorSystem) {
 
         return new DefaultSendProducerFactory(producerSettings, actorSystem);
     }
 
     @Override
-    public SendProducer<String, byte[]> newSendProducer() {
+    public SendProducer<String, ByteBuffer> newSendProducer() {
         return new SendProducer<>(producerSettings, actorSystem);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultSendProducerFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/DefaultSendProducerFactory.java
@@ -21,10 +21,10 @@ import akka.kafka.javadsl.SendProducer;
  */
 final class DefaultSendProducerFactory implements SendProducerFactory {
 
-    private final ProducerSettings<String, String> producerSettings;
+    private final ProducerSettings<String, byte[]> producerSettings;
     private final ActorSystem actorSystem;
 
-    private DefaultSendProducerFactory(final ProducerSettings<String, String> producerSettings,
+    private DefaultSendProducerFactory(final ProducerSettings<String, byte[]> producerSettings,
             final ActorSystem actorSystem) {
 
         this.producerSettings = producerSettings;
@@ -38,14 +38,14 @@ final class DefaultSendProducerFactory implements SendProducerFactory {
      * @param actorSystem the actor system
      * @return a Kafka SendProducerFactory.
      */
-    static DefaultSendProducerFactory getInstance(final ProducerSettings<String, String> producerSettings,
+    static DefaultSendProducerFactory getInstance(final ProducerSettings<String, byte[]> producerSettings,
             final ActorSystem actorSystem) {
 
         return new DefaultSendProducerFactory(producerSettings, actorSystem);
     }
 
     @Override
-    public SendProducer<String, String> newSendProducer() {
+    public SendProducer<String, byte[]> newSendProducer() {
         return new SendProducer<>(producerSettings, actorSystem);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaHeader.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaHeader.java
@@ -23,7 +23,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  * Defines headers that are extracted from a consumed {@code ConsumerRecord} and made available to payload and/or
  * header mappings.
  */
-enum KafkaHeader implements Function<ConsumerRecord<String, String>, Optional<String>> {
+enum KafkaHeader implements Function<ConsumerRecord<String, byte[]>, Optional<String>> {
 
     /**
      * The topic the record is received from.
@@ -39,13 +39,13 @@ enum KafkaHeader implements Function<ConsumerRecord<String, String>, Optional<St
     KAFKA_KEY("kafka.key", ConsumerRecord::key);
 
     private final String name;
-    private final Function<ConsumerRecord<String, String>, String> extractor;
+    private final Function<ConsumerRecord<String, byte[]>, String> extractor;
 
     /**
      * @param name the header name to be used in source header mappings
      */
     KafkaHeader(final String name,
-            final Function<ConsumerRecord<String, String>, String> extractor) {
+            final Function<ConsumerRecord<String, byte[]>, String> extractor) {
         this.name = name;
         this.extractor = extractor;
     }
@@ -58,7 +58,7 @@ enum KafkaHeader implements Function<ConsumerRecord<String, String>, Optional<St
     }
 
     @Override
-    public Optional<String> apply(final ConsumerRecord<String, String> consumerRecord) {
+    public Optional<String> apply(final ConsumerRecord<String, byte[]> consumerRecord) {
         return ofNullable(extractor.apply(consumerRecord));
     }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaHeader.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaHeader.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
 import static java.util.Optional.ofNullable;
 
+import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -23,7 +24,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  * Defines headers that are extracted from a consumed {@code ConsumerRecord} and made available to payload and/or
  * header mappings.
  */
-enum KafkaHeader implements Function<ConsumerRecord<String, byte[]>, Optional<String>> {
+enum KafkaHeader implements Function<ConsumerRecord<String, ByteBuffer>, Optional<String>> {
 
     /**
      * The topic the record is received from.
@@ -39,13 +40,13 @@ enum KafkaHeader implements Function<ConsumerRecord<String, byte[]>, Optional<St
     KAFKA_KEY("kafka.key", ConsumerRecord::key);
 
     private final String name;
-    private final Function<ConsumerRecord<String, byte[]>, String> extractor;
+    private final Function<ConsumerRecord<String, ByteBuffer>, String> extractor;
 
     /**
      * @param name the header name to be used in source header mappings
      */
     KafkaHeader(final String name,
-            final Function<ConsumerRecord<String, byte[]>, String> extractor) {
+            final Function<ConsumerRecord<String, ByteBuffer>, String> extractor) {
         this.name = name;
         this.extractor = extractor;
     }
@@ -58,7 +59,7 @@ enum KafkaHeader implements Function<ConsumerRecord<String, byte[]>, Optional<St
     }
 
     @Override
-    public Optional<String> apply(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public Optional<String> apply(final ConsumerRecord<String, ByteBuffer> consumerRecord) {
         return ofNullable(extractor.apply(consumerRecord));
     }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
@@ -29,7 +29,6 @@ import org.eclipse.ditto.base.model.common.CharsetDeterminer;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.headers.contenttype.ContentType;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.api.ExternalMessageFactory;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
@@ -12,8 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -74,7 +74,7 @@ final class KafkaMessageTransformer {
      */
     @Nullable
     public CommittableTransformationResult transform(
-            final ConsumerMessage.CommittableMessage<String, byte[]> committableMessage) {
+            final ConsumerMessage.CommittableMessage<String, ByteBuffer> committableMessage) {
 
         final TransformationResult result = transform(committableMessage.record());
         if (result == null) {
@@ -94,7 +94,7 @@ final class KafkaMessageTransformer {
      * automated recovery is expected.
      */
     @Nullable
-    public TransformationResult transform(final ConsumerRecord<String, byte[]> consumerRecord) {
+    public TransformationResult transform(final ConsumerRecord<String, ByteBuffer> consumerRecord) {
 
         LOGGER.trace("Received record from kafka: {}", consumerRecord);
 
@@ -107,7 +107,7 @@ final class KafkaMessageTransformer {
 
         try {
             final String key = consumerRecord.key();
-            final byte[] value = consumerRecord.value();
+            final ByteBuffer value = consumerRecord.value();
             final DittoLogger correlationIdScopedLogger = LOGGER.withCorrelationId(correlationId);
             correlationIdScopedLogger.debug(
                     "Transforming incoming kafka message <{}> with headers <{}> and key <{}>.",
@@ -115,7 +115,7 @@ final class KafkaMessageTransformer {
             );
 
             final ExternalMessage externalMessage = ExternalMessageFactory.newExternalMessageBuilder(messageHeaders)
-                    .withTextAndBytes(value == null ? null : new String(value, StandardCharsets.UTF_8), value)
+                    .withTextAndBytes(ByteBufferUtils.toUtf8String(value), value)
                     .withAuthorizationContext(source.getAuthorizationContext())
                     .withEnforcement(headerEnforcementFilterFactory.getFilter(messageHeaders))
                     .withHeaderMapping(source.getHeaderMapping())
@@ -146,7 +146,7 @@ final class KafkaMessageTransformer {
 
     }
 
-    private Map<String, String> extractMessageHeaders(final ConsumerRecord<String, byte[]> consumerRecord) {
+    private Map<String, String> extractMessageHeaders(final ConsumerRecord<String, ByteBuffer> consumerRecord) {
         final Map<String, String> messageHeaders = new HashMap<>();
         for (final Header header : consumerRecord.headers()) {
             if (messageHeaders.put(header.key(), new String(header.value())) != null) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,9 +25,11 @@ import javax.annotation.concurrent.Immutable;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.eclipse.ditto.base.model.common.ByteBufferUtils;
+import org.eclipse.ditto.base.model.common.CharsetDeterminer;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.contenttype.ContentType;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.api.ExternalMessageFactory;
@@ -114,8 +117,11 @@ final class KafkaMessageTransformer {
                     value, messageHeaders, key
             );
 
+            final Charset charset = CharsetDeterminer.getInstance()
+                    .apply(messageHeaders.get(DittoHeaderDefinition.CONTENT_TYPE.getKey()));
+
             final ExternalMessage externalMessage = ExternalMessageFactory.newExternalMessageBuilder(messageHeaders)
-                    .withTextAndBytes(ByteBufferUtils.toUtf8String(value), value)
+                    .withTextAndBytes(ByteBufferUtils.toString(value, charset), value)
                     .withAuthorizationContext(source.getAuthorizationContext())
                     .withEnforcement(headerEnforcementFilterFactory.getFilter(messageHeaders))
                     .withHeaderMapping(source.getHeaderMapping())

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActor.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
@@ -73,7 +75,6 @@ import akka.stream.javadsl.RestartFlow;
 import akka.stream.javadsl.Sink;
 import akka.stream.javadsl.Source;
 import akka.stream.javadsl.SourceQueueWithComplete;
-import akka.util.ByteString;
 
 /**
  * Responsible for publishing {@link org.eclipse.ditto.connectivity.api.ExternalMessage}s into an Kafka
@@ -93,7 +94,7 @@ final class KafkaPublisherActor extends BasePublisherActor<KafkaPublishTarget> {
             final String clientId,
             final ConnectivityStatusResolver connectivityStatusResolver,
 
-final ConnectivityConfig connectivityConfig) {
+            final ConnectivityConfig connectivityConfig) {
         super(connection, clientId, connectivityStatusResolver, connectivityConfig);
         this.dryRun = dryRun;
         final Materializer materializer = Materializer.createMaterializer(this::getContext);
@@ -311,20 +312,20 @@ final ConnectivityConfig connectivityConfig) {
                 "b) The client count of this connection is not configured high enough.";
 
         private final KillSwitch killSwitch;
-        private final SourceQueueWithComplete<ProducerMessage.Envelope<String, String, CompletableFuture<RecordMetadata>>>
+        private final SourceQueueWithComplete<ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>>>
                 sourceQueue;
-        private final AtomicReference<SendProducer<String, String>> sendProducer = new AtomicReference<>();
+        private final AtomicReference<SendProducer<String, byte[]>> sendProducer = new AtomicReference<>();
 
         private KafkaProducerStream(final KafkaProducerConfig config, final Materializer materializer,
                 final SendProducerFactory producerFactory) {
 
             final RestartSettings restartSettings =
-                    RestartSettings.create(config.getMinBackoff(),config.getMaxBackoff(), config.getRandomFactor())
+                    RestartSettings.create(config.getMinBackoff(), config.getMaxBackoff(), config.getRandomFactor())
                             .withMaxRestarts(config.getMaxRestartsCount(), config.getMaxRestartsWithin());
 
-            final Pair<SourceQueueWithComplete<ProducerMessage.Envelope<String, String, CompletableFuture<RecordMetadata>>>, Source<ProducerMessage.Envelope<String, String, CompletableFuture<RecordMetadata>>, NotUsed>>
+            final Pair<SourceQueueWithComplete<ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>>>, Source<ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>>, NotUsed>>
                     sourcePair =
-                    Source.<ProducerMessage.Envelope<String, String, CompletableFuture<RecordMetadata>>>
+                    Source.<ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>>>
                             queue(config.getQueueSize(), OverflowStrategy.dropNew()).preMaterialize(materializer);
 
             sourceQueue = sourcePair.first();
@@ -345,12 +346,12 @@ final ConnectivityConfig connectivityConfig) {
         }
 
         private void handleSendResult(
-                @Nullable final ProducerMessage.Results<String, String, CompletableFuture<RecordMetadata>> results,
+                @Nullable final ProducerMessage.Results<String, byte[], CompletableFuture<RecordMetadata>> results,
                 @Nullable final Throwable exception, final CompletableFuture<RecordMetadata> resultFuture) {
             if (exception == null) {
                 if (results instanceof ProducerMessage.Result) {
-                    final ProducerMessage.Result<String, String, CompletableFuture<RecordMetadata>> result =
-                            (ProducerMessage.Result<String, String, CompletableFuture<RecordMetadata>>) results;
+                    final ProducerMessage.Result<String, byte[], CompletableFuture<RecordMetadata>> result =
+                            (ProducerMessage.Result<String, byte[], CompletableFuture<RecordMetadata>>) results;
                     resultFuture.complete(result.metadata());
                 } else {
                     // should never happen, we provide only ProducerMessage.single to the source
@@ -370,8 +371,8 @@ final ConnectivityConfig connectivityConfig) {
                 final ExternalMessage externalMessage) {
 
             final CompletableFuture<RecordMetadata> resultFuture = new CompletableFuture<>();
-            final ProducerRecord<String, String> producerRecord = getProducerRecord(publishTarget, externalMessage);
-            final ProducerMessage.Envelope<String, String, CompletableFuture<RecordMetadata>> envelope =
+            final ProducerRecord<String, byte[]> producerRecord = getProducerRecord(publishTarget, externalMessage);
+            final ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>> envelope =
                     ProducerMessage.single(producerRecord, resultFuture);
             if (null != sourceQueue) {
                 sourceQueue.offer(envelope).whenComplete(handleQueueOfferResult(externalMessage, resultFuture));
@@ -383,10 +384,10 @@ final ConnectivityConfig connectivityConfig) {
             return resultFuture;
         }
 
-        private ProducerRecord<String, String> getProducerRecord(final KafkaPublishTarget publishTarget,
+        private ProducerRecord<String, byte[]> getProducerRecord(final KafkaPublishTarget publishTarget,
                 final ExternalMessage externalMessage) {
 
-            final String payload = mapExternalMessagePayload(externalMessage);
+            final byte[] payload = mapExternalMessagePayload(externalMessage);
             final Iterable<Header> headers = mapExternalMessageHeaders(externalMessage);
 
             return new ProducerRecord<>(publishTarget.getTopic(),
@@ -404,16 +405,18 @@ final ConnectivityConfig connectivityConfig) {
                     .collect(Collectors.toList());
         }
 
-        private String mapExternalMessagePayload(final ExternalMessage externalMessage) {
-            if (externalMessage.isTextMessage()) {
-                return externalMessage.getTextPayload().orElse("");
-            } else if (externalMessage.isBytesMessage()) {
+        private byte[] mapExternalMessagePayload(final ExternalMessage externalMessage) {
+            if (externalMessage.isBytesMessage()) {
                 return externalMessage.getBytePayload()
-                        .map(ByteString::fromByteBuffer)
-                        .map(ByteString::utf8String)
-                        .orElse("");
+                        .map(ByteBuffer::array)
+                        .orElseGet(() -> new byte[0]);
+            } else if (externalMessage.isTextMessage()) {
+                final Charset charset = getCharsetFromMessage(externalMessage);
+                return externalMessage.getTextPayload()
+                        .map(text -> text.getBytes(charset))
+                        .orElseGet(() -> new byte[0]);
             } else {
-                return "";
+                return new byte[0];
             }
         }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -22,8 +23,8 @@ import java.util.Map;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.ByteBufferDeserializer;
+import org.apache.kafka.common.serialization.ByteBufferSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.ditto.connectivity.model.Connection;
@@ -85,12 +86,12 @@ final class PropertiesFactory {
      *
      * @return the settings.
      */
-    ConsumerSettings<String, byte[]> getConsumerSettings(final boolean dryRun) {
+    ConsumerSettings<String, ByteBuffer> getConsumerSettings(final boolean dryRun) {
         final Config alpakkaConfig = this.config.getConsumerConfig().getAlpakkaConfig();
         final ConnectionCheckerSettings connectionCheckerSettings =
                 ConnectionCheckerSettings.apply(alpakkaConfig.getConfig("connection-checker"));
-        final ConsumerSettings<String, byte[]> consumerSettings =
-                ConsumerSettings.apply(alpakkaConfig, new StringDeserializer(), new ByteArrayDeserializer())
+        final ConsumerSettings<String, ByteBuffer> consumerSettings =
+                ConsumerSettings.apply(alpakkaConfig, new StringDeserializer(), new ByteBufferDeserializer())
                         .withBootstrapServers(bootstrapServers)
                         .withGroupId(connection.getId().toString())
                         .withClientId(clientId + "-consumer")
@@ -108,9 +109,9 @@ final class PropertiesFactory {
         return CommitterSettings.apply(committerConfig);
     }
 
-    ProducerSettings<String, byte[]> getProducerSettings() {
+    ProducerSettings<String, ByteBuffer> getProducerSettings() {
         final Config alpakkaConfig = this.config.getProducerConfig().getAlpakkaConfig();
-        return ProducerSettings.apply(alpakkaConfig, new StringSerializer(), new ByteArraySerializer())
+        return ProducerSettings.apply(alpakkaConfig, new StringSerializer(), new ByteBufferSerializer())
                 .withBootstrapServers(bootstrapServers)
                 .withProperties(getClientIdProperties())
                 .withProperties(getProducerSpecificConfigProperties())

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.eclipse.ditto.connectivity.model.Connection;
@@ -83,12 +85,12 @@ final class PropertiesFactory {
      *
      * @return the settings.
      */
-    ConsumerSettings<String, String> getConsumerSettings(final boolean dryRun) {
+    ConsumerSettings<String, byte[]> getConsumerSettings(final boolean dryRun) {
         final Config alpakkaConfig = this.config.getConsumerConfig().getAlpakkaConfig();
         final ConnectionCheckerSettings connectionCheckerSettings =
                 ConnectionCheckerSettings.apply(alpakkaConfig.getConfig("connection-checker"));
-        final ConsumerSettings<String, String> consumerSettings =
-                ConsumerSettings.apply(alpakkaConfig, new StringDeserializer(), new StringDeserializer())
+        final ConsumerSettings<String, byte[]> consumerSettings =
+                ConsumerSettings.apply(alpakkaConfig, new StringDeserializer(), new ByteArrayDeserializer())
                         .withBootstrapServers(bootstrapServers)
                         .withGroupId(connection.getId().toString())
                         .withClientId(clientId + "-consumer")
@@ -106,9 +108,9 @@ final class PropertiesFactory {
         return CommitterSettings.apply(committerConfig);
     }
 
-    ProducerSettings<String, String> getProducerSettings() {
+    ProducerSettings<String, byte[]> getProducerSettings() {
         final Config alpakkaConfig = this.config.getProducerConfig().getAlpakkaConfig();
-        return ProducerSettings.apply(alpakkaConfig, new StringSerializer(), new StringSerializer())
+        return ProducerSettings.apply(alpakkaConfig, new StringSerializer(), new ByteArraySerializer())
                 .withBootstrapServers(bootstrapServers)
                 .withProperties(getClientIdProperties())
                 .withProperties(getProducerSpecificConfigProperties())

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/SendProducerFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/SendProducerFactory.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
+import java.nio.ByteBuffer;
+
 import akka.kafka.javadsl.SendProducer;
 
 /**
@@ -25,6 +27,6 @@ interface SendProducerFactory {
      *
      * @return the producer.
      */
-    SendProducer<String, byte[]> newSendProducer();
+    SendProducer<String, ByteBuffer> newSendProducer();
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/SendProducerFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/SendProducerFactory.java
@@ -25,6 +25,6 @@ interface SendProducerFactory {
      *
      * @return the producer.
      */
-    SendProducer<String, String> newSendProducer();
+    SendProducer<String, byte[]> newSendProducer();
 
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStreamTest.java
@@ -20,13 +20,14 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.model.ConnectionId;
@@ -56,17 +57,17 @@ import akka.testkit.javadsl.TestKit;
 public final class AtLeastOnceConsumerStreamTest {
 
     private ActorSystem actorSystem;
-    private Source<ConsumerMessage.CommittableMessage<String, byte[]>, Consumer.Control> source;
+    private Source<ConsumerMessage.CommittableMessage<String, ByteBuffer>, Consumer.Control> source;
     private Sink<AcknowledgeableMessage, NotUsed> inboundMappingSink;
-    private final AtomicReference<BoundedSourceQueue<ConsumerMessage.CommittableMessage<String, byte[]>>> sourceQueue =
-            new AtomicReference<>();
+    private final AtomicReference<BoundedSourceQueue<ConsumerMessage.CommittableMessage<String, ByteBuffer>>>
+            sourceQueue = new AtomicReference<>();
     private TestSubscriber.Probe<AcknowledgeableMessage> inboundSinkProbe;
 
     @Before
     public void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem");
         final Consumer.Control control = mock(Consumer.Control.class);
-        source = Source.<ConsumerMessage.CommittableMessage<String, byte[]>>queue(1)
+        source = Source.<ConsumerMessage.CommittableMessage<String, ByteBuffer>>queue(1)
                 .mapMaterializedValue(queue -> {
                     sourceQueue.set(queue);
                     return control;
@@ -99,11 +100,11 @@ public final class AtLeastOnceConsumerStreamTest {
             /*
              * Given we have a kafka source which emits records that are all transformed to External messages.
              */
-            final ConsumerRecord<String, byte[]> consumerRecord =
+            final ConsumerRecord<String, ByteBuffer> consumerRecord =
                     new ConsumerRecord<>("topic", 1, 1, Instant.now().toEpochMilli(), TimestampType.LOG_APPEND_TIME,
-                            -1L, NULL_SIZE, NULL_SIZE, "Key", "Value".getBytes(StandardCharsets.UTF_8),
+                            -1L, NULL_SIZE, NULL_SIZE, "Key", ByteBufferUtils.fromUtf8String("Value"),
                             new RecordHeaders());
-            final ConsumerMessage.CommittableMessage<String, byte[]> committableMessage =
+            final ConsumerMessage.CommittableMessage<String, ByteBuffer> committableMessage =
                     new ConsumerMessage.CommittableMessage<>(consumerRecord, mock(
                             ConsumerMessage.CommittableOffset.class));
             final AtLeastOnceKafkaConsumerSourceSupplier sourceSupplier =
@@ -113,7 +114,7 @@ public final class AtLeastOnceConsumerStreamTest {
             final TransformationResult result = TransformationResult.successful(mock(ExternalMessage.class));
 
             when(messageTransformer.transform(
-                    ArgumentMatchers.<ConsumerMessage.CommittableMessage<String, byte[]>>any()))
+                    ArgumentMatchers.<ConsumerMessage.CommittableMessage<String, ByteBuffer>>any()))
                     .thenReturn(CommittableTransformationResult.of(result, committableMessage.committableOffset()));
             final ConnectionMonitor connectionMonitor = mock(ConnectionMonitor.class);
             final ConnectionMonitor ackMonitor = mock(ConnectionMonitor.class);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
@@ -20,6 +20,7 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -53,9 +54,9 @@ import akka.testkit.javadsl.TestKit;
 public final class AtMostOnceConsumerStreamTest {
 
     private ActorSystem actorSystem;
-    private Source<ConsumerRecord<String, String>, Consumer.Control> source;
+    private Source<ConsumerRecord<String, byte[]>, Consumer.Control> source;
     private Sink<AcknowledgeableMessage, NotUsed> inboundMappingSink;
-    private final AtomicReference<BoundedSourceQueue<ConsumerRecord<String, String>>> sourceQueue =
+    private final AtomicReference<BoundedSourceQueue<ConsumerRecord<String, byte[]>>> sourceQueue =
             new AtomicReference<>();
     private TestSubscriber.Probe<AcknowledgeableMessage> inboundSinkProbe;
 
@@ -63,7 +64,7 @@ public final class AtMostOnceConsumerStreamTest {
     public void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem");
         final Consumer.Control control = mock(Consumer.Control.class);
-        source = Source.<ConsumerRecord<String, String>>queue(1)
+        source = Source.<ConsumerRecord<String, byte[]>>queue(1)
                 .mapMaterializedValue(queue -> {
                     sourceQueue.set(queue);
                     return control;
@@ -96,16 +97,17 @@ public final class AtMostOnceConsumerStreamTest {
             /*
              * Given we have a kafka source which emits records that are all transformed to External messages.
              */
-            final ConsumerRecord<String, String> consumerRecord =
+            final ConsumerRecord<String, byte[]> consumerRecord =
                     new ConsumerRecord<>("topic", 1, 1, Instant.now().toEpochMilli(), TimestampType.LOG_APPEND_TIME,
-                            -1L, NULL_SIZE, NULL_SIZE, "Key", "Value", new RecordHeaders());
+                            -1L, NULL_SIZE, NULL_SIZE, "Key", "Value".getBytes(StandardCharsets.UTF_8),
+                            new RecordHeaders());
             final AtMostOnceKafkaConsumerSourceSupplier sourceSupplier =
                     mock(AtMostOnceKafkaConsumerSourceSupplier.class);
             when(sourceSupplier.get()).thenReturn(source);
             final KafkaMessageTransformer messageTransformer = mock(KafkaMessageTransformer.class);
             final TransformationResult result = TransformationResult.successful(mock(ExternalMessage.class));
-            when(messageTransformer.transform(ArgumentMatchers.<ConsumerRecord<String, String>>any())).thenReturn(
-                    result);
+            when(messageTransformer.transform(ArgumentMatchers.<ConsumerRecord<String, byte[]>>any()))
+                    .thenReturn(result);
             final ConnectionMonitor connectionMonitor = mock(ConnectionMonitor.class);
             final int maxInflight = TestConstants.KAFKA_THROTTLING_CONFIG.getMaxInFlight();
             final Materializer materializer = Materializer.createMaterializer(actorSystem);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
@@ -20,13 +20,14 @@ import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.model.ConnectionId;
@@ -54,9 +55,9 @@ import akka.testkit.javadsl.TestKit;
 public final class AtMostOnceConsumerStreamTest {
 
     private ActorSystem actorSystem;
-    private Source<ConsumerRecord<String, byte[]>, Consumer.Control> source;
+    private Source<ConsumerRecord<String, ByteBuffer>, Consumer.Control> source;
     private Sink<AcknowledgeableMessage, NotUsed> inboundMappingSink;
-    private final AtomicReference<BoundedSourceQueue<ConsumerRecord<String, byte[]>>> sourceQueue =
+    private final AtomicReference<BoundedSourceQueue<ConsumerRecord<String, ByteBuffer>>> sourceQueue =
             new AtomicReference<>();
     private TestSubscriber.Probe<AcknowledgeableMessage> inboundSinkProbe;
 
@@ -64,7 +65,7 @@ public final class AtMostOnceConsumerStreamTest {
     public void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem");
         final Consumer.Control control = mock(Consumer.Control.class);
-        source = Source.<ConsumerRecord<String, byte[]>>queue(1)
+        source = Source.<ConsumerRecord<String, ByteBuffer>>queue(1)
                 .mapMaterializedValue(queue -> {
                     sourceQueue.set(queue);
                     return control;
@@ -97,16 +98,16 @@ public final class AtMostOnceConsumerStreamTest {
             /*
              * Given we have a kafka source which emits records that are all transformed to External messages.
              */
-            final ConsumerRecord<String, byte[]> consumerRecord =
+            final ConsumerRecord<String, ByteBuffer> consumerRecord =
                     new ConsumerRecord<>("topic", 1, 1, Instant.now().toEpochMilli(), TimestampType.LOG_APPEND_TIME,
-                            -1L, NULL_SIZE, NULL_SIZE, "Key", "Value".getBytes(StandardCharsets.UTF_8),
+                            -1L, NULL_SIZE, NULL_SIZE, "Key", ByteBufferUtils.fromUtf8String("Value"),
                             new RecordHeaders());
             final AtMostOnceKafkaConsumerSourceSupplier sourceSupplier =
                     mock(AtMostOnceKafkaConsumerSourceSupplier.class);
             when(sourceSupplier.get()).thenReturn(source);
             final KafkaMessageTransformer messageTransformer = mock(KafkaMessageTransformer.class);
             final TransformationResult result = TransformationResult.successful(mock(ExternalMessage.class));
-            when(messageTransformer.transform(ArgumentMatchers.<ConsumerRecord<String, byte[]>>any()))
+            when(messageTransformer.transform(ArgumentMatchers.<ConsumerRecord<String, ByteBuffer>>any()))
                     .thenReturn(result);
             final ConnectionMonitor connectionMonitor = mock(ConnectionMonitor.class);
             final int maxInflight = TestConstants.KAFKA_THROTTLING_CONFIG.getMaxInFlight();

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaConsumerActorTest.java
@@ -19,8 +19,7 @@ import static org.eclipse.ditto.connectivity.service.messaging.TestConstants.hea
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,21 +28,18 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.common.ResponseType;
-import org.eclipse.ditto.base.service.config.supervision.DefaultExponentialBackOffConfig;
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
 import org.eclipse.ditto.connectivity.model.HeaderMapping;
 import org.eclipse.ditto.connectivity.model.PayloadMapping;
 import org.eclipse.ditto.connectivity.model.ReplyTarget;
 import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
-import org.eclipse.ditto.connectivity.service.config.DefaultConnectionConfig;
 import org.eclipse.ditto.connectivity.service.messaging.AbstractConsumerActorTest;
 import org.eclipse.ditto.connectivity.service.messaging.ConnectivityStatusResolver;
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
 import org.junit.Before;
-
-import com.typesafe.config.ConfigFactory;
 
 import akka.NotUsed;
 import akka.actor.ActorRef;
@@ -58,7 +54,7 @@ import akka.stream.javadsl.Source;
 /**
  * Tests {@code KafkaConsumerActor}.
  */
-public class KafkaConsumerActorTest extends AbstractConsumerActorTest<ConsumerRecord<String, byte[]>> {
+public class KafkaConsumerActorTest extends AbstractConsumerActorTest<ConsumerRecord<String, ByteBuffer>> {
 
     private static final Connection CONNECTION = TestConstants.createConnection();
     private static final String TOPIC = "kafka.topic";
@@ -68,14 +64,14 @@ public class KafkaConsumerActorTest extends AbstractConsumerActorTest<ConsumerRe
     private static final String CUSTOM_KEY = "the.key";
     private static final String CUSTOM_TIMESTAMP = "the.timestamp";
 
-    private BoundedSourceQueue<ConsumerRecord<String, byte[]>> sourceQueue;
-    private Source<ConsumerRecord<String, byte[]>, Consumer.Control> source;
+    private BoundedSourceQueue<ConsumerRecord<String, ByteBuffer>> sourceQueue;
+    private Source<ConsumerRecord<String, ByteBuffer>, Consumer.Control> source;
 
     @Before
     public void initKafka() {
         final Consumer.Control control = mock(Consumer.Control.class);
-        final Pair<BoundedSourceQueue<ConsumerRecord<String, byte[]>>, Source<ConsumerRecord<String, byte[]>, NotUsed>>
-                sourcePair = Source.<ConsumerRecord<String, byte[]>>queue(20)
+        final Pair<BoundedSourceQueue<ConsumerRecord<String, ByteBuffer>>, Source<ConsumerRecord<String, ByteBuffer>, NotUsed>>
+                sourcePair = Source.<ConsumerRecord<String, ByteBuffer>>queue(20)
                 .preMaterialize(Materializer.createMaterializer(actorSystem));
         sourceQueue = sourcePair.first();
         source = sourcePair.second().mapMaterializedValue(notused -> control);
@@ -142,19 +138,19 @@ public class KafkaConsumerActorTest extends AbstractConsumerActorTest<ConsumerRe
     }
 
     @Override
-    protected void consumeMessage(final ActorRef consumerActor, final ConsumerRecord<String, byte[]> inboundMessage,
+    protected void consumeMessage(final ActorRef consumerActor, final ConsumerRecord<String, ByteBuffer> inboundMessage,
             final ActorRef sender) {
         sourceQueue.offer(inboundMessage);
     }
 
     @Override
-    protected ConsumerRecord<String, byte[]> getInboundMessage(final String payload,
+    protected ConsumerRecord<String, ByteBuffer> getInboundMessage(final String payload,
             final Map.Entry<String, Object> header) {
         final Headers headers = new RecordHeaders()
                 .add(toRecordHeader(header))
                 .add(toRecordHeader(REPLY_TO_HEADER));
         return new ConsumerRecord<>(TOPIC, 1, 1, TIMESTAMP, TimestampType.LOG_APPEND_TIME,
-                -1L, NULL_SIZE, NULL_SIZE, KEY, payload.getBytes(StandardCharsets.UTF_8), headers);
+                -1L, NULL_SIZE, NULL_SIZE, KEY, ByteBufferUtils.fromUtf8String(payload), headers);
     }
 
     private RecordHeader toRecordHeader(final Map.Entry<String, ?> header) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
@@ -81,10 +82,10 @@ public final class KafkaMessageTransformerTest {
         final String deviceId = "ditto:test-device";
         final RecordHeaders headers =
                 new RecordHeaders(List.of(new RecordHeader("device_id", deviceId.getBytes(StandardCharsets.UTF_8))));
-        final ConsumerRecord<String, byte[]> consumerRecord = mock(ConsumerRecord.class);
+        final ConsumerRecord<String, ByteBuffer> consumerRecord = mock(ConsumerRecord.class);
         when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.key()).thenReturn("someKey");
-        when(consumerRecord.value()).thenReturn("someValue".getBytes(StandardCharsets.UTF_8));
+        when(consumerRecord.value()).thenReturn(ByteBufferUtils.fromUtf8String("someValue"));
         when(consumerRecord.topic()).thenReturn("someTopic");
         when(consumerRecord.timestamp()).thenReturn(TIMESTAMP);
         final TransformationResult transformResult = underTest.transform(consumerRecord);
@@ -107,8 +108,8 @@ public final class KafkaMessageTransformerTest {
         final String deviceId = "ditto:test-device";
         final RecordHeaders headers =
                 new RecordHeaders(List.of(new RecordHeader("device_id", deviceId.getBytes(StandardCharsets.UTF_8))));
-        final byte[] bytePayload = new byte[]{0, 1, 2, 7, 5, 4};
-        final ConsumerRecord<String, byte[]> consumerRecord = mock(ConsumerRecord.class);
+        final ByteBuffer bytePayload = ByteBuffer.wrap(new byte[]{0, 1, 2, 7, 5, 4});
+        final ConsumerRecord<String, ByteBuffer> consumerRecord = mock(ConsumerRecord.class);
         when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.key()).thenReturn("someKey");
         when(consumerRecord.value()).thenReturn(bytePayload);
@@ -121,8 +122,8 @@ public final class KafkaMessageTransformerTest {
         final ExternalMessage externalMessage = transformResult.getExternalMessage().get();
         assertThat(externalMessage.isTextMessage()).isTrue();
         assertThat(externalMessage.isBytesMessage()).isTrue();
-        assertThat(externalMessage.getTextPayload()).contains(new String(bytePayload, StandardCharsets.UTF_8));
-        assertThat(externalMessage.getBytePayload()).contains(ByteBuffer.wrap(bytePayload));
+        assertThat(externalMessage.getTextPayload()).contains(ByteBufferUtils.toUtf8String(bytePayload));
+        assertThat(externalMessage.getBytePayload()).contains(bytePayload);
         assertThat(externalMessage.getHeaders().get(KAFKA_TOPIC.getName())).isEqualTo("someTopic");
         assertThat(externalMessage.getHeaders().get(KAFKA_KEY.getName())).isEqualTo("someKey");
         assertThat(externalMessage.getHeaders().get(KAFKA_TIMESTAMP.getName())).isEqualTo(Long.toString(TIMESTAMP));
@@ -131,10 +132,10 @@ public final class KafkaMessageTransformerTest {
     @Test
     public void transformWithoutDeviceIdHeaderCausesDittoRuntimeException() {
         final RecordHeaders headers = new RecordHeaders(List.of());
-        final ConsumerRecord<String, byte[]> consumerRecord = mock(ConsumerRecord.class);
+        final ConsumerRecord<String, ByteBuffer> consumerRecord = mock(ConsumerRecord.class);
         when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.key()).thenReturn("someKey");
-        when(consumerRecord.value()).thenReturn("someValue".getBytes(StandardCharsets.UTF_8));
+        when(consumerRecord.value()).thenReturn(ByteBufferUtils.fromUtf8String("someValue"));
         final TransformationResult transformResult = underTest.transform(consumerRecord);
 
         assertThat(transformResult).isNotNull();
@@ -150,10 +151,10 @@ public final class KafkaMessageTransformerTest {
         final String deviceId = "ditto:test-device";
         final RecordHeaders headers =
                 new RecordHeaders(List.of(new RecordHeader("device_id", deviceId.getBytes(StandardCharsets.UTF_8))));
-        final ConsumerRecord<String, byte[]> consumerRecord = mock(ConsumerRecord.class);
+        final ConsumerRecord<String, ByteBuffer> consumerRecord = mock(ConsumerRecord.class);
         when(consumerRecord.headers()).thenReturn(headers);
         when(consumerRecord.key()).thenReturn("someKey");
-        when(consumerRecord.value()).thenReturn("someValue".getBytes(StandardCharsets.UTF_8));
+        when(consumerRecord.value()).thenReturn(ByteBufferUtils.fromUtf8String("someValue"));
         doThrow(new IllegalStateException("Expected")).when(inboundMonitor).success(any(ExternalMessage.class));
 
         final TransformationResult transformResult = underTest.transform(consumerRecord);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
@@ -130,16 +130,6 @@ public final class KafkaMessageTransformerTest {
     }
 
     @Test
-    public void temp() {
-        final String original = "Test";
-        final byte[] utf8Bytes = original.getBytes(StandardCharsets.UTF_8);
-        final byte[] originalBytes = original.getBytes(StandardCharsets.UTF_16);
-        System.out.println(new String(utf8Bytes, StandardCharsets.UTF_8));
-        System.out.println(new String(originalBytes, StandardCharsets.UTF_8));
-        System.out.println(new String(originalBytes, StandardCharsets.UTF_16));
-    }
-
-    @Test
     public void messageWithUTF16CharsetTransformedToExternalMessage() {
         final String deviceId = "ditto:test-device";
         final RecordHeaders headers =

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 import static org.eclipse.ditto.base.model.common.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.mockito.Mockito.mock;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -38,6 +39,7 @@ import org.apache.kafka.common.header.internals.RecordHeader;
 import org.awaitility.Awaitility;
 import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
 import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
+import org.eclipse.ditto.base.model.common.ByteBufferUtils;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -80,7 +82,7 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     private static final String TARGET_TOPIC = "anyTopic";
     private static final String OUTBOUND_ADDRESS = TARGET_TOPIC + "/keyA";
 
-    private final Queue<ProducerRecord<String, byte[]>> published = new ConcurrentLinkedQueue<>();
+    private final Queue<ProducerRecord<String, ByteBuffer>> published = new ConcurrentLinkedQueue<>();
 
     private final DittoConnectivityConfig connectivityConfig =
             DittoConnectivityConfig.of(DefaultScopedConfig.dittoScoped(CONFIG));
@@ -117,12 +119,12 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     @Override
     protected void verifyPublishedMessage() {
         Awaitility.await("wait for published messages").until(() -> !published.isEmpty());
-        final ProducerRecord<String, byte[]> record = checkNotNull(published.poll());
+        final ProducerRecord<String, ByteBuffer> record = checkNotNull(published.poll());
         assertThat(published).isEmpty();
         assertThat(record).isNotNull();
         assertThat(record.topic()).isEqualTo(TARGET_TOPIC);
         assertThat(record.key()).isEqualTo("keyA");
-        assertThat(record.value()).isEqualTo("payload".getBytes(StandardCharsets.UTF_8));
+        assertThat(record.value()).isEqualTo(ByteBufferUtils.fromUtf8String("payload"));
         final List<Header> headers = Arrays.asList(record.headers().toArray());
         shouldContainHeader(headers, "thing_id", TestConstants.Things.THING_ID.toString());
         shouldContainHeader(headers, "suffixed_thing_id", TestConstants.Things.THING_ID + ".some.suffix");
@@ -141,7 +143,7 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     @Override
     protected void verifyPublishedMessageToReplyTarget() {
         Awaitility.await().until(() -> !published.isEmpty());
-        final ProducerRecord<String, byte[]> record = checkNotNull(published.poll());
+        final ProducerRecord<String, ByteBuffer> record = checkNotNull(published.poll());
         assertThat(published).isEmpty();
         assertThat(record.topic()).isEqualTo("replyTarget");
         assertThat(record.key()).isEqualTo("thing:id");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaPublisherActorTest.java
@@ -80,7 +80,7 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     private static final String TARGET_TOPIC = "anyTopic";
     private static final String OUTBOUND_ADDRESS = TARGET_TOPIC + "/keyA";
 
-    private final Queue<ProducerRecord<String, String>> published = new ConcurrentLinkedQueue<>();
+    private final Queue<ProducerRecord<String, byte[]>> published = new ConcurrentLinkedQueue<>();
 
     private final DittoConnectivityConfig connectivityConfig =
             DittoConnectivityConfig.of(DefaultScopedConfig.dittoScoped(CONFIG));
@@ -117,12 +117,12 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     @Override
     protected void verifyPublishedMessage() {
         Awaitility.await("wait for published messages").until(() -> !published.isEmpty());
-        final ProducerRecord<String, String> record = checkNotNull(published.poll());
+        final ProducerRecord<String, byte[]> record = checkNotNull(published.poll());
         assertThat(published).isEmpty();
         assertThat(record).isNotNull();
         assertThat(record.topic()).isEqualTo(TARGET_TOPIC);
         assertThat(record.key()).isEqualTo("keyA");
-        assertThat(record.value()).isEqualTo("payload");
+        assertThat(record.value()).isEqualTo("payload".getBytes(StandardCharsets.UTF_8));
         final List<Header> headers = Arrays.asList(record.headers().toArray());
         shouldContainHeader(headers, "thing_id", TestConstants.Things.THING_ID.toString());
         shouldContainHeader(headers, "suffixed_thing_id", TestConstants.Things.THING_ID + ".some.suffix");
@@ -141,7 +141,7 @@ public class KafkaPublisherActorTest extends AbstractPublisherActorTest {
     @Override
     protected void verifyPublishedMessageToReplyTarget() {
         Awaitility.await().until(() -> !published.isEmpty());
-        final ProducerRecord<String, String> record = checkNotNull(published.poll());
+        final ProducerRecord<String, byte[]> record = checkNotNull(published.poll());
         assertThat(published).isEmpty();
         assertThat(record.topic()).isEqualTo("replyTarget");
         assertThat(record.key()).isEqualTo("thing:id");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/MockSendProducerFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/MockSendProducerFactory.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,12 +37,12 @@ import akka.kafka.testkit.ProducerResultFactory;
 final class MockSendProducerFactory implements SendProducerFactory {
 
     private final String targetTopic;
-    private final Queue<ProducerRecord<String, byte[]>> published;
+    private final Queue<ProducerRecord<String, ByteBuffer>> published;
     @Nullable private final RuntimeException exception;
     private final boolean blocking;
     private final AtomicBoolean wait = new AtomicBoolean();
 
-    private MockSendProducerFactory(final String targetTopic, final Queue<ProducerRecord<String, byte[]>> published,
+    private MockSendProducerFactory(final String targetTopic, final Queue<ProducerRecord<String, ByteBuffer>> published,
             final boolean blocking, final boolean slow, @Nullable final RuntimeException exception) {
         this.targetTopic = targetTopic;
         this.published = published;
@@ -51,12 +52,12 @@ final class MockSendProducerFactory implements SendProducerFactory {
     }
 
     public static MockSendProducerFactory getInstance(
-            final String targetTopic, final Queue<ProducerRecord<String, byte[]>> published) {
+            final String targetTopic, final Queue<ProducerRecord<String, ByteBuffer>> published) {
         return new MockSendProducerFactory(targetTopic, published, false, false, null);
     }
 
     public static MockSendProducerFactory getInstance(final String targetTopic,
-            final Queue<ProducerRecord<String, byte[]>> published, final RuntimeException exception) {
+            final Queue<ProducerRecord<String, ByteBuffer>> published, final RuntimeException exception) {
         return new MockSendProducerFactory(targetTopic, published, false, false, exception);
     }
 
@@ -64,7 +65,7 @@ final class MockSendProducerFactory implements SendProducerFactory {
      * Never publishes any message, returns futures that never complete.
      */
     public static MockSendProducerFactory getBlockingInstance(final String targetTopic,
-            final Queue<ProducerRecord<String, byte[]>> published) {
+            final Queue<ProducerRecord<String, ByteBuffer>> published) {
         return new MockSendProducerFactory(targetTopic, published, true, false, null);
     }
 
@@ -72,13 +73,13 @@ final class MockSendProducerFactory implements SendProducerFactory {
      * Blocks 1 second for the first message published. Continues to operate normally afterwards.
      */
     public static MockSendProducerFactory getSlowStartInstance(final String targetTopic,
-            final Queue<ProducerRecord<String, byte[]>> published) {
+            final Queue<ProducerRecord<String, ByteBuffer>> published) {
         return new MockSendProducerFactory(targetTopic, published, false, true, null);
     }
 
     @Override
-    public SendProducer<String, byte[]> newSendProducer() {
-        final SendProducer<String, byte[]> producer = mock(SendProducer.class);
+    public SendProducer<String, ByteBuffer> newSendProducer() {
+        final SendProducer<String, ByteBuffer> producer = mock(SendProducer.class);
         if (blocking) {
             when(producer.sendEnvelope(any(ProducerMessage.Envelope.class)))
                     .thenAnswer(invocationOnMock -> {
@@ -96,12 +97,12 @@ final class MockSendProducerFactory implements SendProducerFactory {
                             Thread.sleep(1000);
                         }
 
-                        final ProducerMessage.Envelope<String, byte[], CompletableFuture<RecordMetadata>> envelope =
+                        final ProducerMessage.Envelope<String, ByteBuffer, CompletableFuture<RecordMetadata>> envelope =
                                 invocationOnMock.getArgument(0);
                         final RecordMetadata dummyMetadata =
                                 new RecordMetadata(new TopicPartition(targetTopic, 5), 0L, 0L, 0L, 0L, 0, 0);
-                        final ProducerMessage.Message<String, byte[], CompletableFuture<RecordMetadata>> message =
-                                (ProducerMessage.Message<String, byte[], CompletableFuture<RecordMetadata>>) envelope;
+                        final ProducerMessage.Message<String, ByteBuffer, CompletableFuture<RecordMetadata>> message =
+                                (ProducerMessage.Message<String, ByteBuffer, CompletableFuture<RecordMetadata>>) envelope;
                         published.offer(message.record());
                         return CompletableFuture.completedStage(ProducerResultFactory.result(dummyMetadata, message));
                     });

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
@@ -90,7 +90,7 @@ public final class PropertiesFactoryTest {
 
     @Test
     public void addsBootstrapServersAndFlattensPropertiesFromProducerSettings() {
-        final ProducerSettings<String, String> producerSettings = underTest.getProducerSettings();
+        final ProducerSettings<String, byte[]> producerSettings = underTest.getProducerSettings();
         final Map<String, Object> properties = producerSettings.getProperties();
 
         final List<String> servers =
@@ -108,7 +108,7 @@ public final class PropertiesFactoryTest {
     @Test
     public void addsBootstrapServersAndFlattensPropertiesFromConsumerSettings() {
 
-        final ConsumerSettings<String, String> consumerSettings = underTest.getConsumerSettings(false);
+        final ConsumerSettings<String, byte[]> consumerSettings = underTest.getConsumerSettings(false);
         final Map<String, Object> properties = consumerSettings.getProperties();
 
         final List<String> servers =

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
@@ -16,6 +16,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.connectivity.service.messaging.TestConstants.Authorization.AUTHORIZATION_CONTEXT;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -90,7 +91,7 @@ public final class PropertiesFactoryTest {
 
     @Test
     public void addsBootstrapServersAndFlattensPropertiesFromProducerSettings() {
-        final ProducerSettings<String, byte[]> producerSettings = underTest.getProducerSettings();
+        final ProducerSettings<String, ByteBuffer> producerSettings = underTest.getProducerSettings();
         final Map<String, Object> properties = producerSettings.getProperties();
 
         final List<String> servers =
@@ -108,7 +109,7 @@ public final class PropertiesFactoryTest {
     @Test
     public void addsBootstrapServersAndFlattensPropertiesFromConsumerSettings() {
 
-        final ConsumerSettings<String, byte[]> consumerSettings = underTest.getConsumerSettings(false);
+        final ConsumerSettings<String, ByteBuffer> consumerSettings = underTest.getConsumerSettings(false);
         final Map<String, Object> properties = consumerSettings.getProperties();
 
         final List<String> servers =


### PR DESCRIPTION

* This allows us to ensure that bytes will not be modified based on charset

Signed-off-by: Yannic Klem <yannic.klem@bosch.io>