### PR TITLE
Use fully qualified container images

### DIFF
--- a/dockerfile-release
+++ b/dockerfile-release
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
+FROM docker.io/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
 
 ARG MAVEN_REPO=https://repo.eclipse.org/service/local/artifact/maven/content
 ARG SERVICE_STARTER

--- a/dockerfile-snapshot
+++ b/dockerfile-snapshot
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
+FROM docker.io/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
 
 ARG TARGET_DIR
 ARG SERVICE_STARTER

--- a/dockerfile-snapshot-arm64
+++ b/dockerfile-snapshot-arm64
@@ -9,7 +9,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 
-FROM adoptopenjdk/openjdk11-openj9:aarch64-centos-jre-11.0.10_9_openj9-0.24.0
+FROM docker.io/adoptopenjdk/openjdk11-openj9:aarch64-centos-jre-11.0.10_9_openj9-0.24.0
 
 ARG TARGET_DIR
 ARG SERVICE_STARTER


### PR DESCRIPTION
Ditto uses non-qualified container images. This may be an issue, because someone might re-configure the default so something different than `docker.io`, which would give you different images.

Some distributions require you too choose in this case, which breaks the build script of ditto:

~~~
STEP 1/12: FROM adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
? Please select an image: 
  ▸ registry.fedoraproject.org/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
    registry.access.redhat.com/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
    docker.io/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
    quay.io/adoptopenjdk/openjdk11-openj9:jdk-11.0.12_7_openj9-0.27.0-alpine-slim
~~~

The script stops with an interactive prompt.

The safest solution is to fully qualify which images you have in mind. This PR implements this.