### PR TITLE
Use npipe to communicate with docker daemon

### DIFF
--- a/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/MongoContainerFactory.java
+++ b/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/MongoContainerFactory.java
@@ -44,7 +44,7 @@ final class MongoContainerFactory {
 
     private static final MongoContainerFactory INSTANCE = new MongoContainerFactory();
     private static final String UNIX_DOCKER_HOST = "unix:///var/run/docker.sock";
-    private static final String WINDOWS_DOCKER_HOST = "tcp://localhost:2375";
+    private static final String WINDOWS_DOCKER_HOST = "npipe:////./pipe/docker_engine";
 
     private final DockerClient dockerClient;
 


### PR DESCRIPTION
* This makes the ditto build to work with the default setup of docker for desktop
* Windows users are no longer required to activate a potential security risk
  in their docker for desktop setup

Signed-off-by: Yannic Klem <Yannic.Klem@bosch.io>