### PR TITLE
Fix concurrent modification of global variables in a javascript mapper

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingSink.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingSink.java
@@ -78,7 +78,8 @@ public final class InboundMappingSink {
     /**
      * Creates a Sink which is responsible for inbound payload mapping.
      *
-     * @param inboundMappingProcessors the MessageMappingProcessors to use for inbound messages.
+     * @param inboundMappingProcessors the MessageMappingProcessors to use for inbound messages. If at least as many
+     * processors are given as `processorPoolSize`, then each processor is guaranteed to be invoked sequentially.
      * @param connectionId the connectionId
      * @param processorPoolSize how many message processing may happen in parallel per direction (incoming or outgoing).
      * @param inboundDispatchingSink used to dispatch inbound signals.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingSink.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingSink.java
@@ -159,7 +159,7 @@ public final class InboundMappingSink {
 
     private Source<InboundMappingProcessor, NotUsed> getLoopingInboundMappingProcessorSource() {
         return Source.from(inboundMappingProcessors)
-                .concatLazy(Source.lazily(this::getLoopingInboundMappingProcessorSource));
+                .concatLazy(Source.lazySource(this::getLoopingInboundMappingProcessorSource));
     }
 
     private int determinePoolSize(final int connectionPoolSize, final int maxPoolSize) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -217,7 +217,8 @@ public final class OutboundMappingProcessorActor
      * Creates Akka configuration object for this actor.
      *
      * @param clientActor the client actor that created this mapping actor.
-     * @param outboundMappingProcessors the MessageMappingProcessors to use for outbound messages.
+     * @param outboundMappingProcessors the MessageMappingProcessors to use for outbound messages. If at least as many
+     * processors are given as `processorPoolSize`, then each processor is guaranteed to be invoked sequentially.
      * @param connection the connection.
      * @param connectivityConfig the config of the connectivity service with potential overwrites.
      * @param processorPoolSize how many message processing may happen in parallel per direction (incoming or outgoing).

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -316,7 +316,7 @@ public final class OutboundMappingProcessorActor
 
     private Source<OutboundMappingProcessor, NotUsed> getOutboundMappingProcessorSource() {
         return Source.from(outboundMappingProcessors)
-                .concatLazy(Source.lazily(this::getOutboundMappingProcessorSource));
+                .concatLazy(Source.lazySource(this::getOutboundMappingProcessorSource));
     }
 
     /**
@@ -506,6 +506,7 @@ public final class OutboundMappingProcessorActor
 
     private Source<OutboundSignalWithSender, ?> handleOutboundSignal(final OutboundSignalWithSender outbound,
             final OutboundMappingProcessor outboundMappingProcessor) {
+
         final Signal<?> source = outbound.getSource();
         if (dittoLoggingAdapter.isDebugEnabled()) {
             dittoLoggingAdapter.withCorrelationId(source).debug("Handling outbound signal <{}>.", source);
@@ -531,6 +532,7 @@ public final class OutboundMappingProcessorActor
 
     private Source<OutboundSignalWithSender, ?> mapToExternalMessage(final OutboundSignalWithSender outbound,
             final OutboundMappingProcessor outboundMappingProcessor) {
+
         final ConnectionMonitor.InfoProvider infoProvider = InfoProviderFactory.forSignal(outbound.getSource());
         final Set<ConnectionMonitor> outboundMapped = getMonitorsForMappedSignal(outbound);
         final Set<ConnectionMonitor> outboundDropped = getMonitorsForDroppedSignal(outbound);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/mapping/javascript/JavaScriptMessageMapperRhinoTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/mapping/javascript/JavaScriptMessageMapperRhinoTest.java
@@ -26,7 +26,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.annotation.Nullable;
 
@@ -75,6 +77,8 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import akka.actor.ActorSystem;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
 
 /**
  * Tests the {@link JavaScriptMessageMapperRhino} by initializing different mapping templates and ensuring that they
@@ -565,11 +569,12 @@ public final class JavaScriptMessageMapperRhinoTest {
                     "}";
 
 
-
-    private static final JsonValue MAPPING_INCOMING_PROTOBUF_PARSED = JsonFactory.readFrom("{\"header\":{\"message_type\":\"SmokeEvent\",\"timestamp_ms\":\"1595043218316\",\"message_id\":\"95516572-e737-4c90-a5cd-7448f0bcaf37\",\"device_id\":\"com.bosch.cm.ivs_IVS-INTEGRATION-TEST-DEVICE\",\"boot_id\":\"a4e376c3-a288-4db8-8a7b-4657dea5f515\"},\"smoke_start_timestamp_ms\":\"1591096889617\",\"images\":[{\"timestamp_ms\":\"1591251430839\",\"id\":\"39d342bc-93b7-4765-ace6-5ae833739431\",\"camera_identifier\":\"CAM-REAR-01\"}],\"duration_in_seconds\":20,\"confidence\":220,\"total_smoke\":125,\"background_air_quality\":10,\"status\":{}}");
+    private static final JsonValue MAPPING_INCOMING_PROTOBUF_PARSED = JsonFactory.readFrom(
+            "{\"header\":{\"message_type\":\"SmokeEvent\",\"timestamp_ms\":\"1595043218316\",\"message_id\":\"95516572-e737-4c90-a5cd-7448f0bcaf37\",\"device_id\":\"com.bosch.cm.ivs_IVS-INTEGRATION-TEST-DEVICE\",\"boot_id\":\"a4e376c3-a288-4db8-8a7b-4657dea5f515\"},\"smoke_start_timestamp_ms\":\"1591096889617\",\"images\":[{\"timestamp_ms\":\"1591251430839\",\"id\":\"39d342bc-93b7-4765-ace6-5ae833739431\",\"camera_identifier\":\"CAM-REAR-01\"}],\"duration_in_seconds\":20,\"confidence\":220,\"total_smoke\":125,\"background_air_quality\":10,\"status\":{}}");
 
     private static final ByteBuffer MAPPING_INCOMING_PROTOBUF_BYTES = ByteBuffer.wrap(
-            Base64.getDecoder().decode("Co0BCgpTbW9rZUV2ZW50EIyH8P+1LhokOTU1MTY1NzItZTczNy00YzkwLWE1Y2QtNzQ0OGYwYmNhZjM3Iixjb20uYm9zY2guY20uaXZzX0lWUy1JTlRFR1JBVElPTi1URVNULURFVklDRSokYTRlMzc2YzMtYTI4OC00ZGI4LThhN2ItNDY1N2RlYTVmNTE1EJGij6anLho6CLfb5++nLhIkMzlkMzQyYmMtOTNiNy00NzY1LWFjZTYtNWFlODMzNzM5NDMxGgtDQU0tUkVBUi0wMSAUKQAAAAAAgGtAMQAAAAAAQF9AOQAAAAAAACRAQgA=")
+            Base64.getDecoder()
+                    .decode("Co0BCgpTbW9rZUV2ZW50EIyH8P+1LhokOTU1MTY1NzItZTczNy00YzkwLWE1Y2QtNzQ0OGYwYmNhZjM3Iixjb20uYm9zY2guY20uaXZzX0lWUy1JTlRFR1JBVElPTi1URVNULURFVklDRSokYTRlMzc2YzMtYTI4OC00ZGI4LThhN2ItNDY1N2RlYTVmNTE1EJGij6anLho6CLfb5++nLhIkMzlkMzQyYmMtOTNiNy00NzY1LWFjZTYtNWFlODMzNzM5NDMxGgtDQU0tUkVBUi0wMSAUKQAAAAAAgGtAMQAAAAAAQF9AOQAAAAAAACRAQgA=")
     );
 
     private static final String MAPPING_OUTGOING_PROTOBUF_JS =
@@ -753,11 +758,13 @@ public final class JavaScriptMessageMapperRhinoTest {
                 actorSystem
         );
 
-        javaScriptRhinoMapperBinaryWithByteBufferJs = JavaScriptMessageMapperFactory.createJavaScriptMessageMapperRhino();
+        javaScriptRhinoMapperBinaryWithByteBufferJs =
+                JavaScriptMessageMapperFactory.createJavaScriptMessageMapperRhino();
         javaScriptRhinoMapperBinaryWithByteBufferJs.configure(CONNECTION,
                 CONNECTIVITY_CONFIG,
                 JavaScriptMessageMapperFactory
-                        .createJavaScriptMessageMapperConfigurationBuilder("binaryWithByteBufferJS", Collections.emptyMap())
+                        .createJavaScriptMessageMapperConfigurationBuilder("binaryWithByteBufferJS",
+                                Collections.emptyMap())
                         .incomingScript(MAPPING_INCOMING_BINARY_BYTEBUFFER_JS)
                         .loadBytebufferJS(true)
                         .build(),
@@ -1075,7 +1082,6 @@ public final class JavaScriptMessageMapperRhinoTest {
                 .withText(MAPPING_INCOMING_PAYLOAD_STRING)
                 .build();
 
-
         final long startTs = System.nanoTime();
         final List<Adaptable> adaptables = javaScriptRhinoMapperPlain.map(message);
         final Adaptable adaptable = adaptables.get(0);
@@ -1381,7 +1387,8 @@ public final class JavaScriptMessageMapperRhinoTest {
             System.out.println(adaptable);
 
             System.out.println(
-                    "testBinaryWithByteBufferJsJavascriptIncomingMapping Duration: " + (System.nanoTime() - startTs) / 1_000_000.0 +
+                    "testBinaryWithByteBufferJsJavascriptIncomingMapping Duration: " +
+                            (System.nanoTime() - startTs) / 1_000_000.0 +
                             "ms");
 
             assertThat(adaptable.getTopicPath()).satisfies(topicPath -> {
@@ -1413,7 +1420,8 @@ public final class JavaScriptMessageMapperRhinoTest {
             System.out.println(adaptable);
 
             System.out.println(
-                    "testWithProtobufJsJavascriptIncomingMapping Duration: " + (System.nanoTime() - startTs) / 1_000_000.0 +
+                    "testWithProtobufJsJavascriptIncomingMapping Duration: " +
+                            (System.nanoTime() - startTs) / 1_000_000.0 +
                             "ms");
 
             assertThat(adaptable.getTopicPath()).satisfies(topicPath -> {
@@ -1458,7 +1466,8 @@ public final class JavaScriptMessageMapperRhinoTest {
             System.out.println(rawMessage);
 
             System.out.println(
-                    "testWithProtobufJsJavascriptOutgoingMapping Duration: " + (System.nanoTime() - startTs) / 1_000_000.0 +
+                    "testWithProtobufJsJavascriptOutgoingMapping Duration: " +
+                            (System.nanoTime() - startTs) / 1_000_000.0 +
                             "ms");
 
             assertThat(rawMessage.findContentType()).contains("application/vnd.google.protobuf");
@@ -1470,6 +1479,90 @@ public final class JavaScriptMessageMapperRhinoTest {
                     .map(JavaScriptMessageMapperRhinoTest::byteBuffer2String)
                     .isNotEmpty();
         });
+    }
+
+    @Test
+    public void testConcurrentJavascriptIncomingMappingUsingGlobalVariable() {
+        // GIVEN:
+        // Incoming script sleeps for the seconds specified in the text payload,
+        // then reads and sets the thing name as the value of the global variable.
+        final String incomingScript = "var $global = $global;\n" +
+                "function sleep(sec){\n" +
+                "    var start = new Date();\n" +
+                "    var now = new Date();\n" +
+                "    while(now - start < sec*1000) now = new Date();\n" +
+                "}\n" +
+                "function mapToDittoProtocolMsg(\n" +
+                "    headers,\n" +
+                "    textPayload,\n" +
+                "    bytePayload,\n" +
+                "    contentType\n" +
+                ") {\n" +
+                "    $global = textPayload;\n" +
+                "    sleep(parseInt(textPayload, 10));\n" +
+                "    let namespace = \"" + MAPPING_INCOMING_NAMESPACE + "\";\n" +
+                "    let group = \"things\";\n" +
+                "    let channel = \"twin\";\n" +
+                "    let criterion = \"commands\";\n" +
+                "    let action = \"modify\";\n" +
+                "    let path = \"" + MAPPING_INCOMING_PATH + "\";\n" +
+                "    let dittoHeaders = {};\n" +
+                "    dittoHeaders[\"correlation-id\"] = textPayload;\n" +
+                "    let value = textPayload;\n" +
+                "    let name = $global;\n" +
+                "    $global = textPayload;\n" +
+                "    return Ditto.buildDittoProtocolMsg(\n" +
+                "        namespace,\n" +
+                "        name,\n" +
+                "        group,\n" +
+                "        channel,\n" +
+                "        criterion,\n" +
+                "        action,\n" +
+                "        path,\n" +
+                "        dittoHeaders,\n" +
+                "        value\n" +
+                "    );\n" +
+                "}";
+        final var mapper = JavaScriptMessageMapperFactory.createJavaScriptMessageMapperRhino();
+        mapper.configure(CONNECTION,
+                CONNECTIVITY_CONFIG,
+                JavaScriptMessageMapperFactory
+                        .createJavaScriptMessageMapperConfigurationBuilder("plain", Collections.emptyMap())
+                        .incomingScript(incomingScript)
+                        .outgoingScript(MAPPING_OUTGOING_PLAIN)
+                        .build(),
+                actorSystem
+        );
+
+        // WHEN:
+        // Mapper is asked to map the text messages ["5", "4", "3", "2", "1"], which make the mapper sleep for 5 to 1s.
+        final Map<String, String> headers = new HashMap<>();
+        headers.put(ExternalMessage.CONTENT_TYPE_HEADER, CONTENT_TYPE_PLAIN);
+        final var messages = IntStream.range(-5, 0)
+                .map(i -> -i)
+                .mapToObj(i -> ExternalMessageFactory.newExternalMessageBuilder(headers)
+                        .withText(String.valueOf(i))
+                        .build())
+                .collect(Collectors.toList());
+
+        final var results = Source.from(messages)
+                .mapAsync(messages.size(), m -> CompletableFuture.supplyAsync(() -> mapper.map(m)))
+                .mapConcat(ms -> ms)
+                .runWith(Sink.seq(), actorSystem)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(results.size()).isEqualTo(messages.size());
+
+        // THEN:
+        // The results of the mapper should preserve the incoming message order "5", "4", "3", "2", "1".
+        // The results should not be "4", "3", "2", "1", "1" due to the global variable persisting between messages.
+        System.out.println(
+                results.stream().map(a -> a.getTopicPath().getEntityName()).collect(Collectors.joining("\n")));
+        for (int i = 0; i < results.size(); ++i) {
+            final var adaptable = results.get(i);
+            assertThat(adaptable.getTopicPath().getEntityName()).isEqualTo(String.valueOf(5 - i));
+        }
     }
 
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractConsumerActorTest.java
@@ -16,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -251,8 +252,8 @@ public abstract class AbstractConsumerActorTest<M> {
                 InboundMappingProcessor.of(connection, connectivityConfig, actorSystem, protocolAdapter, logger);
         final OutboundMappingProcessor outboundMappingProcessor =
                 OutboundMappingProcessor.of(connection, connectivityConfig, actorSystem, protocolAdapter, logger);
-        final Props props = OutboundMappingProcessorActor.props(clientActor, outboundMappingProcessor, CONNECTION,
-                connectivityConfig, 43);
+        final Props props = OutboundMappingProcessorActor.props(clientActor, List.of(outboundMappingProcessor),
+                CONNECTION, connectivityConfig, 43);
         final ActorRef outboundProcessorActor = actorSystem.actorOf(props,
                 OutboundMappingProcessorActor.ACTOR_NAME + "-" + name.getMethodName());
 
@@ -266,7 +267,7 @@ public abstract class AbstractConsumerActorTest<M> {
                 ConnectivityConfig.of(actorSystem.settings().config()),
                 null);
 
-        return InboundMappingSink.createSink(inboundMappingProcessor,
+        return InboundMappingSink.createSink(List.of(inboundMappingProcessor),
                 CONNECTION_ID,
                 99,
                 inboundDispatchingSink,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractMessageMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractMessageMappingProcessorActorTest.java
@@ -365,7 +365,8 @@ public abstract class AbstractMessageMappingProcessorActorTest {
                 ConnectivityConfig.of(actorSystem.settings().config()),
                 null);
 
-        final var inboundMappingSink = InboundMappingSink.createSink(inboundMappingProcessor,
+        final var inboundMappingSink = InboundMappingSink.createSink(
+                List.of(inboundMappingProcessor),
                 CONNECTION_ID,
                 99,
                 inboundDispatchingSink,
@@ -393,8 +394,8 @@ public abstract class AbstractMessageMappingProcessorActorTest {
                 protocolAdapter,
                 logger);
 
-        final Props props = OutboundMappingProcessorActor.props(kit.getRef(), outboundMappingProcessor, CONNECTION,
-                TestConstants.CONNECTIVITY_CONFIG, 99);
+        final Props props = OutboundMappingProcessorActor.props(kit.getRef(), List.of(outboundMappingProcessor),
+                CONNECTION, TestConstants.CONNECTIVITY_CONFIG, 99);
         return actorSystem.actorOf(props);
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingProcessorActorTest.java
@@ -73,7 +73,7 @@ public final class InboundMappingProcessorActorTest {
             final Sink<Object, ?> inboundSink =
                     Sink.foreach(x -> inboundDispatcher.ref().tell(x, ActorRef.noSender()));
             final InboundMappingProcessor throwingProcessor = createThrowingProcessor();
-            final Sink<Object, NotUsed> inboundMappingSink = InboundMappingSink.createSink(throwingProcessor,
+            final Sink<Object, NotUsed> inboundMappingSink = InboundMappingSink.createSink(List.of(throwingProcessor),
                     TestConstants.createRandomConnectionId(),
                     1,
                     inboundSink,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingProcessorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/InboundMappingProcessorTest.java
@@ -76,15 +76,7 @@ public final class InboundMappingProcessorTest {
     @BeforeClass
     public static void setUp() {
         actorSystem = ActorSystem.create("AkkaTestSystem", TestConstants.CONFIG);
-
-        logger = Mockito.mock(ThreadSafeDittoLoggingAdapter.class);
-        when(logger.withMdcEntry(Mockito.any(CharSequence.class), Mockito.nullable(CharSequence.class)))
-                .thenReturn(logger);
-        when(logger.withCorrelationId(Mockito.nullable(String.class))).thenReturn(logger);
-        when(logger.withCorrelationId(Mockito.nullable(WithDittoHeaders.class))).thenReturn(logger);
-        when(logger.withCorrelationId(Mockito.nullable(DittoHeaders.class))).thenReturn(logger);
-        when(logger.withCorrelationId(Mockito.nullable(CharSequence.class))).thenReturn(logger);
-
+        logger = TestConstants.mockThreadSafeDittoLoggingAdapter();
         protocolAdapterProvider = new DittoProtocolAdapterProvider(Mockito.mock(ProtocolConfig.class));
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
@@ -76,9 +76,11 @@ public final class MappingSinksTest {
             // then reads and sets the thing name as the value of the global variable.
             final int processorPoolSize = 5;
             final var connection = getConnection(getRacyInboundScript(), NOOP_OUTBOUND_SCRIPT, processorPoolSize);
-            final var processor = getInboundMappingProcessor(connection);
+            final var processors = IntStream.range(0, processorPoolSize)
+                    .mapToObj(i -> getInboundMappingProcessor(connection))
+                    .collect(Collectors.toList());
             final var sink = Sink.foreach(o -> testActor().tell(o, ActorRef.noSender()));
-            final var underTest = InboundMappingSink.createSink(processor, connection.getId(),
+            final var underTest = InboundMappingSink.createSink(processors, connection.getId(),
                     processorPoolSize, sink, getMappingConfig(),
                     ThrottlingConfig.of(ConfigFactory.empty()),
                     (MessageDispatcher) resource.getActorSystem().getDispatcher());
@@ -143,8 +145,10 @@ public final class MappingSinksTest {
             // then reads and sets the text payload as the value of the global variable.
             final int processorPoolSize = 5;
             final var connection = getConnection(NOOP_INBOUND_SCRIPT, getRacyOutboundScript(), processorPoolSize);
-            final var processor = getOutboundMappingProcessor(connection);
-            final Props props = OutboundMappingProcessorActor.props(testActor(), processor, connection,
+            final var processors = IntStream.range(0, processorPoolSize)
+                    .mapToObj(i -> getOutboundMappingProcessor(connection))
+                    .collect(Collectors.toList());
+            final Props props = OutboundMappingProcessorActor.props(testActor(), processors, connection,
                     TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = childActorOf(props);
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
@@ -117,7 +117,7 @@ public final class MappingSinksTest {
                         assertThat(signal).isInstanceOf(ModifyAttribute.class);
                         final var modifyAttribute = (ModifyAttribute) signal;
                         assertThat(modifyAttribute.getAttributeValue()).isEqualTo(JsonValue.of(String.valueOf(j)));
-                        assertThat(modifyAttribute.getEntityId().toString()).isEqualTo("ns:" + j);
+                        assertThat(modifyAttribute.getEntityId().toString()).hasToString("ns:" + j);
                         return null;
                     }
 
@@ -173,13 +173,14 @@ public final class MappingSinksTest {
                         expectMsgClass(FiniteDuration.apply(30, "s"), BaseClientActor.PublishMappedMessage.class);
                 assertThat(publish.getOutboundSignal().getMappedOutboundSignals()).hasSize(1);
                 final var outboundSignal = publish.getOutboundSignal().getMappedOutboundSignals().get(0);
-                assertThat(outboundSignal.getExternalMessage().getHeaders().get("i")).isEqualTo(String.valueOf(i));
+                assertThat(outboundSignal.getExternalMessage().getHeaders()).containsEntry("i", String.valueOf(i));
                 assertThat(outboundSignal.getExternalMessage().getTextPayload()).contains(String.valueOf(i));
             }
         }};
     }
 
-    private Map<String, MappingContext> getJavascriptMappings(final String inboundScript, final String outboundScript) {
+    private static Map<String, MappingContext> getJavascriptMappings(final String inboundScript,
+            final String outboundScript) {
         return Map.of("javascript", ConnectivityModelFactory.newMappingContext("JavaScript",
                 JsonObject.newBuilder()
                         .set("incomingScript", inboundScript)
@@ -188,7 +189,7 @@ public final class MappingSinksTest {
                 Map.of(), Collections.emptyMap()));
     }
 
-    private Connection getConnection(final String inboundScript, final String outboundScript, final int poolSize) {
+    private static Connection getConnection(final String inboundScript, final String outboundScript, final int poolSize) {
         final var mappings = getJavascriptMappings(inboundScript, outboundScript);
         final var definition = ConnectivityModelFactory.newPayloadMappingDefinition(mappings);
         final var payloadMapping = ConnectivityModelFactory.newPayloadMapping("javascript");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/MappingSinksTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.service.config.ThrottlingConfig;
+import org.eclipse.ditto.connectivity.api.ExternalMessage;
+import org.eclipse.ditto.connectivity.api.ExternalMessageFactory;
+import org.eclipse.ditto.connectivity.api.MappedInboundExternalMessage;
+import org.eclipse.ditto.connectivity.api.OutboundSignalFactory;
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.model.ConnectivityModelFactory;
+import org.eclipse.ditto.connectivity.model.MappingContext;
+import org.eclipse.ditto.connectivity.service.config.mapping.DefaultMappingConfig;
+import org.eclipse.ditto.connectivity.service.config.mapping.MappingConfig;
+import org.eclipse.ditto.connectivity.service.messaging.mappingoutcome.MappingOutcome;
+import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
+import org.eclipse.ditto.internal.utils.protocol.DittoProtocolAdapterProvider;
+import org.eclipse.ditto.internal.utils.protocol.config.DefaultProtocolConfig;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.protocol.TopicPath;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.modify.ModifyAttribute;
+import org.eclipse.ditto.things.model.signals.events.AttributeModified;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.dispatch.MessageDispatcher;
+import akka.stream.javadsl.Sink;
+import akka.stream.javadsl.Source;
+import akka.testkit.TestKit;
+import scala.concurrent.duration.FiniteDuration;
+
+/**
+ * Tests {@link InboundMappingSink} and its outbound equivalent.
+ */
+public final class MappingSinksTest {
+
+    private static final String NOOP_OUTBOUND_SCRIPT = "function mapFromDittoProtocolMsg(){return null;}";
+    private static final String NOOP_INBOUND_SCRIPT = "function mapToDittoProtocolMsg(){return null;}";
+
+    @Rule
+    public final ActorSystemResource resource = ActorSystemResource.newInstance(ConfigFactory.load("test"));
+
+    @Test
+    public void inboundConcurrentJsMapping() {
+        new TestKit(resource.getActorSystem()) {{
+            // GIVEN:
+            // Incoming script sleeps for the seconds specified in the text payload,
+            // then reads and sets the thing name as the value of the global variable.
+            final int processorPoolSize = 5;
+            final var connection = getConnection(getRacyInboundScript(), NOOP_OUTBOUND_SCRIPT, processorPoolSize);
+            final var processor = getInboundMappingProcessor(connection);
+            final var sink = Sink.foreach(o -> testActor().tell(o, ActorRef.noSender()));
+            final var underTest = InboundMappingSink.createSink(processor, connection.getId(),
+                    processorPoolSize, sink, getMappingConfig(),
+                    ThrottlingConfig.of(ConfigFactory.empty()),
+                    (MessageDispatcher) resource.getActorSystem().getDispatcher());
+
+            // WHEN:
+            // Mapper is asked to map the text messages ["5", "4", "3", "2", "1"], which make the mapper sleep for 5 to 1s.
+            final var messages = IntStream.range(-processorPoolSize, 0)
+                    .map(i -> -i)
+                    .<Object>mapToObj(i -> {
+                        final var string = String.valueOf(i);
+                        final var headers = Map.of("i", string, "content-type", "text/plain");
+                        final var message = ExternalMessageFactory.newExternalMessageBuilder(headers)
+                                .withText(string)
+                                .withPayloadMapping(ConnectivityModelFactory.newPayloadMapping("javascript"))
+                                .build();
+                        return new InboundMappingSink.ExternalMessageWithSender(message, testActor());
+                    })
+                    .collect(Collectors.toList());
+
+            Source.from(messages).to(underTest).run(resource.getActorSystem());
+
+            // THEN:
+            // The results of the mapper should preserve the incoming message order "5", "4", "3", "2", "1".
+            // The results should not be "4", "3", "2", "1", "1" due to the global variable persisting between messages.
+            for (int i = processorPoolSize; i > 0; --i) {
+                final var outcomes = expectMsgClass(FiniteDuration.apply(30, "s"), InboundMappingOutcomes.class);
+                assertThat(outcomes.getOutcomes()).hasSize(1);
+                final int j = i;
+                outcomes.getOutcomes().get(0).accept(new MappingOutcome.Visitor<MappedInboundExternalMessage, Void>() {
+
+                    @Override
+                    public Void onMapped(final String mapperId, final MappedInboundExternalMessage mapped) {
+                        final var signal = mapped.getSignal();
+                        assertThat(signal).isInstanceOf(ModifyAttribute.class);
+                        final var modifyAttribute = (ModifyAttribute) signal;
+                        assertThat(modifyAttribute.getAttributeValue()).isEqualTo(JsonValue.of(String.valueOf(j)));
+                        assertThat(modifyAttribute.getEntityId().toString()).isEqualTo("ns:" + j);
+                        return null;
+                    }
+
+                    @Override
+                    public Void onDropped(final String mapperId, @Nullable final ExternalMessage droppedMessage) {
+                        throw new AssertionError("Not expecting dropped: " + droppedMessage);
+                    }
+
+                    @Override
+                    public Void onError(final String mapperId, final Exception error,
+                            @Nullable final TopicPath topicPath,
+                            @Nullable final ExternalMessage externalMessage) {
+                        throw new AssertionError("Not expecting error: " + externalMessage, error);
+                    }
+                });
+            }
+        }};
+    }
+
+    @Test
+    public void outboundConcurrentJsMapping() {
+        new TestKit(resource.getActorSystem()) {{
+            // GIVEN:
+            // Outgoing script sleeps for the seconds specified in the signal entity name,
+            // then reads and sets the text payload as the value of the global variable.
+            final int processorPoolSize = 5;
+            final var connection = getConnection(NOOP_INBOUND_SCRIPT, getRacyOutboundScript(), processorPoolSize);
+            final var processor = getOutboundMappingProcessor(connection);
+            final Props props = OutboundMappingProcessorActor.props(testActor(), processor, connection,
+                    TestConstants.CONNECTIVITY_CONFIG, 3);
+            final ActorRef underTest = childActorOf(props);
+
+            // WHEN:
+            // Mapper is asked to map the events with thing names ["5", "4", "3", "2", "1"],
+            // which make the mapper sleep for 5 to 1s.
+            for (int i = processorPoolSize; i > 0; --i) {
+                final var string = String.valueOf(i);
+                final var headers = DittoHeaders.of(Map.of("i", string));
+                final var signal = AttributeModified.of(ThingId.of("ns:" + i),
+                        JsonPointer.of("/attributes/i"), JsonValue.of(i), i, null, headers, null);
+                final var message = OutboundSignalFactory.newOutboundSignal(signal, connection.getTargets());
+                underTest.tell(message, testActor());
+            }
+
+            // THEN:
+            // The results of the mapper should preserve the incoming message order with text payload
+            // "5", "4", "3", "2", "1". The results should not have text payload "4", "3", "2", "1", "1"
+            // due to the global variable persisting between messages.
+            for (int i = processorPoolSize; i > 0; --i) {
+                final var publish =
+                        expectMsgClass(FiniteDuration.apply(30, "s"), BaseClientActor.PublishMappedMessage.class);
+                assertThat(publish.getOutboundSignal().getMappedOutboundSignals()).hasSize(1);
+                final var outboundSignal = publish.getOutboundSignal().getMappedOutboundSignals().get(0);
+                assertThat(outboundSignal.getExternalMessage().getHeaders().get("i")).isEqualTo(String.valueOf(i));
+                assertThat(outboundSignal.getExternalMessage().getTextPayload()).contains(String.valueOf(i));
+            }
+        }};
+    }
+
+    private Map<String, MappingContext> getJavascriptMappings(final String inboundScript, final String outboundScript) {
+        return Map.of("javascript", ConnectivityModelFactory.newMappingContext("JavaScript",
+                JsonObject.newBuilder()
+                        .set("incomingScript", inboundScript)
+                        .set("outgoingScript", outboundScript)
+                        .build(),
+                Map.of(), Collections.emptyMap()));
+    }
+
+    private Connection getConnection(final String inboundScript, final String outboundScript, final int poolSize) {
+        final var mappings = getJavascriptMappings(inboundScript, outboundScript);
+        final var definition = ConnectivityModelFactory.newPayloadMappingDefinition(mappings);
+        final var payloadMapping = ConnectivityModelFactory.newPayloadMapping("javascript");
+        final var source = ConnectivityModelFactory.newSourceBuilder(
+                        TestConstants.Sources.SOURCES_WITH_AUTH_CONTEXT.get(0))
+                .payloadMapping(payloadMapping)
+                .build();
+        final var target = ConnectivityModelFactory.newTargetBuilder(TestConstants.Targets.TWIN_TARGET)
+                .payloadMapping(payloadMapping)
+                .build();
+        return TestConstants.createConnection()
+                .toBuilder()
+                .processorPoolSize(poolSize)
+                .payloadMappingDefinition(definition)
+                .setSources(List.of(source))
+                .setTargets(List.of(target))
+                .build();
+    }
+
+    private OutboundMappingProcessor getOutboundMappingProcessor(final Connection connection) {
+        final var provider = new DittoProtocolAdapterProvider(DefaultProtocolConfig.of(ConfigFactory.empty()));
+        final var adapter = provider.getProtocolAdapter(null);
+        final var logger = TestConstants.mockThreadSafeDittoLoggingAdapter();
+        return OutboundMappingProcessor.of(connection, TestConstants.CONNECTIVITY_CONFIG, resource.getActorSystem(),
+                adapter, logger);
+    }
+
+    private InboundMappingProcessor getInboundMappingProcessor(final Connection connection) {
+        final var provider = new DittoProtocolAdapterProvider(DefaultProtocolConfig.of(ConfigFactory.empty()));
+        final var adapter = provider.getProtocolAdapter(null);
+        final var logger = TestConstants.mockThreadSafeDittoLoggingAdapter();
+        return InboundMappingProcessor.of(connection, TestConstants.CONNECTIVITY_CONFIG, resource.getActorSystem(),
+                adapter, logger);
+    }
+
+    private static MappingConfig getMappingConfig() {
+        final var config = ConfigFactory.parseString(
+                "mapping {\n" +
+                        "  javascript {\n" +
+                        "    maxScriptSizeBytes = 50000 # 50kB\n" +
+                        "    maxScriptExecutionTime = 60s\n" +
+                        "    maxScriptStackDepth = 25\n" +
+                        "    commonJsModulePath = \"./target/test-classes/unpacked-test-webjars\"\n" +
+                        "  }\n" +
+                        "}");
+        return DefaultMappingConfig.of(config);
+    }
+
+    private static String getRacyInboundScript() {
+        return "var $global = $global;\n" +
+                "function sleep(sec) {\n" +
+                "    var start = new Date();\n" +
+                "    var now = new Date();\n" +
+                "    while(now - start < sec*1000) now = new Date();\n" +
+                "}\n" +
+                "function mapToDittoProtocolMsg(headers,textPayload,bytePayload,contentType) {\n" +
+                "    $global = textPayload;\n" +
+                "    sleep(parseInt(textPayload, 10));\n" +
+                "    let namespace = \"ns\";\n" +
+                "    let group = \"things\";\n" +
+                "    let channel = \"twin\";\n" +
+                "    let criterion = \"commands\";\n" +
+                "    let action = \"modify\";\n" +
+                "    let path = \"/attributes/i\";\n" +
+                "    let dittoHeaders = {};\n" +
+                "    dittoHeaders[\"correlation-id\"] = textPayload;\n" +
+                "    let value = textPayload;\n" +
+                "    let name = $global;\n" +
+                "    $global = textPayload;\n" +
+                "    return Ditto.buildDittoProtocolMsg(namespace,name,group,channel,criterion,action,path," +
+                "        dittoHeaders,value);\n" +
+                "}";
+    }
+
+    private static String getRacyOutboundScript() {
+        return "var $global = $global;\n" +
+                "function sleep(sec) {\n" +
+                "    var start = new Date();\n" +
+                "    var now = new Date();\n" +
+                "    while(now - start < sec*1000) now = new Date();\n" +
+                "}\n" +
+                "function mapFromDittoProtocolMsg(ns,i,g,ch,cr,a,p,h,value,s,e) {\n" +
+                "    $global = i;\n" +
+                "    sleep(parseInt(i, 10));\n" +
+                "    let payload = $global;\n" +
+                "    $global = i;\n" +
+                "    return Ditto.buildExternalMsg(h, payload, null, 'text/plain');\n" +
+                "}";
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActorTest.java
@@ -96,7 +96,7 @@ public final class OutboundMappingProcessorActorTest {
     public void sendWeakAckForAllSourcesAndTargetsWhenDroppedByAllTargets() {
         new TestKit(actorSystem) {{
             final Props props =
-                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessor(), CONNECTION,
+                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessors(), CONNECTION,
                             TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = actorSystem.actorOf(props);
 
@@ -125,7 +125,7 @@ public final class OutboundMappingProcessorActorTest {
     public void sendWeakAckWhenDroppedBySomeTarget() {
         new TestKit(actorSystem) {{
             final Props props =
-                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessor(), CONNECTION,
+                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessors(), CONNECTION,
                             TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = actorSystem.actorOf(props);
 
@@ -155,7 +155,7 @@ public final class OutboundMappingProcessorActorTest {
     public void sendWeakAckWhenDroppedByMapper() {
         new TestKit(actorSystem) {{
             final Props props =
-                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessor(), CONNECTION,
+                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessors(), CONNECTION,
                             TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = actorSystem.actorOf(props);
 
@@ -183,7 +183,7 @@ public final class OutboundMappingProcessorActorTest {
     public void doNotSendWeakAckForLiveResponse() {
         new TestKit(actorSystem) {{
             final Props props =
-                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessor(), CONNECTION,
+                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessors(), CONNECTION,
                             TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = actorSystem.actorOf(props);
 
@@ -210,7 +210,7 @@ public final class OutboundMappingProcessorActorTest {
     public void expectNoTargetIssuedAckRequestInPublishedSignals() {
         new TestKit(actorSystem) {{
             final Props props =
-                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessor(), CONNECTION,
+                    OutboundMappingProcessorActor.props(clientActorProbe.ref(), getProcessors(), CONNECTION,
                             TestConstants.CONNECTIVITY_CONFIG, 3);
             final ActorRef underTest = actorSystem.actorOf(props);
 
@@ -233,10 +233,10 @@ public final class OutboundMappingProcessorActorTest {
         }};
     }
 
-    private OutboundMappingProcessor getProcessor() {
-        return OutboundMappingProcessor.of(CONNECTION, TestConstants.CONNECTIVITY_CONFIG, actorSystem,
+    private List<OutboundMappingProcessor> getProcessors() {
+        return List.of(OutboundMappingProcessor.of(CONNECTION, TestConstants.CONNECTIVITY_CONFIG, actorSystem,
                 protocolAdapterProvider.getProtocolAdapter("test"),
-                AbstractMessageMappingProcessorActorTest.mockLoggingAdapter());
+                AbstractMessageMappingProcessorActorTest.mockLoggingAdapter()));
     }
 
     private static OutboundSignal outboundTwinEvent(final Attributes attributes, final Collection<String> requestedAcks,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
@@ -65,6 +65,7 @@ import org.eclipse.ditto.base.model.common.ResponseType;
 import org.eclipse.ditto.base.model.entity.metadata.Metadata;
 import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.model.AddressMetric;
@@ -106,6 +107,7 @@ import org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics.Conne
 import org.eclipse.ditto.connectivity.service.messaging.persistence.ConnectionSupervisorActor;
 import org.eclipse.ditto.connectivity.service.messaging.persistence.UsageBasedPriorityProvider;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.persistentactors.config.PingConfig;
@@ -232,6 +234,17 @@ public final class TestConstants {
     public static final Metadata METADATA = Metadata.newBuilder()
             .set("creator", "The epic Ditto team")
             .build();
+
+    public static ThreadSafeDittoLoggingAdapter mockThreadSafeDittoLoggingAdapter() {
+        final var logger = Mockito.mock(ThreadSafeDittoLoggingAdapter.class);
+        when(logger.withMdcEntry(Mockito.any(CharSequence.class), Mockito.nullable(CharSequence.class)))
+                .thenReturn(logger);
+        when(logger.withCorrelationId(Mockito.nullable(String.class))).thenReturn(logger);
+        when(logger.withCorrelationId(Mockito.nullable(WithDittoHeaders.class))).thenReturn(logger);
+        when(logger.withCorrelationId(Mockito.nullable(DittoHeaders.class))).thenReturn(logger);
+        when(logger.withCorrelationId(Mockito.nullable(CharSequence.class))).thenReturn(logger);
+        return logger;
+    }
 
     public static DittoProtocolSub dummyDittoProtocolSub(final ActorRef pubSubMediator) {
         return dummyDittoProtocolSub(pubSubMediator, null);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -329,7 +330,7 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
                 ConnectivityConfig.of(actorSystem.settings().config()),
                 null);
 
-        return InboundMappingSink.createSink(inboundMappingProcessor,
+        return InboundMappingSink.createSink(List.of(inboundMappingProcessor),
                 CONNECTION_ID,
                 99,
                 inboundDispatchingSink,

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -179,7 +179,7 @@ ditto {
       parallelism = 1
       javascript {
         maxScriptSizeBytes = 50000 # 50kB
-        maxScriptExecutionTime = 5000ms
+        maxScriptExecutionTime = 30000ms
         maxScriptStackDepth = 25
         commonJsModulePath = "./target/test-classes/unpacked-test-webjars"
       }

--- a/pom.xml
+++ b/pom.xml
@@ -562,6 +562,7 @@
                         <header>${project.basedir}/src/license-header-2018.txt</header>
                         <header>${project.basedir}/src/license-header-2019.txt</header>
                         <header>${project.basedir}/src/license-header-2020.txt</header>
+                        <header>${project.basedir}/src/license-header-2021.txt</header>
                     </validHeaders>
                     <aggregate>true</aggregate>
                     <quiet>false</quiet>

--- a/src/license-header-2021.txt
+++ b/src/license-header-2021.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2022 Contributors to the Eclipse Foundation
+Copyright (c) 2021 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional
 information regarding copyright ownership.


### PR DESCRIPTION
The javascript payload mapper of a connection can set the global variables of one another during parallel message mapping. It introduces nondeterminism in mapper execution and makes it harder to debug.

This patch made it so that instances of a javascript mapper running in parallel cannot modify the global variables of each other. Global variables remain persistent for performance, but their initial state in a mapper instance can come from any previous mapper instance.