### PR TITLE
Fix dead client actor refs of other client actors

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
@@ -55,6 +55,16 @@ public final class ClientActorRefs {
         sortedRefs = sort(refsByPath);
     }
 
+    /**
+     * Add a new client actor.
+     *
+     * @param newClientActors the new client actors.
+     */
+    public void add(final List<ActorRef> newClientActors) {
+        newClientActors.forEach(newClientActor -> refsByPath.put(newClientActor.path(), newClientActor));
+        sortedRefs = sort(refsByPath);
+    }
+
     public void remove(final ActorRef deadClientActor) {
         refsByPath.remove(deadClientActor.path());
         sortedRefs = sort(refsByPath);
@@ -107,6 +117,14 @@ public final class ClientActorRefs {
             final int i = Math.max(0, Math.abs(index));
             return Optional.of(sortedRefs.get(i % sortedRefs.size()));
         }
+    }
+
+    public int size() {
+        return sortedRefs.size();
+    }
+
+    public List<ActorRef> getSortedRefs() {
+        return sortedRefs;
     }
 
     private static List<ActorRef> sort(final Map<ActorPath, ActorRef> refsByPath) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundDispatchingActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundDispatchingActor.java
@@ -152,6 +152,8 @@ final class OutboundDispatchingActor extends AbstractActor {
         if (hasSourceDeclaredAcks || liveCommandExpectingResponse) {
             // start ackregator for source declared acks
             return AcknowledgementForwarderActor.startAcknowledgementForwarder(getContext(),
+                    self(),
+                    sender(),
                     entityId,
                     signal,
                     settings.getAcknowledgementConfig(),

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistry.java
@@ -325,7 +325,10 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
         mapsKeysToDelete.forEach(loggerKey -> {
             // flush logs before removing from loggers:
             try {
-                LOGGERS.get(loggerKey).close();
+                final ConnectionLogger connectionLogger = LOGGERS.get(loggerKey);
+                if (connectionLogger != null) {
+                    connectionLogger.close();
+                }
             } catch (final IOException e) {
                 LOGGER.warn("Exception during closing logger <{}>: <{}>: {}", loggerKey, e.getClass().getSimpleName(),
                         e.getMessage());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActor.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.persistence;
+
+import static org.eclipse.ditto.connectivity.service.messaging.persistence.ClientActorRefsAggregationActor.AggregationState.AGGREGATED;
+import static org.eclipse.ditto.connectivity.service.messaging.persistence.ClientActorRefsAggregationActor.AggregationState.AGGREGATING;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.ditto.connectivity.service.messaging.BaseClientActor;
+import org.eclipse.ditto.connectivity.service.messaging.ClientActorRefs;
+import org.eclipse.ditto.connectivity.service.messaging.persistence.ClientActorRefsAggregationActor.AggregationData;
+import org.eclipse.ditto.connectivity.service.messaging.persistence.ClientActorRefsAggregationActor.AggregationState;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.slf4j.Logger;
+
+import akka.actor.AbstractFSM;
+import akka.actor.ActorRef;
+import akka.actor.FSM;
+import akka.actor.Props;
+import akka.japi.pf.FSMStateFunctionBuilder;
+import akka.routing.Broadcast;
+
+/**
+ * This class regularly sends a {@link org.eclipse.ditto.connectivity.service.messaging.BaseClientActor.HealthSignal#PING ping}
+ * signal to all client actors and expects a {@link org.eclipse.ditto.connectivity.service.messaging.BaseClientActor.HealthSignal#PONG pong} response.
+ * This way all living client actor refs are determined and finally published to the {@link #receiver}.
+ */
+final class ClientActorRefsAggregationActor extends AbstractFSM<AggregationState, AggregationData> {
+
+    private static final Logger LOGGER = DittoLoggerFactory.getLogger(ClientActorRefsAggregationActor.class);
+    private static final String AGGREGATION_TIMEOUT_TIMER = "aggregationTimeout";
+    private static final String START_AGGREGATION_TIMER = "startAggregation";
+
+    private final Duration aggregationTimeout;
+    private final Duration aggregationInterval;
+    private final int clientCount;
+    private final ActorRef clientActorRouter;
+    private final ActorRef receiver;
+
+    ClientActorRefsAggregationActor(final int clientCount,
+            final ActorRef receiver,
+            final ActorRef clientActorRouter,
+            final Duration aggregationInterval,
+            final Duration aggregationTimeout) {
+        this.clientCount = clientCount;
+        this.receiver = receiver;
+        this.clientActorRouter = clientActorRouter;
+        this.aggregationInterval = aggregationInterval;
+        this.aggregationTimeout = aggregationTimeout;
+    }
+
+    /**
+     * @param clientCount the expected number of clients
+     * @param receiver the receiver of the aggregated {@link ClientActorRefs}. Make sure that this actor ref is not remote as {@link ClientActorRefs} cannot be serialized.
+     * @param clientActorRouter the client actor router used to send broadcasts to all clients.
+     * @param aggregationInterval the interval for aggregation of client actor refs.
+     * @param aggregationTimeout the maximum time the aggregation actor should wait for a response from all client actors.
+     * @return the props of the aggregation actor.
+     */
+    static Props props(final int clientCount,
+            final ActorRef receiver,
+            final ActorRef clientActorRouter,
+            final Duration aggregationInterval,
+            final Duration aggregationTimeout) {
+        return Props.create(ClientActorRefsAggregationActor.class, clientCount, receiver, clientActorRouter,
+                aggregationInterval, aggregationTimeout);
+    }
+
+    private static Duration randomize(final Duration base) {
+        return base.plus(Duration.ofMillis((long) (base.toMillis() * Math.random())));
+    }
+
+    @Override
+    public void preStart() throws Exception {
+        when(AGGREGATED, inAggregatedState());
+        when(AGGREGATING, inAggregatingState());
+
+        startWith(AGGREGATED, AggregationData.initial());
+        initialize();
+        scheduleStartAggregationTimeout();
+    }
+
+    private FSMStateFunctionBuilder<AggregationState, AggregationData> inAggregatedState() {
+        return matchEvent(StartAggregation.class, this::startAggregation)
+                .anyEvent((event, data) -> {
+                    LOGGER.warn("Received unexpected event in {} state.", AGGREGATED);
+                    return stay();
+                });
+    }
+
+    private FSMStateFunctionBuilder<AggregationState, AggregationData> inAggregatingState() {
+        return matchEventEquals(BaseClientActor.HealthSignal.PONG, this::handleClientActorResponse)
+                .eventEquals(StateTimeout(), (event, data) -> {
+                    LOGGER.warn("Did not receive all client actor refs within timeout of {}. Received: {}.",
+                            aggregationTimeout, data.clientActorRefs);
+                    return goToAggregated();
+                })
+                .anyEvent((event, data) -> {
+                    LOGGER.warn("Received unexpected event in {} state.", AGGREGATING);
+                    return stay();
+                });
+    }
+
+    private FSM.State<AggregationState, AggregationData> handleClientActorResponse(
+            final BaseClientActor.HealthSignal pong, final AggregationData data) {
+        final AggregationData newData;
+        final ActorRef sender = sender();
+        if (sender == null) {
+            LOGGER.warn("Received PONG response without sender information. This seems to be a bug.");
+            newData = data;
+        } else {
+            newData = data.addRef(sender);
+        }
+        if (newData.clientActorRefs.size() >= clientCount) {
+            receiver.tell(newData.getClientActorRefs(), ActorRef.noSender());
+            LOGGER.info("Finished aggregation of all client actor refs successfully.");
+            return goToAggregated();
+        } else {
+            return stay().using(newData);
+        }
+    }
+
+    private FSM.State<AggregationState, AggregationData> startAggregation(final StartAggregation startAggregation,
+            final AggregationData data) {
+        LOGGER.info("Starting aggregation of all client actor refs.");
+        clientActorRouter.tell(new Broadcast(BaseClientActor.HealthSignal.PING), getSelf());
+        scheduleAggregationTimeout();
+        return goTo(AGGREGATING).using(data.reset());
+    }
+
+    private FSM.State<AggregationState, AggregationData> goToAggregated() {
+        cancelAggregationTimeout();
+        scheduleStartAggregationTimeout();
+        return goTo(AGGREGATED);
+    }
+
+    private void scheduleAggregationTimeout() {
+        startSingleTimer(AGGREGATION_TIMEOUT_TIMER, StateTimeout(), aggregationTimeout);
+    }
+
+    private void cancelAggregationTimeout() {
+        cancelTimer(AGGREGATION_TIMEOUT_TIMER);
+    }
+
+    private void scheduleStartAggregationTimeout() {
+        startSingleTimer(START_AGGREGATION_TIMER, StartAggregation.INSTANCE, randomize(aggregationInterval));
+    }
+
+    private static class StartAggregation {
+
+        private static final StartAggregation INSTANCE = new StartAggregation();
+
+        private StartAggregation() {}
+    }
+
+    enum AggregationState {
+        AGGREGATING,
+        AGGREGATED;
+    }
+
+    static class AggregationData {
+
+        private final List<ActorRef> clientActorRefs;
+
+        AggregationData(final List<ActorRef> clientActorRefs) {
+            this.clientActorRefs = Collections.unmodifiableList(clientActorRefs);
+        }
+
+        static AggregationData initial() {
+            return new AggregationData(List.of());
+        }
+
+        AggregationData reset() {
+            return new AggregationData(List.of());
+        }
+
+        private AggregationData addRef(final ActorRef actorRef) {
+            final ArrayList<ActorRef> newRefs = new ArrayList<>(clientActorRefs);
+            newRefs.add(actorRef);
+            return new AggregationData(newRefs);
+        }
+
+        private ClientActorRefs getClientActorRefs() {
+            final ClientActorRefs clientActorRefs = ClientActorRefs.empty();
+            clientActorRefs.add(this.clientActorRefs);
+            return clientActorRefs;
+        }
+
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -1045,10 +1045,12 @@ public final class ConnectionPersistenceActor
 
             // start client actor without name so it does not conflict with its previous incarnation
             clientActorRouter = getContext().actorOf(clusterRouterPoolProps);
-            clientActorRefsAggregationActor = getContext().actorOf(
-                    ClientActorRefsAggregationActor.props(clientCount, getSelf(), clientActorRouter,
-                            connectivityConfig.getClientConfig().getClientActorRefsNotificationDelay(),
-                            clientActorAskTimeout));
+            if (clientCount > 1) {
+                clientActorRefsAggregationActor = getContext().actorOf(
+                        ClientActorRefsAggregationActor.props(clientCount, getSelf(), clientActorRouter,
+                                connectivityConfig.getClientConfig().getClientActorRefsNotificationDelay(),
+                                clientActorAskTimeout));
+            }
             updateLoggingIfEnabled();
         } else if (clientActorRouter != null) {
             log.debug("ClientActor already started.");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActorTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.ditto.connectivity.service.messaging.BaseClientActor;
+import org.eclipse.ditto.connectivity.service.messaging.ClientActorRefs;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.routing.Broadcast;
+import akka.testkit.TestKit;
+import akka.testkit.TestProbe;
+import scala.concurrent.duration.FiniteDuration;
+
+public final class ClientActorRefsAggregationActorTest {
+
+    private ActorSystem actorSystem;
+
+    @Before
+    public void setup() {
+        actorSystem = ActorSystem.create(ClientActorRefsAggregationActorTest.class.getSimpleName());
+    }
+
+    @After
+    public void tearDown() {
+        if (actorSystem != null) {
+            actorSystem.terminate();
+        }
+        actorSystem = null;
+    }
+
+    @Test
+    public void aggregationWorksAsExpected() {
+        new TestKit(actorSystem) {{
+            final TestProbe receiverProbe = TestProbe.apply(actorSystem);
+            final TestProbe client1 = TestProbe.apply(actorSystem);
+            final TestProbe client2 = TestProbe.apply(actorSystem);
+            final TestProbe client3 = TestProbe.apply(actorSystem);
+            final TestProbe clientActorRouterProbe = TestProbe.apply(actorSystem);
+            final Duration aggregationInterval = Duration.ofSeconds(2);
+            final Props props =
+                    ClientActorRefsAggregationActor.props(3, receiverProbe.ref(), clientActorRouterProbe.ref(),
+                            aggregationInterval, Duration.ofSeconds(3));
+            final ActorRef underTest = actorSystem.actorOf(props);
+
+            // Verify that aggregation actor broadcasts a PING signal via client actor router
+            final Broadcast broadcast = clientActorRouterProbe.expectMsgClass(
+                    FiniteDuration.apply(aggregationInterval.toSeconds() + 5, TimeUnit.SECONDS),
+                    Broadcast.class);
+
+            assertThat(broadcast.message()).isEqualTo(BaseClientActor.HealthSignal.PING);
+            final ActorRef senderOfBroadCast = clientActorRouterProbe.lastSender();
+            assertThat(senderOfBroadCast).isEqualTo(underTest);
+
+            // When all client actors respond with a PONG signal
+            senderOfBroadCast.tell(BaseClientActor.HealthSignal.PONG, client1.ref());
+            senderOfBroadCast.tell(BaseClientActor.HealthSignal.PONG, client2.ref());
+            senderOfBroadCast.tell(BaseClientActor.HealthSignal.PONG, client3.ref());
+
+            // Then receiver is provided with the aggregated client actor refs
+            final ClientActorRefs clientActorRefs = receiverProbe.expectMsgClass(ClientActorRefs.class);
+
+            assertThat(clientActorRefs.getSortedRefs()).containsOnly(client1.ref(), client2.ref(), client3.ref());
+
+            // Verify that process is repeated
+            clientActorRouterProbe.expectMsgClass(
+                    FiniteDuration.apply(aggregationInterval.toSeconds() + 5, TimeUnit.SECONDS),
+                    Broadcast.class);
+        }};
+    }
+
+    @Test
+    public void aggregationRetriedAfterNormalIntervalInCaseOfTimeoutDuringAggregation() {
+        new TestKit(actorSystem) {{
+            final TestProbe receiverProbe = TestProbe.apply(actorSystem);
+            final TestProbe client1 = TestProbe.apply(actorSystem);
+            final TestProbe client2 = TestProbe.apply(actorSystem);
+            final TestProbe client3 = TestProbe.apply(actorSystem);
+            final TestProbe clientActorRouterProbe = TestProbe.apply(actorSystem);
+            final Duration aggregationInterval = Duration.ofSeconds(2);
+            final Props props =
+                    ClientActorRefsAggregationActor.props(3, receiverProbe.ref(), clientActorRouterProbe.ref(),
+                            aggregationInterval, Duration.ofSeconds(3));
+            final ActorRef underTest = actorSystem.actorOf(props);
+
+            final Broadcast broadcast1 = clientActorRouterProbe.expectMsgClass(
+                    FiniteDuration.apply(aggregationInterval.toSeconds() + 5, TimeUnit.SECONDS),
+                    Broadcast.class);
+
+            assertThat(broadcast1.message()).isEqualTo(BaseClientActor.HealthSignal.PING);
+            final ActorRef senderOfBroadCast1 = clientActorRouterProbe.lastSender();
+            assertThat(senderOfBroadCast1).isEqualTo(underTest);
+
+            senderOfBroadCast1.tell(BaseClientActor.HealthSignal.PONG, client1.ref());
+            senderOfBroadCast1.tell(BaseClientActor.HealthSignal.PONG, client2.ref());
+
+            // Receiver is not getting any message because aggregation timed out
+            receiverProbe.expectNoMessage();
+
+            final Broadcast broadcast2 = clientActorRouterProbe.expectMsgClass(
+                    FiniteDuration.apply(aggregationInterval.toSeconds() + 5, TimeUnit.SECONDS),
+                    Broadcast.class);
+
+            assertThat(broadcast2.message()).isEqualTo(BaseClientActor.HealthSignal.PING);
+            final ActorRef senderOfBroadCast2 = clientActorRouterProbe.lastSender();
+            assertThat(senderOfBroadCast2).isEqualTo(underTest);
+
+            senderOfBroadCast2.tell(BaseClientActor.HealthSignal.PONG, client1.ref());
+            senderOfBroadCast2.tell(BaseClientActor.HealthSignal.PONG, client2.ref());
+            senderOfBroadCast2.tell(BaseClientActor.HealthSignal.PONG, client3.ref());
+
+            final ClientActorRefs clientActorRefs = receiverProbe.expectMsgClass(ClientActorRefs.class);
+
+            assertThat(clientActorRefs.getSortedRefs()).containsOnly(client1.ref(), client2.ref(), client3.ref());
+        }};
+    }
+
+}

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/StreamingSessionActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/streaming/actors/StreamingSessionActor.java
@@ -461,6 +461,8 @@ final class StreamingSessionActor extends AbstractActorWithTimers {
         if (entityIdOptional.isPresent()) {
             final var entityIdWithType = entityIdOptional.get();
             return AcknowledgementForwarderActor.startAcknowledgementForwarder(getContext(),
+                    self(),
+                    sender(),
                     entityIdWithType,
                     signal,
                     acknowledgementConfig,

--- a/internal/models/acks/src/test/java/org/eclipse/ditto/internal/models/acks/AcknowledgementForwarderActorStarterTest.java
+++ b/internal/models/acks/src/test/java/org/eclipse/ditto/internal/models/acks/AcknowledgementForwarderActorStarterTest.java
@@ -25,11 +25,11 @@ import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
+import org.eclipse.ditto.base.model.signals.acks.AcknowledgementRequestDuplicateCorrelationIdException;
 import org.eclipse.ditto.internal.models.acks.config.AcknowledgementConfig;
 import org.eclipse.ditto.internal.models.acks.config.DefaultAcknowledgementConfig;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
-import org.eclipse.ditto.base.model.signals.acks.AcknowledgementRequestDuplicateCorrelationIdException;
 import org.eclipse.ditto.things.model.signals.events.ThingDeleted;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -93,7 +93,6 @@ public final class AcknowledgementForwarderActorStarterTest {
         when(actorContext.actorOf(any(Props.class), anyString()))
                 .thenAnswer((Answer<ActorRef>) invocationOnMock -> actorSystem.actorOf(invocationOnMock.getArgument(0),
                         invocationOnMock.getArgument(1)));
-        when(actorContext.sender()).thenReturn(testProbe.ref());
     }
 
     @Test
@@ -155,7 +154,9 @@ public final class AcknowledgementForwarderActorStarterTest {
     }
 
     private AcknowledgementForwarderActorStarter getActorStarter(final DittoHeaders dittoHeaders) {
-        return AcknowledgementForwarderActorStarter.getInstance(actorContext, KNOWN_ENTITY_ID,
+        return AcknowledgementForwarderActorStarter.getInstance(actorContext, TestProbe.apply(actorSystem).ref(),
+                testProbe.ref(),
+                KNOWN_ENTITY_ID,
                 ThingDeleted.of(KNOWN_ENTITY_ID, 1L, Instant.EPOCH, dittoHeaders, null),
                 acknowledgementConfig, label -> true);
     }

--- a/internal/models/acks/src/test/java/org/eclipse/ditto/internal/models/acks/AcknowledgementForwarderActorTest.java
+++ b/internal/models/acks/src/test/java/org/eclipse/ditto/internal/models/acks/AcknowledgementForwarderActorTest.java
@@ -53,6 +53,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSelection;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
+import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
 /**
@@ -130,10 +131,10 @@ public final class AcknowledgementForwarderActorTest {
                 Acknowledgement.of(acknowledgementLabel, entityId, HttpStatus.ACCEPTED, dittoHeaders);
 
         new TestKit(actorSystem) {{
-            when(actorContext.sender()).thenReturn(getRef());
 
             final Optional<ActorRef> underTest =
-                    AcknowledgementForwarderActor.startAcknowledgementForwarderForTest(actorContext, entityId, signal,
+                    AcknowledgementForwarderActor.startAcknowledgementForwarderForTest(actorContext,
+                            TestProbe.apply(actorSystem).ref(), getRef(), entityId, signal,
                             acknowledgementConfig);
 
             softly.assertThat(underTest).isPresent();


### PR DESCRIPTION
* Former the refreshing was started by all clients. The way it happened
  resulted in the problem that dead client actors are never removed from
  the client actor refs
* Now the refreshing is triggered by the ConnectionPersistenceActor which
  provides a SourceRef of all client actor refs (including themselfs) to
  every client actor