### PR TITLE
Deal with unavailable Kafka broker in publisher

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -173,7 +173,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
     private static final String MESSAGE_MAPPING_PROCESSOR_DISPATCHER = "message-mapping-processor-dispatcher";
     private static final Pattern EXCLUDED_ADDRESS_REPORTING_CHILD_NAME_PATTERN = Pattern.compile(
             OutboundMappingProcessorActor.ACTOR_NAME + "|" + OutboundDispatchingActor.ACTOR_NAME + "|" +
-                    "StreamSupervisor-.*|subscriptionManager");
+                    "ackr.*" + "|" + "StreamSupervisor-.*|subscriptionManager");
     private static final String DITTO_STATE_TIMEOUT_TIMER = "dittoStateTimeout";
     private static final int SOCKET_CHECK_TIMEOUT_MS = 2000;
     private static final String CLOSED_BECAUSE_OF_UNKNOWN_FAILURE_MISCONFIGURATION_STATUS_IN_CLIENT =

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
@@ -35,8 +35,8 @@ import org.eclipse.ditto.connectivity.api.ExternalMessageFactory;
 import org.eclipse.ditto.connectivity.model.EnforcementFilterFactory;
 import org.eclipse.ditto.connectivity.model.Source;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
-import org.eclipse.ditto.internal.utils.akka.logging.DittoLogger;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLogger;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
 import org.eclipse.ditto.internal.utils.tracing.instruments.trace.StartedTrace;
 
@@ -48,7 +48,8 @@ import akka.kafka.ConsumerMessage;
 @Immutable
 final class KafkaMessageTransformer {
 
-    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(KafkaMessageTransformer.class);
+    private static final ThreadSafeDittoLogger LOGGER =
+            DittoLoggerFactory.getThreadSafeLogger(KafkaMessageTransformer.class);
 
     private final Source source;
     private final String sourceAddress;
@@ -110,7 +111,7 @@ final class KafkaMessageTransformer {
         try {
             final String key = consumerRecord.key();
             final ByteBuffer value = consumerRecord.value();
-            final DittoLogger correlationIdScopedLogger = LOGGER.withCorrelationId(correlationId);
+            final ThreadSafeDittoLogger correlationIdScopedLogger = LOGGER.withCorrelationId(correlationId);
             correlationIdScopedLogger.debug(
                     "Transforming incoming kafka message <{}> with headers <{}> and key <{}>.",
                     value, messageHeaders, key

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -20,8 +20,9 @@ ditto {
       # Kafka
       {exceptionName: "org.apache.kafka.common.errors.SaslAuthenticationException", messagePattern: ".*"}
       {exceptionName: "org.apache.kafka.common.errors.UnsupportedSaslMechanismException", messagePattern: ".*"}
-      {exceptionName: "org.apache.kafka.common.errors.IllegalSaslStateException", messagePattern: ".*"},
+      {exceptionName: "org.apache.kafka.common.errors.IllegalSaslStateException", messagePattern: ".*"}
       {exceptionName: "org.apache.kafka.common.errors.SslAuthenticationException", messagePattern: ".*"}
+      {exceptionName: "org.apache.kafka.common.errors.TimeoutException", messagePattern: ".*"}
       # MQTT
       {exceptionName: "com.hivemq.client.mqtt.exceptions.ConnectionClosedException", messagePattern: "Server closed connection without DISCONNECT.*"}
       {exceptionName: "com.hivemq.client.mqtt.exceptions.ConnectionClosedException", messagePattern: "io.netty.channel.unix.Errors$NativeIoException.*"}


### PR DESCRIPTION
Until now a Ditto Kafka connection with targets only did not cope properly with the Kafka broker becoming unavailable.
In such cases publishing timed out and produced appropriate entries in connection log.
Connection live status however, remained always 'open'.
With this commit, a `TimeoutException` while publishing is handled in a way that a `ConnectionFailure` is propagated to parent `BaseClientActor`.
This sets connection live status to 'misconfigured' and triggers reconnect with back-off semantic.
Thus, a potentially unavailable Kafka broker gets appropriately reflected by connection status.

Fixes: #1273