### PR TITLE
Sync Ditto pubsub distributed data against the cluster state at regular intervals

### DIFF
--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
@@ -151,7 +151,7 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
     }
 
     @Override
-    public void resetDDataForCurrentMember() {
+    public void verifyNoDDataForCurrentMember() {
         previousUpdate = LiteralUpdate.empty();
     }
 

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
@@ -51,17 +51,18 @@ import akka.actor.ActorRef;
 import akka.actor.Address;
 import akka.actor.Props;
 import akka.actor.Terminated;
+import akka.cluster.Cluster;
 import akka.cluster.ddata.Key;
 import akka.cluster.ddata.ORMultiMap;
 import akka.cluster.ddata.Replicator;
-import akka.event.LoggingAdapter;
 import akka.japi.pf.ReceiveBuilder;
 
 /**
  * Manage the local and remote ternary relation between actors, group names and declared acknowledgement labels.
  * In case of conflict, prefer data from the cluster member with a smaller address.
  */
-public final class AckUpdater extends AbstractActorWithTimers implements ClusterMemberRemovedAware {
+public final class AckUpdater extends AbstractActorWithTimers implements ClusterStateSyncBehavior<Address>,
+        ClusterMemberRemovedAware {
 
     /**
      * Prefix of this actor's name.
@@ -77,6 +78,7 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
     private final java.util.Set<ActorRef> localChangeRecipients;
     private final Gauge ackSizeMetric;
     private final Map<Key<?>, Map<Address, List<Grouped<String>>>> cachedRemoteAcks;
+    private final Cluster cluster;
 
     private Map<String, Set<String>> remoteAckLabels = Map.of();
     private Map<String, Set<String>> remoteGroups = Map.of();
@@ -92,9 +94,11 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
         localChangeRecipients = new HashSet<>();
         ackSizeMetric = DittoMetrics.gauge("pubsub-ack-size-bytes");
         cachedRemoteAcks = new HashMap<>();
+        cluster = Cluster.get(getContext().getSystem());
         subscribeForClusterMemberRemovedAware();
         ackDData.getReader().receiveChanges(getSelf());
         getTimers().startTimerAtFixedRate(Clock.TICK, Clock.TICK, config.getUpdateInterval());
+        scheduleClusterStateSync(config);
     }
 
     /**
@@ -122,16 +126,37 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
                 .match(Replicator.Changed.class, this::onChanged)
                 .build()
                 .orElse(receiveClusterMemberRemoved())
+                .orElse(getClusterStateSyncBehavior())
                 .orElse(ReceiveBuilder.create().matchAny(this::logUnhandled).build());
     }
 
     @Override
-    public LoggingAdapter log() {
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    @Override
+    public Address toAddress(final Address ddataKey) {
+        return ddataKey;
+    }
+
+    @Override
+    public ThreadSafeDittoLoggingAdapter log() {
         return log;
     }
 
     @Override
-    public DDataWriter<?, ?> getDDataWriter() {
+    public DData<Address, ?, ?> getDData() {
+        return ackDData;
+    }
+
+    @Override
+    public void resetDDataForCurrentMember() {
+        previousUpdate = LiteralUpdate.empty();
+    }
+
+    @Override
+    public DDataWriter<Address, ?> getDDataWriter() {
         return ackDData.getWriter();
     }
 

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.pubsub.actors;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
+import org.eclipse.ditto.internal.utils.pubsub.config.PubSubConfig;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.DData;
+
+import akka.actor.AbstractActor;
+import akka.actor.Actor;
+import akka.actor.Address;
+import akka.actor.Timers;
+import akka.cluster.Cluster;
+import akka.cluster.ClusterEvent;
+import akka.cluster.Member;
+import akka.cluster.MemberStatus;
+import akka.cluster.ddata.ORMultiMap;
+import akka.cluster.ddata.Replicator;
+import akka.japi.pf.ReceiveBuilder;
+import akka.pattern.Patterns;
+import scala.jdk.CollectionConverters;
+
+/**
+ * Mixin to subscribe for cluster events.
+ */
+interface ClusterStateSyncBehavior<T> extends Actor, Timers {
+
+    /**
+     * Get the cluster object of the actor system.
+     *
+     * @return the cluster object.
+     */
+    Cluster getCluster();
+
+    /**
+     * Convert the distributed data key into an address.
+     *
+     * @param ddataKey the key.
+     * @return the address.
+     */
+    Address toAddress(T ddataKey);
+
+    /**
+     * @return the logging adapter of this actor. Must be thread-safe.
+     */
+    ThreadSafeDittoLoggingAdapter log();
+
+    /**
+     * @return the distributed data to maintain. Must be thread-safe.
+     */
+    DData<T, ?, ?> getDData();
+
+    /**
+     * Trigger distributed write of the information related to the current member in the distributed data.
+     * Does NOT have to be thread-safe.
+     */
+    void resetDDataForCurrentMember();
+
+    /**
+     * Schedule periodic sync between the distributed data and the cluster state.
+     *
+     * @param config the pub-sub config.
+     */
+    default void scheduleClusterStateSync(final PubSubConfig config) {
+        final var syncInterval = config.getSyncInterval();
+        final var randomizedSyncInterval =
+                syncInterval.plus(Duration.ofMillis((long) (Math.random() * syncInterval.toMillis())));
+        log().info("Scheduling cluster state sync at <{}> interval (min=<{}>)", randomizedSyncInterval, syncInterval);
+        final var trigger = Control.SYNC_CLUSTER_STATE;
+        timers().startTimerWithFixedDelay(trigger, trigger, randomizedSyncInterval);
+    }
+
+    /**
+     * Create behavior related to cluster state sync.
+     *
+     * @return The behavior.
+     */
+    default AbstractActor.Receive getClusterStateSyncBehavior() {
+        return ReceiveBuilder.create()
+                .matchEquals(Control.SYNC_CLUSTER_STATE, this::syncClusterState)
+                .match(SyncResult.class, this::handleSyncResult)
+                .match(SyncError.class, this::handleSyncError)
+                .build();
+    }
+
+    /**
+     * Start cluster state sync.
+     *
+     * @param trigger The trigger.
+     */
+    default void syncClusterState(final Control trigger) {
+        final var resultFuture = getDData().getReader()
+                .getAllShards((Replicator.ReadConsistency) Replicator.readLocal())
+                .thenApply(this::checkClusterState)
+                .handle((result, error) -> result != null ? result : new SyncError(error));
+
+        Patterns.pipe(resultFuture, context().dispatcher()).to(self());
+    }
+
+    /**
+     * Handle sync error.
+     *
+     * @param syncError The error that aborted cluster state sync.
+     */
+    default void handleSyncError(final SyncError syncError) {
+        log().error(syncError.error, "Failed to sync cluster state");
+    }
+
+    /**
+     * Handle the result of a successful sync.
+     *
+     * @param syncResult The sync result containing stale and missing addresses.
+     */
+    default void handleSyncResult(final SyncResult syncResult) {
+        if (syncResult.isInSync()) {
+            log().info("DData is in sync with cluster state");
+        } else {
+            log().warning("DData out of sync: <{}>", syncResult);
+            if (syncResult.myAddressMissing) {
+                log().warning("Resetting missing info of current member <{}>", getCluster().selfMember());
+                resetDDataForCurrentMember();
+            }
+            if (!syncResult.staleAddresses.isEmpty()) {
+                log().warning("Removing stale addresses <{}>", syncResult.staleAddresses);
+                removeStaleAddresses(syncResult.staleAddresses);
+            }
+        }
+    }
+
+    /**
+     * Remove stale addresses from the distributed data.
+     *
+     * @param staleAddresses the stale address.
+     */
+    default void removeStaleAddresses(final Set<Address> staleAddresses) {
+        final var writer = getDData().getWriter();
+        for (final var address : staleAddresses) {
+            writer.removeAddress(address, writeLocal());
+        }
+    }
+
+    /**
+     * Compare distributed data addresses against the current cluster state.
+     *
+     * @param maps The content of the distributed data.
+     * @return result of comparing distributed data addresses against the cluster state.
+     */
+    default SyncResult checkClusterState(final List<? extends ORMultiMap<T, ?>> maps) {
+        final var clusterState = getCluster().state();
+        final var clusterAddresses = getClusterMemberAddresses(clusterState);
+        final var ddataAddresses = getDDataAddresses(maps);
+        final var isSelfMemberInCluster = isMemberStayingInCluster(getCluster().selfMember());
+        if (isSelfMemberInCluster) {
+            final boolean isMyAddressMissing = !ddataAddresses.contains(getCluster().selfAddress());
+            final Set<Address> staleAddresses = ddataAddresses.stream()
+                    .filter(address -> !clusterAddresses.contains(address))
+                    .collect(Collectors.toSet());
+            return new SyncResult(isMyAddressMissing, staleAddresses);
+        } else {
+            log().info("This member is leaving the cluster. Skipping sync.");
+            return new SyncResult(false, Set.of());
+        }
+    }
+
+    /**
+     * Retrieve addresses saved in distributed data.
+     *
+     * @param maps Maps stored in the distributed data.
+     * @return Address saved in distributed data.
+     */
+    default Set<Address> getDDataAddresses(final List<? extends ORMultiMap<T, ?>> maps) {
+        return maps.stream()
+                .flatMap(orMultiMap ->
+                        CollectionConverters.SetHasAsJava(orMultiMap.entries().keySet()).asJava().stream())
+                .map(this::toAddress)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Get the local write consistency.
+     *
+     * @return the local write consistency.
+     */
+    default Replicator.WriteConsistency writeLocal() {
+        return (Replicator.WriteConsistency) Replicator.writeLocal();
+    }
+
+    /**
+     * Check if a cluster member is staying in the cluster by its status.
+     *
+     * @param member The cluster member.
+     * @return Whether it is staying in the cluster.
+     */
+    static boolean isMemberStayingInCluster(final Member member) {
+        final var status = member.status();
+        return status != MemberStatus.leaving() && status != MemberStatus.exiting() && status != MemberStatus.down() &&
+                status != MemberStatus.removed();
+    }
+
+    /**
+     * Retrieve a set of addresses of cluster members that will stay in the cluster.
+     *
+     * @param clusterState The cluster state.
+     * @return The addresses of members staying in the cluster.
+     */
+    static Set<Address> getClusterMemberAddresses(final ClusterEvent.CurrentClusterState clusterState) {
+        return StreamSupport.stream(clusterState.getMembers().spliterator(), false)
+                .filter(ClusterStateSyncBehavior::isMemberStayingInCluster)
+                .map(Member::address)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Message to inform this actor of the result of syncing against the cluster state.
+     */
+    final class SyncResult {
+
+        private final boolean myAddressMissing;
+        private final Set<Address> staleAddresses;
+
+        private SyncResult(final boolean myAddressMissing, final Set<Address> staleAddresses) {
+            this.myAddressMissing = myAddressMissing;
+            this.staleAddresses = staleAddresses;
+        }
+
+        private boolean isInSync() {
+            return !myAddressMissing && staleAddresses.isEmpty();
+        }
+
+        @Override
+        public String toString() {
+            return "SyncResult[myAddressMissing=" + myAddressMissing +
+                    ", staleAddresses=" + staleAddresses +
+                    "]";
+        }
+    }
+
+    final class SyncError {
+
+        private final Throwable error;
+
+        private SyncError(final Throwable error) {
+            this.error = error;
+        }
+    }
+
+    /**
+     * Internal messages of this behavior.
+     */
+    enum Control {
+
+        /**
+         * Message to trigger sync of the distributed data state against the cluster state.
+         */
+        SYNC_CLUSTER_STATE
+    }
+}

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/ClusterStateSyncBehavior.java
@@ -246,12 +246,16 @@ interface ClusterStateSyncBehavior<T> extends Actor, Timers {
 
         @Override
         public String toString() {
-            return "SyncResult[myAddressMissing=" + myAddressMissing +
+            return getClass().getSimpleName() + " [" +
+                    "myAddressMissing=" + myAddressMissing +
                     ", staleAddresses=" + staleAddresses +
                     "]";
         }
     }
 
+    /**
+     * Message indicating error during syncing against the cluster state containing the cause.
+     */
     final class SyncError {
 
         private final Throwable error;

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
@@ -36,7 +36,7 @@ import org.eclipse.ditto.internal.utils.pubsub.api.SubAck;
 import org.eclipse.ditto.internal.utils.pubsub.api.Subscribe;
 import org.eclipse.ditto.internal.utils.pubsub.api.Unsubscribe;
 import org.eclipse.ditto.internal.utils.pubsub.config.PubSubConfig;
-import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataWriter;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.DData;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.Subscriptions;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.SubscriptionsReader;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.compressed.CompressedDData;
@@ -44,9 +44,11 @@ import org.eclipse.ditto.internal.utils.pubsub.ddata.compressed.CompressedSubscr
 import org.eclipse.ditto.internal.utils.pubsub.ddata.literal.LiteralUpdate;
 
 import akka.actor.ActorRef;
+import akka.actor.Address;
 import akka.actor.Props;
 import akka.actor.Status;
 import akka.actor.Terminated;
+import akka.cluster.Cluster;
 import akka.cluster.ddata.Replicator;
 import akka.japi.pf.ReceiveBuilder;
 
@@ -57,7 +59,8 @@ import akka.japi.pf.ReceiveBuilder;
  * the cluster once requested. Local subscribers should most likely not to get any published message before they
  * receive acknowledgement.
  */
-public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
+public final class SubUpdater extends akka.actor.AbstractActorWithTimers
+        implements ClusterStateSyncBehavior<ActorRef> {
 
     /**
      * Prefix of this actor's name.
@@ -68,11 +71,12 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
 
     private final ThreadSafeDittoLoggingAdapter log = DittoLoggerFactory.getThreadSafeDittoLoggingAdapter(this);
     private final Subscriptions<LiteralUpdate> subscriptions;
-    private final DDataWriter<ActorRef, LiteralUpdate> topicsWriter;
     private final ActorRef subscriber;
     private final Gauge topicSizeMetric;
     private final Gauge awaitUpdateMetric;
     private final Gauge awaitSubAckMetric;
+    private final DData<ActorRef, ?, LiteralUpdate> ddata;
+    private final Cluster cluster;
 
     /**
      * Queue of actors demanding SubAck whose subscriptions are not sent to the distributed data replicator.
@@ -101,10 +105,11 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
     private SubUpdater(final PubSubConfig config,
             final ActorRef subscriber,
             final Subscriptions<LiteralUpdate> subscriptions,
-            final DDataWriter<ActorRef, LiteralUpdate> topicsWriter) {
+            final DData<ActorRef, ?, LiteralUpdate> ddata) {
         this.subscriber = subscriber;
         this.subscriptions = subscriptions;
-        this.topicsWriter = topicsWriter;
+        this.ddata = ddata;
+        cluster = Cluster.get(getContext().getSystem());
 
         // tag metrics by parent name + this name prefix
         // so that the tag is finite and distinct between twin and live topics and declared ack labels.
@@ -114,6 +119,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
         this.awaitSubAckMetric = DittoMetrics.gauge("pubsub-await-acknowledge").tag("name", tagName);
 
         getTimers().startTimerAtFixedRate(Clock.TICK, Clock.TICK, config.getUpdateInterval());
+        scheduleClusterStateSync(config);
     }
 
     /**
@@ -126,7 +132,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
      */
     public static Props props(final PubSubConfig config, final ActorRef subscriber, final CompressedDData topicsDData) {
         return Props.create(SubUpdater.class, config, subscriber, CompressedSubscriptions.of(topicsDData.getSeeds()),
-                topicsDData.getWriter());
+                topicsDData);
     }
 
     @Override
@@ -140,16 +146,17 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
                 .match(DDataOpSuccess.class, this::ddataOpSuccess)
                 .match(Status.Failure.class, this::updateFailure)
                 .matchEquals(ActorEvent.PUBSUB_TERMINATED, this::pubSubTerminated)
-                .matchAny(this::logUnhandled)
-                .build();
+                .build()
+                .orElse(getClusterStateSyncBehavior())
+                .orElse(ReceiveBuilder.create().matchAny(this::logUnhandled).build());
     }
 
-    private static boolean isMoreConsistent(final Replicator.WriteConsistency a, final Replicator.WriteConsistency b) {
+    private boolean isMoreConsistent(final Replicator.WriteConsistency a, final Replicator.WriteConsistency b) {
         return rank(a) > rank(b);
     }
 
     // roughly rank write consistency from the most local to the most global.
-    private static int rank(final Replicator.WriteConsistency a) {
+    private int rank(final Replicator.WriteConsistency a) {
         if (writeLocal().equals(a)) {
             return Integer.MIN_VALUE;
         } else if (a instanceof Replicator.WriteAll) {
@@ -161,10 +168,6 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
         } else {
             return 0;
         }
-    }
-
-    private static Replicator.WriteConsistency writeLocal() {
-        return (Replicator.WriteConsistency) Replicator.writeLocal();
     }
 
     private void subscribe(final Subscribe subscribe) {
@@ -220,7 +223,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
             ddataOp = CompletableFuture.completedStage(null);
         } else if (subscriptions.isEmpty()) {
             snapshot = subscriptions.snapshot();
-            ddataOp = topicsWriter.removeSubscriber(subscriber, writeConsistency);
+            ddataOp = ddata.getWriter().removeSubscriber(subscriber, writeConsistency);
             previousUpdate = LiteralUpdate.empty();
             topicSizeMetric.set(0L);
         } else {
@@ -228,7 +231,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
             final LiteralUpdate nextUpdate = subscriptions.export();
             // take snapshot to give to the subscriber; clear accumulated incremental changes.
             snapshot = subscriptions.snapshot();
-            ddataOp = topicsWriter.put(subscriber, nextUpdate.diff(previousUpdate), writeConsistency);
+            ddataOp = ddata.getWriter().put(subscriber, nextUpdate.diff(previousUpdate), writeConsistency);
             previousUpdate = nextUpdate;
             topicSizeMetric.set(subscriptions.estimateSize());
         }
@@ -373,6 +376,32 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers {
         if (isMoreConsistent(nextWriteConsistency, this.nextWriteConsistency)) {
             this.nextWriteConsistency = nextWriteConsistency;
         }
+    }
+
+    @Override
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    @Override
+    public Address toAddress(final ActorRef ddataKey) {
+        return ddataKey.path().address();
+    }
+
+    @Override
+    public ThreadSafeDittoLoggingAdapter log() {
+        return log;
+    }
+
+    @Override
+    public DData<ActorRef, ?, ?> getDData() {
+        return ddata;
+    }
+
+    @Override
+    public void resetDDataForCurrentMember() {
+        previousUpdate = LiteralUpdate.empty();
+        localSubscriptionsChanged = true;
     }
 
     private enum Clock {

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
@@ -399,9 +399,12 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers
     }
 
     @Override
-    public void resetDDataForCurrentMember() {
-        previousUpdate = LiteralUpdate.empty();
-        localSubscriptionsChanged = true;
+    public void verifyNoDDataForCurrentMember() {
+        if (!subscriptions.isEmpty()) {
+            previousUpdate = LiteralUpdate.empty();
+            localSubscriptionsChanged = true;
+        }
+        // Do nothing for empty subscriptions: No data is expected for the current member.
     }
 
     private enum Clock {

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/config/DefaultPubSubConfig.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/config/DefaultPubSubConfig.java
@@ -39,11 +39,13 @@ final class DefaultPubSubConfig implements PubSubConfig {
     private final String seed;
     private final Duration restartDelay;
     private final Duration updateInterval;
+    private final Duration syncInterval;
 
     private DefaultPubSubConfig(final ConfigWithFallback config) {
         seed = config.getString(ConfigValue.SEED.getConfigPath());
         restartDelay = config.getDuration(ConfigValue.RESTART_DELAY.getConfigPath());
         updateInterval = config.getDuration(ConfigValue.UPDATE_INTERVAL.getConfigPath());
+        syncInterval = config.getDuration(ConfigValue.SYNC_INTERVAL.getConfigPath());
     }
 
     static PubSubConfig of(final Config config) {
@@ -65,12 +67,17 @@ final class DefaultPubSubConfig implements PubSubConfig {
         return updateInterval;
     }
 
+    @Override
+    public Duration getSyncInterval() {
+        return syncInterval;
+    }
+
     private String[] getFieldNames() {
-        return new String[]{"seed", "restartDelay", "updateInterval"};
+        return new String[]{"seed", "restartDelay", "updateInterval", "syncInterval"};
     }
 
     private Object[] getFieldValues() {
-        return new Object[]{seed, restartDelay, updateInterval};
+        return new Object[]{seed, restartDelay, updateInterval, syncInterval};
     }
 
     @Override

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/config/PubSubConfig.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/config/PubSubConfig.java
@@ -42,6 +42,11 @@ public interface PubSubConfig {
     Duration getUpdateInterval();
 
     /**
+     * @return How often to sync the distributed data against the cluster state.
+     */
+    Duration getSyncInterval();
+
+    /**
      * Create a {@code PubSubConfig} object from a {@code Config} object at the key {@code pubsub}.
      *
      * @param config config with path {@code pubsub}.
@@ -85,7 +90,13 @@ public interface PubSubConfig {
         /**
          * How often to flush local subscriptions to the distributed data replicator.
          */
-        UPDATE_INTERVAL("update-interval", Duration.ofSeconds(3L));
+        UPDATE_INTERVAL("update-interval", Duration.ofSeconds(3L)),
+
+        /**
+         * How often to sync distributed data against cluster state.
+         * There is an additional random delay between 0 and 100% of the configured value.
+         */
+        SYNC_INTERVAL("sync-interval", Duration.ofMinutes(5L));
 
         private final String path;
         private final Object defaultValue;

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DDataReader.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DDataReader.java
@@ -12,10 +12,15 @@
  */
 package org.eclipse.ditto.internal.utils.pubsub.ddata;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+
 import akka.actor.ActorRef;
 import akka.actor.Address;
 import akka.cluster.ddata.Key;
 import akka.cluster.ddata.ORMultiMap;
+import akka.cluster.ddata.Replicator;
 
 /**
  * Reader of distributed Bloom filters of subscribed topics.
@@ -67,4 +72,22 @@ public interface DDataReader<K, T> {
      * @return Key of the distributed data.
      */
     Key<ORMultiMap<K, T>> getKey(int shardNumber);
+
+    /**
+     * Asynchronously retrieves the replicated data of a key.
+     *
+     * @param key the key to get the replicated data for.
+     * @param consistency how many replicas to consult.
+     * @return future of the replicated data that completes exceptionally on error.
+     * @since 2.3.0
+     */
+    CompletionStage<Optional<ORMultiMap<K, T>>> get(Key<ORMultiMap<K, T>> key, Replicator.ReadConsistency consistency);
+
+    /**
+     * Retrieve all replicated data shards.
+     *
+     * @param consistency the read consistency.
+     * @return the list of replicated data.
+     */
+    CompletionStage<List<ORMultiMap<K, T>>> getAllShards(Replicator.ReadConsistency consistency);
 }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DDataReader.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DDataReader.java
@@ -79,7 +79,6 @@ public interface DDataReader<K, T> {
      * @param key the key to get the replicated data for.
      * @param consistency how many replicas to consult.
      * @return future of the replicated data that completes exceptionally on error.
-     * @since 2.3.0
      */
     CompletionStage<Optional<ORMultiMap<K, T>>> get(Key<ORMultiMap<K, T>> key, Replicator.ReadConsistency consistency);
 

--- a/internal/utils/pubsub/src/main/resources/reference.conf
+++ b/internal/utils/pubsub/src/main/resources/reference.conf
@@ -8,6 +8,10 @@ ditto {
     update-interval = 3s
     update-interval = ${?DITTO_PUBSUB_UPDATE_INTERVAL}
 
+    // How often to sync the distributed data against the cluster state.
+    sync-interval = 5m
+    sync-interval = ${?DITTO_PUBSUB_SYNC_INTERVAL}
+
     // seed of hash functions; must be identical across the cluster for pub-sub to work.
     // rotate when paranoid about collision attacks.
     seed = """Two households, both alike in dignity,

--- a/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
+++ b/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.pubsub.actors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+
+import org.eclipse.ditto.internal.utils.pubsub.LiteralDDataProvider;
+import org.eclipse.ditto.internal.utils.pubsub.config.PubSubConfig;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataReader;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataWriter;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.compressed.CompressedDData;
+import org.eclipse.ditto.internal.utils.pubsub.ddata.literal.AbstractConfigAwareDDataProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.cluster.Cluster;
+import akka.cluster.ddata.ORMultiMap;
+import akka.cluster.ddata.Replicator;
+import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Tests {@link AckUpdater}.
+ */
+public final class SubUpdaterTest {
+
+    private static final AbstractConfigAwareDDataProvider PROVIDER =
+            LiteralDDataProvider.of("dc-default", "topic");
+
+    private ActorSystem system;
+
+    @Before
+    public void setUpCluster() throws Exception {
+        final CountDownLatch latch = new CountDownLatch(1);
+        system = ActorSystem.create("actorSystem", getTestConf());
+        final Cluster cluster1 = Cluster.get(system);
+        cluster1.registerOnMemberUp(latch::countDown);
+        cluster1.join(cluster1.selfAddress());
+        latch.await();
+    }
+
+    @After
+    public void shutdownCluster() {
+        TestKit.shutdownActorSystem(system);
+    }
+
+    @Test
+    public void clusterStateOutOfSync() {
+        final var system2 = ActorSystem.create("system2", getTestConf());
+        try {
+            new TestKit(system) {{
+                // GIVEN: distributed data contains entry for nonexistent cluster member
+                final var subscriber = TestProbe.apply(system);
+                final var config = PubSubConfig.of(system);
+                final var unknownActor = TestProbe.apply(system2).ref();
+                final var cluster2 = Cluster.get(system2);
+                final var addressMap = Map.of(mockActorRefWithAddress(unknownActor, cluster2), "unknown-value");
+                final CompressedDData ddata = mockDistributedData(addressMap);
+                final ActorRef underTest = system.actorOf(SubUpdater.props(config, subscriber.ref(), ddata));
+
+                // WHEN: AckUpdater is requested to sync against the cluster state
+                underTest.tell(ClusterStateSyncBehavior.Control.SYNC_CLUSTER_STATE, ActorRef.noSender());
+
+                // THEN: AckUpdater removes the extraneous entry
+                Mockito.verify(ddata.getReader(), Mockito.timeout(5000))
+                        .getAllShards(eq((Replicator.ReadConsistency) Replicator.readLocal()));
+                Mockito.verify(ddata.getWriter(), Mockito.timeout(5000))
+                        .removeAddress(eq(cluster2.selfAddress()),
+                                eq((Replicator.WriteConsistency) Replicator.writeLocal()));
+            }};
+        } finally {
+            TestKit.shutdownActorSystem(system2);
+        }
+    }
+
+    @Test
+    public void clusterStateInSync() {
+        new TestKit(system) {{
+            // GIVEN: distributed data contains entry for the current cluster member and no extraneous entries
+            final var subscriberRef = TestProbe.apply(system).ref();
+            final var cluster = Cluster.get(system);
+            final var config = PubSubConfig.of(system);
+            final var addressMap = Map.of(mockActorRefWithAddress(subscriberRef, cluster), "unknown-value");
+            final CompressedDData ddata = mockDistributedData(addressMap);
+            final ActorRef underTest = system.actorOf(SubUpdater.props(config, subscriberRef, ddata));
+
+            // WHEN: AckUpdater is requested to sync against the cluster state
+            underTest.tell(ClusterStateSyncBehavior.Control.SYNC_CLUSTER_STATE, ActorRef.noSender());
+
+            // THEN: AckUpdater does not modify ddata more than needed
+            Mockito.verify(ddata.getReader(), Mockito.timeout(5000))
+                    .getAllShards(eq((Replicator.ReadConsistency) Replicator.readLocal()));
+            Mockito.verify(ddata.getWriter(), Mockito.never()).put(any(), any(), any());
+            Mockito.verify(ddata.getWriter(), Mockito.never()).removeAddress(any(), any());
+        }};
+    }
+
+    private Config getTestConf() {
+        return ConfigFactory.load("pubsub-factory-test.conf");
+    }
+
+    private static ActorRef mockActorRefWithAddress(final ActorRef originalRef, final Cluster cluster) {
+        final var mock = Mockito.mock(ActorRef.class);
+        Mockito.when(mock.path()).thenReturn(cluster.remotePathOf(originalRef));
+        return mock;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    private static CompressedDData mockDistributedData(final Map<ActorRef, String> result) {
+        final ORMultiMap map = Mockito.mock(ORMultiMap.class);
+        Mockito.when(map.getEntries()).thenReturn(result);
+        final var mock = Mockito.mock(CompressedDData.class);
+        final var reader = Mockito.mock(DDataReader.class);
+        final var writer = Mockito.mock(DDataWriter.class);
+        Mockito.when(mock.getReader()).thenReturn(reader);
+        Mockito.when(mock.getWriter()).thenReturn(writer);
+        Mockito.when(reader.get(any(), any())).thenReturn(CompletableFuture.completedStage(Optional.of(map)));
+        Mockito.when(reader.getAllShards(any())).thenReturn(CompletableFuture.completedStage(List.of(map)));
+        Mockito.when(writer.put(any(), any(), any())).thenReturn(CompletableFuture.completedStage(null));
+        return mock;
+    }
+
+}

--- a/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
+++ b/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
@@ -21,12 +21,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
-import org.eclipse.ditto.internal.utils.pubsub.LiteralDDataProvider;
 import org.eclipse.ditto.internal.utils.pubsub.config.PubSubConfig;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataReader;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataWriter;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.compressed.CompressedDData;
-import org.eclipse.ditto.internal.utils.pubsub.ddata.literal.AbstractConfigAwareDDataProvider;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -44,12 +42,9 @@ import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 
 /**
- * Tests {@link AckUpdater}.
+ * Tests {@link SubUpdater}.
  */
 public final class SubUpdaterTest {
-
-    private static final AbstractConfigAwareDDataProvider PROVIDER =
-            LiteralDDataProvider.of("dc-default", "topic");
 
     private ActorSystem system;
 

--- a/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/config/DefaultPubSubConfigTest.java
+++ b/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/config/DefaultPubSubConfigTest.java
@@ -67,6 +67,10 @@ public final class DefaultPubSubConfigTest {
         softly.assertThat(underTest.getUpdateInterval())
                 .as(PubSubConfig.ConfigValue.UPDATE_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(3L));
+
+        softly.assertThat(underTest.getSyncInterval())
+                .as(PubSubConfig.ConfigValue.SYNC_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofMinutes(5L));
     }
 
     @Test
@@ -84,6 +88,10 @@ public final class DefaultPubSubConfigTest {
         softly.assertThat(underTest.getUpdateInterval())
                 .as(PubSubConfig.ConfigValue.UPDATE_INTERVAL.getConfigPath())
                 .isEqualTo(Duration.ofSeconds(4L));
+
+        softly.assertThat(underTest.getSyncInterval())
+                .as(PubSubConfig.ConfigValue.SYNC_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofSeconds(5L));
     }
 
 }

--- a/internal/utils/pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/internal/utils/pubsub/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/internal/utils/pubsub/src/test/resources/pubsub-test.conf
+++ b/internal/utils/pubsub/src/test/resources/pubsub-test.conf
@@ -14,4 +14,5 @@ Is now the two hours' traffic of our stage.
 """
   restart-delay = 11s
   update-interval = 4s
+  sync-interval = 5s
 }


### PR DESCRIPTION
Add a configurable interval for Ditto pubsub to sync its distributed data against the cluster state. This prevents errors due to cluster instability from staying in the distributed data for a long time.