### PR TITLE
Make ClientActorRefs serializable ..

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.connectivity.service.messaging;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -138,6 +139,24 @@ public final class ClientActorRefs implements AkkaJacksonCborSerializable {
                 "refsByPath=" + refsByPath +
                 ", sortedRefs=" + sortedRefs +
                 "]";
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final ClientActorRefs that = (ClientActorRefs) o;
+        return Objects.equals(refsByPath, that.refsByPath) &&
+                Objects.equals(sortedRefs, that.sortedRefs);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(refsByPath, sortedRefs);
     }
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefs.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.internal.utils.cluster.AkkaJacksonCborSerializable;
 import org.eclipse.ditto.internal.utils.pubsub.PubSubFactory;
 
 import akka.actor.ActorPath;
@@ -29,7 +30,7 @@ import akka.actor.ActorRef;
  * Collection of all client actor refs of a connection actor.
  */
 @NotThreadSafe
-public final class ClientActorRefs {
+public final class ClientActorRefs implements AkkaJacksonCborSerializable {
 
     private final Map<ActorPath, ActorRef> refsByPath = new HashMap<>();
     private List<ActorRef> sortedRefs = List.of();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ClientActorRefsAggregationActor.java
@@ -65,7 +65,7 @@ final class ClientActorRefsAggregationActor extends AbstractFSM<AggregationState
 
     /**
      * @param clientCount the expected number of clients
-     * @param receiver the receiver of the aggregated {@link ClientActorRefs}. Make sure that this actor ref is not remote as {@link ClientActorRefs} cannot be serialized.
+     * @param receiver the receiver of the aggregated {@link ClientActorRefs}.
      * @param clientActorRouter the client actor router used to send broadcasts to all clients.
      * @param aggregationInterval the interval for aggregation of client actor refs.
      * @param aggregationTimeout the maximum time the aggregation actor should wait for a response from all client actors.

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -135,10 +135,6 @@ import akka.routing.Broadcast;
 import akka.routing.ConsistentHashingPool;
 import akka.routing.ConsistentHashingRouter;
 import akka.routing.Pool;
-import akka.stream.Materializer;
-import akka.stream.SourceRef;
-import akka.stream.javadsl.Source;
-import akka.stream.javadsl.StreamRefs;
 
 /**
  * Handles {@code *Connection} commands and manages the persistence of connection. The actual connection handling to the
@@ -1092,10 +1088,8 @@ public final class ConnectionPersistenceActor
     }
 
     private void syncClientActorRefs(final ClientActorRefs clientActorRefs) {
-        final SourceRef<ActorRef> clientActorRefsSourceRef = Source.from(clientActorRefs.getSortedRefs())
-                .runWith(StreamRefs.sourceRef(), Materializer.createMaterializer(getContext()));
         if (clientActorRouter != null) {
-            clientActorRouter.tell(new Broadcast(clientActorRefsSourceRef), ActorRef.noSender());
+            clientActorRouter.tell(new Broadcast(clientActorRefs), ActorRef.noSender());
         }
     }
 

--- a/connectivity/service/src/main/resources/connectivity-dev.conf
+++ b/connectivity/service/src/main/resources/connectivity-dev.conf
@@ -27,6 +27,7 @@ ditto {
 akka {
 
   management.http.port = 25610
+  management.http.port = ${?AKKA_MANAGEMENT_PORT}
 
   remote {
     # for debugging purpose

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefsTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.testkit.javadsl.TestKit;
+
+public final class ClientActorRefsTest {
+
+    @ClassRule
+    public static ActorSystemResource actorSystemResource =
+            ActorSystemResource.newInstance(ConfigFactory.load("client-actor-refs-test"));
+
+    @Test
+    public void serializationWorks() {
+        final ActorSystem actorSystem = actorSystemResource.getActorSystem();
+        final ActorRef ref1 = actorSystemResource.newTestProbe().ref();
+        final ActorRef ref2 = actorSystemResource.newTestProbe().ref();
+        final var underTest = ClientActorRefs.empty();
+        underTest.add(ref1);
+        underTest.add(ref2);
+        final var messageReceiver = new TestKit(actorSystem);
+        final var messageSender = new TestKit(actorSystem);
+        final var messageReceiverRef = messageReceiver.getRef();
+
+        messageReceiverRef.tell(underTest, messageSender.getRef());
+
+        final var receivedClientActorRefs = messageReceiver.expectMsgClass(underTest.getClass());
+
+        assertThat(receivedClientActorRefs).isEqualTo(underTest);
+    }
+
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefsTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/ClientActorRefsTest.java
@@ -12,41 +12,33 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 import com.typesafe.config.ConfigFactory;
 
-import akka.actor.ActorRef;
-import akka.actor.ActorSystem;
-import akka.testkit.javadsl.TestKit;
-
+/**
+ * Unit test for {@link ClientActorRefs}.
+ */
 public final class ClientActorRefsTest {
 
     @ClassRule
-    public static ActorSystemResource actorSystemResource =
+    public static final ActorSystemResource ACTOR_SYSTEM_RESOURCE =
             ActorSystemResource.newInstance(ConfigFactory.load("client-actor-refs-test"));
 
     @Test
     public void serializationWorks() {
-        final ActorSystem actorSystem = actorSystemResource.getActorSystem();
-        final ActorRef ref1 = actorSystemResource.newTestProbe().ref();
-        final ActorRef ref2 = actorSystemResource.newTestProbe().ref();
         final var underTest = ClientActorRefs.empty();
-        underTest.add(ref1);
-        underTest.add(ref2);
-        final var messageReceiver = new TestKit(actorSystem);
-        final var messageSender = new TestKit(actorSystem);
+        underTest.add(ACTOR_SYSTEM_RESOURCE.newTestProbe().ref());
+        underTest.add(ACTOR_SYSTEM_RESOURCE.newTestProbe().ref());
+        final var messageReceiver = ACTOR_SYSTEM_RESOURCE.newTestKit();
+        final var messageSender = ACTOR_SYSTEM_RESOURCE.newTestKit();
         final var messageReceiverRef = messageReceiver.getRef();
 
         messageReceiverRef.tell(underTest, messageSender.getRef());
 
-        final var receivedClientActorRefs = messageReceiver.expectMsgClass(underTest.getClass());
-
-        assertThat(receivedClientActorRefs).isEqualTo(underTest);
+        messageReceiver.expectMsg(underTest);
     }
 
 }

--- a/connectivity/service/src/test/resources/client-actor-refs-test.conf
+++ b/connectivity/service/src/test/resources/client-actor-refs-test.conf
@@ -1,0 +1,13 @@
+akka {
+  actor {
+    serialize-messages = on
+
+    serializers {
+      jackson-cbor = "akka.serialization.jackson.JacksonCborSerializer"
+    }
+
+    serialization-bindings {
+      "org.eclipse.ditto.internal.utils.cluster.AkkaJacksonCborSerializable" = jackson-cbor
+    }
+  }
+}


### PR DESCRIPTION
 so we can send this directly instead of sending a SourceRef

Signed-off-by: Yannic Klem <Yannic.Klem@bosch.io>