### PR TITLE
Test and fix false positives of ClusterStateSyncBehavior due to unserialized local actor refs

### DIFF
--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/AckUpdater.java
@@ -320,13 +320,15 @@ public final class AckUpdater extends AbstractActorWithTimers implements Cluster
     // NOT thread-safe
     private void writeLocalDData() {
         final LiteralUpdate diff = createAndSetDDataUpdate();
-        ackDData.getWriter()
-                .put(ownAddress, diff, (Replicator.WriteConsistency) Replicator.writeLocal())
-                .whenComplete((unused, error) -> {
-                    if (error != null) {
-                        log.error(error, "Failed to update local DData");
-                    }
-                });
+        if (!diff.isEmpty()) {
+            ackDData.getWriter()
+                    .put(ownAddress, diff, (Replicator.WriteConsistency) Replicator.writeLocal())
+                    .whenComplete((unused, error) -> {
+                        if (error != null) {
+                            log.error(error, "Failed to update local DData");
+                        }
+                    });
+        }
     }
 
     // NOT thread-safe

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
@@ -231,7 +231,12 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers
             final LiteralUpdate nextUpdate = subscriptions.export();
             // take snapshot to give to the subscriber; clear accumulated incremental changes.
             snapshot = subscriptions.snapshot();
-            ddataOp = ddata.getWriter().put(subscriber, nextUpdate.diff(previousUpdate), writeConsistency);
+            final var diff = nextUpdate.diff(previousUpdate);
+            if (!diff.isEmpty()) {
+                ddataOp = ddata.getWriter().put(subscriber, nextUpdate.diff(previousUpdate), writeConsistency);
+            } else {
+                ddataOp = CompletableFuture.completedStage(null);
+            }
             previousUpdate = nextUpdate;
             topicSizeMetric.set(subscriptions.estimateSize());
         }


### PR DESCRIPTION
Before serialization, local actor refs do not include the IP of
its cluster member as a part of its address. ClusterStateSyncBehavior
should treat such addresses like the address of its own cluster
member.

Changed the unit tests to detect mishandling of unserialized addresses.
