### PR TITLE
fixed that JSON `null` in "correlation-id" of Ditto Protocol headers were parsed as JSON String `"null"`

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/headers/AbstractDittoHeadersBuilder.java
@@ -172,8 +172,10 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
         final Map<String, String> result = new LinkedHashMap<>(jsonObject.getSize());
         jsonObject.forEach(jsonField -> {
             final JsonValue jsonValue = jsonField.getValue();
-            final String stringValue = jsonValue.isString() ? jsonValue.asString() : jsonValue.toString();
-            result.put(jsonField.getKeyName(), stringValue);
+            if (!jsonValue.isNull()) {
+                final String stringValue = jsonValue.isString() ? jsonValue.asString() : jsonValue.toString();
+                result.put(jsonField.getKeyName(), stringValue);
+            }
         });
 
         return result;
@@ -279,7 +281,9 @@ public abstract class AbstractDittoHeadersBuilder<S extends AbstractDittoHeaders
     }
 
     private void putJsonValue(final HeaderDefinition definition, final JsonValue jsonValue) {
-        putCharSequence(definition, jsonValue.isString() ? jsonValue.asString() : jsonValue.toString());
+        if (!jsonValue.isNull()) {
+            putCharSequence(definition, jsonValue.isString() ? jsonValue.asString() : jsonValue.toString());
+        }
     }
 
     @Override

--- a/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
+++ b/base/model/src/test/java/org/eclipse/ditto/base/model/headers/DefaultDittoHeadersBuilderTest.java
@@ -147,6 +147,20 @@ public final class DefaultDittoHeadersBuilderTest {
     }
 
     @Test
+    public void jsonRepresentationOfDittoHeadersWithNullCorrelationIdHasNoCorrelationId() {
+        final DittoHeaders expectedDittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(null)
+                .build();
+        final JsonObject jsonHeadersWithNullCorrelationId = JsonObject.newBuilder()
+                .set(DittoHeaderDefinition.CORRELATION_ID.getKey(), JsonValue.nullLiteral())
+                .build();
+        final DittoHeaders dittoHeaders = DittoHeaders.newBuilder(jsonHeadersWithNullCorrelationId).build();
+
+        assertThat(dittoHeaders).isEqualTo(expectedDittoHeaders);
+        assertThat(dittoHeaders.getCorrelationId()).isEmpty();
+    }
+
+    @Test
     public void jsonRepresentationOfDittoHeadersWithCorrelationIdOnlyIsExpected() {
         final DittoHeaders dittoHeaders = underTest.correlationId(CORRELATION_ID).build();
         final JsonObject jsonObject = dittoHeaders.toJson();

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/ResponseReceiverCache.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/ResponseReceiverCache.java
@@ -203,13 +203,12 @@ final class ResponseReceiverCache implements Extension {
             final boolean refreshCorrelationId) {
 
         final String correlationId;
-        final AtomicBoolean correlationIdRefreshed = new AtomicBoolean(false);
+        final AtomicBoolean correlationIdRefreshed = new AtomicBoolean(refreshCorrelationId);
         if (refreshCorrelationId) {
             final String newId = UUID.randomUUID().toString();
             correlationId = SignalInformationPoint.getCorrelationId(signal)
                     .map(existingId -> existingId + "_" + newId)
                     .orElse(newId);
-            correlationIdRefreshed.set(true);
         } else {
             correlationId = SignalInformationPoint.getCorrelationId(signal)
                     .orElseGet(() -> {

--- a/internal/models/signal/src/test/java/org/eclipse/ditto/internal/models/signal/correlation/CommandAndCommandResponseMatchingValidatorTest.java
+++ b/internal/models/signal/src/test/java/org/eclipse/ditto/internal/models/signal/correlation/CommandAndCommandResponseMatchingValidatorTest.java
@@ -14,6 +14,8 @@ package org.eclipse.ditto.internal.models.signal.correlation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.UUID;
+
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.eclipse.ditto.base.model.acks.AcknowledgementLabel;
 import org.eclipse.ditto.base.model.common.HttpStatus;
@@ -130,6 +132,24 @@ public final class CommandAndCommandResponseMatchingValidatorTest {
                         .isEqualTo("Correlation ID of live response <%s> differs from correlation ID of command <%s>.",
                                 null,
                                 correlationIdCommand));
+    }
+
+    @Test
+    public void applyCommandWithCorrelationIdAndCommandResponseWithSuffixedSameCorrelationId() {
+        final var correlationIdCommand = testNameCorrelationId.getCorrelationId();
+        final var dittoHeaders = DittoHeaders.newBuilder().correlationId(correlationIdCommand).build();
+        final var command = RetrieveThing.of(THING_ID, dittoHeaders);
+        final var correlationIdCommandResponse = correlationIdCommand.withSuffix("_" +
+                UUID.randomUUID());
+        final var responseDittoHeaders = DittoHeaders.newBuilder()
+                .correlationId(correlationIdCommandResponse)
+                .build();
+        final var commandResponse = RetrieveThingResponse.of(THING_ID, JsonObject.empty(), responseDittoHeaders);
+        final var underTest = CommandAndCommandResponseMatchingValidator.getInstance();
+
+        final var validationResult = underTest.apply(command, commandResponse);
+
+        assertThat(validationResult.isSuccess()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
* also fixed correlation-id logging in WebSocketRoute which did not respect the signal specific correlation-id but always used the "channel-correlation-id" for logging