### PR TITLE
Remove left-over tagging for waiting ack counter

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -194,7 +194,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
                 if (dittoRuntimeException != null) {
                     if (isConsideredSuccess(dittoRuntimeException)) {
                         ackTimer.tag(TracingTags.ACK_SUCCESS, true).stop();
-                        ackCounter.tag(TracingTags.ACK_SUCCESS, true).decrement();
+                        ackCounter.decrement();
                         acknowledgeableMessage.settle();
                     } else {
                         final var shouldRedeliver = requiresRedelivery(dittoRuntimeException.getHttpStatus());


### PR DESCRIPTION
ackCounter didn't decrement correctly on precondition failed acks.