### PR TITLE
Ignore DittoMessageMapper for hono delivery failed notifications

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/DittoMessageMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/DittoMessageMapper.java
@@ -44,7 +44,9 @@ public final class DittoMessageMapper extends AbstractMessageMapper {
             .set(MessageMapperConfiguration.CONTENT_TYPE_BLOCKLIST,
                     String.join(",", "application/vnd.eclipse-hono-empty-notification",
                             "application/vnd.eclipse-hono-device-provisioning-notification",
-                            "application/vnd.eclipse-hono-dc-notification+json"))
+                            "application/vnd.eclipse-hono-dc-notification+json",
+                            "application/vnd.eclipse-hono-delivery-failure-notification+json"
+                            ))
             .build();
 
     /**


### PR DESCRIPTION
hono delivery failed notifications lead to mapping failures in connection logs, because the notifications are not in ditto-protocol format and thus the DittoMessageMapper can't map them.