### PR TITLE
Fixed potential race condition in LiveSignalEnforcement.handleAskTimeoutForCommand()

### DIFF
--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/PolicyCommandEnforcement.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/enforcement/PolicyCommandEnforcement.java
@@ -344,12 +344,12 @@ public final class PolicyCommandEnforcement
     }
 
     @Override
-    protected DittoRuntimeException handleAskTimeoutForCommand(final PolicyCommand<?> command,
+    protected Optional<DittoRuntimeException> handleAskTimeoutForCommand(final PolicyCommand<?> command,
             final Throwable askTimeout) {
         log(command).error(askTimeout, "Timeout before building JsonView");
-        return PolicyUnavailableException.newBuilder(command.getEntityId())
+        return Optional.of(PolicyUnavailableException.newBuilder(command.getEntityId())
                 .dittoHeaders(command.getDittoHeaders())
-                .build();
+                .build());
     }
 
     @Override


### PR DESCRIPTION
which threw a 503 (ThingNotAvailable) exception and caused a race condition against a "graceful timeout"
* made the handleAskTimeoutForCommand() return an Optional and proceed with a null element in the CompletionStage if the optional was empty