### PR TITLE
Add configurable idle timeout for HTTP Push connections

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactory.java
@@ -135,6 +135,7 @@ final class DefaultHttpPushFactory implements HttpPushFactory {
         if (passwordSeparatorLocation >= 0) {
             final String username = userInfo.substring(0, passwordSeparatorLocation);
             final String password = userInfo.substring(Math.min(userInfo.length(), passwordSeparatorLocation + 1));
+
             return request.addCredentials(HttpCredentials.createBasicHttpCredentials(username, password));
         } else {
             return request;
@@ -154,6 +155,7 @@ final class DefaultHttpPushFactory implements HttpPushFactory {
         } else {
             baseUriStrToUse = baseUriStr;
         }
+
         return baseUriStrToUse;
     }
 
@@ -166,6 +168,7 @@ final class DefaultHttpPushFactory implements HttpPushFactory {
         } else {
             pathWithQueryToUse = PATH_DELIMITER + pathWithQuery;
         }
+
         return pathWithQueryToUse;
     }
 
@@ -232,6 +235,7 @@ final class DefaultHttpPushFactory implements HttpPushFactory {
     private static <T> Pair<Try<HttpResponse>, T> onRequestTimeout(final Pair<HttpRequest, T> requestPair) {
         final Try<HttpResponse> failure =
                 new Failure<>(new TimeoutException("Request timed out: " + requestPair.first().getUri()));
+
         return Pair.create(failure, requestPair.second());
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActor.java
@@ -294,7 +294,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
     private Flow<Pair<HttpRequest, HttpPushContext>, Pair<Try<HttpResponse>, HttpPushContext>, ?>
     buildHttpRequestFlow(final HttpPushConfig config) {
 
-        final Duration requestTimeout = config.getRequestTimeout();
+        final Duration requestTimeout = HttpPushSpecificConfig.fromConnection(connection, config).idleTimeout();
 
         final PreparedTimer timer = DittoMetrics.timer("http_publish_request_time")
                 // Set maximum duration higher than request timeout to avoid race conditions
@@ -389,10 +389,10 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                 result = requestWithoutEntity.withEntity(getTextPayload(message));
             } else {
                 result = requestWithoutEntity.withEntity(getBytePayload(message));
-        }
+            }
 
-        return result;
-    }
+            return result;
+        }
 
     }
 
@@ -451,7 +451,8 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                     l.debug("Got response <{} {} {}>", response.status(), response.getHeaders(),
                             response.entity().getContentType());
 
-                    toCommandResponseOrAcknowledgement(signal, autoAckTarget, response, maxTotalMessageSize, ackSizeQuota,
+                    toCommandResponseOrAcknowledgement(signal, autoAckTarget, response, maxTotalMessageSize,
+                            ackSizeQuota,
                             targetAuthorizationContext)
                             .thenAccept(resultFuture::complete)
                             .exceptionally(e -> {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActor.java
@@ -204,6 +204,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
         if (query != null) {
             newUri = newUri.rawQueryString(query);
         }
+
         return newUri;
     }
 
@@ -221,6 +222,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                 }
             }
         }
+
         return Pair.create(headers, contentType);
     }
 
@@ -255,7 +257,6 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
 
     private static CompletionStage<JsonValue> getResponseBody(final HttpResponse response, final int maxBytes,
             final Materializer materializer) {
-
         return response.entity()
                 .withSizeLimit(maxBytes)
                 .toStrict(READ_BODY_TIMEOUT_MS, materializer)
@@ -301,7 +302,6 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
         final BiConsumer<Duration, ConnectionMonitor.InfoProvider> logRequestTimes =
                 (duration, infoProvider) -> connectionLogger.success(infoProvider,
                         "HTTP request took <{0}> ms.", duration.toMillis());
-
 
         final Flow<Pair<HttpRequest, HttpPushContext>, Pair<HttpRequest, HttpPushContext>, NotUsed> oauthFlow =
                 ClientCredentialsFlowVisitor.eval(getContext().getSystem(), config, connection);
@@ -449,8 +449,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                             response.entity().getContentType());
 
                     toCommandResponseOrAcknowledgement(signal, autoAckTarget, response, maxTotalMessageSize,
-                            ackSizeQuota,
-                            targetAuthorizationContext)
+                            ackSizeQuota, targetAuthorizationContext)
                             .thenAccept(resultFuture::complete)
                             .exceptionally(e -> {
                                 resultFuture.completeExceptionally(e);
@@ -528,7 +527,6 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
                     // There is an issued ack declared but its not live-response => handle response as acknowledgement.
                     result = Acknowledgement.of(autoAckLabel.get(), entityId, httpStatus, mergedDittoHeaders, body);
                 }
-
             } else {
                 // No Acks declared as issued acks => Handle response either as live response or as acknowledgement
                 // or as fallback build a response for local diagnostics.
@@ -590,6 +588,7 @@ final class HttpPublisherActor extends BasePublisherActor<HttpPublishTarget> {
         } else {
             result = null;
         }
+
         return Optional.ofNullable(result);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactory.java
@@ -39,11 +39,6 @@ import scala.util.Try;
 public interface HttpPushFactory {
 
     /**
-     * Specific config name for the amount of concurrent HTTP requests to make.
-     */
-    String PARALLELISM_JSON_KEY = "parallelism";
-
-    /**
      * Create a request template without headers or payload for an HTTP publish target.
      * Published external messages set the headers and payload.
      *

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactory.java
@@ -91,4 +91,5 @@ public interface HttpPushFactory {
             final ConnectionLogger connectionLogger, final Supplier<SshTunnelState> tunnelConfigSupplier) {
         return DefaultHttpPushFactory.of(connection, httpPushConfig, connectionLogger, tunnelConfigSupplier);
     }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
@@ -26,6 +26,7 @@ import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueType;
 
 /**
  * Class providing access to HTTP push specific configuration.
@@ -34,9 +35,7 @@ import com.typesafe.config.ConfigFactory;
 public final class HttpPushSpecificConfig {
 
     static final String IDLE_TIMEOUT = "idleTimeout";
-
     static final String PARALLELISM = "parallelism";
-
     static final String OMIT_REQUEST_BODY = "omitRequestBody";
 
     private final Config specificConfig;
@@ -66,6 +65,7 @@ public final class HttpPushSpecificConfig {
         defaultMap.put(IDLE_TIMEOUT, httpConfig.getRequestTimeout());
         defaultMap.put(PARALLELISM, 1);
         defaultMap.put(OMIT_REQUEST_BODY, httpConfig.getOmitRequestBodyMethods());
+
         return defaultMap;
     }
 
@@ -90,7 +90,11 @@ public final class HttpPushSpecificConfig {
         try {
             return specificConfig.getStringList(OMIT_REQUEST_BODY);
         } catch (final ConfigException.WrongType e) {
-            return List.of(specificConfig.getString(OMIT_REQUEST_BODY).split(","));
+            final var configValue = specificConfig.getValue(OMIT_REQUEST_BODY);
+            if (ConfigValueType.STRING == configValue.valueType()) {
+                return List.of(specificConfig.getString(OMIT_REQUEST_BODY).split(","));
+            }
+            throw e;
         }
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.httppush;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Class providing access to HTTP push specific configuration.
+ */
+@Immutable
+public final class HttpPushSpecificConfig {
+
+    static final String IDLE_TIMEOUT = "idleTimeout";
+
+    private final Config specificConfig;
+
+    private HttpPushSpecificConfig(final Config specificConfig) {
+        this.specificConfig = specificConfig;
+    }
+
+    /**
+     * Creates a new instance of HttpSpecificConfig based on the {@code specificConfig} of the passed
+     * {@code connection}.
+     *
+     * @param connection the Connection to extract the {@code specificConfig} map from.
+     * @param httpConfig the http config to create the default config from.
+     * @return the new HttpSpecificConfig instance
+     */
+    public static HttpPushSpecificConfig fromConnection(final Connection connection, final HttpPushConfig httpConfig) {
+        final Map<String, Object> defaultConfig = toDefaultConfig(httpConfig);
+        final Config config = ConfigFactory.parseMap(connection.getSpecificConfig())
+                .withFallback(ConfigFactory.parseMap(defaultConfig));
+
+        return new HttpPushSpecificConfig(config);
+    }
+
+    private static Map<String, Object> toDefaultConfig(final HttpPushConfig httpConfig) {
+        final Map<String, Object> defaultMap = new HashMap<>();
+        defaultMap.put(IDLE_TIMEOUT, httpConfig.getRequestTimeout());
+        return defaultMap;
+    }
+
+    /**
+     * @return the idle timeout applied for HTTP push requests.
+     */
+    public Duration idleTimeout() {
+        return specificConfig.getDuration(IDLE_TIMEOUT);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final HttpPushSpecificConfig that = (HttpPushSpecificConfig) o;
+        return Objects.equals(specificConfig, that.specificConfig);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(specificConfig);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "specificConfig=" + specificConfig +
+                "]";
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfig.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.connectivity.service.messaging.httppush;
 
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
@@ -23,6 +24,7 @@ import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
 import com.typesafe.config.ConfigFactory;
 
 /**
@@ -32,6 +34,10 @@ import com.typesafe.config.ConfigFactory;
 public final class HttpPushSpecificConfig {
 
     static final String IDLE_TIMEOUT = "idleTimeout";
+
+    static final String PARALLELISM = "parallelism";
+
+    static final String OMIT_REQUEST_BODY = "omitRequestBody";
 
     private final Config specificConfig;
 
@@ -58,6 +64,8 @@ public final class HttpPushSpecificConfig {
     private static Map<String, Object> toDefaultConfig(final HttpPushConfig httpConfig) {
         final Map<String, Object> defaultMap = new HashMap<>();
         defaultMap.put(IDLE_TIMEOUT, httpConfig.getRequestTimeout());
+        defaultMap.put(PARALLELISM, 1);
+        defaultMap.put(OMIT_REQUEST_BODY, httpConfig.getOmitRequestBodyMethods());
         return defaultMap;
     }
 
@@ -66,6 +74,24 @@ public final class HttpPushSpecificConfig {
      */
     public Duration idleTimeout() {
         return specificConfig.getDuration(IDLE_TIMEOUT);
+    }
+
+    /**
+     * @return the parallelism applied to HTTP publishing.
+     */
+    public Integer parallelism() {
+        return specificConfig.getInt(PARALLELISM);
+    }
+
+    /**
+     * @return for which HTTP methods request bodies should be omitted.
+     */
+    public List<String> omitRequestBody() {
+        try {
+            return specificConfig.getStringList(OMIT_REQUEST_BODY);
+        } catch (final ConfigException.WrongType e) {
+            return List.of(specificConfig.getString(OMIT_REQUEST_BODY).split(","));
+        }
     }
 
     @Override

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactoryTest.java
@@ -13,10 +13,10 @@
 package org.eclipse.ditto.connectivity.service.messaging.httppush;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Map;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * Unit tests for {@link DefaultHttpPushFactory}.
@@ -25,24 +25,25 @@ public final class DefaultHttpPushFactoryTest {
 
     @Test
     public void ensureParsedParallelismIsAlwaysFactorOfTwo() {
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "1")))
-                .isEqualTo(1);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "2")))
-                .isEqualTo(2);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "3")))
-                .isEqualTo(4);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "4")))
-                .isEqualTo(4);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "5")))
-                .isEqualTo(8);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "8")))
-                .isEqualTo(8);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "9")))
-                .isEqualTo(16);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "10")))
-                .isEqualTo(16);
-        assertThat(DefaultHttpPushFactory.parseParallelism(Map.of(HttpPushFactory.PARALLELISM_JSON_KEY, "16")))
-                .isEqualTo(16);
+        final var mockConf = Mockito.mock(HttpPushSpecificConfig.class);
+        when(mockConf.parallelism()).thenReturn(1);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(1);
+        when(mockConf.parallelism()).thenReturn(2);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(2);
+        when(mockConf.parallelism()).thenReturn(3);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(4);
+        when(mockConf.parallelism()).thenReturn(4);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(4);
+        when(mockConf.parallelism()).thenReturn(5);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(8);
+        when(mockConf.parallelism()).thenReturn(8);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(8);
+        when(mockConf.parallelism()).thenReturn(9);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(16);
+        when(mockConf.parallelism()).thenReturn(10);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(16);
+        when(mockConf.parallelism()).thenReturn(16);
+        assertThat(DefaultHttpPushFactory.parseParallelism(mockConf)).isEqualTo(16);
     }
 
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPublisherActorTest.java
@@ -13,7 +13,7 @@
 package org.eclipse.ditto.connectivity.service.messaging.httppush;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpPublisherActor.OMIT_REQUEST_BODY_CONFIG_KEY;
+import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpPushSpecificConfig.OMIT_REQUEST_BODY;
 import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpTestDittoProtocolHelper.signalToJsonString;
 import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpTestDittoProtocolHelper.signalToMultiMapped;
 import static org.mockito.Mockito.mock;
@@ -907,13 +907,13 @@ public final class HttpPublisherActorTest extends AbstractPublisherActorTest {
     @Test
     public void testOmitRequestBody() throws Exception {
         testOmitRequestBody(HttpMethods.GET, Map.of(), true);
-        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, "GET"), true);
-        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, "POST"), false);
-        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, ""), false);
+        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY, "GET"), true);
+        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY, "POST"), false);
+        testOmitRequestBody(HttpMethods.GET, Map.of(OMIT_REQUEST_BODY, ""), false);
         testOmitRequestBody(HttpMethods.DELETE, Map.of(), true);
-        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, "GET,DELETE"), true);
-        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, "GET"), false);
-        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY_CONFIG_KEY, ""), false);
+        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY, "GET,DELETE"), true);
+        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY, "GET"), false);
+        testOmitRequestBody(HttpMethods.DELETE, Map.of(OMIT_REQUEST_BODY, ""), false);
     }
 
     private void testOmitRequestBody(final HttpMethod method, final Map<String, String> specificConfig,

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactoryTest.java
@@ -386,7 +386,6 @@ public final class HttpPushFactoryTest {
                 ConnectivityStatus.OPEN,
                 "http://127.0.0.1:" + binding.localAddress().getPort())
                 .targets(singletonList(AbstractBaseClientActorTest.HTTP_TARGET))
-                .specificConfig(Map.of())
                 .build();
     }
 
@@ -398,6 +397,7 @@ public final class HttpPushFactoryTest {
                 "  username = \"username\"\n" +
                 "  password = \"password\"\n" +
                 "}");
+
         return DefaultHttpProxyConfig.ofProxy(config);
     }
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushFactoryTest.java
@@ -386,6 +386,7 @@ public final class HttpPushFactoryTest {
                 ConnectivityStatus.OPEN,
                 "http://127.0.0.1:" + binding.localAddress().getPort())
                 .targets(singletonList(AbstractBaseClientActorTest.HTTP_TARGET))
+                .specificConfig(Map.of())
                 .build();
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfigTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.httppush;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.eclipse.ditto.connectivity.model.Connection;
+import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public final class HttpPushSpecificConfigTest {
+
+    private HttpPushConfig httpConfig;
+    private Connection connection;
+
+    @Before
+    public void setup() {
+        httpConfig = Mockito.mock(HttpPushConfig.class);
+        when(httpConfig.getRequestTimeout()).thenReturn(Duration.ofSeconds(2));
+        connection = Mockito.mock(Connection.class);
+    }
+
+    @Test
+    public void parseHttpSpecificConfig() {
+        final Map<String, String> configuredSpecificConfig = new HashMap<>();
+        configuredSpecificConfig.put(HttpPushSpecificConfig.IDLE_TIMEOUT, "3s");
+
+        when(connection.getSpecificConfig()).thenReturn(configuredSpecificConfig);
+        final var specificConfig = HttpPushSpecificConfig.fromConnection(connection, httpConfig);
+
+        assertThat(specificConfig.idleTimeout()).isEqualTo(Duration.ofSeconds(3));
+    }
+
+    @Test
+    public void defaultConfig() {
+        when(connection.getSpecificConfig()).thenReturn(Collections.emptyMap());
+        final HttpPushSpecificConfig specificConfig = HttpPushSpecificConfig.fromConnection(connection, httpConfig);
+
+        assertThat(specificConfig.idleTimeout()).isEqualTo(Duration.ofSeconds(2));
+    }
+
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushSpecificConfigTest.java
@@ -16,9 +16,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 import java.time.Duration;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.eclipse.ditto.connectivity.model.Connection;
 import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
@@ -26,6 +29,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+/**
+ * Unit test for {@link HttpPushSpecificConfig}.
+ */
 public final class HttpPushSpecificConfigTest {
 
     private HttpPushConfig httpConfig;
@@ -34,27 +40,38 @@ public final class HttpPushSpecificConfigTest {
     @Before
     public void setup() {
         httpConfig = Mockito.mock(HttpPushConfig.class);
-        when(httpConfig.getRequestTimeout()).thenReturn(Duration.ofSeconds(2));
         connection = Mockito.mock(Connection.class);
     }
 
     @Test
     public void parseHttpSpecificConfig() {
+        final String omitBodyRequest = "OPTIONS,DELETE";
         final Map<String, String> configuredSpecificConfig = new HashMap<>();
         configuredSpecificConfig.put(HttpPushSpecificConfig.IDLE_TIMEOUT, "3s");
+        configuredSpecificConfig.put(HttpPushSpecificConfig.PARALLELISM, "2");
+        configuredSpecificConfig.put(HttpPushSpecificConfig.OMIT_REQUEST_BODY, omitBodyRequest);
 
+        when(httpConfig.getRequestTimeout()).thenReturn(Duration.ofSeconds(2));
         when(connection.getSpecificConfig()).thenReturn(configuredSpecificConfig);
         final var specificConfig = HttpPushSpecificConfig.fromConnection(connection, httpConfig);
 
         assertThat(specificConfig.idleTimeout()).isEqualTo(Duration.ofSeconds(3));
+        assertThat(specificConfig.parallelism()).isEqualTo(2);
+        assertThat(specificConfig.omitRequestBody())
+                .isEqualTo(Arrays.stream(omitBodyRequest.split(",")).collect(Collectors.toList()));
     }
 
     @Test
     public void defaultConfig() {
+        final List<String> expectedOmittedRequestBody = List.of("GET", "DELETE");
         when(connection.getSpecificConfig()).thenReturn(Collections.emptyMap());
+        when(httpConfig.getRequestTimeout()).thenReturn(Duration.ofSeconds(60));
+        when(httpConfig.getOmitRequestBodyMethods()).thenReturn(expectedOmittedRequestBody);
         final HttpPushSpecificConfig specificConfig = HttpPushSpecificConfig.fromConnection(connection, httpConfig);
 
-        assertThat(specificConfig.idleTimeout()).isEqualTo(Duration.ofSeconds(2));
+        assertThat(specificConfig.idleTimeout()).isEqualTo(Duration.ofSeconds(60));
+        assertThat(specificConfig.parallelism()).isEqualTo(1);
+        assertThat(specificConfig.omitRequestBody()).isEqualTo(expectedOmittedRequestBody);
     }
 
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.connectivity.service.messaging.httppush;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.ditto.connectivity.service.messaging.TestConstants.Authorization.AUTHORIZATION_CONTEXT;
+import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpPushSpecificConfig.OMIT_REQUEST_BODY;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
@@ -129,7 +130,7 @@ public final class HttpPushValidatorTest {
     @Test
     public void testInvalidOmitBodyHttpMethod() {
         final Connection connection = getConnectionWithTarget("POST:events").toBuilder()
-                .specificConfig(Map.of(HttpPublisherActor.OMIT_REQUEST_BODY_CONFIG_KEY, "GET,DELET,POST"))
+                .specificConfig(Map.of(OMIT_REQUEST_BODY, "GET,DELET,POST"))
                 .build();
         verifyConnectionConfigurationInvalidExceptionIsThrown(connection, "It contains an invalid HTTP method");
     }
@@ -155,7 +156,7 @@ public final class HttpPushValidatorTest {
     @Test
     public void testEmptyOmitBodyHttpMethods() {
         final Connection connection = getConnectionWithTarget("POST:events").toBuilder()
-                .specificConfig(Map.of(HttpPublisherActor.OMIT_REQUEST_BODY_CONFIG_KEY, ""))
+                .specificConfig(Map.of(OMIT_REQUEST_BODY, ""))
                 .build();
         underTest.validate(connection, DittoHeaders.empty(), actorSystem, connectivityConfig);
     }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
@@ -135,6 +135,18 @@ public final class HttpPushValidatorTest {
     }
 
     @Test
+    public void testInvalidIdleTime() {
+        final var idleTimeout = "-3s";
+        final Connection connection = getConnectionWithTarget("POST:events").toBuilder()
+                .specificConfig(Map.of(HttpPushSpecificConfig.IDLE_TIMEOUT, idleTimeout))
+                .build();
+        verifyConnectionConfigurationInvalidExceptionIsThrown(connection,
+                "Idle timeout '" + idleTimeout.substring(0, idleTimeout.length() - 1) +
+                        "' is not within the allowed range of [0, " + HttpPushValidator.MAX_IDLE_TIMEOUT.toSeconds() +
+                        "] seconds.");
+    }
+
+    @Test
     public void testNullOmitBodyHttpMethods() {
         final Connection connection = getConnectionWithTarget("POST:events").toBuilder().build();
         underTest.validate(connection, DittoHeaders.empty(), actorSystem, connectivityConfig);
@@ -154,7 +166,7 @@ public final class HttpPushValidatorTest {
 
     private static Connection getConnectionWithHostAndTarget(final String host, final String target) {
         return ConnectivityModelFactory.newConnectionBuilder(CONNECTION_ID, ConnectionType.HTTP_PUSH,
-                        ConnectivityStatus.OPEN, "http://" + host + ":80")
+                ConnectivityStatus.OPEN, "http://" + host + ":80")
                 .targets(singletonList(ConnectivityModelFactory.newTargetBuilder()
                         .address(target)
                         .authorizationContext(AUTHORIZATION_CONTEXT)


### PR DESCRIPTION
The idle timeout the HTTP publisher waits for a response from the consumer can then be configured via the specific config of the HTTP Push connection.
Additionally moved the existing HTTP Push specific config to own class and adjusted the validation.