### PR TITLE
Fix that wrong metadata in search updater causes patch failure

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/WriteResultAndErrors.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/WriteResultAndErrors.java
@@ -34,16 +34,19 @@ public final class WriteResultAndErrors {
     private final BulkWriteResult bulkWriteResult;
     private final List<BulkWriteError> bulkWriteErrors;
     @Nullable private final Throwable unexpectedError;
+    private final String bulkWriteCorrelationId;
 
     private WriteResultAndErrors(
             final List<AbstractWriteModel> writeModels,
             final BulkWriteResult bulkWriteResult,
             final List<BulkWriteError> bulkWriteErrors,
-            @Nullable final Throwable unexpectedError) {
+            @Nullable final Throwable unexpectedError,
+            final String bulkWriteCorrelationId) {
         this.writeModels = writeModels;
         this.bulkWriteResult = bulkWriteResult;
         this.bulkWriteErrors = bulkWriteErrors;
         this.unexpectedError = unexpectedError;
+        this.bulkWriteCorrelationId = bulkWriteCorrelationId;
     }
 
     /**
@@ -51,11 +54,13 @@ public final class WriteResultAndErrors {
      *
      * @param writeModels the write models requested.
      * @param bulkWriteResult the successful bulk write result.
+     * @param bulkWriteCorrelationId a correlationId to use for correlating bulk write log statements.
      * @return the write result without errors.
      */
     public static WriteResultAndErrors success(final List<AbstractWriteModel> writeModels,
-            final BulkWriteResult bulkWriteResult) {
-        return new WriteResultAndErrors(writeModels, bulkWriteResult, Collections.emptyList(), null);
+            final BulkWriteResult bulkWriteResult,
+            final String bulkWriteCorrelationId) {
+        return new WriteResultAndErrors(writeModels, bulkWriteResult, Collections.emptyList(), null, bulkWriteCorrelationId);
     }
 
     /**
@@ -63,12 +68,14 @@ public final class WriteResultAndErrors {
      *
      * @param writeModels the requested write models.
      * @param mongoBulkWriteException the exception.
+     * @param bulkWriteCorrelationId a correlationId to use for correlating bulk write log statements.
      * @return the write result with errors.
      */
     public static WriteResultAndErrors failure(final List<AbstractWriteModel> writeModels,
-            final MongoBulkWriteException mongoBulkWriteException) {
+            final MongoBulkWriteException mongoBulkWriteException,
+            final String bulkWriteCorrelationId) {
         return new WriteResultAndErrors(writeModels, mongoBulkWriteException.getWriteResult(),
-                mongoBulkWriteException.getWriteErrors(), null);
+                mongoBulkWriteException.getWriteErrors(), null, bulkWriteCorrelationId);
     }
 
     /**
@@ -77,12 +84,14 @@ public final class WriteResultAndErrors {
      *
      * @param writeModels the requested write models.
      * @param unexpectedError the unexpected error.
+     * @param bulkWriteCorrelationId a correlationId to use for correlating bulk write log statements.
      * @return the write result with an unexpected error.
      */
     public static WriteResultAndErrors unexpectedError(final List<AbstractWriteModel> writeModels,
-            final Throwable unexpectedError) {
+            final Throwable unexpectedError,
+            final String bulkWriteCorrelationId) {
         return new WriteResultAndErrors(writeModels, BulkWriteResult.unacknowledged(), Collections.emptyList(),
-                unexpectedError);
+                unexpectedError, bulkWriteCorrelationId);
     }
 
     /**
@@ -121,6 +130,15 @@ public final class WriteResultAndErrors {
         return Optional.ofNullable(unexpectedError);
     }
 
+    /**
+     * Retrieve the correlationId of the bulk write operation to use for correlating log statements.
+     *
+     * @return the correlationId of the bulk write operation.
+     */
+    public String getBulkWriteCorrelationId() {
+        return bulkWriteCorrelationId;
+    }
+
     @Override
     public boolean equals(final Object o) {
         if (o instanceof WriteResultAndErrors) {
@@ -128,7 +146,8 @@ public final class WriteResultAndErrors {
             return Objects.equals(writeModels, that.writeModels) &&
                     Objects.equals(bulkWriteResult, that.bulkWriteResult) &&
                     Objects.equals(bulkWriteErrors, that.bulkWriteErrors) &&
-                    Objects.equals(unexpectedError, that.unexpectedError);
+                    Objects.equals(unexpectedError, that.unexpectedError) &&
+                    Objects.equals(bulkWriteCorrelationId, that.bulkWriteCorrelationId);
         } else {
             return false;
         }
@@ -136,7 +155,7 @@ public final class WriteResultAndErrors {
 
     @Override
     public int hashCode() {
-        return Objects.hash(writeModels, bulkWriteResult, bulkWriteErrors, unexpectedError);
+        return Objects.hash(writeModels, bulkWriteResult, bulkWriteErrors, unexpectedError, bulkWriteCorrelationId);
     }
 
     @Override
@@ -146,6 +165,7 @@ public final class WriteResultAndErrors {
                 ",bulkWriteResult=" + bulkWriteResult +
                 ",bulkWriteErrors=" + bulkWriteErrors +
                 ",unexpectedError=" + unexpectedError +
+                ",bulkWriteCorrelationId=" + bulkWriteCorrelationId +
                 "]";
     }
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -188,6 +188,8 @@ final class ThingUpdater extends AbstractActorWithStashWithTimers {
 
     private void recoveryComplete(final AbstractWriteModel writeModel) {
         log.debug("Recovered: <{}>", writeModel);
+        thingRevision = writeModel.getMetadata().getThingRevision();
+        writeModel.getMetadata().getPolicyRevision().ifPresent(policyRevision -> this.policyRevision = policyRevision);
         lastWriteModel = writeModel;
         getContext().become(recoveredBehavior());
         unstashAll();

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlowTest.java
@@ -73,7 +73,7 @@ public final class BulkWriteResultAckFlowTest {
         );
 
         // WHEN
-        final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.success(writeModels, result);
+        final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.success(writeModels, result, "correlation");
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN
@@ -92,7 +92,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with errors, one of which is not duplicate key
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()), "correlation");
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: the non-duplicate-key error triggers a failure acknowledgement
@@ -110,7 +110,7 @@ public final class BulkWriteResultAckFlowTest {
         // WHEN: BulkWriteResultAckFlow receives unexpected error
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.unexpectedError(writeModels,
                 new MongoSocketReadException("Gee, database is down. Whatever shall I do?", new ServerAddress(),
-                        new IllegalMonitorStateException("Unsupported resolution")));
+                        new IllegalMonitorStateException("Unsupported resolution")), "correlation");
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: all ThingUpdaters receive negative acknowledgement.
@@ -136,7 +136,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with at least 1 error with out-of-bound index
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()), "correlation");
         final String message = runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: All updates are considered failures
@@ -161,7 +161,7 @@ public final class BulkWriteResultAckFlowTest {
 
         // WHEN: BulkWriteResultAckFlow receives partial update success with errors, one of which is not duplicate key
         final WriteResultAndErrors resultAndErrors = WriteResultAndErrors.failure(writeModels,
-                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()));
+                new MongoBulkWriteException(result, updateFailure, null, new ServerAddress(), Set.of()), "correlation");
         runBulkWriteResultAckFlowAndGetFirstLogEntry(resultAndErrors);
 
         // THEN: only the non-duplicate-key sender receives negative acknowledgement

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -12,18 +12,32 @@
  */
 package org.eclipse.ditto.thingsearch.service.updater.actors;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+
 import java.time.Duration;
 import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.assertj.core.api.Assertions;
 import org.bson.BsonArray;
 import org.bson.BsonDocument;
+import org.bson.BsonDocumentReader;
 import org.bson.BsonInt64;
 import org.bson.BsonString;
+import org.bson.Document;
+import org.bson.codecs.DecoderContext;
+import org.bson.codecs.DocumentCodec;
 import org.eclipse.ditto.base.api.common.Shutdown;
 import org.eclipse.ditto.base.api.common.ShutdownReasonFactory;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
+import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
+import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClientSettings;
 import org.eclipse.ditto.policies.api.PolicyReferenceTag;
 import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.model.PolicyId;
@@ -32,13 +46,24 @@ import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.events.ThingCreated;
 import org.eclipse.ditto.thingsearch.api.UpdateReason;
+import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
+import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingWriteModel;
+import org.eclipse.ditto.thingsearch.service.starter.actors.MongoClientExtension;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mongodb.scala.bson.BsonNumber;
+import org.reactivestreams.Subscriber;
 
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.ReplaceOneModel;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.reactivestreams.client.FindPublisher;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
@@ -47,6 +72,7 @@ import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Props;
 import akka.cluster.pubsub.DistributedPubSubMediator;
+import akka.stream.testkit.TestPublisher;
 import akka.testkit.TestProbe;
 import akka.testkit.javadsl.TestKit;
 import scala.concurrent.duration.FiniteDuration;
@@ -72,10 +98,31 @@ public final class ThingUpdaterTest {
     private TestProbe pubSubTestProbe;
     private TestProbe changeQueueTestProbe;
 
+    private MongoClientExtension mongoClientExtension;
+    private DittoMongoClient dittoMongoClient;
+    private MongoDatabase mongoDatabase;
+    private MongoCollection<Document> searchCollection;
+    private FindPublisher<Document> findPublisher;
+
     @Before
     public void setUpBase() {
         final Config config = ConfigFactory.load("test");
         startActorSystem(config);
+        mongoClientExtension = Mockito.mock(MongoClientExtension.class);
+        dittoMongoClient = Mockito.mock(DittoMongoClient.class);
+        Mockito.when(mongoClientExtension.getSearchClient()).thenReturn(dittoMongoClient);
+        mongoDatabase = Mockito.mock(MongoDatabase.class);
+        Mockito.when(dittoMongoClient.getDefaultDatabase()).thenReturn(mongoDatabase);
+        Mockito.when(dittoMongoClient.getDittoSettings()).thenReturn(DittoMongoClientSettings.getBuilder().build());
+        searchCollection = Mockito.mock(MongoCollection.class);
+        Mockito.when(mongoDatabase.getCollection(PersistenceConstants.THINGS_COLLECTION_NAME))
+                .thenReturn(searchCollection);
+        findPublisher = Mockito.mock(FindPublisher.class);
+        Mockito.when(searchCollection.find(Filters.eq(PersistenceConstants.FIELD_ID, THING_ID.toString())))
+                .thenReturn(findPublisher);
+        Mockito.when(findPublisher.limit(anyInt())).thenReturn(findPublisher);
+        Mockito.when(findPublisher.skip(anyInt())).thenReturn(findPublisher);
+        Mockito.when(findPublisher.sort(any())).thenReturn(findPublisher);
     }
 
     @After
@@ -184,7 +231,8 @@ public final class ThingUpdaterTest {
         new TestKit(actorSystem) {{
             final Props props = Props.create(ThingUpdater.class,
                     () -> new ThingUpdater(pubSubTestProbe.ref(), changeQueueTestProbe.ref(), 0.0,
-                            Duration.ofMinutes(1), 0.0, false, true));
+                            Duration.ofMinutes(1), 0.0, mongoClientExtension, false, true,
+                            writeModel -> {}));
             final var underTest = childActorOf(props, THING_ID.toString());
 
             final var document = new BsonDocument()
@@ -208,27 +256,64 @@ public final class ThingUpdaterTest {
     }
 
     @Test
-    public void forceUpdateAfterInitialStart() {
+    public void forceUpdateAfterInitialStart() throws InterruptedException {
         new TestKit(actorSystem) {{
             final PolicyId policyId = PolicyId.of(THING_ID);
             final Duration forceUpdateAfterStartTimeout = Duration.ofSeconds(1);
 
+            final TestPublisher.Probe<Object> probe = TestPublisher.probe(1, actorSystem);
+            doAnswer(invocation -> {
+                probe.subscribe(invocation.getArgument(0, Subscriber.class));
+                return null;
+            }).when(findPublisher).subscribe(any());
+
+            final CountDownLatch recoveryCompleteLatch = new CountDownLatch(1);
+            final Consumer<AbstractWriteModel> recoveryCompleteConsumer = writeModel -> {
+                recoveryCompleteLatch.countDown();
+            };
             final Props props = Props.create(ThingUpdater.class,
                     () -> new ThingUpdater(pubSubTestProbe.ref(), changeQueueTestProbe.ref(), 0.0,
-                            forceUpdateAfterStartTimeout, 0.0, false, true));
+                            forceUpdateAfterStartTimeout, 0.0, mongoClientExtension, true, true,
+                            recoveryCompleteConsumer));
             final var underTest = childActorOf(props, THING_ID.toString());
 
+            final long request = probe.expectRequest();
+            DocumentCodec codec = new DocumentCodec();
+            DecoderContext decoderContext = DecoderContext.builder().build();
+            final var existingIndexDocument = codec.decode(new BsonDocumentReader(new BsonDocument()
+                    .append(PersistenceConstants.FIELD_ID, new BsonString(THING_ID.toString()))
+                    .append(PersistenceConstants.FIELD_REVISION, new BsonInt64(1234L))
+                    .append(PersistenceConstants.FIELD_POLICY_ID, new BsonString(THING_ID.toString()))
+                    .append(PersistenceConstants.FIELD_POLICY_REVISION, new BsonInt64(1L))
+                    .append(PersistenceConstants.FIELD_NAMESPACE, new BsonString(THING_ID.getNamespace()))
+                    .append(PersistenceConstants.FIELD_GLOBAL_READ, new BsonString("pre:ditto"))
+                    .append(PersistenceConstants.FIELD_SORTING, new BsonDocument().append("Lorem ipsum",
+                            new BsonString("Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
+                                    "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.")))
+                    .append(PersistenceConstants.FIELD_INTERNAL, new BsonArray())
+            ), decoderContext);
+            probe.sendNext(existingIndexDocument);
+
+            // wait until Actor was recovered:
+            assertThat(recoveryCompleteLatch.await(5L, TimeUnit.SECONDS)).isTrue();
+
             final var document = new BsonDocument()
-                    .append("_revision", new BsonInt64(1234))
+                    .append("_revision", new BsonInt64(1235))
                     .append("d", new BsonArray())
                     .append("s", new BsonDocument().append("Lorem ipsum", new BsonString(
                             "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " +
                                     "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
                     )));
-            final var writeModel = ThingWriteModel.of(Metadata.of(THING_ID, 1234L, policyId, 1L, null), document);
+            final var writeModel = ThingWriteModel.of(Metadata.of(THING_ID, 1235L, policyId, 1L, null), document);
 
-            // GIVEN: updater is recovered with a write model
-            underTest.tell(writeModel, ActorRef.noSender());
+            // WHEN: updater is requested to compute incremental update against the next update
+            underTest.tell(writeModel, getRef());
+
+            final UpdateOneModel<?> updateOneModel = expectMsgClass(UpdateOneModel.class);
+            Assertions.assertThat(updateOneModel.getFilter()).isEqualTo(Filters.and(
+                    Filters.eq(PersistenceConstants.FIELD_ID, new BsonString(THING_ID.toString())),
+                    Filters.eq(PersistenceConstants.FIELD_REVISION, BsonNumber.apply(1234L))
+            ));
 
             // WHEN: force-update-after-start-timeout passes
             final var waitDuration =
@@ -249,7 +334,8 @@ public final class ThingUpdaterTest {
     private ActorRef createThingUpdaterActor() {
         final Props props = Props.create(ThingUpdater.class,
                 () -> new ThingUpdater(pubSubTestProbe.ref(), changeQueueTestProbe.ref(), 0.0, Duration.ofMinutes(1),
-                        0.0, false, false));
+                        0.0, mongoClientExtension, false, false,
+                        writeModel -> {}));
         return actorSystem.actorOf(props, THING_ID.toString());
     }
 


### PR DESCRIPTION
When loading the search index after initialization of the ThingUpdater, the metadata was not updated accordingly to the retrieved data, but the revision was kept at `-1` which caused the next update to be a full update and also fail all other changes included in a bulk write.

This bugfix fixes that.