### PR TITLE
Adapt error propagation of tunnel errors 

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -651,7 +651,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         if (to == CONNECTING) {
             clientConnectingGauge.set(1L);
         }
-        // dont use else if since we might use goTo(CONNECTING) if in CONNECTING state. This will cause another onTransition.
+        // do not use else if since we might use goTo(CONNECTING) if in CONNECTING state. This will cause another onTransition.
         if (from == CONNECTING) {
             clientConnectingGauge.reset();
         }
@@ -1017,6 +1017,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
     private FSM.State<BaseClientState, BaseClientData> connectionTimedOut(final BaseClientData data) {
         data.getSessionSenders().forEach(sender -> {
             final DittoRuntimeException error = ConnectionFailedException.newBuilder(connectionId())
+                    .description("Connection attempt timed out.")
                     .dittoHeaders(sender.second())
                     .build();
             sender.first().tell(new Status.Failure(error), getSelf());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -812,7 +812,7 @@ public final class ConnectionPersistenceActor
         broadcastToClientActorsIfStarted(closeConnection)
                 .thenAccept(response -> getSelf().tell(command, ActorRef.noSender()))
                 .exceptionally(error -> {
-                    // stop client actors anyway---the closed status is already persisted.
+                    // stop client actors anyway --- the closed status is already persisted.
                     stopClientActors();
                     return handleException("disconnect", command.getSender(), error);
                 });
@@ -1182,7 +1182,7 @@ public final class ConnectionPersistenceActor
         CHECK_LOGGING_ACTIVE,
 
         /**
-         * Indicates the the priority of the connection should get updated
+         * Indicates the priority of the connection should get updated
          */
         TRIGGER_UPDATE_PRIORITY
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/tunnel/SshTunnelActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/tunnel/SshTunnelActor.java
@@ -218,11 +218,13 @@ public final class SshTunnelActor extends AbstractActorWithTimers implements Cre
 
     private void handleTunnelClosed(final TunnelClosed tunnelClosed) {
         if (tunnelClosed.getError() != null) {
-            connectionLogger.failure("SSH Tunnel failed: {0}", getMessage(tunnelClosed.getError()));
-            logger.debug("SSH Tunnel failed: {0}", getMessage(tunnelClosed.getError()));
+            final String message = String.format("SSH Tunnel failed: %s", getMessage(tunnelClosed.getError()));
+            connectionLogger.failure(message);
+            logger.warning(message);
         } else {
-            connectionLogger.success("SSH Tunnel closed");
-            logger.debug("SSH Tunnel closed");
+            final String msg = "SSH Tunnel closed";
+            connectionLogger.success(msg);
+            logger.debug(msg);
         }
         notifyParentAndCleanup(tunnelClosed);
     }

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -668,7 +668,8 @@ ditto {
       # Initial timeout when connecting to a remote system. If the connection could not be established after this time,
       # the service will try to reconnect. If a failure happened during connecting, then the service will wait
       # for at least this time until it will try to reconnect. The max timeout is defined in connecting-max-timeout.
-      connecting-min-timeout = 60s
+      # this timeout needs to be smaller than ditto.connectivity.connection.client-actor-ask-timeout in connectivity.conf
+      connecting-min-timeout = 50s
       connecting-min-timeout = ${?CONNECTIVITY_CLIENT_CONNECTING_MIN_TIMEOUT}
       # Max timeout (until reconnecting) when connecting to a remote system.
       # Should be greater than connecting-min-timeout.


### PR DESCRIPTION
Propagate all errors to the parent actor in case the SSH tunnel failed.
Adapt connecting-min-timeout to 50s because this timeout needs to be smaller than ditto.connectivity.connection.client-actor-ask-timeout in connectivity.conf which is currently 55s.
      