### PR TITLE
Adapt documentation for building ditto

### DIFF
--- a/documentation/src/main/resources/pages/ditto/installation-building.md
+++ b/documentation/src/main/resources/pages/ditto/installation-building.md
@@ -8,29 +8,11 @@ permalink: installation-building.html
 ## Building with Apache Maven
 
 In order to build Ditto with Maven, you'll need:
-* JDK 11 >= 11.0.5,
-* Apache Maven 3.x installed,
+* JDK 17 >= 17.0.2,
+* Apache Maven >=3.8 installed,
 * a running Docker daemon (at least version 18.06 CE).
 
 ```bash
 mvn clean install
 sh build-images.sh
 ```
-
-## Building with Docker
-
-In order to build Ditto with Docker, you'll need a running Docker daemon (at least version 18.06 CE).
-
-If you do not have the appropriate Maven and JDK version available, you can also use a Maven Docker image as build 
-environment.
-
-```bash
-docker run -it --rm --name mvn-ditto \
-    -v "$PWD":/usr/src/mymaven -w /usr/src/mymaven \
-    -u root \
-    maven:3.6-jdk-11 \
-    mvn clean install
-
-sh build-images.sh
-```
-


### PR DESCRIPTION
* Removed building with docker as this is not working correctly because of
  'docker inside docker' for our MongoDB integration tests
* Adapt versions to recently upgraded versions