### PR TITLE
Don't publish messages with failed enrichments and issue failed ack

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfig.java
@@ -34,6 +34,7 @@ public final class DefaultMappingConfig implements MappingConfig {
     private final int bufferSize;
     private final int parallelism;
     private final int maxPoolSize;
+    private final boolean publishFailedEnrichments;
     private final JavaScriptConfig javaScriptConfig;
     private final MapperLimitsConfig mapperLimitsConfig;
 
@@ -41,6 +42,7 @@ public final class DefaultMappingConfig implements MappingConfig {
         bufferSize = config.getNonNegativeIntOrThrow(MappingConfigValue.BUFFER_SIZE);
         parallelism = config.getPositiveIntOrThrow(MappingConfigValue.PARALLELISM);
         maxPoolSize = config.getPositiveIntOrThrow(MappingConfigValue.MAX_POOL_SIZE);
+        publishFailedEnrichments = config.getBoolean(MappingConfigValue.PUBLISH_FAILED_ENRICHMENTS.getConfigPath());
         mapperLimitsConfig = DefaultMapperLimitsConfig.of(config);
         javaScriptConfig = DefaultJavaScriptConfig.of(config);
     }
@@ -75,6 +77,11 @@ public final class DefaultMappingConfig implements MappingConfig {
     }
 
     @Override
+    public boolean getPublishFailedEnrichments() {
+        return publishFailedEnrichments;
+    }
+
+    @Override
     public JavaScriptConfig getJavaScriptConfig() {
         return javaScriptConfig;
     }
@@ -96,13 +103,14 @@ public final class DefaultMappingConfig implements MappingConfig {
         return bufferSize == that.bufferSize &&
                 parallelism == that.parallelism &&
                 maxPoolSize == that.maxPoolSize &&
+                publishFailedEnrichments == that.publishFailedEnrichments &&
                 Objects.equals(javaScriptConfig, that.javaScriptConfig) &&
                 Objects.equals(mapperLimitsConfig, that.mapperLimitsConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(bufferSize, parallelism, maxPoolSize, javaScriptConfig, mapperLimitsConfig);
+        return Objects.hash(bufferSize, parallelism, maxPoolSize, publishFailedEnrichments, javaScriptConfig, mapperLimitsConfig);
     }
 
     @Override
@@ -111,6 +119,7 @@ public final class DefaultMappingConfig implements MappingConfig {
                 "bufferSize=" + bufferSize +
                 ", parallelism=" + parallelism +
                 ", maxPoolSize=" + maxPoolSize +
+                ", publishFailedEnrichments=" + publishFailedEnrichments +
                 ", javaScriptConfig=" + javaScriptConfig +
                 ", mapperLimitsConfig=" + mapperLimitsConfig +
                 "]";

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/MappingConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/mapping/MappingConfig.java
@@ -47,6 +47,11 @@ public interface MappingConfig {
     int getMaxPoolSize();
 
     /**
+     * @return whether messages with failed enrichments should be published.
+     */
+    boolean getPublishFailedEnrichments();
+
+    /**
      * Returns the config of the JavaScript message mapping.
      *
      * @return the config.
@@ -79,7 +84,12 @@ public interface MappingConfig {
         /**
          * The maximum parallelism used for mapping inbound and outbound messages in mapping processor actor.
          */
-        MAX_POOL_SIZE("max-pool-size", 5);
+        MAX_POOL_SIZE("max-pool-size", 5),
+
+        /**
+         * If messages with failed enrichments should be published.
+         */
+        PUBLISH_FAILED_ENRICHMENTS("publish-failed-enrichments", false);
 
         private final String path;
         private final Object defaultValue;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -204,6 +204,32 @@ public final class OutboundMappingProcessorActor
         }
     }
 
+    private static void issueFailedAcknowledgements(final Signal<?> signal,
+            final Predicate<AcknowledgementLabel> isFailedAckLabel,
+            final DittoRuntimeException dre,
+            final ActorRef sender) {
+
+        final Set<AcknowledgementRequest> requestedAcks = signal.getDittoHeaders().getAcknowledgementRequests();
+        final boolean customAckRequested = requestedAcks.stream()
+                .anyMatch(request -> !DittoAcknowledgementLabel.contains(request.getLabel()));
+
+        final Optional<EntityId> entityIdWithType = extractEntityId(signal);
+        if (customAckRequested && entityIdWithType.isPresent()) {
+            final List<AcknowledgementLabel> failedAckLabels = requestedAcks.stream()
+                    .map(AcknowledgementRequest::getLabel)
+                    .filter(isFailedAckLabel)
+                    .collect(Collectors.toList());
+            if (!failedAckLabels.isEmpty()) {
+                final DittoHeaders dittoHeaders = signal.getDittoHeaders();
+                final List<Acknowledgement> ackList = failedAckLabels.stream()
+                        .map(label -> failedAck(label, entityIdWithType.get(), dittoHeaders, dre))
+                        .collect(Collectors.toList());
+                final Acknowledgements failedAcks = Acknowledgements.of(ackList, dittoHeaders);
+                sender.tell(failedAcks, ActorRef.noSender());
+            }
+        }
+    }
+
     private int determinePoolSize(final int connectionPoolSize, final int maxPoolSize) {
         if (connectionPoolSize > maxPoolSize) {
             dittoLoggingAdapter.info("Configured pool size <{}> is greater than the configured max pool size <{}>." +
@@ -403,11 +429,11 @@ public final class OutboundMappingProcessorActor
                             .warning("Could not retrieve extra data due to: {} {}", error.getClass().getSimpleName(),
                                     error.getMessage());
                     // recover from all errors to keep message-mapping-stream running despite enrichment failures
-                    return Collections.singletonList(recoverFromEnrichmentError(outboundSignal, target, error));
+                    return recoverFromEnrichmentError(outboundSignal, target, error);
                 });
     }
 
-    private static Optional<EntityId> extractEntityId(Signal<?> signal) {
+    private static Optional<EntityId> extractEntityId(final Signal<?> signal) {
         return Optional.of(signal)
                 .filter(WithEntityId.class::isInstance)
                 .map(WithEntityId.class::cast)
@@ -415,8 +441,7 @@ public final class OutboundMappingProcessorActor
     }
 
     // Called inside future; must be thread-safe
-    @Nullable
-    private OutboundSignalWithSender recoverFromEnrichmentError(final OutboundSignalWithSender outboundSignal,
+    private List<OutboundSignalWithSender> recoverFromEnrichmentError(final OutboundSignalWithSender outboundSignal,
             final Target target, final Throwable error) {
 
         final var dittoRuntimeException = DittoRuntimeException.asDittoRuntimeException(error, t ->
@@ -443,9 +468,9 @@ public final class OutboundMappingProcessorActor
             clientActor.tell(connectionFailure, getSelf());
         }
         if (mappingConfig.getPublishFailedEnrichments()) {
-            return outboundSignal.setTargets(Collections.singletonList(target));
+            return Collections.singletonList(outboundSignal.setTargets(Collections.singletonList(target)));
         } else {
-            return null;
+            return Collections.singletonList(outboundSignal.setFailedEnrichment(dittoRuntimeException, target));
         }
     }
 
@@ -629,23 +654,48 @@ public final class OutboundMappingProcessorActor
                         return List.of();
                     } else {
                         final ActorRef sender = outboundSignals.get(0).sender;
-                        final List<Mapped> mappedSignals = outboundSignals.stream()
-                                .map(OutboundSignalWithSender::asMapped)
-                                .collect(Collectors.toList());
                         final List<Target> targetsToPublishAt = outboundSignals.stream()
                                 .map(OutboundSignal::getTargets)
                                 .flatMap(List::stream)
                                 .collect(Collectors.toList());
                         final Predicate<AcknowledgementLabel> willPublish =
                                 ConnectionValidator.getTargetIssuedAcknowledgementLabels(connection.getId(),
-                                                targetsToPublishAt)
+                                        targetsToPublishAt)
                                         .collect(Collectors.toSet())::contains;
+                        final var signalsWithoutEnrichmentFailures =
+                                filterFailedEnrichments(outboundSignals, willPublish);
+                        final List<Mapped> mappedSignals = signalsWithoutEnrichmentFailures
+                                .map(OutboundSignalWithSender::asMapped)
+                                .collect(Collectors.toList());
                         issueWeakAcknowledgements(outbound.getSource(),
                                 willPublish.negate().and(outboundMappingProcessor::isTargetIssuedAck),
                                 sender);
                         return List.of(OutboundSignalFactory.newMultiMappedOutboundSignal(mappedSignals, sender));
                     }
                 });
+    }
+
+    private static Stream<OutboundSignalWithSender> filterFailedEnrichments(
+            final Collection<OutboundSignalWithSender> signals,
+            final Predicate<AcknowledgementLabel> predicate) {
+
+        return signals.stream().filter(signal -> {
+            if (null != signal.enrichmentFailure) {
+                final var optionalAcknowledgementLabel = signal.getTargets()
+                        .get(signal.getTargets().indexOf(signal.enrichmentFailure.second()))
+                        .getIssuedAcknowledgementLabel();
+                if (optionalAcknowledgementLabel.isPresent()) {
+                    final Predicate<AcknowledgementLabel> perTargetPredicate =
+                            optionalAcknowledgementLabel.get()::equals;
+                    final var combinedPredicate = predicate.and(perTargetPredicate);
+                    issueFailedAcknowledgements(signal.getSource(), combinedPredicate, signal.enrichmentFailure.first(),
+                            signal.sender);
+                }
+                return false;
+            } else {
+                return true;
+            }
+        });
     }
 
     private Collection<OutboundSignalWithSender> applyFilter(final OutboundSignalWithSender outboundSignalWithExtra,
@@ -745,31 +795,44 @@ public final class OutboundMappingProcessorActor
         return Acknowledgement.weak(label, entityId, dittoHeaders, payload);
     }
 
+    private static Acknowledgement failedAck(final AcknowledgementLabel label,
+            final EntityId entityId,
+            final DittoHeaders dittoHeaders,
+            final DittoRuntimeException dre) {
+        final JsonValue payload = JsonValue.of("Acknowledgement was issued automatically as failed ack, " +
+                "because the signal enrichment failed: " + dre.getMessage());
+        return Acknowledgement.of(label, entityId, dre.getHttpStatus(), dittoHeaders, payload);
+    }
+
     static final class OutboundSignalWithSender implements OutboundSignal {
 
         private final OutboundSignal delegate;
         private final ActorRef sender;
 
         @Nullable
+        private final Pair<DittoRuntimeException, Target> enrichmentFailure;
+        @Nullable
         private final JsonObject extra;
 
         private OutboundSignalWithSender(final OutboundSignal delegate,
                 final ActorRef sender,
+                @Nullable final Pair<DittoRuntimeException, Target> enrichmentFailure,
                 @Nullable final JsonObject extra) {
 
             this.delegate = delegate;
             this.sender = sender;
+            this.enrichmentFailure = enrichmentFailure;
             this.extra = extra;
         }
 
         static OutboundSignalWithSender of(final Signal<?> signal, final ActorRef sender) {
             final OutboundSignal outboundSignal =
                     OutboundSignalFactory.newOutboundSignal(signal, Collections.emptyList());
-            return new OutboundSignalWithSender(outboundSignal, sender, null);
+            return new OutboundSignalWithSender(outboundSignal, sender, null, null);
         }
 
         static OutboundSignalWithSender of(final OutboundSignal outboundSignal, final ActorRef sender) {
-            return new OutboundSignalWithSender(outboundSignal, sender, null);
+            return new OutboundSignalWithSender(outboundSignal, sender, null, null);
         }
 
         @Override
@@ -794,18 +857,25 @@ public final class OutboundMappingProcessorActor
 
         private OutboundSignalWithSender setTargets(final List<Target> targets) {
             return new OutboundSignalWithSender(OutboundSignalFactory.newOutboundSignal(delegate.getSource(), targets),
-                    sender, extra);
+                    sender, enrichmentFailure, extra);
+        }
+
+        // Also set target, because enrichment can fail per target.
+        private OutboundSignalWithSender setFailedEnrichment(final DittoRuntimeException e, final Target t) {
+            return new OutboundSignalWithSender(
+                    OutboundSignalFactory.newOutboundSignal(delegate.getSource(), getTargets()),
+                    sender, Pair.apply(e, t), extra);
         }
 
         private OutboundSignalWithSender setExtra(final JsonObject extra) {
             return new OutboundSignalWithSender(
                     OutboundSignalFactory.newOutboundSignal(delegate.getSource(), getTargets()),
-                    sender, extra
+                    sender, enrichmentFailure, extra
             );
         }
 
         private OutboundSignalWithSender mapped(final Mapped mapped) {
-            return new OutboundSignalWithSender(mapped, sender, extra);
+            return new OutboundSignalWithSender(mapped, sender, enrichmentFailure, extra);
         }
 
         private Mapped asMapped() {
@@ -817,6 +887,7 @@ public final class OutboundMappingProcessorActor
             return getClass().getSimpleName() + " [" +
                     "delegate=" + delegate +
                     ", sender=" + sender +
+                    ", enrichmentFailure=" + enrichmentFailure +
                     ", extra=" + extra +
                     "]";
         }
@@ -832,12 +903,13 @@ public final class OutboundMappingProcessorActor
             final OutboundSignalWithSender that = (OutboundSignalWithSender) o;
             return Objects.equals(delegate, that.delegate) &&
                     Objects.equals(sender, that.sender) &&
+                    Objects.equals(enrichmentFailure, that.enrichmentFailure) &&
                     Objects.equals(extra, that.extra);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(delegate, sender, extra);
+            return Objects.hash(delegate, sender, enrichmentFailure, extra);
         }
 
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -415,6 +415,7 @@ public final class OutboundMappingProcessorActor
     }
 
     // Called inside future; must be thread-safe
+    @Nullable
     private OutboundSignalWithSender recoverFromEnrichmentError(final OutboundSignalWithSender outboundSignal,
             final Target target, final Throwable error) {
 
@@ -441,7 +442,11 @@ public final class OutboundMappingProcessorActor
                     ConnectionFailure.internal(getSelf(), dittoRuntimeException, "Signal enrichment failed");
             clientActor.tell(connectionFailure, getSelf());
         }
-        return outboundSignal.setTargets(Collections.singletonList(target));
+        if (mappingConfig.getPublishFailedEnrichments()) {
+            return outboundSignal.setTargets(Collections.singletonList(target));
+        } else {
+            return null;
+        }
     }
 
     private void logEnrichmentFailure(final OutboundSignal outboundSignal, final DittoRuntimeException error) {

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -563,6 +563,10 @@ ditto {
       max-pool-size = 5
       max-pool-size = ${?CONNECTIVITY_MESSAGE_MAPPING_MAX_POOL_SIZE}
 
+      # Whether messages with failed enrichments should be published.
+      publish-failed-enrichments = false
+      publish-failed-enrichments = ${?CONNECTIVITY_MESSAGE_MAPPING_PUBLISH_FAILED_ENRICHMENTS}
+
       javascript {
         # the maximum script size in bytes of a mapping script to run
         # prevents loading big JS dependencies into the script (e.g. jQuery which has ~250kB)

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/mapping/DefaultMappingConfigTest.java
@@ -19,7 +19,6 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.eclipse.ditto.connectivity.service.config.javascript.JavaScriptConfig;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -63,7 +62,7 @@ public final class DefaultMappingConfigTest {
 
         softly.assertThat(underTest.toString())
                 .contains(underTest.getClass().getSimpleName())
-                .contains("javaScriptConfig", "mapperLimitsConfig", "bufferSize", "parallelism", "maxPoolSize");
+                .contains("javaScriptConfig", "mapperLimitsConfig", "publishFailedEnrichments", "bufferSize", "parallelism", "maxPoolSize");
     }
 
     @Test
@@ -79,8 +78,12 @@ public final class DefaultMappingConfigTest {
                 .isEqualTo(67890);
 
         softly.assertThat(underTest.getMaxPoolSize())
-                .describedAs(MappingConfig.MappingConfigValue.PARALLELISM.getConfigPath())
+                .describedAs(MappingConfig.MappingConfigValue.MAX_POOL_SIZE.getConfigPath())
                 .isEqualTo(37);
+
+        softly.assertThat(underTest.getPublishFailedEnrichments())
+                .describedAs(MappingConfig.MappingConfigValue.PUBLISH_FAILED_ENRICHMENTS.getConfigPath())
+                .isEqualTo(true);
     }
 
 }

--- a/connectivity/service/src/test/resources/mapping-test.conf
+++ b/connectivity/service/src/test/resources/mapping-test.conf
@@ -6,6 +6,8 @@ mapping {
 
   max-pool-size = 37
 
+  publish-failed-enrichments = true
+
   javascript {
     maxScriptSizeBytes = 42000
     maxScriptExecutionTime = 815ms

--- a/connectivity/service/src/test/resources/test.conf
+++ b/connectivity/service/src/test/resources/test.conf
@@ -196,7 +196,7 @@ ditto {
     signal-enrichment {
       provider = "org.eclipse.ditto.connectivity.service.mapping.ConnectivityByRoundTripSignalEnrichmentProvider"
       provider-config {
-        ask-timeout = 10s
+        ask-timeout = 2s
         // configure cache here in case signal enrichment provider gets swapped to the caching implementation
         cache {
           maximum-size = 1000


### PR DESCRIPTION
Adds the possibility to activate/deactivate whether messages with failed enrichments should be published.
The prior default was, that the messages were published. The new default is that these messages will be dropped and a failed acknowledgement will be issued for the target acknowledgement.
To reactivate the prior behaviour, set `CONNECTIVITY_MESSAGE_MAPPING_PUBLISH_FAILED_ENRICHMENTS` to true.