### PR TITLE
Filter for incorrect element types in jsonArray of feature definitions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -27,7 +27,7 @@
 
     <properties>
         <scala.version>2.13</scala.version> <!-- for scala libraries the scala version is used in their artifactId -->
-        <scala.full.version>2.13.6</scala.full.version>
+        <scala.full.version>2.13.8</scala.full.version>
 
         <javac.source>17</javac.source>
         <javac.target>17</javac.target>
@@ -64,7 +64,7 @@
         <slf4j.version>1.7.33</slf4j.version>
         <logback.version>1.2.10</logback.version>
         <logstash-logback-encoder.version>7.0.1</logstash-logback-encoder.version>
-        <fluency.version>2.6.1</fluency.version>
+        <fluency.version>2.6.3</fluency.version>
         <janino.version>3.1.6</janino.version>
 
         <!-- ### Metrics and Tracing -->

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/httppush/DefaultHttpPushFactory.java
@@ -188,11 +188,11 @@ final class DefaultHttpPushFactory implements HttpPushFactory {
             final ConnectHttp connectHttpsWithCustomSSLContext =
                     ConnectHttp.toHostHttps(baseUri).withCustomHttpsContext(httpsConnectionContext);
             // explicitly added <T> as in (some?) IntelliJ idea the line would show an error:
-            flow = http.cachedHostConnectionPoolHttps(connectHttpsWithCustomSSLContext, poolSettings, log);
+            flow = http.<HttpPushContext>cachedHostConnectionPoolHttps(connectHttpsWithCustomSSLContext, poolSettings, log);
         } else {
             // explicitly added <T> as in (some?) IntelliJ idea the line would show an error:
             // no SSL, hence no need for SSLContextCreator
-            flow = http.cachedHostConnectionPool(ConnectHttp.toHost(baseUri), poolSettings, log);
+            flow = http.<HttpPushContext>cachedHostConnectionPool(ConnectHttp.toHost(baseUri), poolSettings, log);
         }
 
         // make requests in parallel

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestTimeoutHandlingDirective.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/directives/RequestTimeoutHandlingDirective.java
@@ -100,10 +100,11 @@ public final class RequestTimeoutHandlingDirective {
         final Duration duration = mutableTimer.getDuration();
         final String requestPath = mutableTimer.getTag(TracingTags.REQUEST_PATH);
 
-        if (requestPath != null && requestPath.contains("/search/things") &&
-                SEARCH_WARN_TIMEOUT_MS.minus(duration).isNegative()) {
-            logger.warn("Encountered slow search which took over <{}> ms: <{}> ms!", SEARCH_WARN_TIMEOUT_MS.toMillis(),
-                    duration.toMillis());
+        if (requestPath != null && requestPath.contains("/search/things")) {
+            if (SEARCH_WARN_TIMEOUT_MS.minus(duration).isNegative()) {
+                logger.warn("Encountered slow search which took over <{}> ms: <{}> ms!", SEARCH_WARN_TIMEOUT_MS.toMillis(),
+                        duration.toMillis());
+            }
         } else if (HTTP_WARN_TIMEOUT_MS.minus(duration).isNegative()) {
             logger.warn("Encountered slow HTTP request which took over <{}> ms: <{}> ms!",
                     HTTP_WARN_TIMEOUT_MS.toMillis(), duration.toMillis());

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/things/FeaturesRoute.java
@@ -19,7 +19,6 @@ import org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
 import org.eclipse.ditto.gateway.service.util.config.endpoints.MessageConfig;
 import org.eclipse.ditto.json.JsonFactory;
-import org.eclipse.ditto.json.JsonKey;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.commands.modify.DeleteFeature;
@@ -58,11 +57,6 @@ final class FeaturesRoute extends AbstractRoute {
     static final String PATH_PROPERTIES = "properties";
     static final String PATH_DESIRED_PROPERTIES = "desiredProperties";
     static final String PATH_DEFINITION = "definition";
-
-    static final JsonKey FEATURE_JSON_KEY = JsonKey.of(PATH_FEATURES);
-    static final JsonKey PROPERTIES_JSON_KEY = JsonKey.of(PATH_PROPERTIES);
-    static final JsonKey DESIRED_PROPERTIES_JSON_KEY = JsonKey.of(PATH_DESIRED_PROPERTIES);
-    static final JsonKey DEFINITION_JSON_KEY = JsonKey.of(PATH_DEFINITION);
 
     private final MessagesRoute messagesRoute;
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
@@ -60,14 +60,14 @@ final class ImmutableFeatureDefinition implements FeatureDefinition {
             throw new FeatureDefinitionEmptyException();
         }
 
-        final List<JsonValue> notStringValues = featureDefinitionEntriesAsJsonArray.stream()
-                .filter(jsonValue -> !jsonValue.isString())
-                .collect(Collectors.toList());
-        if (!notStringValues.isEmpty()) {
-            throw DefinitionIdentifierInvalidException.newBuilder(notStringValues.get(0).formatAsString())
-                    .description("The provided identifier is not a string.")
-                    .build();
-        }
+        featureDefinitionEntriesAsJsonArray.stream()
+                .forEach(jsonValue -> {
+                    if (!jsonValue.isString()) {
+                        throw DefinitionIdentifierInvalidException.newBuilder(jsonValue.formatAsString())
+                                .description("The provided identifier is not a JSON string, please adjust it accordingly.")
+                                .build();
+                    }
+                });
 
         final List<DefinitionIdentifier> identifiersFromJson = featureDefinitionEntriesAsJsonArray.stream()
                 .filter(JsonValue::isString)

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
@@ -60,6 +60,15 @@ final class ImmutableFeatureDefinition implements FeatureDefinition {
             throw new FeatureDefinitionEmptyException();
         }
 
+        final List<JsonValue> notStringValues = featureDefinitionEntriesAsJsonArray.stream()
+                .filter(jsonValue -> !jsonValue.isString())
+                .collect(Collectors.toList());
+        if (!notStringValues.isEmpty()) {
+            throw DefinitionIdentifierInvalidException.newBuilder(notStringValues.get(0).formatAsString())
+                    .description("The provided identifier is not a string.")
+                    .build();
+        }
+
         final List<DefinitionIdentifier> identifiersFromJson = featureDefinitionEntriesAsJsonArray.stream()
                 .filter(JsonValue::isString)
                 .map(JsonValue::asString)

--- a/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionTest.java
+++ b/things/model/src/test/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinitionTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonFactory;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -180,6 +179,19 @@ public final class ImmutableFeatureDefinitionTest {
         assertThatExceptionOfType(FeatureDefinitionEmptyException.class)
                 .isThrownBy(() -> ImmutableFeatureDefinition.fromJson(JsonFactory.newArray()))
                 .withMessage("Feature Definition must not be empty!")
+                .withNoCause();
+    }
+
+    @Test
+    public void fromJsonWithIncorrectTypeFailsWithException() {
+        final JsonArray jsonArray = JsonFactory.newArrayBuilder()
+                .add(1.5)
+                .add(FIRST_IDENTIFIER.toString())
+                .build();
+
+        assertThatExceptionOfType(DefinitionIdentifierInvalidException.class)
+                .isThrownBy(() -> ImmutableFeatureDefinition.fromJson(jsonArray))
+                .withMessage("Definition identifier <1.5> is invalid!")
                 .withNoCause();
     }
 


### PR DESCRIPTION
This PR fixes a serialization error and validates that only strings can be used in the feature definition array.