### PR TITLE
made Kafka client "session.timeout.ms" and "heartbeat.interval.ms" explicit in Ditto config

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -424,6 +424,21 @@ ditto {
               metadata.max.age.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
               connections.max.idle.ms = 180000
               connections.max.idle.ms = ${?KAFKA_CONNECTION_MAX_IDLE_MS}
+
+              # The timeout used to detect client failures when using Kafka's group management facility.
+              # The client sends periodic heartbeats to indicate its liveness to the broker.
+              # If no heartbeats are received by the broker before the expiration of this session timeout,
+              # then the broker will remove this client from the group and initiate a rebalance.
+              session.timeout.ms = 10000
+              session.timeout.ms = ${?KAFKA_SESSION_TIMEOUT_MS}
+
+              # The expected time between heartbeats to the consumer coordinator when using Kafka's group management facilities.
+              # Heartbeats are used to ensure that the consumer's session stays active and to facilitate rebalancing
+              # when new consumers join or leave the group.
+              # The value must be set lower than `session.timeout.ms`, but typically should be set no higher
+              # than 1/3 of that value:
+              heartbeat.interval.ms = 3000
+              heartbeat.interval.ms = ${?KAFKA_HEARTBEAT_INTERVAL_MS}
             }
           }
           metric-collecting-interval = 10s


### PR DESCRIPTION
* and provide environment variables for overwriting those