### PR TITLE
Fix creation of tmp log files

### DIFF
--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -51,10 +51,12 @@
                     <level>info</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <!-- daily rollover as default-->
-                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
+                    <!-- The rollover period is inferred from the fileNamePattern -->
+                    <!-- daily rollover as default -->
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>

--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -50,13 +50,13 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/concierge.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default-->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"concierge","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -53,7 +53,7 @@
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
                     <!-- daily rollover as default -->
-                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM}.gz}</fileNamePattern>
+                    <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/concierge.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <!-- maxHistory is based on the rollover period of the fileNamePattern -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -51,10 +51,12 @@
                     <level>info</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <!-- The rollover period is inferred from the fileNamePattern -->
                     <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/connectivity.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -50,13 +50,13 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/connectivity.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/connectivity.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"connectivity","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -242,9 +242,10 @@ Gathering logs for a running Ditto installation can be achieved by:
 * writing logs to log files: this can be done by setting the environment variable `DITTO_LOGGING_FILE_APPENDER` to `true`
    * configure the amount of log files, and the total amount of space used for logs files via these environment 
      variables. It is also possible to clean up old log files and archives at start up.
-     In case `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` is used it is necessary to configure also `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS`.
-       * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz)
-       * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS` (default: 10) 
+     In case `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` is used it is necessary to configure also `DITTO_LOGGING_MAX_LOG_FILE_HISTORY`.
+     The detailed meaning of these config values is described in the [logback documentation](https://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy).  
+       * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz) - the rollover period is inferred from the fileNamePattern
+       * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY` (default: 10)
        * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: 1GB)
        * `DITTO_LOGGING_CLEAN_HISTORY_ON_START` (default: false)
    * the format in which logging is done is "LogstashEncoder" format - that way the logfiles may easily be imported into

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -241,7 +241,8 @@ Gathering logs for a running Ditto installation can be achieved by:
     
 * writing logs to log files: this can be done by setting the environment variable `DITTO_LOGGING_FILE_APPENDER` to `true`
    * configure the amount of log files, and the total amount of space used for logs files via these environment 
-     variables. It is also possible to clean up old log files and archives at start up:
+     variables. It is also possible to clean up old log files and archives at start up.
+     In case `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` is used it is necessary to configure also `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS`.
        * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz)
        * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS` (default: 10) 
        * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: 1GB)

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -240,11 +240,12 @@ Gathering logs for a running Ditto installation can be achieved by:
    * configure `DITTO_LOGGING_LOGSTASH_SERVER` to contain the endpoint of a logstash server
     
 * writing logs to log files: this can be done by setting the environment variable `DITTO_LOGGING_FILE_APPENDER` to `true`
-   * configure the amount of log files, and the total amount of space used for logs files via these two environment 
-     variables:
+   * configure the amount of log files, and the total amount of space used for logs files via these environment 
+     variables. It is also possible to clean up old log files and archives at start up:
        * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz)
        * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS` (default: 10) 
        * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: 1GB)
+       * `DITTO_LOGGING_CLEAN_HISTORY_ON_START` (default: false)
    * the format in which logging is done is "LogstashEncoder" format - that way the logfiles may easily be imported into
      an ELK stack
    * when running Ditto in Kubernetes apply the `ditto-log-files.yaml` to your Kubernetes cluster in order to 

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -51,10 +51,12 @@
                     <level>info</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <!-- daily rollover as default-->
+                    <!-- The rollover period is inferred from the fileNamePattern -->
+                    <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/gateway.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
-                    <!-- Keep 10 days' worth of history capped at 1GB total size as default-->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -50,13 +50,13 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/gateway.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default-->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/gateway.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default-->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"gateway","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -50,13 +50,13 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/policies.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default-->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/policies.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"policies","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -51,10 +51,12 @@
                     <level>info</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <!-- daily rollover as default-->
+                    <!-- The rollover period is inferred from the fileNamePattern -->
+                    <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/policies.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -50,7 +50,6 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-<!--                <file>/var/log/ditto/things.log</file>-->
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
                     <!-- daily rollover as default -->

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -52,10 +52,12 @@
                 </filter>
 <!--                <file>/var/log/ditto/things.log</file>-->
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <!-- daily rollover as default-->
+                    <!-- The rollover period is inferred from the fileNamePattern -->
+                    <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/things.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -50,13 +50,14 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/things.log</file>
+<!--                <file>/var/log/ditto/things.log</file>-->
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default-->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/things.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"things","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -50,13 +50,13 @@
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
                     <level>info</level>
                 </filter>
-                <file>/var/log/ditto/thing-search.log</file>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- daily rollover as default-->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/thing-search.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
                     <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
+                    <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>
                 <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                     <customFields>{"appname":"thing-search","instance_index":"${INSTANCE_INDEX}"}</customFields>

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -51,10 +51,12 @@
                     <level>info</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                    <!-- daily rollover as default-->
+                    <!-- The rollover period is inferred from the fileNamePattern -->
+                    <!-- daily rollover as default -->
                     <fileNamePattern>${DITTO_LOGGING_FILE_NAME_PATTERN:-/var/log/ditto/thing-search.log.%d{yyyy-MM-dd}.gz}</fileNamePattern>
                     <!-- Keep 10 days' worth of history capped at 1GB total size as default -->
-                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY_IN_DAYS:-10}</maxHistory>
+                    <!-- maxHistory is based on the rollover period of the fileNamePattern -->
+                    <maxHistory>${DITTO_LOGGING_MAX_LOG_FILE_HISTORY:-10}</maxHistory>
                     <totalSizeCap>${DITTO_LOGGING_TOTAL_LOG_FILE_SIZE:-1GB}</totalSizeCap>
                     <cleanHistoryOnStart>${DITTO_LOGGING_CLEAN_HISTORY_ON_START:-false}</cleanHistoryOnStart>
                 </rollingPolicy>


### PR DESCRIPTION
Because of a bug in logback core library there are created many tmp files when the log file appender feature is used.
These files aren't deleted by logback after compressing the log files. 
This PR fixes the issue by removing the <file> property in the logback.xml of each Ditto service.