### PR TITLE
fixed placeholder resolvment in "commandHeaders" of "ImplicitThingCreation" mapper

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/ImplicitThingCreationMessageMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/ImplicitThingCreationMessageMapper.java
@@ -15,21 +15,25 @@ package org.eclipse.ditto.connectivity.service.mapping;
 import static org.eclipse.ditto.base.model.exceptions.DittoJsonException.wrapJsonRuntimeException;
 
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
 import org.eclipse.ditto.base.model.common.Placeholders;
 import org.eclipse.ditto.base.model.entity.id.NamespacedEntityIdInvalidException;
+import org.eclipse.ditto.base.model.headers.DittoHeaderDefinition;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatcher;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTagMatchers;
 import org.eclipse.ditto.base.model.signals.GlobalErrorRegistry;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
+import org.eclipse.ditto.connectivity.api.placeholders.ConnectivityPlaceholders;
+import org.eclipse.ditto.connectivity.api.placeholders.RequestPlaceholder;
 import org.eclipse.ditto.connectivity.model.MessageMapperConfigurationInvalidException;
 import org.eclipse.ditto.connectivity.service.config.mapping.MappingConfig;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLogger;
@@ -42,6 +46,7 @@ import org.eclipse.ditto.placeholders.ExpressionResolver;
 import org.eclipse.ditto.placeholders.HeadersPlaceholder;
 import org.eclipse.ditto.placeholders.PlaceholderFactory;
 import org.eclipse.ditto.placeholders.PlaceholderFilter;
+import org.eclipse.ditto.placeholders.TimePlaceholder;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.protocol.Adaptable;
@@ -72,7 +77,9 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
     private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(ImplicitThingCreationMessageMapper.class);
 
     private static final DittoProtocolAdapter DITTO_PROTOCOL_ADAPTER = DittoProtocolAdapter.newInstance();
+    private static final TimePlaceholder TIME_PLACEHOLDER = TimePlaceholder.getInstance();
     private static final HeadersPlaceholder HEADERS_PLACEHOLDER = PlaceholderFactory.newHeadersPlaceholder();
+    private static final RequestPlaceholder REQUEST_PLACEHOLDER = ConnectivityPlaceholders.newRequestPlaceholder();
     private static final String THING_TEMPLATE = "thing";
     private static final String ALLOW_POLICY_LOCKOUT_OPTION = "allowPolicyLockout";
     private static final String COMMAND_HEADERS = "commandHeaders";
@@ -80,8 +87,9 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
     private static final String THING_ID_CONFIGURATION_PROPERTY = THING_TEMPLATE + "/" + THING_ID;
     private static final String POLICY_ID = "policyId";
     private static final String POLICY_ID_CONFIGURATION_PROPERTY = THING_TEMPLATE + "/" + POLICY_ID;
+    public static final EntityTagMatcher ASTERISK = EntityTagMatcher.asterisk();
 
-    private final Function<Map<String, String>, ExpressionResolver> resolverFactory;
+    private final BiFunction<Map<String, String>, AuthorizationContext, ExpressionResolver> resolverFactory;
 
     private String thingTemplate;
     private Map<String, String> commandHeaders;
@@ -92,7 +100,7 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
      */
     @SuppressWarnings("unused")
     public ImplicitThingCreationMessageMapper() {
-        this(ImplicitThingCreationMessageMapper::getHeadersExpressionResolver);
+        this(ImplicitThingCreationMessageMapper::getExpressionResolver);
     }
 
     /**
@@ -100,7 +108,8 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
      *
      * @param resolverFactory the creator of expression resolver.
      */
-    public ImplicitThingCreationMessageMapper(final Function<Map<String, String>, ExpressionResolver> resolverFactory) {
+    public ImplicitThingCreationMessageMapper(
+            final BiFunction<Map<String, String>, AuthorizationContext, ExpressionResolver> resolverFactory) {
         this.resolverFactory = resolverFactory;
     }
 
@@ -112,13 +121,16 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         commandHeaders = configuration.findProperty(COMMAND_HEADERS, JsonValue::isObject, JsonValue::asObject)
                 .filter(configuredHeaders -> !configuredHeaders.isEmpty())
                 .map(configuredHeaders -> {
-                    final Map<String, String> newCommandHeaders = new HashMap<>();
+                    final Map<String, String> newCommandHeaders = new LinkedHashMap<>();
+                    newCommandHeaders.put(DittoHeaderDefinition.IF_NONE_MATCH.getKey(), ASTERISK.toString());
                     for (final JsonField field : configuredHeaders) {
                         newCommandHeaders.put(field.getKeyName(), field.getValue().formatAsString());
                     }
                     return Collections.unmodifiableMap(newCommandHeaders);
                 })
-                .orElse(Map.of());
+                .orElseGet(() -> DittoHeaders.newBuilder()
+                        .ifNoneMatch(EntityTagMatchers.fromList(Collections.singletonList(ASTERISK)))
+                        .build());
 
         final JsonObject thingJson = JsonObject.of(thingTemplate);
 
@@ -170,7 +182,8 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         LOGGER.withCorrelationId(message.getInternalHeaders()).debug("Received ExternalMessage: {}", message);
 
         final Map<String, String> externalHeaders = message.getHeaders();
-        final ExpressionResolver expressionResolver = resolverFactory.apply(externalHeaders);
+        final ExpressionResolver expressionResolver = resolverFactory.apply(externalHeaders,
+                message.getAuthorizationContext().orElse(null));
 
         final String resolvedTemplate;
         if (Placeholders.containsAnyPlaceholder(thingTemplate)) {
@@ -179,17 +192,14 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
             resolvedTemplate = thingTemplate;
         }
 
-        if (Placeholders.containsAnyPlaceholder(thingTemplate)) {
-            commandHeaders = resolveCommandHeaders(message, commandHeaders);
-        }
+        commandHeaders = resolveCommandHeaders(expressionResolver, commandHeaders);
 
         final Signal<CreateThing> createThing = getCreateThingSignal(message, resolvedTemplate);
         final Adaptable adaptable = DITTO_PROTOCOL_ADAPTER.toAdaptable(createThing);
 
         // we cannot set the header on CreateThing directly because it is filtered when mapped to an adaptable
-        final DittoHeaders modifiedHeaders = adaptable.getDittoHeaders().toBuilder()
+        final DittoHeaders modifiedHeaders = DittoHeaders.of(commandHeaders).toBuilder()
                 .allowPolicyLockout(allowPolicyLockout)
-                .ifNoneMatch(EntityTagMatchers.fromList(Collections.singletonList(EntityTagMatcher.asterisk())))
                 .build();
         final Adaptable adaptableWithModifiedHeaders = adaptable.setDittoHeaders(modifiedHeaders);
 
@@ -199,9 +209,13 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         return Collections.singletonList(adaptableWithModifiedHeaders);
     }
 
-    private static ExpressionResolver getHeadersExpressionResolver(final Map<String, String> headers) {
+    private static ExpressionResolver getExpressionResolver(final Map<String, String> headers,
+            @Nullable final AuthorizationContext authorizationContext) {
         return PlaceholderFactory.newExpressionResolver(
-                PlaceholderFactory.newPlaceholderResolver(HEADERS_PLACEHOLDER, headers));
+                PlaceholderFactory.newPlaceholderResolver(TIME_PLACEHOLDER, new Object()),
+                PlaceholderFactory.newPlaceholderResolver(HEADERS_PLACEHOLDER, headers),
+                PlaceholderFactory.newPlaceholderResolver(REQUEST_PLACEHOLDER, authorizationContext)
+        );
     }
 
     private static String applyPlaceholderReplacement(final String template, final ExpressionResolver resolver) {
@@ -219,17 +233,14 @@ public final class ImplicitThingCreationMessageMapper extends AbstractMessageMap
         return CreateThing.of(newThing, inlinePolicyJson, copyPolicyFrom, dittoHeaders);
     }
 
-    private Map<String, String> resolveCommandHeaders(final ExternalMessage externalMessage,
-            final Map<String, String> errorResponseHeaders) {
-        final ExpressionResolver resolver = resolverFactory.apply(externalMessage.getHeaders());
-        final Map<String, String> resolvedHeaders = new HashMap<>();
-        errorResponseHeaders.forEach((key, value) ->
+    private static Map<String, String> resolveCommandHeaders(final ExpressionResolver resolver,
+            final Map<String, String> unresolvedHeaders) {
+        final Map<String, String> resolvedHeaders = new LinkedHashMap<>();
+        unresolvedHeaders.forEach((key, value) ->
                 resolver.resolve(value).toOptional().ifPresent(resolvedHeaderValue ->
                         resolvedHeaders.put(key, resolvedHeaderValue)
                 )
         );
-        // throws IllegalArgumentException or SubjectInvalidException
-        // if resolved headers are missing mandatory headers or the resolved subject is invalid.
         return resolvedHeaders;
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/RawMessageMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/mapping/RawMessageMapper.java
@@ -29,6 +29,8 @@ import org.eclipse.ditto.base.model.headers.contenttype.ContentType;
 import org.eclipse.ditto.connectivity.api.ExternalMessage;
 import org.eclipse.ditto.connectivity.api.ExternalMessageBuilder;
 import org.eclipse.ditto.connectivity.api.ExternalMessageFactory;
+import org.eclipse.ditto.connectivity.api.placeholders.ConnectivityPlaceholders;
+import org.eclipse.ditto.connectivity.api.placeholders.RequestPlaceholder;
 import org.eclipse.ditto.connectivity.service.config.mapping.MappingConfig;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
@@ -45,7 +47,9 @@ import org.eclipse.ditto.messages.model.MessageHeaders;
 import org.eclipse.ditto.messages.model.MessagesModelFactory;
 import org.eclipse.ditto.messages.model.signals.commands.MessageDeserializer;
 import org.eclipse.ditto.placeholders.ExpressionResolver;
+import org.eclipse.ditto.placeholders.HeadersPlaceholder;
 import org.eclipse.ditto.placeholders.PlaceholderFactory;
+import org.eclipse.ditto.placeholders.TimePlaceholder;
 import org.eclipse.ditto.protocol.Adaptable;
 import org.eclipse.ditto.protocol.MessagePath;
 import org.eclipse.ditto.protocol.Payload;
@@ -74,6 +78,10 @@ public final class RawMessageMapper extends AbstractMessageMapper {
      */
     private static final ContentType DEFAULT_OUTGOING_CONTENT_TYPE =
             ContentType.of(ContentTypes.TEXT_PLAIN_UTF8.toString());
+
+    private static final TimePlaceholder TIME_PLACEHOLDER = TimePlaceholder.getInstance();
+    private static final HeadersPlaceholder HEADERS_PLACEHOLDER = PlaceholderFactory.newHeadersPlaceholder();
+    private static final RequestPlaceholder REQUEST_PLACEHOLDER = ConnectivityPlaceholders.newRequestPlaceholder();
 
     /**
      * Default incoming content type is binary.
@@ -236,9 +244,12 @@ public final class RawMessageMapper extends AbstractMessageMapper {
 
     private static Optional<MessageHeaders> evaluateIncomingMessageHeaders(final ExternalMessage externalMessage,
             final Map<String, String> incomingMessageHeaders) {
-        final ExpressionResolver resolver =
-                PlaceholderFactory.newExpressionResolver(PlaceholderFactory.newHeadersPlaceholder(),
-                        externalMessage.getHeaders());
+        final ExpressionResolver resolver = PlaceholderFactory.newExpressionResolver(
+                PlaceholderFactory.newPlaceholderResolver(TIME_PLACEHOLDER, new Object()),
+                PlaceholderFactory.newPlaceholderResolver(HEADERS_PLACEHOLDER, externalMessage.getHeaders()),
+                PlaceholderFactory.newPlaceholderResolver(REQUEST_PLACEHOLDER,
+                        externalMessage.getAuthorizationContext().orElse(null))
+        );
         final String contentTypeKey = DittoHeaderDefinition.CONTENT_TYPE.getKey();
         final String contentType = resolve(resolver, incomingMessageHeaders, contentTypeKey);
         if (contentType == null) {

--- a/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
+++ b/documentation/src/main/resources/_data/sidebars/ditto_sidebar.yml
@@ -23,9 +23,9 @@ entries:
       - title: Release Notes
         output: web
         folderitems:
-          - title: 2.4.0
-            url: /release_notes_240.html
-            output: web
+#          - title: 2.4.0
+#            url: /release_notes_240.html
+#            output: web
           - title: 2.3.2
             url: /release_notes_232.html
             output: web

--- a/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
@@ -314,7 +314,6 @@ Example of a template defined in `options`:
 }
 ```
 
-
 ### UpdateTwinWithLiveResponse mapper
 
 This mapper creates a [merge Thing command](protocol-specification-things-merge.html) when a 

--- a/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-mapping.md
@@ -231,11 +231,19 @@ Example configuration:
   the content-type header. Default to `text/plain; charset=UTF-8`.
 * `incomingMessageHeaders` (optional): A JSON object containing the following headers needed to construct a message
   command or response envelope containing the incoming message as payload in the field `"value"`. 
-  Placeholder expressions reading from the protocol headers of incoming messages may be used.
+  The following placeholders may be used in the headers:
+
+    | Placeholder                       | Description                                                                                            |
+    |-----------------------------------|--------------|
+    | `{%raw%}{{ header:<header-name> }}{%endraw%}` | header value from the external message, e.g. from protocol headers                                     |
+    | `{%raw%}{{ request:subjectId }}{%endraw%}` | the first authenticated subjectId which did the request - the one of the connection source in this case |
+    | `{%raw%}{{ time:now }}{%endraw%}` | the current timestamp in ISO-8601 format as string in UTC timezone                                                    | 
+    | `{%raw%}{{ time:now_epoch_millis }}{%endraw%}` | the current timestamp in "milliseconds since epoch" formatted as string                                | 
+
    * `content-type` (optional): The content type with which to encode the incoming message as payload.
-     Default to `{%raw%}{{ header:content-type | fn:default('application/octet-stream') }}{%endraw%}`.
-     If resolved to the Ditto protocol content type `application/vnd.eclipse.ditto+json`, then the entire payload
-     is interpreted as a Ditto protocol message instead.
+      Default to `{%raw%}{{ header:content-type | fn:default('application/octet-stream') }}{%endraw%}`.
+      If resolved to the Ditto protocol content type `application/vnd.eclipse.ditto+json`, then the entire payload
+      is interpreted as a Ditto protocol message instead.
    * `status` (optional): Include for message responses. Exclude for message commands. Default to
      `{%raw%}{{ header:status }}{%endraw%}`.
    * `subject` (mandatory for MQTT 3): Subject of the message. Default to `{%raw%}{{ header:subject }}{%endraw%}`.
@@ -257,8 +265,39 @@ The created thing contains the values defined in the template, configured in the
 
 * `thing` (required): The values of the thing that is created implicitly. It can either contain fixed values
  or header placeholders (e.g. `{%raw%}{{ header:device_id }}{%endraw%}`).
+    * the following placeholders may be used inside the `"thing"` JSON:
+
+      | Placeholder                       | Description                                                                                             |
+      |------------------------------------|--------------|
+      | `{%raw%}{{ header:<header-name> }}{%endraw%}` | header value from the external message, e.g. from protocol headers                                      |
+      | `{%raw%}{{ request:subjectId }}{%endraw%}` | the first authenticated subjectId which did the request - the one of the connection source in this case |
+      | `{%raw%}{{ time:now }}{%endraw%}` | the current timestamp in ISO-8601 format as string in UTC timezone                                                     | 
+      | `{%raw%}{{ time:now_epoch_millis }}{%endraw%}` | the current timestamp in "milliseconds since epoch" formatted as string                                 | 
+
+    * The `"thing"` JSON may also include:
+      * an inline policy: `"_policy"` containing the [Policy JSON](basic-policy.html#model-specification) to create a new policy
+        from and link with the thing
+      * a "copy policy from" statement: `"_copyPolicyFrom"` - see also [create Thing alternatives](protocol-examples-creatething.html#alternative-creatething-commands)
+          * either including a policyId to copy from
+          * or containing the link to a thing to copy the policy from in the form: `{% raw %}{{ ref:things/<theThingId>/policyId }}{% endraw %}`
+
+* `commandHeaders` (optional, default: `{"If-None-Match": "*"}`): The Ditto headers to use for constructing the "create thing" command for creating the
+  twin and to use for creating errors.
+    * in this configured headers, the following placeholders may be used:
+
+      | Placeholder                       | Description                                                                                             |
+      |-----------------------------------|--------------|
+      | `{%raw%}{{ header:<header-name> }}{%endraw%}` | header value from the external message, e.g. from protocol headers                                      |
+      | `{%raw%}{{ request:subjectId }}{%endraw%}` | the first authenticated subjectId which did the request - the one of the connection source in this case |
+      | `{%raw%}{{ time:now }}{%endraw%}` | the current timestamp in ISO-8601 format as string in UTC timezone                                                     | 
+      | `{%raw%}{{ time:now_epoch_millis }}{%endraw%}` | the current timestamp in "milliseconds since epoch" formatted as string                                 | 
+
+* `allowPolicyLockout` (optional, default: `true`): whether it should be allowed to create policies without having `WRITE`
+  permissions in the created policy for the subject which creates the policy 
+  (the [authorizationContext](connectivity-manage-connections.html#authorization) of the connection source which 
+  received the message for which a thing should be created implicitly)
  
-Example of a template defined in  `options`:
+Example of a template defined in `options`:
 ```json
 {
   "thing": {
@@ -266,9 +305,15 @@ Example of a template defined in  `options`:
     "attributes": {
       "CreatedBy": "ImplicitThingCreation"
     }
-  }
+  },
+  "commandHeaders": {
+    "If-None-Match": "*",
+    "correlation-id": "{%raw%}{{ header:correlation-id }}{%endraw%}"
+  },
+  "allowPolicyLockout": true
 }
 ```
+
 
 ### UpdateTwinWithLiveResponse mapper
 
@@ -283,12 +328,12 @@ This mapper creates a [merge Thing command](protocol-specification-things-merge.
   (default applied Ditto headers if not configured: `"response-required": false`, `"if-match": "*"`).
    * in this configured headers, the following placeholders may be used:
 
-       | Placeholder                       | Description                                                                                             |
-       |---------------------------------------------------------------------------------------------------------|--------------|
-       | `{%raw%}{{ header:<header-name> }}{%endraw%}` | header value from the external message, e.g. from protocol headers                                      |
+       | Placeholder                       | Description                                                                                            |
+       |-----------------------------------|--------------|
+       | `{%raw%}{{ header:<header-name> }}{%endraw%}` | header value from the external message, e.g. from protocol headers                                     |
        | `{%raw%}{{ request:subjectId }}{%endraw%}` | the first authenticated subjectId which did the request - the one of the connection source in this case |
-       | `{%raw%}{{ time:now }}{%endraw%}` | the current timestamp in ISO-8601 format as string in UTC timezone                                                     | 
-       | `{%raw%}{{ time:now_epoch_millis }}{%endraw%}` | the current timestamp in "milliseconds since epoch" formatted as string                                 | 
+       | `{%raw%}{{ time:now }}{%endraw%}` | the current timestamp in ISO-8601 format as string in UTC timezone                                                    | 
+       | `{%raw%}{{ time:now_epoch_millis }}{%endraw%}` | the current timestamp in "milliseconds since epoch" formatted as string                                | 
 
 
 Example configuration:

--- a/documentation/src/main/resources/pages/ditto/release_notes_240.md
+++ b/documentation/src/main/resources/pages/ditto/release_notes_240.md
@@ -1,9 +1,9 @@
 ---
 title: Release notes 2.4.0
 tags: [release_notes]
-published: false
+published: true
 keywords: release notes, announcements, changelog
-summary: "Version 2.4.0 of Eclipse Ditto, released on ??.??.2022"
+summary: "Version 2.4.0 of Eclipse Ditto, released on xx.xx.2022"
 permalink: release_notes_240.html
 ---
 


### PR DESCRIPTION
* they were only resolved when the thingTemplate contained any placeholders
* also added additional placeholder resolvers for resolving "time:" and "request:subjectId" (useful for inline policy)
* added the missing documentation for the "ImplicitThingCreation" mapper options

* also added Time + Request placeholder resolvers to RawMessageMapper's header mapping