### PR TITLE
Respect in-flight messages for throttling alerts

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -139,7 +139,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
                 .tag(TracingTags.CONNECTION_TYPE, connectionType.getName())
                 .start();
         final var ackCounter = MetricAlertRegistry.getMetricsAlertGaugeOrDefault(
-                CounterKey.of(connectionId, null, null, sourceAddress), MetricAlertRegistry.COUNTER_ACK_HANDLING,
+                CounterKey.of(connectionId, sourceAddress), MetricAlertRegistry.COUNTER_ACK_HANDLING,
                 connectionType, connectivityConfig)
                 .tag(TracingTags.CONNECTION_ID, connectionId.toString())
                 .tag(TracingTags.CONNECTION_TYPE, connectionType.toString())

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -43,6 +43,8 @@ import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.messaging.InboundMappingSink.ExternalMessageWithSender;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.DefaultConnectionMonitorRegistry;
+import org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics.CounterKey;
+import org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics.MetricAlertRegistry;
 import org.eclipse.ditto.internal.models.acks.config.AcknowledgementConfig;
 import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLoggingAdapter;
 import org.eclipse.ditto.internal.utils.config.InstanceIdentifierSupplier;
@@ -65,7 +67,6 @@ import kamon.context.Context;
 public abstract class BaseConsumerActor extends AbstractActorWithTimers {
 
     private static final String TIMER_ACK_HANDLING = "connectivity_ack_handling";
-    private static final String COUNTER_ACK_HANDLING = "connectivity_ack_handling_counter";
 
     protected final String sourceAddress;
     protected final Source source;
@@ -76,6 +77,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
     protected final ConnectivityStatusResolver connectivityStatusResolver;
 
     private final Sink<Object, ?> inboundMappingSink;
+    private final ConnectivityConfig connectivityConfig;
     private final AcknowledgementConfig acknowledgementConfig;
 
     @Nullable private ResourceStatus resourceStatus;
@@ -95,6 +97,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
         this.connectivityStatusResolver = checkNotNull(connectivityStatusResolver, "connectivityStatusResolver");
         resetResourceStatus();
 
+        this.connectivityConfig = connectivityConfig;
         acknowledgementConfig = connectivityConfig.getAcknowledgementConfig();
 
         inboundMonitor = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig)
@@ -135,7 +138,9 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
                 .tag(TracingTags.CONNECTION_ID, connectionId.toString())
                 .tag(TracingTags.CONNECTION_TYPE, connectionType.getName())
                 .start();
-        final var ackCounter = DittoMetrics.gauge(COUNTER_ACK_HANDLING)
+        final var ackCounter = MetricAlertRegistry.getMetricsAlertGaugeOrDefault(
+                CounterKey.of(connectionId, null, null, sourceAddress), MetricAlertRegistry.COUNTER_ACK_HANDLING,
+                connectionType, connectivityConfig)
                 .tag(TracingTags.CONNECTION_ID, connectionId.toString())
                 .tag(TracingTags.CONNECTION_TYPE, connectionType.toString())
                 .increment();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/ConnectivityCounterRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/ConnectivityCounterRegistry.java
@@ -122,7 +122,7 @@ public final class ConnectivityCounterRegistry implements ConnectionMonitorRegis
                 .forEach(metricType -> {
                     final ConnectionId connectionId = connection.getId();
                     final ConnectionType connectionType = connection.getConnectionType();
-                    final CounterKey key = CounterKey.of(connectionId, metricType, metricDirection, address);
+                    final CounterKey key = CounterKey.of(connectionId, address, metricType, metricDirection);
                     final MetricsAlert delegatingAlert = new DelegatingAlert(() -> alertRegistry.getAlert(key,
                             connectionType, connectivityConfig));
                     counters.computeIfAbsent(key,
@@ -168,7 +168,7 @@ public final class ConnectivityCounterRegistry implements ConnectionMonitorRegis
             final MetricType metricType,
             final MetricDirection metricDirection,
             final String address) {
-        final CounterKey key = CounterKey.of(connectionId, metricType, metricDirection, address);
+        final CounterKey key = CounterKey.of(connectionId, address, metricType, metricDirection);
         final MetricsAlert alert = alertRegistry.getAlert(key, connectionType, connectivityConfig);
 
         return counters.computeIfAbsent(key,

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/CounterKey.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/CounterKey.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
@@ -25,11 +26,11 @@ import org.eclipse.ditto.connectivity.model.MetricType;
 /**
  * Identifies a counter by connection id, metric direction, metric type and address.
  */
-final class CounterKey {
+public final class CounterKey {
 
     private final ConnectionId connectionId;
-    private final MetricType metricType;
-    private final MetricDirection metricDirection;
+    @Nullable private final MetricType metricType;
+    @Nullable private final MetricDirection metricDirection;
     private final String address;
 
     /**
@@ -40,16 +41,22 @@ final class CounterKey {
      * @param metricDirection the metricDirection
      * @param address the address
      */
-    private CounterKey(final ConnectionId connectionId, final MetricType metricType,
-            final MetricDirection metricDirection, final String address) {
+    private CounterKey(final ConnectionId connectionId,
+            @Nullable final MetricType metricType,
+            @Nullable final MetricDirection metricDirection,
+            final String address) {
+
         this.connectionId = checkNotNull(connectionId, "connectionId");
-        this.metricType = checkNotNull(metricType, "metricType");
-        this.metricDirection = checkNotNull(metricDirection, "metricDirection");
+        this.metricType = metricType;
+        this.metricDirection = metricDirection;
         this.address = checkNotNull(address, "address");
     }
 
-    static CounterKey of(final ConnectionId connectionId, final MetricType metricType,
-            final MetricDirection metricDirection, final String address) {
+    public static CounterKey of(final ConnectionId connectionId,
+            @Nullable final MetricType metricType,
+            @Nullable final MetricDirection metricDirection,
+            final String address) {
+
         return new CounterKey(connectionId, metricType, metricDirection, address);
     }
 
@@ -57,12 +64,12 @@ final class CounterKey {
         return connectionId;
     }
 
-    MetricType getMetricType() {
-        return metricType;
+    Optional<MetricType> getMetricType() {
+        return Optional.ofNullable(metricType);
     }
 
-    MetricDirection getMetricDirection() {
-        return metricDirection;
+    Optional<MetricDirection> getMetricDirection() {
+        return Optional.ofNullable(metricDirection);
     }
 
     String getAddress() {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/CounterKey.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/CounterKey.java
@@ -29,35 +29,52 @@ import org.eclipse.ditto.connectivity.model.MetricType;
 public final class CounterKey {
 
     private final ConnectionId connectionId;
-    @Nullable private final MetricType metricType;
-    @Nullable private final MetricDirection metricDirection;
     private final String address;
 
-    /**
-     * New map key.
-     *
-     * @param connectionId connection id
-     * @param metricType the metricType
-     * @param metricDirection the metricDirection
-     * @param address the address
-     */
+    @Nullable private final MetricType metricType;
+    @Nullable private final MetricDirection metricDirection;
+
     private CounterKey(final ConnectionId connectionId,
+            final String address,
             @Nullable final MetricType metricType,
-            @Nullable final MetricDirection metricDirection,
-            final String address) {
+            @Nullable final MetricDirection metricDirection) {
 
         this.connectionId = checkNotNull(connectionId, "connectionId");
+        this.address = checkNotNull(address, "address");
+
         this.metricType = metricType;
         this.metricDirection = metricDirection;
-        this.address = checkNotNull(address, "address");
     }
 
-    public static CounterKey of(final ConnectionId connectionId,
-            @Nullable final MetricType metricType,
-            @Nullable final MetricDirection metricDirection,
-            final String address) {
+    /**
+     * Returns a new {@code CounterKey}.
+     *
+     * @param connectionId the connection id of the counter.
+     * @param address the address of the counter.
+     * @return the CounterKey.
+     */
+    public static CounterKey of(final ConnectionId connectionId, final String address) {
 
-        return new CounterKey(connectionId, metricType, metricDirection, address);
+        return new CounterKey(connectionId, address, null, null);
+    }
+
+    /**
+     *
+     * Returns a new {@code CounterKey}.
+     *
+     * @param connectionId the connection id of the counter.
+     * @param address the address of the counter.
+     * @param metricType the metric type of the counter.
+     * @param metricDirection the metric direction of the counter.
+     * @return the CounterKey.
+     */
+    public static CounterKey of(final ConnectionId connectionId,
+            final String address,
+            final MetricType metricType,
+            final MetricDirection metricDirection) {
+        checkNotNull(metricType, "metricType");
+        checkNotNull(metricDirection, "metricDirection");
+        return new CounterKey(connectionId, address, metricType, metricDirection);
     }
 
     ConnectionId getConnectionId() {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricAlertRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricAlertRegistry.java
@@ -68,8 +68,8 @@ public final class MetricAlertRegistry {
     private static MetricsAlertFactory getThrottledAlert() {
         return (source, connectionType, config, isGauge) -> {
             // target counter is INBOUND + THROTTLED
-            final CounterKey target = CounterKey.of(source.getConnectionId(), MetricType.THROTTLED,
-                    MetricDirection.INBOUND, source.getAddress());
+            final CounterKey target = CounterKey.of(source.getConnectionId(), source.getAddress(), MetricType.THROTTLED,
+                    MetricDirection.INBOUND);
 
             return new ThrottledMetricsAlert(THROTTLING_DETECTION_WINDOW,
                     calculateThrottlingLimitFromConfig(connectionType, config, isGauge),

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricAlertRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricAlertRegistry.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics;
 
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,13 +28,17 @@ import org.eclipse.ditto.connectivity.model.MetricDirection;
 import org.eclipse.ditto.connectivity.model.MetricType;
 import org.eclipse.ditto.connectivity.service.config.ConnectionThrottlingConfig;
 import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.Gauge;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.KamonGauge;
 
 import akka.japi.Pair;
 
 /**
  * Registry to keep track and update existing {@code MetricsAlerts}.
  */
-final class MetricAlertRegistry {
+public final class MetricAlertRegistry {
+
+    public static final String COUNTER_ACK_HANDLING = "connectivity_ack_handling_counter";
 
     /**
      * Defines which measurement window is used to detect throttling i.e. what is the maximum allowed messages per
@@ -50,19 +56,23 @@ final class MetricAlertRegistry {
             Pair.apply(ConnectionType.AMQP_10, MetricsAlert.Key.CONSUMED_INBOUND), getThrottledAlert(),
             Pair.apply(ConnectionType.KAFKA, MetricsAlert.Key.MAPPED_INBOUND), getThrottledAlert());
 
+    private static final Map<Pair<ConnectionType, String>, MetricsAlertFactory> GAUGE_ALERT_DEFINITIONS = Map.of(
+            Pair.apply(ConnectionType.AMQP_10, COUNTER_ACK_HANDLING), getThrottledAlert(),
+            Pair.apply(ConnectionType.KAFKA, COUNTER_ACK_HANDLING), getThrottledAlert());
+
     private static final ConcurrentMap<Pair<ConnectionType, CounterKey>, MetricsAlert> ALERTS =
             new ConcurrentHashMap<>();
 
     private final Map<Pair<ConnectionType, MetricsAlert.Key>, MetricsAlertFactory> customAlerts = new HashMap<>();
 
     private static MetricsAlertFactory getThrottledAlert() {
-        return (source, connectionType, config) -> {
+        return (source, connectionType, config, isGauge) -> {
             // target counter is INBOUND + THROTTLED
             final CounterKey target = CounterKey.of(source.getConnectionId(), MetricType.THROTTLED,
                     MetricDirection.INBOUND, source.getAddress());
 
             return new ThrottledMetricsAlert(THROTTLING_DETECTION_WINDOW,
-                    calculateThrottlingLimitFromConfig(connectionType, config),
+                    calculateThrottlingLimitFromConfig(connectionType, config, isGauge),
                     () -> ConnectivityCounterRegistry.lookup(target));
         };
     }
@@ -76,32 +86,49 @@ final class MetricAlertRegistry {
      */
     void registerCustomAlert(final ConnectionType connectionType, final MetricsAlert.Key key,
             final MetricsAlertFactory metricsAlertFactory) {
+
         customAlerts.put(Pair.apply(connectionType, key), metricsAlertFactory);
     }
 
     @Nullable
     MetricsAlert getAlert(final CounterKey counterKey, final ConnectionType connectionType,
             final ConnectivityConfig connectivityConfig) {
+
+        checkNotNull(counterKey.getMetricDirection(), "metricDirection");
+        checkNotNull(counterKey.getMetricType(), "metricType");
         return Optional.ofNullable(ALERTS.get(Pair.apply(connectionType, counterKey)))
-                .or(() -> MetricsAlert.Key.from(counterKey.getMetricDirection(), counterKey.getMetricType())
+                .or(() -> MetricsAlert.Key.from(counterKey.getMetricDirection().get(), counterKey.getMetricType().get())
                         .map(key -> Optional.ofNullable(ALERT_DEFINITIONS.get(Pair.apply(connectionType, key)))
                                 .orElse(customAlerts.get(Pair.apply(connectionType, key))))
                         .map(creator -> ALERTS.computeIfAbsent(Pair.apply(connectionType, counterKey),
-                                mk -> creator.create(counterKey, connectionType, connectivityConfig))))
+                                mk -> creator.create(counterKey, connectionType, connectivityConfig, false))))
                 .orElse(null);
     }
 
+
+    public static Gauge getMetricsAlertGaugeOrDefault(final CounterKey counterKey,
+            final String gaugeName,
+            final ConnectionType connectionType,
+            final ConnectivityConfig connectivityConfig) {
+
+        return Optional.ofNullable(GAUGE_ALERT_DEFINITIONS.get(Pair.apply(connectionType, gaugeName)))
+                .map(alertFactory -> alertFactory.create(counterKey, connectionType, connectivityConfig, true))
+                .map(alert -> MetricsAlertGauge.newGauge(gaugeName, alert, THROTTLING_DETECTION_WINDOW))
+                .orElse(KamonGauge.newGauge(gaugeName));
+    }
+
     private static long calculateThrottlingLimitFromConfig(final ConnectionType connectionType,
-            final ConnectivityConfig config) {
+            final ConnectivityConfig config, final boolean isGauge) {
+
         switch (connectionType) {
             case AMQP_10:
                 final ConnectionThrottlingConfig amqp10ThrottlingConfig =
                         config.getConnectionConfig().getAmqp10Config().getConsumerConfig().getThrottlingConfig();
-                return perInterval(amqp10ThrottlingConfig, THROTTLING_DETECTION_WINDOW.getResolution());
+                return perInterval(amqp10ThrottlingConfig, THROTTLING_DETECTION_WINDOW.getResolution(), isGauge);
             case KAFKA:
                 final ConnectionThrottlingConfig kafkaThrottlingConfig =
                         config.getConnectionConfig().getKafkaConfig().getConsumerConfig().getThrottlingConfig();
-                return perInterval(kafkaThrottlingConfig, THROTTLING_DETECTION_WINDOW.getResolution());
+                return perInterval(kafkaThrottlingConfig, THROTTLING_DETECTION_WINDOW.getResolution(), isGauge);
             case AMQP_091:
             case HTTP_PUSH:
             case MQTT:
@@ -112,7 +139,19 @@ final class MetricAlertRegistry {
         }
     }
 
-    private static long perInterval(final ConnectionThrottlingConfig throttlingConfig, final Duration resolution) {
+    private static long perInterval(final ConnectionThrottlingConfig throttlingConfig, final Duration resolution,
+            final boolean isGauge) {
+
+        final long result;
+        if (isGauge) {
+            result = perIntervalForGauge(throttlingConfig);
+        } else {
+            result = perIntervalForConnectionMetric(throttlingConfig, resolution);
+        }
+        return result;
+    }
+
+    private static long perIntervalForConnectionMetric(final ConnectionThrottlingConfig throttlingConfig, final Duration resolution) {
         final double tolerance = throttlingConfig.getThrottlingDetectionTolerance();
         final Duration interval = throttlingConfig.getInterval();
         // calculate factor to adjust the limit to the given resolution
@@ -122,6 +161,13 @@ final class MetricAlertRegistry {
 
         // apply the configured tolerance to the resulting limit
         return (long) (limitAdjustedToResolution * (1 - tolerance));
+    }
+
+    private static long perIntervalForGauge(final ConnectionThrottlingConfig throttlingConfig) {
+        // Return plain max inflight, since this is the single threshold determining in-flight throttling without
+        // influence of time window.
+        final double tolerance = throttlingConfig.getThrottlingDetectionTolerance();
+        return (long) (throttlingConfig.getMaxInFlight() * (1 - tolerance));
     }
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertFactory.java
@@ -24,11 +24,12 @@ public interface MetricsAlertFactory {
     /**
      * Creates a new instance of a metrics alert.
      *
-     * @param counterKey the key that identifies a counter
-     * @param connectionType the connection type
-     * @param connectivityConfig the connectivity config
-     * @return the new metrics alert
+     * @param counterKey the key that identifies a counter.
+     * @param connectionType the connection type.
+     * @param connectivityConfig the connectivity config.
+     * @param isGauge whether the alert is a gauge or not.
+     * @return the new metrics alert.
      */
     MetricsAlert create(final CounterKey counterKey, final ConnectionType connectionType,
-            final ConnectivityConfig connectivityConfig);
+            final ConnectivityConfig connectivityConfig, final boolean isGauge);
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGauge.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGauge.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.time.Instant;
+import java.util.Map;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.Gauge;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.KamonGauge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Kamon based implementation of {@link org.eclipse.ditto.internal.utils.metrics.instruments.gauge.Gauge}, which can
+ * be used for triggering Connection Metric alerts.
+ */
+@Immutable
+public final class MetricsAlertGauge implements Gauge {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MetricsAlertGauge.class);
+
+    private final Gauge delegee;
+    private final MetricsAlert metricsAlert;
+    private final MeasurementWindow measurementWindow;
+
+    private MetricsAlertGauge(final Gauge delegee,
+            final MetricsAlert metricsAlert,
+            final MeasurementWindow measurementWindow) {
+
+        this.delegee = delegee;
+        this.metricsAlert = metricsAlert;
+        this.measurementWindow = measurementWindow;
+    }
+
+    /**
+     * Creates a new instance of {@code MetricsAlertGauge}.
+     * @param name the name of the gauge.
+     * @param metricsAlert the metrics alert that should be evaluated and conditionally triggered.
+     * @param measurementWindow the measurement window to which the alert applies.
+     * @return the new instance.
+     */
+    public static Gauge newGauge(final String name, final MetricsAlert metricsAlert,
+            final MeasurementWindow measurementWindow) {
+
+        checkNotNull(name, "name");
+        return new MetricsAlertGauge(KamonGauge.newGauge(checkNotNull(name, "name")),
+                checkNotNull(metricsAlert, "metricsAlert"),
+                checkNotNull(measurementWindow, "measurementWindow"));
+    }
+
+    @Override
+    public Gauge increment() {
+        delegee.increment();
+        final long value = get();
+        if (metricsAlert.evaluateCondition(measurementWindow, 99999, value)) {
+            LOGGER.debug("Triggering metric alert: <{}>", metricsAlert);
+            metricsAlert.triggerAction(Instant.now().toEpochMilli(), value);
+        }
+        return this;
+    }
+
+    @Override
+    public Gauge decrement() {
+        delegee.decrement();
+        return this;
+    }
+
+    @Override
+    public void set(final Long value) {
+        delegee.set(value);
+    }
+
+    @Override
+    public void set(final Double value) {
+        delegee.set(value);
+    }
+
+    @Override
+    public Long get() {
+       return delegee.get();
+    }
+
+    @Override
+    public Gauge tag(final String key, final String value) {
+        final var taggedDelegee = delegee.tag(key, value);
+        return new MetricsAlertGauge(taggedDelegee, metricsAlert, measurementWindow);
+    }
+
+    @Override
+    public Gauge tags(final Map<String, String> tags) {
+        final var taggedDelegee = delegee.tags(tags);
+        return new MetricsAlertGauge(taggedDelegee, metricsAlert, measurementWindow);
+    }
+
+    @Nullable
+    @Override
+    public String getTag(final String key) {
+        return delegee.getTag(key);
+    }
+
+    @Override
+    public Map<String, String> getTags() {
+        return delegee.getTags();
+    }
+
+    /**
+     * Sets the value of the gauge to 0.
+     *
+     * @return True if value could be set successfully.
+     */
+    @Override
+    public boolean reset() {
+        delegee.reset();
+        return true;
+    }
+
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "delegee=" + delegee +
+                ", metricsAlert=" + metricsAlert +
+                ", measurementWindow=" + measurementWindow +
+                "]";
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/SlidingWindowCounter.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/SlidingWindowCounter.java
@@ -59,14 +59,14 @@ public final class SlidingWindowCounter {
     private final Map<MeasurementWindow, Long> lastTimestampOverrides;
 
     private SlidingWindowCounter(final SlidingWindowCounterBuilder builder) {
-        this.metricsCounter = builder.metricsCounter;
-        this.clock = builder.clock;
-        this.metricsAlert = builder.metricsAlert;
-        this.cleanUpEnabled = builder.cleanUpEnabled;
-        this.windowsForRecording = builder.recordingMeasurementWindows;
-        this.windowsForReporting = builder.reportingMeasurementWindows;
-        this.maximumPerSlot = builder.maximumPerSlot;
-        this.lastTimestampOverrides = builder.lastTimestampOverrides;
+        metricsCounter = builder.metricsCounter;
+        clock = builder.clock;
+        metricsAlert = builder.metricsAlert;
+        cleanUpEnabled = builder.cleanUpEnabled;
+        windowsForRecording = builder.recordingMeasurementWindows;
+        windowsForReporting = builder.reportingMeasurementWindows;
+        maximumPerSlot = builder.maximumPerSlot;
+        lastTimestampOverrides = builder.lastTimestampOverrides;
 
         minResolution = Stream.of(windowsForRecording)
                 .map(MeasurementWindow::getResolution)

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/ThrottledMetricsAlert.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/ThrottledMetricsAlert.java
@@ -46,6 +46,10 @@ final class ThrottledMetricsAlert implements MetricsAlert {
 
     @Override
     public boolean evaluateCondition(final MeasurementWindow window, final long slot, final long value) {
+        final boolean result = targetMeasurementWindow == window && value > threshold;
+        LOGGER.debug("{}: Evaluating connection throttle alert: <{}> to <{}>, based on window: <{}>:<{}> " +
+                "and threshold: <{}>:<{}>.", slot, getClass().getSimpleName(), result, window, targetMeasurementWindow,
+                value, threshold);
         return targetMeasurementWindow == window && value > threshold;
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGaugeTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGaugeTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.ConnectionType;
+import org.eclipse.ditto.connectivity.service.config.Amqp10Config;
+import org.eclipse.ditto.connectivity.service.config.Amqp10ConsumerConfig;
+import org.eclipse.ditto.connectivity.service.config.ConnectionConfig;
+import org.eclipse.ditto.connectivity.service.config.ConnectionThrottlingConfig;
+import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
+import org.eclipse.ditto.internal.utils.metrics.instruments.gauge.Gauge;
+import org.junit.Before;
+import org.junit.Test;
+
+public class MetricsAlertGaugeTest {
+
+    private Gauge sut;
+
+    @Before
+    public void setup() {
+        final var connectivityConf = mock(ConnectivityConfig.class);
+        final var connectionConf = mock(ConnectionConfig.class);
+        final var amqp10Conf = mock(Amqp10Config.class);
+        final var consumerConf = mock(Amqp10ConsumerConfig.class);
+        final var throttlingConf = mock(ConnectionThrottlingConfig.class);
+        when(connectivityConf.getConnectionConfig()).thenReturn(connectionConf);
+        when(connectionConf.getAmqp10Config()).thenReturn(amqp10Conf);
+        when(amqp10Conf.getConsumerConfig()).thenReturn(consumerConf);
+        when(consumerConf.getThrottlingConfig()).thenReturn(throttlingConf);
+        when(throttlingConf.getMaxInFlight()).thenReturn(2);
+        sut = MetricAlertRegistry.getMetricsAlertGaugeOrDefault(
+                CounterKey.of(ConnectionId.generateRandom(), null, null, ""), MetricAlertRegistry.COUNTER_ACK_HANDLING,
+                ConnectionType.AMQP_10, connectivityConf);
+        sut.reset();
+    }
+
+    @Test
+    public void setAndGet() {
+        sut.set(9L);
+        assertThat(sut.get()).isEqualTo(9L);
+    }
+
+    @Test
+    public void reset() {
+        sut.set(5L);
+        assertThat(sut.get()).isEqualTo(5L);
+        sut.reset();
+        assertThat(sut.get()).isEqualTo(0L);
+    }
+
+    @Test
+    public void increment() {
+        sut.set(5L);
+        assertThat(sut.get()).isEqualTo(5L);
+        sut.increment();
+        assertThat(sut.get()).isEqualTo(6L);
+    }
+
+    @Test
+    public void decrement() {
+        sut.set(5L);
+        assertThat(sut.get()).isEqualTo(5L);
+        sut.decrement();
+        assertThat(sut.get()).isEqualTo(4L);
+    }
+
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGaugeTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/metrics/MetricsAlertGaugeTest.java
@@ -44,7 +44,7 @@ public class MetricsAlertGaugeTest {
         when(consumerConf.getThrottlingConfig()).thenReturn(throttlingConf);
         when(throttlingConf.getMaxInFlight()).thenReturn(2);
         sut = MetricAlertRegistry.getMetricsAlertGaugeOrDefault(
-                CounterKey.of(ConnectionId.generateRandom(), null, null, ""), MetricAlertRegistry.COUNTER_ACK_HANDLING,
+                CounterKey.of(ConnectionId.generateRandom(), ""), MetricAlertRegistry.COUNTER_ACK_HANDLING,
                 ConnectionType.AMQP_10, connectivityConf);
         sut.reset();
     }


### PR DESCRIPTION
Add throttling alerts based on in-flight message gauge.
This also gives the opportunity to add other gauge based alertings.