### PR TITLE
split up the "policy enforcer cache" and the "thing cache" configuration in search

### DIFF
--- a/connectivity/service/pom.xml
+++ b/connectivity/service/pom.xml
@@ -409,7 +409,7 @@ jmh-generator-annprocess). jmh-generator-annprocess overwrites the whole META-IN
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <classesDirectory>${build.outputDirectory}</classesDirectory>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
                 </configuration>
             </plugin>
         </plugins>

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamCacheConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamCacheConfig.java
@@ -48,7 +48,7 @@ public final class DefaultStreamCacheConfig implements StreamCacheConfig {
     /**
      * Returns an instance of DefaultStreamCacheConfig based on the settings of the specified Config.
      *
-     * @param config is supposed to provide the settings of the stream cache config at {@value configPath}.
+     * @param config is supposed to provide the settings of the stream cache config.
      * @param configPath the supposed path of the nested cache config settings.
      * @return the instance.
      * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultStreamConfig.java
@@ -34,12 +34,16 @@ public final class DefaultStreamConfig implements StreamConfig {
     private static final String RETRIEVAL_CONFIG_PATH = "retrieval";
     private static final String ASK_WITH_RETRY_CONFIG_PATH = "ask-with-retry";
 
+    private static final String POLICY_CACHE_CONFIG_PATH = "policy-cache";
+    private static final String THING_CACHE_CONFIG_PATH = "thing-cache";
+
     private final int maxArraySize;
     private final Duration writeInterval;
+    private final AskWithRetryConfig askWithRetryConfig;
     private final StreamStageConfig retrievalConfig;
     private final PersistenceStreamConfig persistenceStreamConfig;
-    private final StreamCacheConfig streamCacheConfig;
-    private final AskWithRetryConfig askWithRetryConfig;
+    private final StreamCacheConfig policyCacheConfig;
+    private final StreamCacheConfig thingCacheConfig;
 
     private DefaultStreamConfig(final ConfigWithFallback streamScopedConfig) {
         maxArraySize = streamScopedConfig.getNonNegativeIntOrThrow(StreamConfigValue.MAX_ARRAY_SIZE);
@@ -47,7 +51,8 @@ public final class DefaultStreamConfig implements StreamConfig {
         askWithRetryConfig = DefaultAskWithRetryConfig.of(streamScopedConfig, ASK_WITH_RETRY_CONFIG_PATH);
         retrievalConfig = DefaultStreamStageConfig.getInstance(streamScopedConfig, RETRIEVAL_CONFIG_PATH);
         persistenceStreamConfig = DefaultPersistenceStreamConfig.of(streamScopedConfig);
-        streamCacheConfig = DefaultStreamCacheConfig.of(streamScopedConfig);
+        policyCacheConfig = DefaultStreamCacheConfig.of(streamScopedConfig, POLICY_CACHE_CONFIG_PATH);
+        thingCacheConfig = DefaultStreamCacheConfig.of(streamScopedConfig, THING_CACHE_CONFIG_PATH);
     }
 
     /**
@@ -87,8 +92,13 @@ public final class DefaultStreamConfig implements StreamConfig {
     }
 
     @Override
-    public StreamCacheConfig getCacheConfig() {
-        return streamCacheConfig;
+    public StreamCacheConfig getPolicyCacheConfig() {
+        return policyCacheConfig;
+    }
+
+    @Override
+    public StreamCacheConfig getThingCacheConfig() {
+        return thingCacheConfig;
     }
 
     @Override
@@ -105,13 +115,14 @@ public final class DefaultStreamConfig implements StreamConfig {
                 askWithRetryConfig.equals(that.askWithRetryConfig) &&
                 retrievalConfig.equals(that.retrievalConfig) &&
                 persistenceStreamConfig.equals(that.persistenceStreamConfig) &&
-                streamCacheConfig.equals(that.streamCacheConfig);
+                policyCacheConfig.equals(that.policyCacheConfig) &&
+                thingCacheConfig.equals(that.thingCacheConfig);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(maxArraySize, writeInterval, askWithRetryConfig, retrievalConfig,
-                persistenceStreamConfig, streamCacheConfig);
+                persistenceStreamConfig, policyCacheConfig, thingCacheConfig);
     }
 
     @Override
@@ -122,7 +133,8 @@ public final class DefaultStreamConfig implements StreamConfig {
                 ", askWithRetryConfig=" + askWithRetryConfig +
                 ", retrievalConfig=" + retrievalConfig +
                 ", persistenceStreamConfig=" + persistenceStreamConfig +
-                ", streamCacheConfig=" + streamCacheConfig +
+                ", policyCacheConfig=" + policyCacheConfig +
+                ", thingCacheConfig=" + thingCacheConfig +
                 "]";
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamCacheConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamCacheConfig.java
@@ -49,7 +49,7 @@ public interface StreamCacheConfig extends CacheConfig {
         /**
          * The name of the dispatcher to run async cache loaders which do not block threads.
          */
-        DISPATCHER_NAME("dispatcher", "policy-enforcer-cache-dispatcher"),
+        DISPATCHER_NAME("dispatcher", "akka.actor.default-dispatcher"),
 
         /**
          * The delay before retrying a cache query if the cached value is out of date.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/StreamConfig.java
@@ -62,11 +62,18 @@ public interface StreamConfig {
     PersistenceStreamConfig getPersistenceConfig();
 
     /**
-     * Returns the configuration settings of the stream cache.
+     * Returns the configuration settings of the policy enforcers to cache.
      *
      * @return the config.
      */
-    StreamCacheConfig getCacheConfig();
+    StreamCacheConfig getPolicyCacheConfig();
+
+    /**
+     * Returns the configuration settings of the things to cache.
+     *
+     * @return the config.
+     */
+    StreamCacheConfig getThingCacheConfig();
 
     /**
      * An enumeration of known config path expressions and their associated default values for {@code StreamConfig}.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -59,7 +59,6 @@ import akka.NotUsed;
 import akka.actor.ActorRef;
 import akka.actor.ActorSystem;
 import akka.actor.Scheduler;
-import akka.dispatch.MessageDispatcher;
 import akka.japi.pf.PFBuilder;
 import akka.stream.javadsl.Flow;
 import akka.stream.javadsl.Keep;
@@ -83,15 +82,15 @@ final class EnforcementFlow {
             final ActorRef thingsShardRegion,
             final Cache<EnforcementCacheKey, Entry<Enforcer>> policyEnforcerCache,
             final AskWithRetryConfig askWithRetryConfig,
-            final StreamCacheConfig streamCacheConfig,
+            final StreamCacheConfig thingCacheConfig,
             final int maxArraySize,
-            final Executor cacheDispatcher) {
+            final Executor thingCacheDispatcher) {
 
         thingsFacade = createThingsFacade(actorSystem, thingsShardRegion, askWithRetryConfig.getAskTimeout(),
-                streamCacheConfig, cacheDispatcher);
+                thingCacheConfig, thingCacheDispatcher);
         this.policyEnforcerCache = policyEnforcerCache;
         searchUpdateObserver = SearchUpdateObserver.get(actorSystem);
-        cacheRetryDelay = streamCacheConfig.getRetryDelay();
+        cacheRetryDelay = thingCacheConfig.getRetryDelay();
         this.maxArraySize = maxArraySize;
     }
 
@@ -102,7 +101,6 @@ final class EnforcementFlow {
      * @param updaterStreamConfig configuration of the updater stream.
      * @param thingsShardRegion the shard region to retrieve things from.
      * @param policiesShardRegion the shard region to retrieve policies from.
-     * @param cacheDispatcher dispatcher for the enforcer cache.
      * @param scheduler the scheduler to use for retrying timed out asks for the policy enforcer cache loader.
      * @return an EnforcementFlow object.
      */
@@ -110,21 +108,25 @@ final class EnforcementFlow {
             final StreamConfig updaterStreamConfig,
             final ActorRef thingsShardRegion,
             final ActorRef policiesShardRegion,
-            final MessageDispatcher cacheDispatcher,
             final Scheduler scheduler) {
 
         final var askWithRetryConfig = updaterStreamConfig.getAskWithRetryConfig();
-        final var streamCacheConfig = updaterStreamConfig.getCacheConfig();
+        final var policyCacheConfig = updaterStreamConfig.getPolicyCacheConfig();
+        final var policyCacheDispatcher = actorSystem.dispatchers()
+                .lookup(policyCacheConfig.getDispatcherName());
 
         final AsyncCacheLoader<EnforcementCacheKey, Entry<PolicyEnforcer>> policyEnforcerCacheLoader =
                 new PolicyEnforcerCacheLoader(askWithRetryConfig, scheduler, policiesShardRegion);
         final Cache<EnforcementCacheKey, Entry<Enforcer>> policyEnforcerCache =
-                CacheFactory.createCache(policyEnforcerCacheLoader, streamCacheConfig,
-                                "things-search_enforcementflow_enforcer_cache_policy", cacheDispatcher)
+                CacheFactory.createCache(policyEnforcerCacheLoader, policyCacheConfig,
+                                "things-search_enforcementflow_enforcer_cache_policy", policyCacheDispatcher)
                         .projectValues(PolicyEnforcer::project, PolicyEnforcer::embed);
 
+        final var thingCacheConfig = updaterStreamConfig.getThingCacheConfig();
+        final var thingCacheDispatcher = actorSystem.dispatchers()
+                .lookup(thingCacheConfig.getDispatcherName());
         return new EnforcementFlow(actorSystem, thingsShardRegion, policyEnforcerCache, askWithRetryConfig,
-                streamCacheConfig, updaterStreamConfig.getMaxArraySize(), cacheDispatcher);
+                thingCacheConfig, updaterStreamConfig.getMaxArraySize(), thingCacheDispatcher);
     }
 
     private static EnforcementCacheKey getPolicyCacheKey(final PolicyId policyId) {
@@ -298,13 +300,13 @@ final class EnforcementFlow {
     private static CachingSignalEnrichmentFacade createThingsFacade(final ActorSystem actorSystem,
             final ActorRef thingsShardRegion,
             final Duration timeout,
-            final CacheConfig streamCacheConfig,
-            final Executor cacheDispatcher) {
+            final CacheConfig thingCacheConfig,
+            final Executor thingCacheDispatcher) {
 
         final var sudoRetrieveThingFacade = SudoSignalEnrichmentFacade.of(thingsShardRegion, timeout);
         final var cachingSignalEnrichmentFacadeProvider = CachingSignalEnrichmentFacadeProvider.get(actorSystem);
         return cachingSignalEnrichmentFacadeProvider.getSignalEnrichmentFacade(actorSystem, sudoRetrieveThingFacade,
-                streamCacheConfig, cacheDispatcher, "things-search_enforcementflow_enforcer_cache_things");
+                thingCacheConfig, thingCacheDispatcher, "things-search_enforcementflow_enforcer_cache_things");
     }
 
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SearchUpdaterStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/SearchUpdaterStream.java
@@ -20,7 +20,6 @@ import java.util.function.Function;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.service.common.config.PersistenceStreamConfig;
-import org.eclipse.ditto.thingsearch.service.common.config.StreamCacheConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.StreamStageConfig;
 import org.eclipse.ditto.thingsearch.service.common.config.UpdaterConfig;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.AbstractWriteModel;
@@ -99,13 +98,8 @@ public final class SearchUpdaterStream {
 
         final var streamConfig = updaterConfig.getStreamConfig();
 
-        final StreamCacheConfig cacheConfig = streamConfig.getCacheConfig();
-        final String dispatcherName = cacheConfig.getDispatcherName();
-        final var messageDispatcher = actorSystem.dispatchers().lookup(dispatcherName);
-
         final var enforcementFlow =
-                EnforcementFlow.of(actorSystem, streamConfig, thingsShard, policiesShard, messageDispatcher,
-                        actorSystem.getScheduler());
+                EnforcementFlow.of(actorSystem, streamConfig, thingsShard, policiesShard, actorSystem.getScheduler());
 
         final var mongoSearchUpdaterFlow =
                 MongoSearchUpdaterFlow.of(database, streamConfig.getPersistenceConfig(), searchUpdateMapper);

--- a/thingsearch/service/src/main/resources/things-search.conf
+++ b/thingsearch/service/src/main/resources/things-search.conf
@@ -201,24 +201,40 @@ ditto {
           }
         }
 
-        cache {
+        policy-cache {
           # name of the dispatcher to run async cache loaders, which do not block threads
           dispatcher = "policy-enforcer-cache-dispatcher"
 
           # delay before retrying a cache query if the cached value is out of date
           retry-delay = 1s
-          retry-delay = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_RETRY_DELAY}
+          retry-delay = ${?THINGS_SEARCH_UPDATER_STREAM_POLICY_CACHE_RETRY_DELAY}
 
           # how many enforcers to cache
           maximum-size = 20000
-          maximum-size = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_SIZE}
+          maximum-size = ${?THINGS_SEARCH_UPDATER_STREAM_POLICY_CACHE_SIZE}
 
           # lifetime of a cached enforcer. set very high because entries are invalidated lazily
           expire-after-write = 2h
-          expire-after-write = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_EXPIRY}
+          expire-after-write = ${?THINGS_SEARCH_UPDATER_STREAM_POLICY_CACHE_EXPIRY}
 
           expire-after-access = 30m
-          expire-after-access = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_EXPIRY_AFTER_ACCESS}
+          expire-after-access = ${?THINGS_SEARCH_UPDATER_STREAM_POLICY_CACHE_EXPIRY_AFTER_ACCESS}
+        }
+
+        thing-cache {
+          # name of the dispatcher to run async cache loaders, which do not block threads
+          dispatcher = "thing-cache-dispatcher"
+
+          # how many things to cache
+          maximum-size = 20000
+          maximum-size = ${?THINGS_SEARCH_UPDATER_STREAM_THING_CACHE_SIZE}
+
+          # lifetime of a cached thing
+          expire-after-write = 2h
+          expire-after-write = ${?THINGS_SEARCH_UPDATER_STREAM_THING_CACHE_EXPIRY}
+
+          expire-after-access = 30m
+          expire-after-access = ${?THINGS_SEARCH_UPDATER_STREAM_THING_CACHE_EXPIRY_AFTER_ACCESS}
         }
 
       }
@@ -280,6 +296,18 @@ policy-enforcer-cache-dispatcher {
     max-pool-size-max = 256
     max-pool-size-max = ${?CACHE_DISPATCHER_POOL_SIZE_MAX}
     max-pool-size-max = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MAX}
+  }
+}
+
+thing-cache-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?CACHE_DISPATCHER_POOL_SIZE_MAX}
+    max-pool-size-max = ${?THING_CACHE_DISPATCHER_POOL_SIZE_MAX}
   }
 }
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlowTest.java
@@ -111,8 +111,8 @@ public final class EnforcementFlowTest {
 
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
-                    EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                    EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(), 
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -163,7 +163,7 @@ public final class EnforcementFlowTest {
         final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
         final EnforcementFlow underTest =
                 EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                        system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                        system.getScheduler());
 
         materializeTestProbes(underTest.create(1));
 
@@ -239,7 +239,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -302,7 +302,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -355,7 +355,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -400,7 +400,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -444,7 +444,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -487,7 +487,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 
@@ -554,7 +554,7 @@ public final class EnforcementFlowTest {
             final StreamConfig streamConfig = DefaultStreamConfig.of(ConfigFactory.empty());
             final EnforcementFlow underTest =
                     EnforcementFlow.of(system, streamConfig, thingsProbe.ref(), policiesProbe.ref(),
-                            system.dispatchers().defaultGlobalDispatcher(), system.getScheduler());
+                            system.getScheduler());
 
             materializeTestProbes(underTest.create(1));
 

--- a/thingsearch/service/src/test/resources/actors-test.conf
+++ b/thingsearch/service/src/test/resources/actors-test.conf
@@ -150,24 +150,19 @@ ditto {
           }
         }
 
-        cache {
-          // name of the dispatcher to run async cache loaders, which do not block threads
+        policy-cache {
           dispatcher = "policy-enforcer-cache-dispatcher"
-
-          // delay before retrying a cache query if the cached value is out of date
           retry-delay = 1s
-          retry-delay = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_RETRY_DELAY}
-
-          # how many enforcers to cache
           maximum-size = 20000
-          maximum-size = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_SIZE}
-
-          # lifetime of a cached enforcer. set very high because entries are invalidated lazily
           expire-after-write = 2h
-          expire-after-write = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_EXPIRY}
-
           expire-after-access = 30m
-          expire-after-access = ${?THINGS_SEARCH_UPDATER_STREAM_CACHE_EXPIRY_AFTER_ACCESS}
+        }
+        thing-cache {
+          dispatcher = "thing-cache-dispatcher"
+          retry-delay = 1s
+          maximum-size = 20000
+          expire-after-write = 2h
+          expire-after-access = 30m
         }
       }
     }
@@ -205,6 +200,18 @@ blocked-namespaces-dispatcher {
 }
 
 policy-enforcer-cache-dispatcher {
+  type = "Dispatcher"
+  executor = "thread-pool-executor"
+  thread-pool-executor {
+    keep-alive-time = 60s
+    fixed-pool-size = off
+    max-pool-size-max = 256
+    max-pool-size-max = ${?CACHE_DISPATCHER_POOL_SIZE_MAX}
+    max-pool-size-max = ${?POLICY_ENFORCER_CACHE_DISPATCHER_POOL_SIZE_MAX}
+  }
+}
+
+thing-cache-dispatcher {
   type = "Dispatcher"
   executor = "thread-pool-executor"
   thread-pool-executor {


### PR DESCRIPTION
* before, the same cache config was used for both different aspects