### PR TITLE
Make double decoding of connection usernames/passwords configurable

### DIFF
--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/Connection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/Connection.java
@@ -134,16 +134,18 @@ public interface Connection extends Jsonifiable.WithFieldSelectorAndPredicate<Js
     /**
      * Returns the username part of the URI of this {@code Connection}.
      *
+     * @param shouldUriDecode whether the username should be URI-decoded.
      * @return the username.
      */
-    Optional<String> getUsername();
+    Optional<String> getUsername(boolean shouldUriDecode);
 
     /**
      * Returns the password part of the URI of this {@code Connection}.
      *
+     * @param shouldUriDecode whether the password should be URI-decoded.
      * @return the password.
      */
-    Optional<String> getPassword();
+    Optional<String> getPassword(boolean shouldUriDecode);
 
     /**
      * Returns the hostname part of the URI of this {@code Connection}.

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/Connection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/Connection.java
@@ -131,6 +131,15 @@ public interface Connection extends Jsonifiable.WithFieldSelectorAndPredicate<Js
      */
     String getProtocol();
 
+
+    /**
+     * Returns the username part of the URI of this {@code Connection}.
+     *
+     * @return the username.
+     * @deprecated since 2.4.0 use {@link #getUsername(boolean)} instead.
+     */
+    Optional<String> getUsername();
+
     /**
      * Returns the username part of the URI of this {@code Connection}.
      *
@@ -138,6 +147,14 @@ public interface Connection extends Jsonifiable.WithFieldSelectorAndPredicate<Js
      * @return the username.
      */
     Optional<String> getUsername(boolean shouldUriDecode);
+
+    /**
+     * Returns the password part of the URI of this {@code Connection}.
+     *
+     * @return the password.
+     * @deprecated since 2.4.0 use {@link #getPassword(boolean)} instead.
+     */
+    Optional<String> getPassword();
 
     /**
      * Returns the password part of the URI of this {@code Connection}.

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
@@ -321,9 +321,19 @@ final class ImmutableConnection implements Connection {
     }
 
     @Override
+    public Optional<String> getUsername() {
+        return getUsername(true);
+    }
+
+    @Override
     public Optional<String> getUsername(final boolean shouldUriDecode) {
         final Optional<String> username = uri.getUserName();
         return shouldUriDecode ? username.map(ImmutableConnection::tryDecodeUriComponent) : username;
+    }
+
+    @Override
+    public Optional<String> getPassword() {
+        return getPassword(true);
     }
 
     @Override

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
@@ -15,8 +15,10 @@ package org.eclipse.ditto.connectivity.model;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkArgument;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -319,13 +321,22 @@ final class ImmutableConnection implements Connection {
     }
 
     @Override
-    public Optional<String> getUsername() {
-        return uri.getUserName();
+    public Optional<String> getUsername(final boolean shouldUriDecode) {
+        return uri.getUserName().map(ImmutableConnection::tryDecodeUriComponent);
     }
 
     @Override
-    public Optional<String> getPassword() {
-        return uri.getPassword();
+    public Optional<String> getPassword(final boolean shouldUriDecode) {
+        return uri.getPassword().map(ImmutableConnection::tryDecodeUriComponent);
+    }
+
+    private static String tryDecodeUriComponent(final String string) {
+        try {
+            final String withoutPlus = string.replace("+", "%2B");
+            return URLDecoder.decode(withoutPlus, "UTF-8");
+        } catch (final IllegalArgumentException | UnsupportedEncodingException e) {
+            return string;
+        }
     }
 
     @Override

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
@@ -322,12 +322,14 @@ final class ImmutableConnection implements Connection {
 
     @Override
     public Optional<String> getUsername(final boolean shouldUriDecode) {
-        return uri.getUserName().map(ImmutableConnection::tryDecodeUriComponent);
+        final Optional<String> username = uri.getUserName();
+        return shouldUriDecode ? username.map(ImmutableConnection::tryDecodeUriComponent) : username;
     }
 
     @Override
     public Optional<String> getPassword(final boolean shouldUriDecode) {
-        return uri.getPassword().map(ImmutableConnection::tryDecodeUriComponent);
+        final Optional<String> password = uri.getPassword();
+        return shouldUriDecode ? password.map(ImmutableConnection::tryDecodeUriComponent) : password;
     }
 
     private static String tryDecodeUriComponent(final String string) {

--- a/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
+++ b/connectivity/model/src/main/java/org/eclipse/ditto/connectivity/model/ImmutableConnection.java
@@ -15,10 +15,8 @@ package org.eclipse.ditto.connectivity.model;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkArgument;
 import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -826,8 +824,8 @@ final class ImmutableConnection implements Connection {
             final String userInfo = uri.getUserInfo();
             if (userInfo != null && userInfo.contains(USERNAME_PASSWORD_SEPARATOR)) {
                 final int separatorIndex = userInfo.indexOf(USERNAME_PASSWORD_SEPARATOR);
-                userName = tryDecodeUriComponent(userInfo.substring(0, separatorIndex));
-                password = tryDecodeUriComponent(userInfo.substring(separatorIndex + 1));
+                userName = userInfo.substring(0, separatorIndex);
+                password = userInfo.substring(separatorIndex + 1);
             } else {
                 userName = null;
                 password = null;
@@ -835,15 +833,6 @@ final class ImmutableConnection implements Connection {
 
             // must be initialized after all else
             uriStringWithMaskedPassword = createUriStringWithMaskedPassword();
-        }
-
-        private static String tryDecodeUriComponent(final String string) {
-            try {
-                final String withoutPlus = string.replace("+", "%2B");
-                return URLDecoder.decode(withoutPlus, "UTF-8");
-            } catch (final IllegalArgumentException | UnsupportedEncodingException e) {
-                return string;
-            }
         }
 
         private String createUriStringWithMaskedPassword() {

--- a/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/ImmutableConnectionTest.java
+++ b/connectivity/model/src/test/java/org/eclipse/ditto/connectivity/model/ImmutableConnectionTest.java
@@ -36,7 +36,6 @@ import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -471,7 +470,7 @@ public final class ImmutableConnectionTest {
     public void parsePasswordWithPlusSignDoubleEncoded() {
         final ImmutableConnection.ConnectionUri underTest =
                 ImmutableConnection.ConnectionUri.of("amqps://foo:bar%252Bbaz@hono.eclipse.org:5671/vhost");
-        assertThat(underTest.getPassword()).contains("bar+baz");
+        assertThat(underTest.getPassword()).contains("bar%2Bbaz");
     }
 
     @Test

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/ConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/ConnectionConfig.java
@@ -155,6 +155,12 @@ public interface ConnectionConfig extends WithSupervisorConfig, WithActivityChec
     boolean areAllClientActorsOnOneNode();
 
     /**
+     * Whether usernames and passwords in connection URIs should be double decoded, when creating the connection.
+     * @return whether double decoding in enabled.
+     */
+    boolean doubleDecodingEnabled();
+
+    /**
      * An enumeration of the known config path expressions and their associated default values for
      * {@code ConnectionConfig}.
      */
@@ -213,7 +219,12 @@ public interface ConnectionConfig extends WithSupervisorConfig, WithActivityChec
         /**
          * How often the priority of a connection is getting updated.
          */
-        PRIORITY_UPDATE_INTERVAL("priority-update-interval", Duration.ofHours(24L));
+        PRIORITY_UPDATE_INTERVAL("priority-update-interval", Duration.ofHours(24L)),
+
+        /**
+         * Whether double decoding of usernames and passwords in connection URIs is enabled.
+         */
+        DOUBLE_DECODING_ENABLED("double-decoding-enabled", true);
 
         private final String path;
         private final Object defaultValue;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfig.java
@@ -60,6 +60,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     private final Duration ackLabelDeclareInterval;
     private final Duration priorityUpdateInterval;
     private final boolean allClientActorsOnOneNode;
+    private final boolean doubleDecodingEnabled;
 
     private DefaultConnectionConfig(final ConfigWithFallback config) {
         clientActorAskTimeout =
@@ -88,6 +89,8 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 config.getBoolean(ConnectionConfigValue.ALL_CLIENT_ACTORS_ON_ONE_NODE.getConfigPath());
         priorityUpdateInterval =
                 config.getNonNegativeAndNonZeroDurationOrThrow(ConnectionConfigValue.PRIORITY_UPDATE_INTERVAL);
+        doubleDecodingEnabled = config.getBoolean(ConnectionConfigValue.DOUBLE_DECODING_ENABLED.getConfigPath());
+
     }
 
     /**
@@ -215,6 +218,11 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
     }
 
     @Override
+    public boolean doubleDecodingEnabled() {
+        return doubleDecodingEnabled;
+    }
+
+    @Override
     public boolean equals(final Object o) {
         if (this == o) {
             return true;
@@ -243,7 +251,8 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 Objects.equals(maxNumberOfSources, that.maxNumberOfSources) &&
                 Objects.equals(ackLabelDeclareInterval, that.ackLabelDeclareInterval) &&
                 Objects.equals(priorityUpdateInterval, that.priorityUpdateInterval) &&
-                allClientActorsOnOneNode == that.allClientActorsOnOneNode;
+                allClientActorsOnOneNode == that.allClientActorsOnOneNode &&
+                doubleDecodingEnabled == that.doubleDecodingEnabled;
     }
 
     @Override
@@ -252,7 +261,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 blockedHostnames, blockedSubnets, blockedHostRegex, supervisorConfig, snapshotConfig,
                 acknowledgementConfig, cleanupConfig, maxNumberOfTargets, maxNumberOfSources, activityCheckConfig,
                 amqp10Config, amqp091Config, mqttConfig, kafkaConfig, httpPushConfig, ackLabelDeclareInterval,
-                priorityUpdateInterval, allClientActorsOnOneNode);
+                priorityUpdateInterval, allClientActorsOnOneNode, doubleDecodingEnabled);
     }
 
     @Override
@@ -279,6 +288,7 @@ public final class DefaultConnectionConfig implements ConnectionConfig {
                 ", ackLabelDeclareInterval=" + ackLabelDeclareInterval +
                 ", priorityUpdateInterval=" + priorityUpdateInterval +
                 ", allClientActorsOnOneNode=" + allClientActorsOnOneNode +
+                ", doubleDecodingEnabled=" + doubleDecodingEnabled +
                 "]";
     }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/PlainCredentialsSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/PlainCredentialsSupplier.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.amqp;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.Optional;
 
 import org.eclipse.ditto.connectivity.model.Connection;
@@ -52,23 +50,9 @@ public interface PlainCredentialsSupplier {
      * @return the URI.
      */
     static PlainCredentialsSupplier fromUri() {
-        return (connection, doubleDecodingEnabled) ->
-                connection.getUsername().flatMap(username ->
-                        connection.getPassword().map(password -> {
-                            final String u =
-                                    doubleDecodingEnabled ? tryDecodeUriComponent(username) : username;
-                            final String p =
-                                    doubleDecodingEnabled ? tryDecodeUriComponent(password) : password;
-                                return UserPasswordCredentials.newInstance(u, p);}));
-    }
-
-    private static String tryDecodeUriComponent(final String string) {
-        try {
-            final String withoutPlus = string.replace("+", "%2B");
-            return URLDecoder.decode(withoutPlus, "UTF-8");
-        } catch (final IllegalArgumentException | UnsupportedEncodingException e) {
-            return string;
-        }
+        return (connection, doubleDecodingEnabled) -> connection.getUsername(doubleDecodingEnabled).flatMap(username ->
+                connection.getPassword(doubleDecodingEnabled)
+                        .map(password -> UserPasswordCredentials.newInstance(username, password)));
     }
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/PlainCredentialsSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/PlainCredentialsSupplier.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.amqp;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Optional;
 
 import org.eclipse.ditto.connectivity.model.Connection;
@@ -29,9 +31,10 @@ public interface PlainCredentialsSupplier {
      * Get the username-password credentials of a connection.
      *
      * @param connection the connection.
+     * @param doubleDecodingEnabled whether double decoding of usernames and passwords is enabled.
      * @return the optional credentials.
      */
-    Optional<UserPasswordCredentials> get(Connection connection);
+    Optional<UserPasswordCredentials> get(Connection connection, boolean doubleDecodingEnabled);
 
     /**
      * Remove userinfo from a connection URI.
@@ -49,9 +52,23 @@ public interface PlainCredentialsSupplier {
      * @return the URI.
      */
     static PlainCredentialsSupplier fromUri() {
-        return connection ->
+        return (connection, doubleDecodingEnabled) ->
                 connection.getUsername().flatMap(username ->
-                        connection.getPassword().map(password ->
-                                UserPasswordCredentials.newInstance(username, password)));
+                        connection.getPassword().map(password -> {
+                            final String u =
+                                    doubleDecodingEnabled ? tryDecodeUriComponent(username) : username;
+                            final String p =
+                                    doubleDecodingEnabled ? tryDecodeUriComponent(password) : password;
+                                return UserPasswordCredentials.newInstance(u, p);}));
     }
+
+    private static String tryDecodeUriComponent(final String string) {
+        try {
+            final String withoutPlus = string.replace("+", "%2B");
+            return URLDecoder.decode(withoutPlus, "UTF-8");
+        } catch (final IllegalArgumentException | UnsupportedEncodingException e) {
+            return string;
+        }
+    }
+
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/SaslPlainCredentialsSupplier.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/SaslPlainCredentialsSupplier.java
@@ -38,13 +38,13 @@ final class SaslPlainCredentialsSupplier implements PlainCredentialsSupplier {
     }
 
     @Override
-    public Optional<UserPasswordCredentials> get(final Connection connection) {
+    public Optional<UserPasswordCredentials> get(final Connection connection, final boolean doubleDecodingEnabled) {
         final Optional<Credentials> optionalCredentials = connection.getCredentials();
         if (optionalCredentials.isPresent()) {
             final var credentials = optionalCredentials.get();
             final var requestSigning = credentials.accept(amqpConnectionSigningExtension);
-            return requestSigning.createSignedCredentials().or(() -> FROM_URI.get(connection));
+            return requestSigning.createSignedCredentials().or(() -> FROM_URI.get(connection, doubleDecodingEnabled));
         }
-        return FROM_URI.get(connection);
+        return FROM_URI.get(connection, doubleDecodingEnabled);
     }
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaClientActor.java
@@ -78,7 +78,8 @@ public final class KafkaClientActor extends BaseClientActor {
         super(connection, proxyActor, connectionActor, dittoHeaders, connectivityConfigOverwrites);
         kafkaConfig = connectivityConfig().getConnectionConfig().getKafkaConfig();
         kafkaConsumerActors = new ArrayList<>();
-        propertiesFactory = PropertiesFactory.newInstance(connection, kafkaConfig, getClientId(connection.getId()));
+        propertiesFactory = PropertiesFactory.newInstance(connection, kafkaConfig, getClientId(connection.getId()),
+                connectivityConfig().getConnectionConfig().doubleDecodingEnabled());
         this.publisherActorFactory = publisherActorFactory;
         pendingStatusReportsFromStreams = new HashSet<>();
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaValidator.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.apache.kafka.common.errors.InvalidTopicException;
@@ -56,25 +57,31 @@ public final class KafkaValidator extends AbstractProtocolValidator {
     private static final Collection<String> ACCEPTED_SCHEMES = List.of("tcp", "ssl");
     private static final Collection<String> SECURE_SCHEMES = List.of("ssl");
 
-    private static final Collection<KafkaSpecificConfig> SPECIFIC_CONFIGS =
-            List.of(KafkaAuthenticationSpecificConfig.getInstance(),
-                    KafkaBootstrapServerSpecificConfig.getInstance(),
-                    KafkaConsumerGroupSpecificConfig.getInstance(),
-                    KafkaConsumerOffsetResetSpecificConfig.getInstance());
+    @Nullable private static KafkaValidator instance;
 
-    private static final KafkaValidator INSTANCE = new KafkaValidator();
+    private final Collection<KafkaSpecificConfig> specificConfigs;
 
-    private KafkaValidator() {
+    private KafkaValidator(final boolean doubleDecodingEnabled) {
         super();
+        specificConfigs = List.of(KafkaAuthenticationSpecificConfig.getInstance(doubleDecodingEnabled),
+                KafkaBootstrapServerSpecificConfig.getInstance(),
+                KafkaConsumerGroupSpecificConfig.getInstance(),
+                KafkaConsumerOffsetResetSpecificConfig.getInstance());
     }
 
     /**
      * Returns an instance of the Kafka validator.
      *
+     * @param doubleDecodingEnabled whether username and password should get double decoded.
      * @return the instance.
      */
-    public static KafkaValidator getInstance() {
-        return INSTANCE;
+    public static KafkaValidator getInstance(final boolean doubleDecodingEnabled) {
+        KafkaValidator result = instance;
+        if (null == result) {
+            result = new KafkaValidator(doubleDecodingEnabled);
+            instance = result;
+        }
+        return result;
     }
 
     @Override
@@ -218,8 +225,8 @@ public final class KafkaValidator extends AbstractProtocolValidator {
         }
     }
 
-    private static void validateSpecificConfigs(final Connection connection, final DittoHeaders dittoHeaders) {
-        for (final KafkaSpecificConfig specificConfig : SPECIFIC_CONFIGS) {
+    private void validateSpecificConfigs(final Connection connection, final DittoHeaders dittoHeaders) {
+        for (final KafkaSpecificConfig specificConfig : specificConfigs) {
             if (specificConfig.isApplicable(connection)) {
                 specificConfig.validateOrThrow(connection, dittoHeaders);
             }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq;
 
-import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -57,11 +56,11 @@ abstract class AbstractHiveMqttClientFactory {
     // duplicate code unavoidable because there is no common interface
     // between Mqtt3SimpleAuthBuilder.Nested and Mqtt5SimpleAuthBuilder.Nested
     @SuppressWarnings("Duplicates")
-    void configureSimpleAuth(final Mqtt3SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection, final boolean doubleDecodingEnabled) {
-        final Optional<String> username =
-                connection.getUsername().map(u -> doubleDecodingEnabled ? tryDecodeUriComponent(u) : u);
-        final Optional<String> password =
-                connection.getPassword().map(p -> doubleDecodingEnabled ? tryDecodeUriComponent(p) : p);
+    void configureSimpleAuth(final Mqtt3SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection,
+            final boolean doubleDecodingEnabled) {
+
+        final Optional<String> username = connection.getUsername(doubleDecodingEnabled);
+        final Optional<String> password = connection.getPassword(doubleDecodingEnabled);
         if (username.isPresent() && password.isPresent()) {
             simpleAuth.username(username.get())
                     .password(password.get().getBytes(StandardCharsets.UTF_8))
@@ -69,23 +68,14 @@ abstract class AbstractHiveMqttClientFactory {
         }
     }
 
-    private static String tryDecodeUriComponent(final String string) {
-        try {
-            final String withoutPlus = string.replace("+", "%2B");
-            return URLDecoder.decode(withoutPlus, StandardCharsets.UTF_8);
-        } catch (final IllegalArgumentException e) {
-            return string;
-        }
-    }
-
     // duplicate code unavoidable because there is no common interface
     // between Mqtt3SimpleAuthBuilder.Nested and Mqtt5SimpleAuthBuilder.Nested
     @SuppressWarnings("Duplicates")
-    void configureSimpleAuth(final Mqtt5SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection, final boolean doubleDecodingEnabled) {
-        final Optional<String> username =
-                connection.getUsername().map(u -> doubleDecodingEnabled ? tryDecodeUriComponent(u) : u);
-        final Optional<String> password =
-                connection.getPassword().map(p -> doubleDecodingEnabled ? tryDecodeUriComponent(p) : p);
+    void configureSimpleAuth(final Mqtt5SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection,
+            final boolean doubleDecodingEnabled) {
+
+        final Optional<String> username = connection.getUsername(doubleDecodingEnabled);
+        final Optional<String> password = connection.getPassword(doubleDecodingEnabled);
         if (username.isPresent() && password.isPresent()) {
             simpleAuth.username(username.get())
                     .password(password.get().getBytes(StandardCharsets.UTF_8))

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractHiveMqttClientFactory.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.connectivity.service.messaging.mqtt.hivemq;
 
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -56,25 +57,38 @@ abstract class AbstractHiveMqttClientFactory {
     // duplicate code unavoidable because there is no common interface
     // between Mqtt3SimpleAuthBuilder.Nested and Mqtt5SimpleAuthBuilder.Nested
     @SuppressWarnings("Duplicates")
-    void configureSimpleAuth(final Mqtt3SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection) {
-        final Optional<String> possibleUsername = connection.getUsername();
-        final Optional<String> possiblePassword = connection.getPassword();
-        if (possibleUsername.isPresent() && possiblePassword.isPresent()) {
-            simpleAuth.username(possibleUsername.get())
-                    .password(possiblePassword.get().getBytes(StandardCharsets.UTF_8))
+    void configureSimpleAuth(final Mqtt3SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection, final boolean doubleDecodingEnabled) {
+        final Optional<String> username =
+                connection.getUsername().map(u -> doubleDecodingEnabled ? tryDecodeUriComponent(u) : u);
+        final Optional<String> password =
+                connection.getPassword().map(p -> doubleDecodingEnabled ? tryDecodeUriComponent(p) : p);
+        if (username.isPresent() && password.isPresent()) {
+            simpleAuth.username(username.get())
+                    .password(password.get().getBytes(StandardCharsets.UTF_8))
                     .applySimpleAuth();
+        }
+    }
+
+    private static String tryDecodeUriComponent(final String string) {
+        try {
+            final String withoutPlus = string.replace("+", "%2B");
+            return URLDecoder.decode(withoutPlus, StandardCharsets.UTF_8);
+        } catch (final IllegalArgumentException e) {
+            return string;
         }
     }
 
     // duplicate code unavoidable because there is no common interface
     // between Mqtt3SimpleAuthBuilder.Nested and Mqtt5SimpleAuthBuilder.Nested
     @SuppressWarnings("Duplicates")
-    void configureSimpleAuth(final Mqtt5SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection) {
-        final Optional<String> possibleUsername = connection.getUsername();
-        final Optional<String> possiblePassword = connection.getPassword();
-        if (possibleUsername.isPresent() && possiblePassword.isPresent()) {
-            simpleAuth.username(possibleUsername.get())
-                    .password(possiblePassword.get().getBytes(StandardCharsets.UTF_8))
+    void configureSimpleAuth(final Mqtt5SimpleAuthBuilder.Nested<?> simpleAuth, final Connection connection, final boolean doubleDecodingEnabled) {
+        final Optional<String> username =
+                connection.getUsername().map(u -> doubleDecodingEnabled ? tryDecodeUriComponent(u) : u);
+        final Optional<String> password =
+                connection.getPassword().map(p -> doubleDecodingEnabled ? tryDecodeUriComponent(p) : p);
+        if (username.isPresent() && password.isPresent()) {
+            simpleAuth.username(username.get())
+                    .password(password.get().getBytes(StandardCharsets.UTF_8))
                     .applySimpleAuth();
         }
     }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/AbstractMqttClientActor.java
@@ -263,7 +263,8 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
                         true, // this is the publisher client, always respect last will config
                         getMqttClientConnectedListener(PUBLISHER),
                         getMqttClientDisconnectedListener(PUBLISHER, cancelReconnect),
-                        connectionLogger);
+                        connectionLogger,
+                        connectivityConfig().getConnectionConfig().doubleDecodingEnabled());
                 publisherClient = new ClientWithCancelSwitch(createdClient, cancelReconnect);
             } else {
                 // use the same client for subscribers and publisher
@@ -329,7 +330,8 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
                 applyLastWillConfig,
                 getMqttClientConnectedListener(clientRole),
                 getMqttClientDisconnectedListener(clientRole, cancelReconnect),
-                connectionLogger);
+                connectionLogger,
+                connectivityConfig().getConnectionConfig().doubleDecodingEnabled());
         client = new ClientWithCancelSwitch(createdClient, cancelReconnect);
 
         if (willSubscribe) {
@@ -356,7 +358,7 @@ abstract class AbstractMqttClientActor<S, P, Q extends MqttClient, R> extends Ba
         try {
             testClient =
                     getClientFactory().newClient(connectionToBeTested, mqttClientId, mqttConfig, testMqttSpecificConfig,
-                            false, connectionLogger);
+                            false, connectionLogger, connectivityConfig().getConnectionConfig().doubleDecodingEnabled());
         } catch (final Exception e) {
             return CompletableFuture.completedFuture(new Status.Failure(e.getCause()));
         }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt3ClientFactory.java
@@ -55,10 +55,11 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
 
         return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig,
-                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
+                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger, doubleDecodingEnabled).buildAsync();
     }
 
     @Override
@@ -69,12 +70,13 @@ public final class DefaultHiveMqtt3ClientFactory extends AbstractHiveMqttClientF
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
 
         final Mqtt3ClientBuilder mqtt3ClientBuilder =
                 configureClientBuilder(MqttClient.builder().useMqttVersion3(), connection, identifier,
                         connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
-        configureSimpleAuth(mqtt3ClientBuilder.simpleAuth(), connection);
+        configureSimpleAuth(mqtt3ClientBuilder.simpleAuth(), connection, doubleDecodingEnabled);
         if (applyLastWillConfig) {
             configureWillPublish(mqtt3ClientBuilder, mqttSpecificConfig);
         }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/DefaultHiveMqtt5ClientFactory.java
@@ -54,10 +54,12 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
 
         return newClientBuilder(connection, identifier, mqttConfig, mqttSpecificConfig,
-                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger).buildAsync();
+                applyLastWillConfig, connectedListener, disconnectedListener, connectionLogger,
+                doubleDecodingEnabled).buildAsync();
     }
 
     @Override
@@ -68,11 +70,13 @@ public final class DefaultHiveMqtt5ClientFactory extends AbstractHiveMqttClientF
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
+
         final Mqtt5ClientBuilder mqtt5ClientBuilder =
                 configureClientBuilder(MqttClient.builder().useMqttVersion5(), connection, identifier,
                         connectedListener, disconnectedListener, connectionLogger, mqttConfig.getEventLoopThreads());
-        configureSimpleAuth(mqtt5ClientBuilder.simpleAuth(), connection);
+        configureSimpleAuth(mqtt5ClientBuilder.simpleAuth(), connection, doubleDecodingEnabled);
         if (applyLastWillConfig) {
             configureWillPublish(mqtt5ClientBuilder, mqttSpecificConfig);
         }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/HiveMqttClientFactory.java
@@ -42,6 +42,7 @@ interface HiveMqttClientFactory<Q, B> {
      * @param connectedListener the connected listener passed to the created client
      * @param disconnectedListener the disconnected listener passed to the created client
      * @param connectionLogger the connection logger
+     * @param doubleDecodingEnabled whether username and password should get double decoded.
      * @return the new client.
      */
     Q newClient(Connection connection,
@@ -51,7 +52,8 @@ interface HiveMqttClientFactory<Q, B> {
             boolean applyLastWillConfig,
             @Nullable MqttClientConnectedListener connectedListener,
             @Nullable MqttClientDisconnectedListener disconnectedListener,
-            ConnectionLogger connectionLogger);
+            ConnectionLogger connectionLogger,
+            boolean doubleDecodingEnabled);
 
     /**
      * Creates a new MQTT client builder.
@@ -65,6 +67,7 @@ interface HiveMqttClientFactory<Q, B> {
      * @param connectedListener the connected listener passed to the created client
      * @param disconnectedListener the disconnected listener passed to the created client
      * @param connectionLogger the connection logger
+     * @param doubleDecodingEnabled whether username and password should get double decoded.
      * @return the new mqtt client builder.
      */
     B newClientBuilder(Connection connection,
@@ -74,7 +77,8 @@ interface HiveMqttClientFactory<Q, B> {
             boolean applyLastWillConfig,
             @Nullable MqttClientConnectedListener connectedListener,
             @Nullable MqttClientDisconnectedListener disconnectedListener,
-            ConnectionLogger connectionLogger);
+            ConnectionLogger connectionLogger,
+            boolean doubleDecodingEnabled);
 
     /**
      * Creates a new client.
@@ -86,6 +90,7 @@ interface HiveMqttClientFactory<Q, B> {
      * specific config
      * @param applyLastWillConfig whether to apply the last will configuration
      * @param connectionLogger the connection logger
+     * @param doubleDecodingEnabled whether username and password should get double decoded.
      * @return the new client.
      */
     default Q newClient(final Connection connection,
@@ -93,9 +98,11 @@ interface HiveMqttClientFactory<Q, B> {
             final MqttConfig mqttConfig,
             final MqttSpecificConfig mqttSpecificConfig,
             final boolean applyLastWillConfig,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
+
         return newClient(connection, identifier, mqttConfig, mqttSpecificConfig, applyLastWillConfig,
-                null, null, connectionLogger);
+                null, null, connectionLogger, doubleDecodingEnabled);
     }
 
 }

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -1134,7 +1134,7 @@ public final class ConnectionPersistenceActor
                         AmqpValidator.newInstance(),
                         Mqtt3Validator.newInstance(mqttConfig),
                         Mqtt5Validator.newInstance(mqttConfig),
-                        KafkaValidator.getInstance(),
+                        KafkaValidator.getInstance(connectivityConfig.getConnectionConfig().doubleDecodingEnabled()),
                         HttpPushValidator.newInstance(connectivityConfig.getConnectionConfig().getHttpPushConfig()));
 
         final DittoConnectivityCommandValidator dittoCommandValidator =

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -140,6 +140,10 @@ ditto {
       all-client-actors-on-one-node = false
       all-client-actors-on-one-node = ${?CONNECTIVITY_ALL_CLIENT_ACTORS_ON_ONE_NODE}
 
+      # Whether double decoding of usernames and passwords in connection URIs is enabled.
+      double-decoding-enabled = true
+      double-decoding-enabled = ${?CONNECTIVITY_DOUBLE_DECODING_ENABLED}
+
       acknowledgement {
         # lifetime of ack forwarder. Must be bigger than the largest possible command timeout (60s)
         forwarder-fallback-timeout = 65s

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/config/DefaultConnectionConfigTest.java
@@ -26,7 +26,6 @@ import org.eclipse.ditto.internal.models.signalenrichment.SignalEnrichmentConfig
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.SnapshotConfig;
 import org.eclipse.ditto.internal.utils.persistentactors.cleanup.CleanupConfig;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -156,6 +155,10 @@ public final class DefaultConnectionConfigTest {
         softly.assertThat(underTest.areAllClientActorsOnOneNode())
                 .as(ConnectionConfig.ConnectionConfigValue.ALL_CLIENT_ACTORS_ON_ONE_NODE.getConfigPath())
                 .isEqualTo(true);
+
+        softly.assertThat(underTest.doubleDecodingEnabled())
+                .as(ConnectionConfig.ConnectionConfigValue.DOUBLE_DECODING_ENABLED.getConfigPath())
+                .isEqualTo(false);
     }
 
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpSpecificConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpSpecificConfigTest.java
@@ -31,59 +31,52 @@ import com.typesafe.config.ConfigFactory;
 public final class AmqpSpecificConfigTest {
 
     @Test
-    public void decodeDoublyEncodedUsernameAndPassword() {
+    public void decodeDoublyEncodedUsernameAndPasswordDouble() {
         final var uri = "amqps://%2525u%2525s%2525e%2525r:%2525p%2525a%2525%252Bs%2525s@localhost:1234/";
-        final var connection = TestConstants.createConnection()
-                .toBuilder()
-                .uri(uri)
-                .build();
-
-        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
-                PlainCredentialsSupplier.fromUri());
-
-        assertThat(underTest.render(uri))
-                .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
-                        "?jms.clientID=CID&jms.username=%25u%25s%25e%25r&jms.password=%25p%25a%25%2Bs%25s" +
-                        "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
-                        "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
-                        "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
-                        "&failover.useReconnectBackOff=true");
+        testDecoding(uri, "%25u%25s%25e%25r", "%25p%25a%25%2Bs%25s", true);
     }
+
+    @Test
+    public void decodeDoublyEncodedUsernameAndPasswordSingle() {
+        final var uri = "amqps://%2525u%2525s%2525e%2525r:%2525p%2525a%2525%252Bs%2525s@localhost:1234/";
+        testDecoding(uri, "%2525u%2525s%2525e%2525r", "%2525p%2525a%2525%252Bs%2525s", false);
+    }
+
 
     @Test
     public void decodeSinglyEncodedUsernameAndPasswordContainingPercentageSign() {
         final var uri = "amqps://%25u%25s%25e%25r:%25p%25a%25%2Bs%25s@localhost:1234/";
-        final var connection = TestConstants.createConnection()
-                .toBuilder()
-                .uri(uri)
-                .build();
-
-        final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
-                PlainCredentialsSupplier.fromUri());
-
-        assertThat(underTest.render(uri))
-                .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
-                        "?jms.clientID=CID&jms.username=%25u%25s%25e%25r&jms.password=%25p%25a%25%2Bs%25s" +
-                        "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
-                        "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
-                        "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
-                        "&failover.useReconnectBackOff=true");
+        testDecoding(uri, "%25u%25s%25e%25r", "%25p%25a%25%2Bs%25s", false);
     }
 
     @Test
-    public void decodeSinglyEncodedUsernameAndPassword() {
+    public void decodeSinglyEncodedUsernameAndPasswordDouble() {
         final var uri = "amqps://user:pa%2Bss@localhost:1234/";
+        testDecoding(uri, "user", "pa%2Bss", true);
+    }
+
+    @Test
+    public void decodeSinglyEncodedUsernameAndPasswordSingle() {
+        final var uri = "amqps://user:pa%2Bss@localhost:1234/";
+        testDecoding(uri, "user", "pa%2Bss", false);
+    }
+
+    private static void testDecoding(final String uri,
+            final String expectedUsername,
+            final String expectedPassword,
+            final boolean doubleDecodingEnabled) {
+
         final var connection = TestConstants.createConnection()
                 .toBuilder()
                 .uri(uri)
                 .build();
 
         final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
-                PlainCredentialsSupplier.fromUri());
+                PlainCredentialsSupplier.fromUri(), doubleDecodingEnabled);
 
         assertThat(underTest.render(uri))
                 .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
-                        "?jms.clientID=CID&jms.username=user&jms.password=pa%2Bss" +
+                        "?jms.clientID=CID&jms.username=" + expectedUsername + "&jms.password=" + expectedPassword +
                         "&failover.startupMaxReconnectAttempts=5&failover.maxReconnectAttempts=-1" +
                         "&failover.initialReconnectDelay=128&failover.reconnectDelay=128" +
                         "&failover.maxReconnectDelay=900000&failover.reconnectBackOffMultiplier=2" +
@@ -97,7 +90,7 @@ public final class AmqpSpecificConfigTest {
         final var defaultConfig = AmqpSpecificConfig.toDefaultConfig(amqp10Config);
 
         final var underTest = AmqpSpecificConfig.withDefault("CID", connection, defaultConfig,
-                PlainCredentialsSupplier.fromUri());
+                PlainCredentialsSupplier.fromUri(), true);
 
         assertThat(underTest.render("amqps://localhost:1234/"))
                 .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
@@ -114,7 +107,7 @@ public final class AmqpSpecificConfigTest {
     public void withoutFailover() {
         final var connection = TestConstants.createConnection().toBuilder().failoverEnabled(false).build();
         final var underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
-                PlainCredentialsSupplier.fromUri());
+                PlainCredentialsSupplier.fromUri(), true);
         assertThat(underTest.render("amqps://localhost:1234/"))
                 .isEqualTo("amqps://localhost:1234/?amqp.saslMechanisms=PLAIN&jms.clientID=CID" +
                         "&jms.username=username&jms.password=password");
@@ -126,7 +119,7 @@ public final class AmqpSpecificConfigTest {
         final PlainCredentialsSupplier plainCredentialsSupplier = connection -> Optional.of(credentials);
         final Connection connection = TestConstants.createConnection();
         final AmqpSpecificConfig underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
-                plainCredentialsSupplier);
+                plainCredentialsSupplier, true);
         assertThat(underTest.render("amqps://localhost:1234/"))
                 .isEqualTo("failover:(amqps://localhost:1234/?amqp.saslMechanisms=PLAIN)" +
                         "?jms.clientID=CID&jms.username=foo&jms.password=bar" +

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpSpecificConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpSpecificConfigTest.java
@@ -116,7 +116,8 @@ public final class AmqpSpecificConfigTest {
     @Test
     public void withPlainCredentials() {
         final UserPasswordCredentials credentials = UserPasswordCredentials.newInstance("foo", "bar");
-        final PlainCredentialsSupplier plainCredentialsSupplier = connection -> Optional.of(credentials);
+        final PlainCredentialsSupplier plainCredentialsSupplier =
+                (connection, doubleDecodingEnabled) -> Optional.of(credentials);
         final Connection connection = TestConstants.createConnection();
         final AmqpSpecificConfig underTest = AmqpSpecificConfig.withDefault("CID", connection, Map.of(),
                 plainCredentialsSupplier, true);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/SaslPlainCredentialsSupplierTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/SaslPlainCredentialsSupplierTest.java
@@ -72,7 +72,7 @@ public final class SaslPlainCredentialsSupplierTest {
                 .credentials(credentials)
                 .build();
         final Optional<UserPasswordCredentials> result =
-                SaslPlainCredentialsSupplier.of(actorSystem).get(connection);
+                SaslPlainCredentialsSupplier.of(actorSystem).get(connection, true);
 
         assertCredentialsContainCorrectSignature(result, signing);
     }
@@ -97,7 +97,7 @@ public final class SaslPlainCredentialsSupplierTest {
                 .credentials(null)
                 .build();
         final Optional<UserPasswordCredentials> result =
-                SaslPlainCredentialsSupplier.of(actorSystem).get(connection);
+                SaslPlainCredentialsSupplier.of(actorSystem).get(connection, true);
 
         assertThat(result)
                 .withFailMessage(
@@ -114,7 +114,7 @@ public final class SaslPlainCredentialsSupplierTest {
                 .build();
 
         final Optional<UserPasswordCredentials> result =
-                SaslPlainCredentialsSupplier.of(actorSystem).get(connection);
+                SaslPlainCredentialsSupplier.of(actorSystem).get(connection, true);
 
         assertThat(result).contains(UserPasswordCredentials.newInstance("user", "pass"));
     }
@@ -128,7 +128,7 @@ public final class SaslPlainCredentialsSupplierTest {
                 .build();
 
         assertThatExceptionOfType(MessageSendingFailedException.class)
-                .isThrownBy(() -> SaslPlainCredentialsSupplier.of(actorSystem).get(connection));
+                .isThrownBy(() -> SaslPlainCredentialsSupplier.of(actorSystem).get(connection, true));
     }
 
     private Instant extractExpiryFromSharedAccessSignature(final String password) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/httppush/HttpPushValidatorTest.java
@@ -16,6 +16,7 @@ import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.ditto.connectivity.service.messaging.TestConstants.Authorization.AUTHORIZATION_CONTEXT;
 import static org.eclipse.ditto.connectivity.service.messaging.httppush.HttpPushSpecificConfig.OMIT_REQUEST_BODY;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
@@ -35,8 +36,10 @@ import org.eclipse.ditto.connectivity.model.Topic;
 import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.config.HttpPushConfig;
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
-import org.eclipse.ditto.connectivity.service.messaging.kafka.KafkaValidator;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import com.typesafe.config.ConfigFactory;
 
@@ -78,7 +81,7 @@ public final class HttpPushValidatorTest {
 
     @Test
     public void testImmutability() {
-        assertInstancesOf(KafkaValidator.class, areImmutable());
+        assertInstancesOf(HttpPushValidator.class, areImmutable(), provided(HttpPushConfig.class).isAlsoImmutable());
     }
 
     @Test

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaAuthenticationSpecificConfigTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaAuthenticationSpecificConfigTest.java
@@ -64,7 +64,7 @@ public final class KafkaAuthenticationSpecificConfigTest {
 
     @Before
     public void setUp() {
-        underTest = KafkaAuthenticationSpecificConfig.getInstance();
+        underTest = KafkaAuthenticationSpecificConfig.getInstance(true);
     }
 
     @Test

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaValidatorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaValidatorTest.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.connectivity.service.messaging.kafka;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.eclipse.ditto.connectivity.service.messaging.TestConstants.Authorization.AUTHORIZATION_CONTEXT;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
@@ -32,8 +33,10 @@ import org.eclipse.ditto.connectivity.model.ConnectivityStatus;
 import org.eclipse.ditto.connectivity.model.Topic;
 import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
-import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import akka.actor.ActorSystem;
 import akka.testkit.javadsl.TestKit;
@@ -68,12 +71,12 @@ public final class KafkaValidatorTest {
 
     @Before
     public void setUp() {
-        underTest = KafkaValidator.getInstance();
+        underTest = KafkaValidator.getInstance(true);
     }
 
     @Test
     public void testImmutability() {
-        assertInstancesOf(KafkaValidator.class, areImmutable());
+        assertInstancesOf(KafkaValidator.class, areImmutable(), provided(KafkaSpecificConfig.class).isAlsoImmutable());
     }
 
     @Test

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactoryTest.java
@@ -86,7 +86,7 @@ public final class PropertiesFactoryTest {
 
     @Before
     public void setUp() {
-        underTest = PropertiesFactory.newInstance(connection, kafkaConfig, UUID.randomUUID().toString());
+        underTest = PropertiesFactory.newInstance(connection, kafkaConfig, UUID.randomUUID().toString(), true);
     }
 
     @Test

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt3ClientFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt3ClientFactory.java
@@ -110,7 +110,8 @@ class MockHiveMqtt3ClientFactory implements HiveMqtt3ClientFactory {
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
 
         final Mqtt3AsyncClient client = mock(Mqtt3AsyncClient.class);
         when(client.toAsync()).thenReturn(client);
@@ -183,10 +184,12 @@ class MockHiveMqtt3ClientFactory implements HiveMqtt3ClientFactory {
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
+
         final Mqtt3Client client =
                 newClient(connection, identifier, mqttConfig, mqttSpecificConfig, applyLastWillConfig,
-                        connectedListener, disconnectedListener, connectionLogger);
+                        connectedListener, disconnectedListener, connectionLogger, doubleDecodingEnabled);
         final Mqtt3ClientBuilder builder = Mockito.mock(Mqtt3ClientBuilder.class);
         Mockito.doReturn(client).when(builder).build();
         return builder;

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/MockHiveMqtt5ClientFactory.java
@@ -113,7 +113,8 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
 
         final Mqtt5AsyncClient client = mock(Mqtt5AsyncClient.class);
         doReturn(client).when(client).toAsync();
@@ -186,10 +187,12 @@ class MockHiveMqtt5ClientFactory implements HiveMqtt5ClientFactory {
             final boolean applyLastWillConfig,
             @Nullable final MqttClientConnectedListener connectedListener,
             @Nullable final MqttClientDisconnectedListener disconnectedListener,
-            final ConnectionLogger connectionLogger) {
+            final ConnectionLogger connectionLogger,
+            final boolean doubleDecodingEnabled) {
+
         final Mqtt5Client client =
                 newClient(connection, identifier, mqttConfig, mqttSpecificConfig, applyLastWillConfig,
-                        connectedListener, disconnectedListener, connectionLogger);
+                        connectedListener, disconnectedListener, connectionLogger, doubleDecodingEnabled);
         final Mqtt5ClientBuilder builder = Mockito.mock(Mqtt5ClientBuilder.class);
         final Mqtt5ClientAdvancedConfigBuilder.Nested<Mqtt5ClientBuilder> advancedConfig =
                 Mockito.mock(Mqtt5ClientAdvancedConfigBuilder.Nested.class);

--- a/connectivity/service/src/test/resources/connection-test.conf
+++ b/connectivity/service/src/test/resources/connection-test.conf
@@ -29,6 +29,8 @@ connection {
 
   all-client-actors-on-one-node = true
 
+  double-decoding-enabled = false
+
   ack-label-declare-interval = 99s
 
   mqtt {


### PR DESCRIPTION
Adds the possibility to configure whether connections usernames and passwords should be double decoded when connecting.
Leaves the default as enabled.