### PR TITLE
#1345 fixed fn:substring-after assuming delimiter is only 1 character

### DIFF
--- a/placeholders/src/main/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringAfter.java
+++ b/placeholders/src/main/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringAfter.java
@@ -44,7 +44,8 @@ final class PipelineFunctionSubstringAfter implements PipelineFunction {
 
         return value.onResolved(previousStage -> {
             if (previousStage.contains(splitValue)) {
-                return PipelineElement.resolved(previousStage.substring(previousStage.indexOf(splitValue) + 1));
+                return PipelineElement.resolved(previousStage.substring(previousStage.indexOf(splitValue) +
+                        splitValue.length()));
             } else {
                 return PipelineElement.unresolved();
             }

--- a/placeholders/src/test/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringAfterTest.java
+++ b/placeholders/src/test/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringAfterTest.java
@@ -52,6 +52,11 @@ public class PipelineFunctionSubstringAfterTest {
     }
 
     @Test
+    public void applyForLongerDelimiter() {
+        assertThat(function.apply(KNOWN_INPUT, "('eclipse.ditto:')", expressionResolver)).contains(EXPECTED_RESULT);
+    }
+
+    @Test
     public void returnsEmptyForEmptyInput() {
         assertThat(function.apply(EMPTY_INPUT, "('" + SUBSTRING_AT + "')", expressionResolver)).isEmpty();
     }

--- a/placeholders/src/test/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringBeforeTest.java
+++ b/placeholders/src/test/java/org/eclipse/ditto/placeholders/PipelineFunctionSubstringBeforeTest.java
@@ -52,6 +52,11 @@ public class PipelineFunctionSubstringBeforeTest {
     }
 
     @Test
+    public void applyForLongerDelimiter() {
+        assertThat(function.apply(KNOWN_INPUT, "(':any.thing.o')", expressionResolver)).contains(EXPECTED_RESULT);
+    }
+
+    @Test
     public void returnsEmptyForEmptyInput() {
         assertThat(function.apply(EMPTY_INPUT, "('" + SUBSTRING_AT + "')", expressionResolver)).isEmpty();
     }


### PR DESCRIPTION
Fixes: #1345 