### PR TITLE
Minor improvements to search updater mechanism

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLogger.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLogger.java
@@ -32,8 +32,8 @@ import org.eclipse.ditto.connectivity.model.LogEntry;
 import org.eclipse.ditto.connectivity.model.LogLevel;
 import org.eclipse.ditto.connectivity.model.LogType;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
-import org.eclipse.ditto.internal.utils.akka.logging.DittoLogger;
 import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLogger;
 import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.komamitsu.fluency.BufferFullException;
 import org.komamitsu.fluency.EventTime;
@@ -46,7 +46,8 @@ import org.komamitsu.fluency.Fluency;
 final class FluentPublishingConnectionLogger
         extends AbstractConnectionLogger<FluentPublishingConnectionLogger.Builder, FluentPublishingConnectionLogger> {
 
-    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(FluentPublishingConnectionLogger.class);
+    private static final ThreadSafeDittoLogger LOGGER =
+            DittoLoggerFactory.getThreadSafeLogger(FluentPublishingConnectionLogger.class);
 
     private static final String TAG_CONNECTION_ID = "connectionId";
 

--- a/policies/api/src/main/java/org/eclipse/ditto/policies/api/PolicyTag.java
+++ b/policies/api/src/main/java/org/eclipse/ditto/policies/api/PolicyTag.java
@@ -16,15 +16,20 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.internal.models.streaming.AbstractEntityIdWithRevision;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.policies.model.PolicyId;
-import org.eclipse.ditto.internal.models.streaming.AbstractEntityIdWithRevision;
 
 /**
  * Represents the ID and revision of a Policy.
  */
 @Immutable
 public final class PolicyTag extends AbstractEntityIdWithRevision<PolicyId> {
+
+    /**
+     * Defines a Publish/Subscribe topic on which PolicyTag message are published whenever the policy was modified.
+     */
+    public static final String PUB_SUB_TOPIC_MODIFIED = "policy-modified";
 
     /**
      * Defines a Publish/Subscribe topic on which PolicyTag message are published whenever the policy enforcer caches

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -192,13 +192,14 @@ public final class PolicyPersistenceActor
 
     @Override
     protected void publishEvent(final PolicyEvent<?> event) {
-        pubSubMediator.tell(DistPubSubAccess.publishViaGroup(PolicyEvent.TYPE_PREFIX, event), getSender());
+
+        final PolicyTag policyTag = PolicyTag.of(entityId, event.getRevision());
+        pubSubMediator.tell(DistPubSubAccess.publishViaGroup(PolicyTag.PUB_SUB_TOPIC_MODIFIED, policyTag), getSender());
 
         final boolean policyEnforcerInvalidatedPreemptively = Boolean.parseBoolean(event.getDittoHeaders()
                 .getOrDefault(DittoHeaderDefinition.POLICY_ENFORCER_INVALIDATED_PREEMPTIVELY.getKey(),
                         Boolean.FALSE.toString()));
         if (!policyEnforcerInvalidatedPreemptively) {
-            final PolicyTag policyTag = PolicyTag.of(entityId, event.getRevision());
             pubSubMediator.tell(DistPubSubAccess.publish(PolicyTag.PUB_SUB_TOPIC_INVALIDATE_ENFORCERS, policyTag),
                     getSender());
         }
@@ -245,7 +246,6 @@ public final class PolicyPersistenceActor
     }
 
     @Override
-    @SuppressWarnings("unchecked")
     protected PolicyEvent<?> modifyEventBeforePersist(final PolicyEvent<?> event) {
         final PolicyEvent<?> superEvent = super.modifyEventBeforePersist(event);
 

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -192,6 +192,7 @@ public final class PolicyPersistenceActor
 
     @Override
     protected void publishEvent(final PolicyEvent<?> event) {
+        pubSubMediator.tell(DistPubSubAccess.publishViaGroup(PolicyEvent.TYPE_PREFIX, event), getSender());
 
         final PolicyTag policyTag = PolicyTag.of(entityId, event.getRevision());
         pubSubMediator.tell(DistPubSubAccess.publishViaGroup(PolicyTag.PUB_SUB_TOPIC_MODIFIED, policyTag), getSender());

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/EnforcedThingMapper.java
@@ -38,6 +38,7 @@ import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
+import org.eclipse.ditto.thingsearch.api.UpdateReason;
 import org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.ThingWriteModel;
@@ -107,8 +108,11 @@ public final class EnforcedThingMapper {
                         Optional.ofNullable(oldMetadata).flatMap(Metadata::getModified).orElse(null),
                         Optional.ofNullable(oldMetadata).map(Metadata::getEvents).orElse(List.of()),
                         Optional.ofNullable(oldMetadata).map(Metadata::getTimers).orElse(List.of()),
-                        Optional.ofNullable(oldMetadata).map(Metadata::getSenders).orElse(List.of()))
-                .withOrigin(Optional.ofNullable(oldMetadata).flatMap(Metadata::getOrigin).orElse(null));
+                        Optional.ofNullable(oldMetadata).map(Metadata::getSenders).orElse(List.of()),
+                        Optional.ofNullable(oldMetadata).flatMap(Metadata::getOrigin).orElse(null),
+                        Optional.ofNullable(oldMetadata).map(Metadata::getUpdateReasons)
+                                .orElse(List.of(UpdateReason.UNKNOWN))
+                );
 
         return ThingWriteModel.of(metadata, toBsonDocument(thing, enforcer, maxArraySize, metadata));
     }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/Metadata.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
@@ -140,6 +139,8 @@ public final class Metadata {
      * @param events the events included in the metadata causing the search update.
      * @param timers the timers measuring the search updater's consistency lag.
      * @param senders the senders.
+     * @param origin the origin.
+     * @param updateReasons the update reasons.
      * @return the new Metadata object.
      */
     public static Metadata of(final ThingId thingId,
@@ -149,10 +150,12 @@ public final class Metadata {
             @Nullable final Instant modified,
             final List<ThingEvent<?>> events,
             final Collection<StartedTimer> timers,
-            final Collection<ActorRef> senders) {
+            final Collection<ActorRef> senders,
+            @Nullable final ActorRef origin,
+            final Collection<UpdateReason> updateReasons) {
 
         return new Metadata(thingId, thingRevision, policyId, policyRevision, modified, events, timers, senders,
-                false, false, null, List.of(UpdateReason.UNKNOWN));
+                false, false, origin, updateReasons);
     }
 
     /**
@@ -380,14 +383,11 @@ public final class Metadata {
      * @return the new metadata with concatenated senders.
      */
     public Metadata append(final Metadata newMetadata) {
-        final List<ThingEvent<?>> newEvents =
-                Stream.concat(events.stream(), newMetadata.events.stream()).collect(Collectors.toList());
-        final List<StartedTimer> newTimers =
-                Stream.concat(timers.stream(), newMetadata.timers.stream()).collect(Collectors.toList());
-        final List<ActorRef> newSenders =
-                Stream.concat(senders.stream(), newMetadata.senders.stream()).collect(Collectors.toList());
-        final List<UpdateReason> newReasons =
-                Stream.concat(updateReasons.stream(), newMetadata.updateReasons.stream()).collect(Collectors.toList());
+        final List<ThingEvent<?>> newEvents = Stream.concat(events.stream(), newMetadata.events.stream()).toList();
+        final List<StartedTimer> newTimers = Stream.concat(timers.stream(), newMetadata.timers.stream()).toList();
+        final List<ActorRef> newSenders = Stream.concat(senders.stream(), newMetadata.senders.stream()).toList();
+        final List<UpdateReason> newReasons = Stream.concat(updateReasons.stream(), newMetadata.updateReasons.stream())
+                .toList();
         return new Metadata(newMetadata.thingId, newMetadata.thingRevision, newMetadata.policyId,
                 newMetadata.policyRevision, newMetadata.modified, newEvents, newTimers, newSenders,
                 invalidateThing || newMetadata.invalidateThing,

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BulkWriteResultAckFlow.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.ShardedMessageEnvelope;
@@ -169,7 +168,9 @@ final class BulkWriteResultAckFlow {
         for (final Metadata metadata : metadataList) {
             metadata.sendNAck(); // also stops timer even if no acknowledgement is requested
             metadata.sendBulkWriteCompleteToOrigin(bulkWriteCorrelationId);
-            final UpdateThingResponse response = createFailureResponse(metadata, DittoHeaders.empty());
+            final UpdateThingResponse response = createFailureResponse(metadata, DittoHeaders.newBuilder()
+                    .correlationId(bulkWriteCorrelationId)
+                    .build());
             metadata.getOrigin().ifPresentOrElse(
                     origin -> origin.tell(response, ActorRef.noSender()),
                     () -> {
@@ -252,7 +253,7 @@ final class BulkWriteResultAckFlow {
                 .stream()
                 .map(MongoWriteModel::getDitto)
                 .map(AbstractWriteModel::getMetadata)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     private static String logResult(final String status, final WriteResultAndErrors writeResultAndErrors,

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
@@ -124,11 +124,9 @@ public final class SearchUpdaterRootActor extends AbstractActor {
         startClusterSingletonActor(NewEventForwarder.ACTOR_NAME,
                 NewEventForwarder.props(thingEventSub, updaterShard, blockedNamespaces));
 
-        // start policy event forwarder
-        final var policyEventForwarderProps =
-                PolicyEventForwarder.props(pubSubMediator, thingsUpdaterActor, blockedNamespaces,
-                        searchUpdaterPersistence);
-        startChildActor(PolicyEventForwarder.ACTOR_NAME, policyEventForwarderProps);
+        // start policy modification forwarder
+        startChildActor(PolicyModificationForwarder.ACTOR_NAME, PolicyModificationForwarder.props(
+                pubSubMediator, thingsUpdaterActor, blockedNamespaces, searchUpdaterPersistence));
 
         // start background sync actor as cluster singleton
         final var backgroundSyncActorProps = BackgroundSyncActor.props(


### PR DESCRIPTION
improved search-updater logic by:
* not publishing a `PolicyEvent`, instead publish a `PolicyTag` and consume in `PolicyModificationForwarder` to detect changes to a policy
* preserving the `updateReason` in Metadata build in EnforcedThingMapper
* adding better log statements to find out problems