### PR TITLE
Add QUERY_CONFIG_ENABLED to swagger-ui deployment

### DIFF
--- a/deployment/docker/docker-compose.yml
+++ b/deployment/docker/docker-compose.yml
@@ -222,6 +222,8 @@ services:
     image: docker.io/swaggerapi/swagger-ui:v4.6.1
     mem_limit: 32m
     restart: always
+    environment:
+      - QUERY_CONFIG_ENABLED=true
     volumes:
        - ../../documentation/src/main/resources/openapi:/usr/share/nginx/html/openapi:ro
        - ../../documentation/src/main/resources/images:/usr/share/nginx/html/images:ro

--- a/deployment/kubernetes/deploymentFiles/swagger/swagger.yaml
+++ b/deployment/kubernetes/deploymentFiles/swagger/swagger.yaml
@@ -33,6 +33,9 @@ spec:
       containers:
       - name: swagger-ui
         image: docker.io/swaggerapi/swagger-ui:v4.6.1
+        env:
+        - name: QUERY_CONFIG_ENABLED
+          value: "true"
         volumeMounts:
         - name: swagger-ui-api
           mountPath: /usr/share/nginx/html/openapi


### PR DESCRIPTION
Fix loading of openapi definition by enabling query config. If not configured the loading via query parameter isn't working. 