### PR TITLE
Add field selector for RetrievePolicy command

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/WithSelectedFields.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/WithSelectedFields.java
@@ -1,34 +1,35 @@
- /*
-  * Copyright (c) 2022 Contributors to the Eclipse Foundation
-  *
-  * See the NOTICE file(s) distributed with this work for additional
-  * information regarding copyright ownership.
-  *
-  * This program and the accompanying materials are made available under the
-  * terms of the Eclipse Public License 2.0 which is available at
-  * http://www.eclipse.org/legal/epl-2.0
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */
- package org.eclipse.ditto.base.model.signals.commands;
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.base.model.signals.commands;
 
- import java.util.Optional;
+import java.util.Optional;
 
 import org.eclipse.ditto.json.JsonFieldSelector;
 
- /**
-  * Command enabled for field selecting.
-  * @since 2.4.0
-  */
- public interface WithSelectedFields {
+/**
+ * Command enabled for field selecting.
+ *
+ * @since 2.4.0
+ */
+public interface WithSelectedFields {
 
-     /**
-      * Returns the selected fields which are to be included in the JSON of the retrieved entity.
-      *
-      * @return the selected fields.
-      */
-     default Optional<JsonFieldSelector> getSelectedFields() {
-         return Optional.empty();
-     }
+    /**
+     * Returns the selected fields which are to be included in the JSON of the retrieved entity.
+     *
+     * @return the selected fields.
+     */
+    default Optional<JsonFieldSelector> getSelectedFields() {
+        return Optional.empty();
+    }
 
- }
+}

--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/WithSelectedFields.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/commands/WithSelectedFields.java
@@ -1,5 +1,5 @@
  /*
-  * Copyright (c) 2021 Contributors to the Eclipse Foundation
+  * Copyright (c) 2022 Contributors to the Eclipse Foundation
   *
   * See the NOTICE file(s) distributed with this work for additional
   * information regarding copyright ownership.
@@ -10,15 +10,23 @@
   *
   * SPDX-License-Identifier: EPL-2.0
   */
- package org.eclipse.ditto.things.model.signals.commands;
+ package org.eclipse.ditto.base.model.signals.commands;
 
  import java.util.Optional;
 
- import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonFieldSelector;
 
- public interface WithSelectedFields extends org.eclipse.ditto.base.model.signals.commands.WithSelectedFields {
+ /**
+  * Command enabled for field selecting.
+  * @since 2.4.0
+  */
+ public interface WithSelectedFields {
 
-     @Override
+     /**
+      * Returns the selected fields which are to be included in the JSON of the retrieved entity.
+      *
+      * @return the selected fields.
+      */
      default Optional<JsonFieldSelector> getSelectedFields() {
          return Optional.empty();
      }

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -4490,10 +4490,77 @@ paths:
         response contains the policy as JSON object.
 
         Tip: If you don't know the policy ID of a thing, request it via GET `/things/{thingId}`.
+
+        Optionally, you can use the field selectors (see parameter `fields`) to only get specific fields,
+        which you are interested in.
+
+        ### Example:
+        Use the field selector `_revision` to retrieve the revision of the policy.
       tags:
         - Policies
       parameters:
         - $ref: '#/components/parameters/PolicyIdPathParam'
+        - name: fields
+          in: query
+          description: |-
+            Contains a comma-separated list of fields to be included in the returned
+            JSON.
+
+            #### Selectable fields
+
+            * `policyId`
+            * `entries`
+
+               Supports selecting arbitrary sub-fields by using a comma-separated list:
+                * several entry paths can be passed as a comma-separated list of JSON pointers (RFC-6901)
+
+                  For example:
+                    * `?fields=entries/ditto` would select only the `ditto` entry value(if present)
+                    * `?fields=entries/ditto,entries/user` would select only `ditto` and
+                       `user` entry values (if present)
+
+              Supports selecting arbitrary sub-fields of objects by wrapping sub-fields inside parentheses `( )`:
+                * a comma-separated list of sub-fields (a sub-field is a JSON pointer (RFC-6901)
+                  separated with `/`) to select
+
+                * sub-selectors can be used to request only specific sub-fields by placing expressions
+                  in parentheses `( )` after a selected subfield
+
+                  For example:
+                   * `?fields=entries(ditto,user)` would select only `ditto`
+                      and `user` entry values (if present)
+                   * `?fields=entries(ditto/subjects)` would select the `subjects` value
+                      inside the `ditto` entry
+                   * `?fields=entries/ditto/subjects(issuer:google,issuer:azure)` would select the `issuer:google` and
+                      `issuer:azure` values inside the `subjects` object inside the `entries` object
+
+            * `_namespace`
+
+              Specifically selects the namespace also contained in the `policyId`
+
+            * `_revision`
+
+              Specifically selects the revision of the policy. The revision is a counter, which is incremented on each modification of a policy.
+
+            * `_created`
+
+              Specifically selects the created timestamp of the policy in ISO-8601 UTC format. The timestamp is set on creation of a policy.
+
+            * `_modified`
+
+              Specifically selects the modified timestamp of the policy in ISO-8601 UTC format. The timestamp is set on each modification of a policy.
+
+            * `_metadata`
+
+              Specifically selects the Metadata of the policy. The content is a JSON object having the policy's JSON structure with the difference that the JSON leaves of the policy are JSON objects containing the metadata.
+
+            #### Examples
+
+            * `?fields=policyId,entries,_revision`
+            * `?fields=entries(ditto,user),_namespace`
+          required: false
+          schema:
+            type: string
         - $ref: '#/components/parameters/IfMatchHeaderParam'
         - $ref: '#/components/parameters/IfNoneMatchHeaderParam'
         - $ref: '#/components/parameters/TimeoutParam'

--- a/documentation/src/main/resources/openapi/sources/parameters/policyFieldsQueryParam.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/policyFieldsQueryParam.yml
@@ -1,0 +1,71 @@
+# Copyright (c) 2022 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Eclipse Public License 2.0 which is available at
+# http://www.eclipse.org/legal/epl-2.0
+#
+# SPDX-License-Identifier: EPL-2.0
+name: fields
+in: query
+description: |-
+  Contains a comma-separated list of fields to be included in the returned
+  JSON.
+
+  #### Selectable fields
+
+  * `policyId`
+  * `entries`
+
+     Supports selecting arbitrary sub-fields by using a comma-separated list:
+      * several entry paths can be passed as a comma-separated list of JSON pointers (RFC-6901)
+
+        For example:
+          * `?fields=entries/ditto` would select only the `ditto` entry value(if present)
+          * `?fields=entries/ditto,entries/user` would select only `ditto` and
+             `user` entry values (if present)
+
+    Supports selecting arbitrary sub-fields of objects by wrapping sub-fields inside parentheses `( )`:
+      * a comma-separated list of sub-fields (a sub-field is a JSON pointer (RFC-6901)
+        separated with `/`) to select
+
+      * sub-selectors can be used to request only specific sub-fields by placing expressions
+        in parentheses `( )` after a selected subfield
+
+        For example:
+         * `?fields=entries(ditto,user)` would select only `ditto`
+            and `user` entry values (if present)
+         * `?fields=entries(ditto/subjects)` would select the `subjects` value
+            inside the `ditto` entry
+         * `?fields=entries/ditto/subjects(issuer:google,issuer:azure)` would select the `issuer:google` and
+            `issuer:azure` values inside the `subjects` object inside the `entries` object
+
+  * `_namespace`
+
+    Specifically selects the namespace also contained in the `policyId`
+
+  * `_revision`
+
+    Specifically selects the revision of the policy. The revision is a counter, which is incremented on each modification of a policy.
+
+  * `_created`
+
+    Specifically selects the created timestamp of the policy in ISO-8601 UTC format. The timestamp is set on creation of a policy.
+
+  * `_modified`
+
+    Specifically selects the modified timestamp of the policy in ISO-8601 UTC format. The timestamp is set on each modification of a policy.
+
+  * `_metadata`
+
+    Specifically selects the Metadata of the policy. The content is a JSON object having the policy's JSON structure with the difference that the JSON leaves of the policy are JSON objects containing the metadata.
+
+  #### Examples
+
+  * `?fields=policyId,entries,_revision`
+  * `?fields=entries(ditto,user),_namespace`
+required: false
+schema:
+  type: string

--- a/documentation/src/main/resources/openapi/sources/paths/policies/policy.yml
+++ b/documentation/src/main/resources/openapi/sources/paths/policies/policy.yml
@@ -15,10 +15,17 @@ get:
     response contains the policy as JSON object.
 
     Tip: If you don't know the policy ID of a thing, request it via GET `/things/{thingId}`.
+
+    Optionally, you can use the field selectors (see parameter `fields`) to only get specific fields,
+    which you are interested in.
+
+    ### Example:
+    Use the field selector `_revision` to retrieve the revision of the policy.
   tags:
     - Policies
   parameters:
     - $ref: '../../parameters/policyIdPathParam.yml'
+    - $ref: '../../parameters/policyFieldsQueryParam.yml'
     - $ref: '../../parameters/ifMatchHeaderParam.yml'
     - $ref: '../../parameters/ifNoneMatchHeaderParam.yml'
     - $ref: '../../parameters/timeoutParam.yml'

--- a/documentation/src/main/resources/pages/ditto/protocol-specification-policies-retrieve.md
+++ b/documentation/src/main/resources/pages/ditto/protocol-specification-policies-retrieve.md
@@ -18,6 +18,7 @@ Retrieves a Policy identified by the `<namespace>/<policyName>` pair in the `top
 |-----------|-------------------------|
 | **topic** | `<namespace>/<policyName>/policies/commands/retrieve`     |
 | **path**  | `/`     |
+| **fields** | Contains a comma separated list of fields to be included in the returned JSON. |
 
 ### Response
 

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicy-withfieldselector.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/generated/commands/query/retrievepolicy-withfieldselector.md
@@ -1,0 +1,12 @@
+## RetrievePolicy
+
+```json
+{
+  "topic": "org.eclipse.ditto/the_policy_id/policies/commands/retrieve",
+  "headers": {
+    "correlation-id": "<command-correlation-id>"
+  },
+  "path": "/",
+  "fields": "policyId,_revision"
+}
+```

--- a/documentation/src/main/resources/pages/ditto/protocol/examples/policies/protocol-examples-policies-retrievepolicy.md
+++ b/documentation/src/main/resources/pages/ditto/protocol/examples/policies/protocol-examples-policies-retrievepolicy.md
@@ -8,6 +8,9 @@ permalink: protocol-examples-policies-retrievepolicy.html
 {% capture command %}{% include_relative generated/commands/query/retrievepolicy.md %}{% endcapture %}
 {{ command | markdownify }}
 
+{% capture command %}{% include_relative generated/commands/query/retrievepolicy-withfieldselector.md %}{% endcapture %}
+{{ command | markdownify }}
+
 {% capture response %}{% include_relative generated/commands/query/retrievepolicyresponse.md %}{% endcapture %}
 {{ response | markdownify }}
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/AbstractRoute.java
@@ -139,7 +139,7 @@ public abstract class AbstractRoute extends AllDirectives {
      * @param fieldsString the fields as string.
      * @return the Optional JsonFieldSelector
      */
-    public static Optional<JsonFieldSelector> calculateSelectedFields(final Optional<String> fieldsString) {
+    protected static Optional<JsonFieldSelector> calculateSelectedFields(final Optional<String> fieldsString) {
         return fieldsString.map(fs -> JsonFactory.newFieldSelector(fs, JSON_FIELD_SELECTOR_PARSE_OPTIONS));
     }
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesParameter.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesParameter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.endpoints.routes.policies;
+
+/**
+ * An enumeration of the query parameters for the policies REST API.
+ */
+public enum PoliciesParameter {
+
+    /**
+     * Request parameter for including only the selected fields in the Policy JSON document(s).
+     */
+    FIELDS("fields");
+
+    private final String parameterValue;
+
+    PoliciesParameter(final String parameterValue) {
+        this.parameterValue = parameterValue;
+    }
+
+    @Override
+    public String toString() {
+        return parameterValue;
+    }
+
+}

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRoute.java
@@ -26,7 +26,6 @@ import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.gateway.service.endpoints.routes.AbstractRoute;
 import org.eclipse.ditto.gateway.service.endpoints.routes.RouteBaseProperties;
-import org.eclipse.ditto.gateway.service.endpoints.routes.things.ThingsParameter;
 import org.eclipse.ditto.gateway.service.security.authentication.AuthenticationResult;
 import org.eclipse.ditto.gateway.service.security.authentication.jwt.JwtAuthenticationResult;
 import org.eclipse.ditto.json.JsonFactory;
@@ -121,7 +120,7 @@ public final class PoliciesRoute extends AbstractRoute {
         return pathEndOrSingleSlash(() ->
                 concat(
                         // GET /policies/<policyId>?fields=<fieldsString>
-                        get(() -> parameterOptional(ThingsParameter.FIELDS.toString(), fieldsString ->
+                        get(() -> parameterOptional(PoliciesParameter.FIELDS.toString(), fieldsString ->
                                 handlePerRequest(ctx, RetrievePolicy.of(policyId, dittoHeaders,
                                         calculateSelectedFields(fieldsString).orElse(null)))
                         )),

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRouteTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/policies/PoliciesRouteTest.java
@@ -91,6 +91,12 @@ public final class PoliciesRouteTest extends EndpointTestBase {
     }
 
     @Test
+    public void getPolicyWithFields() {
+        getRoute(getPreAuthResult()).run(HttpRequest.GET("/policies/org.eclipse.ditto%3Adummy?fields=_revision"))
+                .assertStatusCode(StatusCodes.OK);
+    }
+
+    @Test
     public void deletePolicy() {
         getRoute(getPreAuthResult()).run(HttpRequest.DELETE("/policies/org.eclipse.ditto%3Adummy"))
                 .assertStatusCode(StatusCodes.OK);

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/PolicyQueryCommand.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/signals/commands/query/PolicyQueryCommand.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.policies.model.signals.commands.query;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
 
 /**
@@ -20,7 +21,8 @@ import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
  *
  * @param <T> the type of the implementing class.
  */
-public interface PolicyQueryCommand<T extends PolicyQueryCommand<T>> extends PolicyCommand<T> {
+public interface PolicyQueryCommand<T extends PolicyQueryCommand<T>> extends PolicyCommand<T>,
+        WithSelectedFields {
 
     @Override
     T setDittoHeaders(DittoHeaders dittoHeaders);

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mapper/PolicyQuerySignalMapper.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mapper/PolicyQuerySignalMapper.java
@@ -12,15 +12,21 @@
  */
 package org.eclipse.ditto.protocol.mapper;
 
+import org.eclipse.ditto.policies.model.signals.commands.query.PolicyQueryCommand;
+import org.eclipse.ditto.protocol.PayloadBuilder;
 import org.eclipse.ditto.protocol.ProtocolFactory;
 import org.eclipse.ditto.protocol.TopicPathBuilder;
-import org.eclipse.ditto.policies.model.signals.commands.query.PolicyQueryCommand;
 
 final class PolicyQuerySignalMapper extends AbstractQuerySignalMapper<PolicyQueryCommand<?>> {
 
     @Override
     TopicPathBuilder getTopicPathBuilder(final PolicyQueryCommand<?> command) {
         return ProtocolFactory.newTopicPathBuilder(command.getEntityId()).policies();
+    }
+
+    @Override
+    void enhancePayloadBuilder(final PolicyQueryCommand<?> command, final PayloadBuilder payloadBuilder) {
+        command.getSelectedFields().ifPresent(payloadBuilder::withFields);
     }
 
 }

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractMappingStrategies.java
@@ -18,16 +18,17 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonObject;
-import org.eclipse.ditto.json.JsonParseException;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.json.Jsonifiable;
-import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonParseException;
 import org.eclipse.ditto.protocol.Adaptable;
 import org.eclipse.ditto.protocol.JsonifiableMapper;
 import org.eclipse.ditto.protocol.TopicPath;
+import org.eclipse.ditto.things.model.ThingId;
 
 /**
  * Abstract base class for implementations of {@link MappingStrategies}. It implements the {@link #find(String)}
@@ -72,6 +73,11 @@ abstract class AbstractMappingStrategies<T extends Jsonifiable.WithPredicate<Jso
         return adaptable.getPayload().getHttpStatus()
                 .map(HttpStatus.CREATED::equals)
                 .orElseThrow(() -> JsonParseException.newBuilder().build());
+    }
+
+    @Nullable
+    protected static JsonFieldSelector selectedFieldsFrom(final Adaptable adaptable) {
+        return adaptable.getPayload().getFields().orElse(null);
     }
 
     protected static ThingId thingIdFrom(final Adaptable adaptable) {

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractPolicyMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractPolicyMappingStrategies.java
@@ -77,6 +77,15 @@ abstract class AbstractPolicyMappingStrategies<T extends Jsonifiable.WithPredica
         return PoliciesModelFactory.newPolicy(value);
     }
 
+    protected static JsonObject policyJsonFrom(final Adaptable adaptable) {
+        return adaptable.getPayload()
+                .getValue()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .orElseThrow(
+                        () -> new NullPointerException("Payload value must be a non-null object."));
+    }
+
     /**
      * Policy entry from policy entry.
      *

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractThingMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/AbstractThingMappingStrategies.java
@@ -16,15 +16,17 @@ import java.util.Map;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.base.model.json.Jsonifiable;
 import org.eclipse.ditto.json.JsonField;
-import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonParseException;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
-import org.eclipse.ditto.base.model.json.Jsonifiable;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.protocol.Adaptable;
+import org.eclipse.ditto.protocol.JsonifiableMapper;
+import org.eclipse.ditto.protocol.TopicPath;
+import org.eclipse.ditto.protocol.UnknownPathException;
 import org.eclipse.ditto.things.model.Attributes;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.FeatureDefinition;
@@ -33,10 +35,6 @@ import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingDefinition;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.protocol.Adaptable;
-import org.eclipse.ditto.protocol.JsonifiableMapper;
-import org.eclipse.ditto.protocol.TopicPath;
-import org.eclipse.ditto.protocol.UnknownPathException;
 
 /**
  * Provides helper methods to map from {@link Adaptable}s to things commands.
@@ -52,15 +50,6 @@ abstract class AbstractThingMappingStrategies<T extends Jsonifiable.WithPredicat
 
     protected AbstractThingMappingStrategies(final Map<String, JsonifiableMapper<T>> mappingStrategies) {
         super(mappingStrategies);
-    }
-
-    protected static AuthorizationSubject authorizationSubjectFrom(final Adaptable adaptable) {
-        return AuthorizationSubject.newInstance(leafValue(adaptable.getPayload().getPath()));
-    }
-
-    @Nullable
-    protected static JsonFieldSelector selectedFieldsFrom(final Adaptable adaptable) {
-        return adaptable.getPayload().getFields().orElse(null);
     }
 
     @Nullable

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandMappingStrategies.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.protocol.mappingstrategies;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.ditto.protocol.JsonifiableMapper;
 import org.eclipse.ditto.policies.model.signals.commands.query.PolicyQueryCommand;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicy;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyEntries;
@@ -24,6 +23,7 @@ import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResource;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResources;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubject;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubjects;
+import org.eclipse.ditto.protocol.JsonifiableMapper;
 
 /**
  * Defines mapping strategies (map from signal type to JsonifiableMapper) for policy query commands.
@@ -46,7 +46,8 @@ final class PolicyQueryCommandMappingStrategies extends AbstractPolicyMappingStr
 
         mappingStrategies.put(RetrievePolicy.TYPE,
                 adaptable -> RetrievePolicy.of(policyIdFromTopicPath(adaptable.getTopicPath()),
-                        dittoHeadersFrom(adaptable)));
+                        dittoHeadersFrom(adaptable),
+                        selectedFieldsFrom(adaptable)));
 
         mappingStrategies.put(RetrievePolicyEntry.TYPE,
                 adaptable -> RetrievePolicyEntry.of(policyIdFromTopicPath(adaptable.getTopicPath()),

--- a/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandResponseMappingStrategies.java
+++ b/protocol/src/main/java/org/eclipse/ditto/protocol/mappingstrategies/PolicyQueryCommandResponseMappingStrategies.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.protocol.mappingstrategies;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.eclipse.ditto.protocol.JsonifiableMapper;
 import org.eclipse.ditto.policies.model.signals.commands.query.PolicyQueryCommandResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyEntriesResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrievePolicyEntryResponse;
@@ -24,6 +23,7 @@ import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResourceR
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveResourcesResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubjectResponse;
 import org.eclipse.ditto.policies.model.signals.commands.query.RetrieveSubjectsResponse;
+import org.eclipse.ditto.protocol.JsonifiableMapper;
 
 /**
  * Defines mapping strategies (map from signal type to JsonifiableMapper) for policy query command responses.
@@ -55,7 +55,7 @@ final class PolicyQueryCommandResponseMappingStrategies
             final Map<String, JsonifiableMapper<PolicyQueryCommandResponse<?>>> mappingStrategies) {
         mappingStrategies.put(RetrievePolicyResponse.TYPE,
                 adaptable -> RetrievePolicyResponse.of(policyIdFromTopicPath(adaptable.getTopicPath()),
-                        policyFrom(adaptable), dittoHeadersFrom(adaptable)));
+                        policyJsonFrom(adaptable), dittoHeadersFrom(adaptable)));
     }
 
     private static void addPolicyEntryResponses(

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/WithSelectedFields.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/WithSelectedFields.java
@@ -1,26 +1,29 @@
- /*
-  * Copyright (c) 2021 Contributors to the Eclipse Foundation
-  *
-  * See the NOTICE file(s) distributed with this work for additional
-  * information regarding copyright ownership.
-  *
-  * This program and the accompanying materials are made available under the
-  * terms of the Eclipse Public License 2.0 which is available at
-  * http://www.eclipse.org/legal/epl-2.0
-  *
-  * SPDX-License-Identifier: EPL-2.0
-  */
- package org.eclipse.ditto.things.model.signals.commands;
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.model.signals.commands;
 
- import java.util.Optional;
+import java.util.Optional;
 
- import org.eclipse.ditto.json.JsonFieldSelector;
+import org.eclipse.ditto.json.JsonFieldSelector;
 
- public interface WithSelectedFields extends org.eclipse.ditto.base.model.signals.commands.WithSelectedFields {
+/**
+ * @deprecated since 2.4.0 use {@link org.eclipse.ditto.base.model.signals.commands.WithSelectedFields} instead.
+ */
+public interface WithSelectedFields extends org.eclipse.ditto.base.model.signals.commands.WithSelectedFields {
 
-     @Override
-     default Optional<JsonFieldSelector> getSelectedFields() {
-         return Optional.empty();
-     }
+    @Override
+    default Optional<JsonFieldSelector> getSelectedFields() {
+        return Optional.empty();
+    }
 
- }
+}

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThing.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThing.java
@@ -23,6 +23,12 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
@@ -30,13 +36,7 @@ import org.eclipse.ditto.json.JsonFieldSelector;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableCommand;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
-import org.eclipse.ditto.base.model.signals.commands.CommandJsonDeserializer;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
 
 /**
@@ -163,6 +163,7 @@ public final class RetrieveThing extends AbstractCommand<RetrieveThing> implemen
     @Override
     protected void appendPayload(final JsonObjectBuilder jsonObjectBuilder, final JsonSchemaVersion schemaVersion,
             final Predicate<JsonField> thePredicate) {
+
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         jsonObjectBuilder.set(ThingCommand.JsonFields.JSON_THING_ID, thingId.toString(), predicate);
         if (null != selectedFields) {

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThings.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThings.java
@@ -34,7 +34,6 @@ import org.eclipse.ditto.base.model.json.JsonParsableCommand;
 import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
 import org.eclipse.ditto.base.model.signals.commands.WithNamespace;
-import org.eclipse.ditto.base.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -48,6 +47,7 @@ import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.things.model.ThingConstants;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
+import org.eclipse.ditto.things.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.MissingThingIdsException;
 
 /**

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThings.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/RetrieveThings.java
@@ -28,6 +28,13 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.FieldType;
+import org.eclipse.ditto.base.model.json.JsonParsableCommand;
+import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
+import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
+import org.eclipse.ditto.base.model.signals.commands.WithNamespace;
+import org.eclipse.ditto.base.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonCollectors;
 import org.eclipse.ditto.json.JsonFactory;
@@ -38,16 +45,9 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.json.FieldType;
-import org.eclipse.ditto.base.model.json.JsonParsableCommand;
-import org.eclipse.ditto.base.model.json.JsonSchemaVersion;
 import org.eclipse.ditto.things.model.ThingConstants;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.base.model.signals.commands.AbstractCommand;
-import org.eclipse.ditto.base.model.signals.commands.WithNamespace;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
-import org.eclipse.ditto.things.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.things.model.signals.commands.exceptions.MissingThingIdsException;
 
 /**

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/ThingQueryCommand.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/ThingQueryCommand.java
@@ -13,8 +13,8 @@
 package org.eclipse.ditto.things.model.signals.commands.query;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
+import org.eclipse.ditto.things.model.signals.commands.WithSelectedFields;
 
 /**
  * Aggregates all {@link org.eclipse.ditto.things.model.signals.commands.ThingCommand}s which query the state of things (read, ...).

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/ThingQueryCommand.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/signals/commands/query/ThingQueryCommand.java
@@ -13,8 +13,8 @@
 package org.eclipse.ditto.things.model.signals.commands.query;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.signals.commands.WithSelectedFields;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommand;
-import org.eclipse.ditto.things.model.signals.commands.WithSelectedFields;
 
 /**
  * Aggregates all {@link org.eclipse.ditto.things.model.signals.commands.ThingCommand}s which query the state of things (read, ...).


### PR DESCRIPTION
Makes it possible to specify fields of a policy which should be returned in the RetrievePolicyResponse.
This also gives the opportunity to retrieve hidden fields. (i.e. _revision)