### PR TITLE
adjust `DITTO_LOGGING_FILE_APPENDER` env key to be "true" so that file appender is used

### DIFF
--- a/concierge/service/src/main/resources/logback.xml
+++ b/concierge/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -102,7 +102,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>

--- a/connectivity/service/src/main/resources/logback.xml
+++ b/connectivity/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -106,7 +106,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -243,7 +243,7 @@ or `pre-authenticated:service`. `*` will match any number of characters, and `?`
 Gathering logs for a running Ditto installation can be achieved by:
 
 * sending logs to STDOUT/STDERR: this is the default
-   * can be disabled by setting the environment variable `DITTO_LOGGING_DISABLE_SYSOUT_LOG`
+   * can be disabled by setting the environment variable `DITTO_LOGGING_DISABLE_SYSOUT_LOG` to `true`
    * Benefits: simple, works with all Docker logging drivers (e.g. "awslogs", "splunk", etc.)
 
 * pushing logs into ELK stack: this can be done by setting the environment variable `DITTO_LOGGING_LOGSTASH_SERVER`
@@ -254,10 +254,11 @@ Gathering logs for a running Ditto installation can be achieved by:
      variables. It is also possible to clean up old log files and archives at start up.
      In case `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` is used it is necessary to configure also `DITTO_LOGGING_MAX_LOG_FILE_HISTORY`.
      The detailed meaning of these config values is described in the [logback documentation](https://logback.qos.ch/manual/appenders.html#TimeBasedRollingPolicy).  
-       * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: /var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz) - the rollover period is inferred from the fileNamePattern
-       * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY` (default: 10)
-       * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: 1GB)
-       * `DITTO_LOGGING_CLEAN_HISTORY_ON_START` (default: false)
+       * `DITTO_LOGGING_FILE_APPENDER_THRESHOLD` (default: `info`) - the threshold `level` to use for logging (only greater or equal levels will be logged)
+       * `DITTO_LOGGING_FILE_NAME_PATTERN` (default: `/var/log/ditto/<service-name>.log.%d{yyyy-MM-dd}.gz`) - the rollover period is inferred from the fileNamePattern
+       * `DITTO_LOGGING_MAX_LOG_FILE_HISTORY` (default: `10`)
+       * `DITTO_LOGGING_TOTAL_LOG_FILE_SIZE` (default: `1GB`)
+       * `DITTO_LOGGING_CLEAN_HISTORY_ON_START` (default: `false`)
    * the format in which logging is done is "LogstashEncoder" format - that way the logfiles may easily be imported into
      an ELK stack
    * when running Ditto in Kubernetes apply the `ditto-log-files.yaml` to your Kubernetes cluster in order to 

--- a/gateway/service/src/main/resources/logback.xml
+++ b/gateway/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -104,7 +104,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>

--- a/policies/service/src/main/resources/logback.xml
+++ b/policies/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -104,7 +104,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>

--- a/things/service/src/main/resources/logback.xml
+++ b/things/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -104,7 +104,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>

--- a/thingsearch/service/src/main/resources/logback.xml
+++ b/thingsearch/service/src/main/resources/logback.xml
@@ -44,11 +44,11 @@
         </then>
     </if>
 
-    <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+    <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
         <then>
             <appender name="file" class="ch.qos.logback.core.rolling.RollingFileAppender">
                 <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-                    <level>info</level>
+                    <level>${DITTO_LOGGING_FILE_APPENDER_THRESHOLD:-info}</level>
                 </filter>
                 <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
                     <!-- The rollover period is inferred from the fileNamePattern -->
@@ -104,7 +104,7 @@
             </then>
         </if>
 
-        <if condition='isDefined("DITTO_LOGGING_FILE_APPENDER")'>
+        <if condition='property("DITTO_LOGGING_FILE_APPENDER").equals("true")'>
             <then>
                 <appender-ref ref="file"/>
             </then>


### PR DESCRIPTION
* added new `DITTO_LOGGING_FILE_APPENDER_THRESHOLD` variable configuring the "level" threshold for the logging file appender