### PR TITLE
In case of ThingDeleteModel always consider model as not outdated

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -496,9 +496,10 @@ final class ThingUpdater extends AbstractActorWithStashWithTimers {
             @Nullable final AbstractWriteModel lastWriteModel,
             final AbstractWriteModel nextWriteModel) {
 
-        if (nextWriteModel instanceof ThingDeleteModel && nextWriteModel.getMetadata().getThingRevision() < 0) {
+        if (nextWriteModel instanceof ThingDeleteModel) {
             /*
-             * This branch is required because missed ThingDeletes will always have revision -1.
+             * This branch is required because missed ThingDeletes will always have revision -1 or same revision as
+             * last write model.
              * This also comes with a downside that it can happen that a thing delete model will come after a create
              * model in wrong order, so the thing will be removed from the index incorrectly.
              * However, in this case the thing will become eventually consistent either by the next background sync or

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -281,7 +281,8 @@ public final class ThingUpdaterTest {
 
             // WHEN: updater is requested to compute incremental update of an older write model
             underTest.tell(UpdateThing.of(THING_ID, UpdateReason.UNKNOWN, DittoHeaders.empty()), getRef());
-            final var olderWriteModel = ThingDeleteModel.of(Metadata.of(THING_ID, 1233, null, null, null));
+            final var olderWriteModel =
+                    ThingWriteModel.of(Metadata.of(THING_ID, 1233, null, null, null), document);
             underTest.tell(olderWriteModel, getRef());
 
             // THEN: expect no update.


### PR DESCRIPTION
See java comment:

```
             * This branch is required because missed ThingDeletes will always have revision -1.
             * This also comes with a downside that it can happen that a thing delete model will come after a create
             * model in wrong order, so the thing will be removed from the index incorrectly.
             * However, in this case the thing will become eventually consistent either by the next background sync or
             * the next update.
```             