### PR TITLE
Make Ditto default namespace configurable 

### DIFF
--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/ConciergeConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/ConciergeConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.concierge.service.common;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.service.config.ServiceSpecificConfig;
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 import org.eclipse.ditto.internal.utils.health.config.WithHealthCheckConfig;
 
 /**
@@ -22,6 +23,14 @@ import org.eclipse.ditto.internal.utils.health.config.WithHealthCheckConfig;
  */
 @Immutable
 public interface ConciergeConfig extends ServiceSpecificConfig, WithHealthCheckConfig {
+
+
+    /**
+     * Returns the default namespace which is used when no namespace is provided.
+     *
+     * @return the default namespace.
+     */
+    String getDefaultNamespace();
 
     /**
      * Returns the config of Concierge's enforcement behaviour.
@@ -43,5 +52,33 @@ public interface ConciergeConfig extends ServiceSpecificConfig, WithHealthCheckC
      * @return the config.
      */
     ThingsAggregatorConfig getThingsAggregatorConfig();
+
+    enum ConciergeConfigValue implements KnownConfigValue {
+
+        /**
+         * The default namespace to use for creating things without specified namespace.
+         *
+         * @since 2.5.0
+         */
+        DEFAULT_NAMESPACE("default-namespace", "org.eclipse.ditto");
+
+        private final String path;
+        private final Object defaultValue;
+
+        ConciergeConfigValue(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+    }
 
 }

--- a/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DittoConciergeConfig.java
+++ b/concierge/service/src/main/java/org/eclipse/ditto/concierge/service/common/DittoConciergeConfig.java
@@ -14,7 +14,6 @@ package org.eclipse.ditto.concierge.service.common;
 
 import java.util.Objects;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.service.config.DittoServiceConfig;
@@ -41,6 +40,7 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
     private final DefaultEnforcementConfig enforcementConfig;
     private final DefaultCachesConfig cachesConfig;
     private final DefaultThingsAggregatorConfig thingsAggregatorConfig;
+    private final String defaultNamespace;
 
     private DittoConciergeConfig(final ScopedConfig dittoScopedConfig) {
         serviceSpecificConfig = DittoServiceConfig.of(dittoScopedConfig, CONFIG_PATH);
@@ -48,6 +48,7 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
         enforcementConfig = DefaultEnforcementConfig.of(serviceSpecificConfig);
         cachesConfig = DefaultCachesConfig.of(serviceSpecificConfig);
         thingsAggregatorConfig = DefaultThingsAggregatorConfig.of(serviceSpecificConfig);
+        defaultNamespace = dittoScopedConfig.getString(ConciergeConfigValue.DEFAULT_NAMESPACE.getConfigPath());
     }
 
     /**
@@ -60,6 +61,11 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
      */
     public static DittoConciergeConfig of(final ScopedConfig dittoScopedConfig) {
         return new DittoConciergeConfig(dittoScopedConfig);
+    }
+
+    @Override
+    public String getDefaultNamespace() {
+        return defaultNamespace;
     }
 
     @Override
@@ -113,7 +119,7 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
     }
 
     @Override
-    public boolean equals(@Nullable final Object o) {
+    public boolean equals(final Object o) {
         if (this == o) {
             return true;
         }
@@ -122,16 +128,15 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
         }
         final DittoConciergeConfig that = (DittoConciergeConfig) o;
         return serviceSpecificConfig.equals(that.serviceSpecificConfig) &&
-                healthCheckConfig.equals(that.healthCheckConfig) &&
-                enforcementConfig.equals(that.enforcementConfig) &&
-                cachesConfig.equals(that.cachesConfig) &&
-                thingsAggregatorConfig.equals(that.thingsAggregatorConfig);
+                healthCheckConfig.equals(that.healthCheckConfig) && enforcementConfig.equals(that.enforcementConfig) &&
+                cachesConfig.equals(that.cachesConfig) && thingsAggregatorConfig.equals(that.thingsAggregatorConfig) &&
+                defaultNamespace.equals(that.defaultNamespace);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(serviceSpecificConfig, healthCheckConfig, enforcementConfig, cachesConfig,
-                thingsAggregatorConfig);
+                thingsAggregatorConfig, defaultNamespace);
     }
 
     @Override
@@ -142,6 +147,8 @@ public final class DittoConciergeConfig implements ConciergeConfig, WithConfigPa
                 ", enforcementConfig=" + enforcementConfig +
                 ", cachesConfig=" + cachesConfig +
                 ", thingsAggregatorConfig=" + thingsAggregatorConfig +
+                ", defaultNamespace='" + defaultNamespace +
                 "]";
     }
+
 }

--- a/concierge/service/src/main/resources/concierge.conf
+++ b/concierge/service/src/main/resources/concierge.conf
@@ -4,7 +4,11 @@ ditto {
   mapping-strategy.implementation = "org.eclipse.ditto.concierge.service.ConciergeMappingStrategies"
   mapping-strategy.implementation = ${?MAPPING_STRATEGY_IMPLEMENTATION}
 
+  default-namespace = "org.eclipse.ditto"
+  default-namespace = ${?DITTO_DEFAULT_NAMESPACE}
+
   concierge {
+
     enforcement {
       # configuration for retrieval of policies/things during enforcement via sharding
       ask-with-retry {

--- a/concierge/service/src/test/resources/test.conf
+++ b/concierge/service/src/test/resources/test.conf
@@ -1,4 +1,6 @@
 ditto {
+  default-namespace = "org.eclipse.ditto"
+
   concierge {
     caches {
       ask-timeout = 10s


### PR DESCRIPTION
With this PR it is possible to configure the default namespace which is used for entities which do not specify a namespace by default. Use the default namespace for all CreateThing commands if no namespace or the empty namespace is provided.