### PR TITLE
Stop thing updater if initial update fails

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
@@ -192,8 +192,8 @@ public final class BackgroundSyncStream {
                             );
             return Source.completionStageSource(askFuture);
         } else {
-            // policy ID does not exist: entry should be updated in search index
-            return Source.single(persisted);
+            // policy ID does not exist: entry should not be updated in search index
+            return Source.empty();
         }
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActor.java
@@ -119,8 +119,7 @@ public final class BackgroundSyncActor
     @Override
     protected void preEnhanceSleepingBehavior(final ReceiveBuilder sleepingReceiveBuilder) {
         sleepingReceiveBuilder.matchEquals(Control.BOOKMARK_THING_ID,
-                        trigger ->
-                                // ignore scheduled bookmark messages when sleeping
+                        trigger -> // ignore scheduled bookmark messages when sleeping
                                 log.debug("Ignoring: <{}>", trigger)
                 )
                 .match(ThingId.class, thingId ->

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 
 import org.bson.BsonArray;
@@ -596,6 +595,32 @@ public final class ThingUpdaterTest {
             // WHEN: An event of the next revision arrives
             underTest.tell(AttributeModified.of(THING_ID, JsonPointer.of("x"), JsonValue.of(5), REVISION + 1, null,
                     DittoHeaders.empty(), null), ActorRef.noSender());
+
+            // THEN: Update is triggered only once
+            inputProbe.expectMsgClass(ThingUpdater.Data.class);
+            inputProbe.expectNoMessage(FiniteDuration.apply(5, "s"));
+        }};
+    }
+
+    @Test
+    public void initialUpdateSkipped() {
+        new TestKit(system) {{
+            // GIVEN: search mapper decides to skip updates
+            final TestProbe inputProbe = TestProbe.apply(system);
+            final Flow<ThingUpdater.Data, ThingUpdater.Result, NotUsed> flow = Flow.fromSinkAndSource(
+                    Sink.foreach(data -> inputProbe.ref().tell(data, ActorRef.noSender())),
+                    Source.empty()
+            );
+
+            final Props props =
+                    ThingUpdater.props(flow, id -> Source.single(ThingDeleteModel.of(Metadata.of(THING_ID, -1, null,
+                                    null, null))), SEARCH_CONFIG,
+                            TestProbe.apply(system).ref());
+            final ActorRef underTest = watch(childActorOf(props, ACTOR_NAME));
+
+            // WHEN: An event of the next revision arrives
+            underTest.tell(UpdateThing.of(THING_ID, UpdateReason.BACKGROUND_SYNC, DittoHeaders.empty()),
+                    ActorRef.noSender());
 
             // THEN: Update is triggered only once
             inputProbe.expectMsgClass(ThingUpdater.Data.class);


### PR DESCRIPTION
...otherwise the update is repeated endlessly.

Also do not trigger sync for things without a policy id.