### PR TITLE
Fix indexing of arrays and enable it by default

### DIFF
--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -914,6 +914,8 @@ the same commands.
 
 For each command type, please refer to the corresponding segment of "Managing background cleanup" for the exact format.
 
+{% include note.html content="Only a subset of the configuration has an effect when changed via `common.commands:modifyConfig` command: `enabled`, `quiet-period` and `keep.events`. Refer to [Ditto configuration](installation-operating.html#ditto-configuration) for instructions how to modify the other configuration settings." %}
+
 #### Force search index update for one thing
 
 The search index should rarely become out-of-sync for a long time, and it can repair itself

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -895,7 +895,7 @@ the same commands.
 
 ```json
 {
-  "targetActorSelection": "/user/thingsSearchRoot/searchUpdaterRoot/backgroundSyncProxy",
+  "targetActorSelection": "/user/thingsWildcardSearchRoot/searchUpdaterRoot/backgroundSyncProxy",
   "headers": {
     "aggregate": false,
     "is-grouped-topic": true
@@ -924,7 +924,7 @@ for a particular thing by a DevOp-command and bring the entry up-to-date immedia
 
 ```json
 {
-  "targetActorSelection": "/user/thingsSearchRoot/searchUpdaterRoot/thingsUpdater",
+  "targetActorSelection": "/user/thingsWildcardSearchRoot/searchUpdaterRoot/thingsUpdater",
   "headers": {
     "aggregate": false,
     "is-grouped-topic": true

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClient.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/DittoMongoClient.java
@@ -60,4 +60,11 @@ public interface DittoMongoClient extends MongoClient {
      */
     MongoClientSettings getClientSettings();
 
+    /**
+     * Returns the max wire version of the MongoDB server, or 0 if the client is disconnected.
+     *
+     * @return the max wire version.
+     */
+    int getMaxWireVersion();
+
 }

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/MongoClientWrapper.java
@@ -38,6 +38,7 @@ import com.mongodb.ReadPreference;
 import com.mongodb.ServerAddress;
 import com.mongodb.WriteConcern;
 import com.mongodb.connection.ClusterDescription;
+import com.mongodb.connection.ServerDescription;
 import com.mongodb.connection.netty.NettyStreamFactoryFactory;
 import com.mongodb.event.CommandListener;
 import com.mongodb.event.ConnectionPoolListener;
@@ -221,6 +222,16 @@ public final class MongoClientWrapper implements DittoMongoClient {
     @Override
     public MongoClientSettings getClientSettings() {
         return clientSettings;
+    }
+
+    @Override
+    public int getMaxWireVersion() {
+        return mongoClient.getClusterDescription()
+                .getServerDescriptions()
+                .stream()
+                .mapToInt(ServerDescription::getMaxWireVersion)
+                .max()
+                .orElse(0);
     }
 
     @Override

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbUriSupplierTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoDbUriSupplierTest.java
@@ -39,7 +39,7 @@ public final class MongoDbUriSupplierTest {
 
     private static final String SOURCE_URI = "mongodb://user-name-1234-5678-abcdefg:password12345@" +
             "first.hostname.com:10000,second.hostname.com:20000,third.hostname.com:30000,fourth.hostname" +
-            "fifth.hostname.com:50000,sixth.hostname.com:60000,seventh:hostname.com:70000" +
+            "fifth.hostname.com:50000,sixth.hostname.com:60000,seventh.hostname.com:65000" +
             "/database-name?replicaSet=streched-0003&maxIdleTimeMS=240000&w=majority" +
             "&readPreference=primaryPreferred&ssl=true&sslInvalidHostNameAllowed=true";
 

--- a/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/MongoDbResource.java
+++ b/internal/utils/test/src/test/java/org/eclipse/ditto/internal/utils/test/mongo/MongoDbResource.java
@@ -26,7 +26,7 @@ import org.junit.rules.ExternalResource;
  * the MongoDB container address instead of starting its own container.
  */
 @NotThreadSafe
-public final class MongoDbResource extends ExternalResource implements Closeable {
+public final class MongoDbResource extends ExternalResource {
 
     private static final int MONGO_INTERNAL_PORT = 27017;
     private static final String MONGO_CONTAINER_ALREADY_STARTED = "Mongo container has already been started.";
@@ -62,11 +62,11 @@ public final class MongoDbResource extends ExternalResource implements Closeable
             mongoContainer.remove();
             mongoContainer = null;
         }
-    }
-
-    @Override
-    public void close() throws IOException {
-        mongoContainerFactory.close();
+        try {
+            mongoContainerFactory.close();
+        } catch (final IOException e) {
+            throw new AssertionError(e);
+        }
     }
 
     /**

--- a/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/UpdateThing.java
+++ b/thingsearch/api/src/main/java/org/eclipse/ditto/thingsearch/api/commands/sudo/UpdateThing.java
@@ -133,13 +133,13 @@ public final class UpdateThing extends AbstractCommand<UpdateThing> implements S
      * "thingId".
      */
     public static UpdateThing fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
-        return of(
-                ThingId.of(jsonObject.getValueOrThrow(JSON_THING_ID)),
-                jsonObject.getValueOrThrow(JSON_INVALIDATE_THING),
-                jsonObject.getValueOrThrow(JSON_INVALIDATE_POLICY),
-                UpdateReason.valueOf(jsonObject.getValueOrThrow(JSON_UPDATE_REASON)),
-                dittoHeaders
-        );
+        final UpdateReason updateReason = jsonObject.getValue(JSON_UPDATE_REASON)
+                .map(UpdateThing::updateReasonFromString)
+                .orElse(UpdateReason.UNKNOWN);
+        final boolean invalidateThing = jsonObject.getValue(JSON_INVALIDATE_THING).orElse(false);
+        final boolean invalidatePolicy = jsonObject.getValue(JSON_INVALIDATE_POLICY).orElse(false);
+        return of(ThingId.of(jsonObject.getValueOrThrow(JSON_THING_ID)), invalidateThing, invalidatePolicy,
+                updateReason, dittoHeaders);
     }
 
     @Override
@@ -239,6 +239,14 @@ public final class UpdateThing extends AbstractCommand<UpdateThing> implements S
                 ",invalidatePolicy=" + invalidatePolicy +
                 ",updateReason=" + updateReason +
                 "]";
+    }
+
+    private static UpdateReason updateReasonFromString(final String name) {
+        try {
+            return UpdateReason.valueOf(name);
+        } catch (final IllegalArgumentException e) {
+            return UpdateReason.UNKNOWN;
+        }
     }
 
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitor.java
@@ -35,9 +35,11 @@ final class BsonDiffVisitor implements BsonValueVisitor<Function<BsonValue, Bson
 
     private final BsonSizeVisitor bsonSizeVisitor = new BsonSizeVisitor();
     private final boolean recurseIntoArrays;
+    private final int maxWireVersion;
 
-    BsonDiffVisitor(final boolean recurseIntoArrays) {
+    BsonDiffVisitor(final boolean recurseIntoArrays, final int maxWireVersion) {
         this.recurseIntoArrays = recurseIntoArrays;
+        this.maxWireVersion = maxWireVersion;
     }
 
     @Override
@@ -66,7 +68,7 @@ final class BsonDiffVisitor implements BsonValueVisitor<Function<BsonValue, Bson
             if (value.equals(oldValue)) {
                 return BsonDiff.empty(replacementSize);
             } else if (oldValue.isArray()) {
-                final var bsonArrayDiff = BsonArrayDiff.diff(key, value, oldValue.asArray());
+                final var bsonArrayDiff = BsonArrayDiff.diff(key, value, oldValue.asArray(), maxWireVersion);
                 final var diffSize = key.length() + bsonSizeVisitor.eval(bsonArrayDiff);
                 if (diffSize <= replacementSize) {
                     return BsonDiff.set(replacementSize, diffSize, key, bsonArrayDiff);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/AbstractWriteModel.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/AbstractWriteModel.java
@@ -69,7 +69,8 @@ public abstract class AbstractWriteModel {
      * @return Either the MongoDB write model of this object or an incremental update converting the document of
      * the previous model into this one.
      */
-    public Optional<MongoWriteModel> toIncrementalMongo(@Nullable final AbstractWriteModel previousWriteModel) {
+    public Optional<MongoWriteModel> toIncrementalMongo(@Nullable final AbstractWriteModel previousWriteModel,
+            final int maxWireVersion) {
         return Optional.of(MongoWriteModel.of(this, toMongo(), false));
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/ThingWriteModel.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/model/ThingWriteModel.java
@@ -73,11 +73,12 @@ public final class ThingWriteModel extends AbstractWriteModel {
     }
 
     @Override
-    public Optional<MongoWriteModel> toIncrementalMongo(@Nullable final AbstractWriteModel previousWriteModel) {
+    public Optional<MongoWriteModel> toIncrementalMongo(@Nullable final AbstractWriteModel previousWriteModel,
+            final int maxWireVersion) {
         if (previousWriteModel instanceof ThingWriteModel thingWriteModel) {
-            return computeDiff(thingWriteModel);
+            return computeDiff(thingWriteModel, maxWireVersion);
         } else {
-            return super.toIncrementalMongo(previousWriteModel);
+            return super.toIncrementalMongo(previousWriteModel, maxWireVersion);
         }
     }
 
@@ -156,7 +157,7 @@ public final class ThingWriteModel extends AbstractWriteModel {
                 "]";
     }
 
-    private Optional<MongoWriteModel> computeDiff(final ThingWriteModel lastWriteModel) {
+    private Optional<MongoWriteModel> computeDiff(final ThingWriteModel lastWriteModel, final int maxWireVersion) {
         final WriteModel<BsonDocument> mongoWriteModel;
         final boolean isPatchUpdate;
 
@@ -166,38 +167,40 @@ public final class ThingWriteModel extends AbstractWriteModel {
             PATCH_SKIP_COUNT.increment();
             return Optional.empty();
         }
-        final Optional<BsonDiff> diff = tryComputeDiff(getThingDocument(), lastWriteModel.getThingDocument());
+        final var diff = tryComputeDiff(getThingDocument(), lastWriteModel.getThingDocument(), maxWireVersion);
         if (diff.isPresent() && diff.get().isDiffSmaller()) {
             final var aggregationPipeline = diff.get().consumeAndExport();
             if (aggregationPipeline.isEmpty()) {
-                LOGGER.debug("Skipping update due to {} <{}>", "empty diff", ((AbstractWriteModel) this).getClass().getSimpleName());
+                LOGGER.debug("Skipping update due to {} <{}>", "empty diff",
+                        ((AbstractWriteModel) this).getClass().getSimpleName());
                 LOGGER.trace("Skipping update due to {} <{}>", "empty diff", this);
                 PATCH_SKIP_COUNT.increment();
                 return Optional.empty();
             }
             final var filter = asPatchUpdate(lastWriteModel.getMetadata().getThingRevision()).getFilter();
             mongoWriteModel = new UpdateOneModel<>(filter, aggregationPipeline);
-             LOGGER.debug("Using incremental update <{}>", mongoWriteModel.getClass().getSimpleName());
-             LOGGER.trace("Using incremental update <{}>", mongoWriteModel);
-             PATCH_UPDATE_COUNT.increment();
+            LOGGER.debug("Using incremental update <{}>", mongoWriteModel.getClass().getSimpleName());
+            LOGGER.trace("Using incremental update <{}>", mongoWriteModel);
+            PATCH_UPDATE_COUNT.increment();
             isPatchUpdate = true;
         } else {
             mongoWriteModel = this.toMongo();
-             LOGGER.debug("Using replacement because diff is bigger or nonexistent: <{}>",
+            LOGGER.debug("Using replacement because diff is bigger or nonexistent: <{}>",
                     mongoWriteModel.getClass().getSimpleName());
-             if (LOGGER.isTraceEnabled()) {
+            if (LOGGER.isTraceEnabled()) {
                 LOGGER.trace("Using replacement because diff is bigger or nonexistent. Diff=<{}>",
                         diff.map(BsonDiff::consumeAndExport));
-             }
-             FULL_UPDATE_COUNT.increment();
+            }
+            FULL_UPDATE_COUNT.increment();
             isPatchUpdate = false;
         }
         return Optional.of(MongoWriteModel.of(this, mongoWriteModel, isPatchUpdate));
     }
 
-    private Optional<BsonDiff> tryComputeDiff(final BsonDocument minuend, final BsonDocument subtrahend) {
+    private Optional<BsonDiff> tryComputeDiff(final BsonDocument minuend, final BsonDocument subtrahend,
+            final int maxWireVersion) {
         try {
-            return Optional.of(BsonDiff.minusThingDocs(minuend, subtrahend));
+            return Optional.of(BsonDiff.minusThingDocs(minuend, subtrahend, maxWireVersion));
         } catch (final BsonInvalidOperationException e) {
             LOGGER.error("Failed to compute BSON diff between <{}> and <{}>", minuend, subtrahend, e);
             return Optional.empty();

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/DefaultSearchUpdateMapper.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/DefaultSearchUpdateMapper.java
@@ -33,8 +33,11 @@ public final class DefaultSearchUpdateMapper extends SearchUpdateMapper {
      */
     @SuppressWarnings("unused")
     private DefaultSearchUpdateMapper(final ActorSystem actorSystem) {
-        super(actorSystem);
-        // Nothing to initialize.
+        this(actorSystem, 0);
+    }
+
+    private DefaultSearchUpdateMapper(final ActorSystem actorSystem, final Integer maxWireVersion) {
+        super(actorSystem, maxWireVersion);
     }
 
     @Override

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -131,8 +131,8 @@ ditto {
 
       stream {
         # arrays bigger than this are not indexed.
-        # array indexing is turned off by default because it only works for MongoDB 5.0 or above.
-        max-array-size = 0
+        # array indexing is more efficient for MongoDB 5.0 or above.
+        max-array-size = -1
         max-array-size = ${?THINGS_SEARCH_UPDATER_STREAM_MAX_ARRAY_SIZE}
 
         # minimum delay between event dumps must be at least 1s

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -130,8 +130,9 @@ ditto {
       }
 
       stream {
-        # arrays bigger than this are not indexed. unlimited by default.
-        max-array-size = -1
+        # arrays bigger than this are not indexed.
+        # array indexing is turned off by default because it only works for MongoDB 5.0 or above.
+        max-array-size = 0
         max-array-size = ${?THINGS_SEARCH_UPDATER_STREAM_MAX_ARRAY_SIZE}
 
         # minimum delay between event dumps must be at least 1s

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
@@ -15,6 +15,8 @@ package org.eclipse.ditto.thingsearch.service.persistence.write.mapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.policies.model.PoliciesResourceType.THING;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 
 import org.bson.BsonDocument;
@@ -37,6 +39,8 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.reactivestreams.Publisher;
 
 import com.mongodb.reactivestreams.client.MongoCollection;
@@ -49,10 +53,7 @@ import akka.testkit.javadsl.TestKit;
 /**
  * Tests incremental update.
  */
-public final class BsonDiffVisitorIT {
-
-    @ClassRule
-    public static final MongoDbResource MONGO_RESOURCE = new MongoDbResource("5.0");
+abstract class BsonDiffVisitorIT {
 
     private DittoMongoClient client;
     private MongoCollection<Document> collection;
@@ -60,10 +61,12 @@ public final class BsonDiffVisitorIT {
     private Policy policy;
     private Policy policy2;
 
+    protected abstract MongoDbResource getMongoDbResource();
+
     @Before
     public void init() {
         client = MongoClientWrapper.getBuilder()
-                .hostnameAndPort(MONGO_RESOURCE.getBindIp(), MONGO_RESOURCE.getPort())
+                .hostnameAndPort(getMongoDbResource().getBindIp(), getMongoDbResource().getPort())
                 .defaultDatabaseName("test")
                 .build();
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
@@ -15,7 +15,6 @@ package org.eclipse.ditto.thingsearch.service.persistence.write.mapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.ditto.policies.model.PoliciesResourceType.THING;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.bson.BsonDocument;
@@ -35,7 +34,6 @@ import org.eclipse.ditto.policies.model.SubjectType;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -117,7 +115,7 @@ public final class BsonDiffVisitorIT {
         final BsonDocument nextThingDoc =
                 EnforcedThingMapper.toBsonDocument(nextThing, policy, metadata);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, 13);
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 
@@ -151,7 +149,7 @@ public final class BsonDiffVisitorIT {
         final BsonDocument nextThingDoc =
                 EnforcedThingMapper.toBsonDocument(nextThing, policy2, metadata);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, 13);
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 
@@ -185,7 +183,7 @@ public final class BsonDiffVisitorIT {
         final BsonDocument nextThingDoc =
                 EnforcedThingMapper.toBsonDocument(nextThing, policy2, metadata);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, 13);
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 
@@ -221,7 +219,7 @@ public final class BsonDiffVisitorIT {
 
         assertThat(prevThingDoc).isNotEqualTo(nextThingDoc);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, client.getMaxWireVersion());
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 
@@ -257,7 +255,7 @@ public final class BsonDiffVisitorIT {
 
         assertThat(prevThingDoc).isNotEqualTo(nextThingDoc);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, 13);
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 
@@ -291,7 +289,7 @@ public final class BsonDiffVisitorIT {
         final BsonDocument nextThingDoc =
                 EnforcedThingMapper.toBsonDocument(nextThing, policy, metadata);
 
-        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc);
+        final BsonDiff diff = BsonDiff.minusThingDocs(nextThingDoc, prevThingDoc, 13);
 
         final List<BsonDocument> updateDoc = diff.consumeAndExport();
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorIT.java
@@ -62,11 +62,6 @@ public final class BsonDiffVisitorIT {
     private Policy policy;
     private Policy policy2;
 
-    @AfterClass
-    public static void closeMongoResource() throws IOException {
-        MONGO_RESOURCE.close();
-    }
-
     @Before
     public void init() {
         client = MongoClientWrapper.getBuilder()

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorV4IT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorV4IT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.mapping;
+
+import org.eclipse.ditto.internal.utils.test.mongo.MongoDbResource;
+import org.junit.ClassRule;
+
+/**
+ * Tests incremental update against default MongoDB version.
+ */
+public final class BsonDiffVisitorV4IT extends BsonDiffVisitorIT {
+
+    @ClassRule
+    public static final MongoDbResource MONGO_RESOURCE = new MongoDbResource();
+
+    @Override
+    protected MongoDbResource getMongoDbResource() {
+        return MONGO_RESOURCE;
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorV5IT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/mapping/BsonDiffVisitorV5IT.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.mapping;
+
+import org.eclipse.ditto.internal.utils.test.mongo.MongoDbResource;
+import org.junit.ClassRule;
+
+/**
+ * Tests incremental update against MongoDB 5.0.
+ */
+public final class BsonDiffVisitorV5IT extends BsonDiffVisitorIT {
+
+    @ClassRule
+    public static final MongoDbResource MONGO_RESOURCE = new MongoDbResource("5.0");
+
+    @Override
+    protected MongoDbResource getMongoDbResource() {
+        return MONGO_RESOURCE;
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/TestSearchUpdaterStream.java
@@ -77,7 +77,7 @@ public final class TestSearchUpdaterStream {
                 null, -1);
         final var mongoWriteModel =
                 writeModel.toIncrementalMongo(
-                        ThingDeleteModel.of(Metadata.ofDeleted(thing.getEntityId().orElseThrow()))).orElseThrow();
+                        ThingDeleteModel.of(Metadata.ofDeleted(thing.getEntityId().orElseThrow())), 13).orElseThrow();
 
         return Source.single(mongoWriteModel)
                 .via(mongoSearchUpdaterFlow.create())
@@ -106,7 +106,7 @@ public final class TestSearchUpdaterStream {
      */
     private Source<WriteResultAndErrors, NotUsed> delete(final Metadata metadata) {
         final AbstractWriteModel writeModel = ThingDeleteModel.of(metadata);
-        return Source.single(writeModel.toIncrementalMongo(writeModel).orElseThrow())
+        return Source.single(writeModel.toIncrementalMongo(writeModel, 13).orElseThrow())
                 .via(mongoSearchUpdaterFlow.create())
                 .map(ThingUpdater.Result::resultAndErrors);
     }

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -17,7 +17,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 
 import org.bson.BsonArray;

--- a/thingsearch/service/src/test/resources/actors-test.conf
+++ b/thingsearch/service/src/test/resources/actors-test.conf
@@ -6,7 +6,7 @@ ditto {
 
   mongodb {
 
-    uri = "mongodb://user-name-1234-5678-abcdefg:password12345@first.hostname.com:10000,second.hostname.com:20000,third.hostname.com:30000,fourth.hostnamefifth.hostname.com:50000,sixth.hostname.com:60000,seventh:hostname.com:70000/database-name?replicaSet=streched-0003&maxIdleTimeMS=240000&w=majority&readPreference=primaryPreferred&ssl=true&sslInvalidHostNameAllowed=true"
+    uri = "mongodb://user-name-1234-5678-abcdefg:password12345@first.hostname.com:10000,second.hostname.com:20000,third.hostname.com:30000,fourth.hostnamefifth.hostname.com:50000,sixth.hostname.com:60000,seventh.hostname.com:65000/database-name?replicaSet=streched-0003&maxIdleTimeMS=240000&w=majority&readPreference=primaryPreferred&ssl=true&sslInvalidHostNameAllowed=true"
 
     database = "searchDB"
     database = ${?MONGO_DB_DATABASE}


### PR DESCRIPTION
- Choose operator based on wire version of the MongoDB server.
- Array indexing will continue to work for MongoDB versions below 5.0. It is more efficient for 5.0 or above.