### PR TITLE
Improve test stability

### DIFF
--- a/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
+++ b/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
@@ -24,7 +24,7 @@ import akka.cluster.ddata.Replicator;
 /**
  * This class is the default implementation of the distributed data config.
  */
-class DefaultDistributedDataConfig implements DistributedDataConfig {
+final class DefaultDistributedDataConfig implements DistributedDataConfig {
 
     private static final String CONFIG_PATH = "ddata";
 

--- a/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
+++ b/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DefaultDistributedDataConfig.java
@@ -24,7 +24,7 @@ import akka.cluster.ddata.Replicator;
 /**
  * This class is the default implementation of the distributed data config.
  */
-final class DefaultDistributedDataConfig implements DistributedDataConfig {
+public final class DefaultDistributedDataConfig implements DistributedDataConfig {
 
     private static final String CONFIG_PATH = "ddata";
 

--- a/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DistributedData.java
+++ b/internal/utils/ddata/src/main/java/org/eclipse/ditto/internal/utils/ddata/DistributedData.java
@@ -65,6 +65,8 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
 
     private final Executor ddataExecutor;
 
+    private final DistributedDataConfig config;
+
     /**
      * Create a wrapper of distributed data replicator.
      *
@@ -80,6 +82,7 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
         readTimeout = config.getReadTimeout();
         writeTimeout = config.getWriteTimeout();
         numberOfShards = config.getNumberOfShards();
+        this.config = config;
     }
 
     /**
@@ -169,6 +172,16 @@ public abstract class DistributedData<R extends ReplicatedData> implements Exten
      */
     public ActorRef getReplicator() {
         return replicator;
+    }
+
+    /**
+     * Get the config of this distributed data.
+     *
+     * @return The config.
+     * @since 3.0.0
+     */
+    public DistributedDataConfig getConfig() {
+        return config;
     }
 
     private Void handleUpdateResponse(final Object reply, final Key<R> key) {

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/DistributedSubImpl.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/DistributedSubImpl.java
@@ -30,7 +30,6 @@ import org.eclipse.ditto.internal.utils.pubsub.api.Subscribe;
 import org.eclipse.ditto.internal.utils.pubsub.api.Unsubscribe;
 
 import akka.actor.ActorRef;
-import akka.cluster.ddata.Replicator;
 import akka.pattern.Patterns;
 
 /**
@@ -42,13 +41,11 @@ final class DistributedSubImpl implements DistributedSub {
     final ActorRef subSupervisor;
 
     private final DistributedDataConfig config;
-    private final Replicator.WriteConsistency writeConsistency;
     private final long ddataDelayInMillis;
 
     DistributedSubImpl(final DistributedDataConfig config, final ActorRef subSupervisor) {
         this.config = config;
         this.subSupervisor = subSupervisor;
-        writeConsistency = config.getSubscriptionWriteConsistency();
         ddataDelayInMillis = config.getSubscriptionDelay().toMillis();
     }
 

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/DistributedSubImpl.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/DistributedSubImpl.java
@@ -61,7 +61,7 @@ final class DistributedSubImpl implements DistributedSub {
         if (group != null) {
             checkNotEmpty(group, "group");
         }
-        final Subscribe subscribe = Subscribe.of(topics, subscriber, writeConsistency, true, filter, group, resubscribe);
+        final Subscribe subscribe = Subscribe.of(topics, subscriber, true, filter, group, resubscribe);
         final CompletionStage<SubAck> subAckFuture = askSubSupervisor(subscribe);
 
         if (ddataDelayInMillis <= 0) {
@@ -79,7 +79,7 @@ final class DistributedSubImpl implements DistributedSub {
     @Override
     public CompletionStage<SubAck> unsubscribeWithAck(final Collection<String> topics,
             final ActorRef subscriber) {
-        return askSubSupervisor(Unsubscribe.of(topics, subscriber, writeConsistency, true));
+        return askSubSupervisor(Unsubscribe.of(topics, subscriber, true));
     }
 
     private CompletionStage<SubAck> askSubSupervisor(final Request request) {
@@ -89,24 +89,19 @@ final class DistributedSubImpl implements DistributedSub {
 
     @Override
     public void subscribeWithoutAck(final Collection<String> topics, final ActorRef subscriber) {
-        final Request request =
-                Subscribe.of(topics, subscriber,
-                        (Replicator.WriteConsistency) Replicator.writeLocal(), false, null);
+        final Request request = Subscribe.of(topics, subscriber, false, null);
         subSupervisor.tell(request, subscriber);
     }
 
     @Override
     public void unsubscribeWithoutAck(final Collection<String> topics, final ActorRef subscriber) {
-        final Request request =
-                Unsubscribe.of(topics, subscriber,
-                        (Replicator.WriteConsistency) Replicator.writeLocal(), false);
+        final Request request = Unsubscribe.of(topics, subscriber, false);
         subSupervisor.tell(request, subscriber);
     }
 
     @Override
     public void removeSubscriber(final ActorRef subscriber) {
-        final Request request =
-                RemoveSubscriber.of(subscriber, (Replicator.WriteConsistency) Replicator.writeLocal(), false);
+        final Request request = RemoveSubscriber.of(subscriber, false);
         subSupervisor.tell(request, subscriber);
     }
 

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/Publisher.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/Publisher.java
@@ -185,6 +185,7 @@ public final class Publisher extends AbstractActor {
     }
 
     private void topicSubscribersChanged(final Replicator.Changed<?> event) {
+        log.debug("Topics changed <{}>", event.key());
         final Map<ActorRef, scala.collection.immutable.Set<String>> mmap =
                 CollectionConverters.asJava(((ORMultiMap<ActorRef, String>) event.dataValue()).entries());
         final Map<ActorRef, List<Grouped<Long>>> deserializedMMap = mmap.entrySet()

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdater.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.pubsub.actors;
 
+import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -92,7 +93,7 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers
     /**
      * Write consistency of the next message to the replicator.
      */
-    private Replicator.WriteConsistency nextWriteConsistency = writeLocal();
+    private Replicator.WriteConsistency nextWriteConsistency = defaultWriteConsistency();
 
     /**
      * Whether local subscriptions changed.
@@ -452,5 +453,9 @@ public final class SubUpdater extends akka.actor.AbstractActorWithTimers
             this.payload = payload;
             this.seqNr = seqNr;
         }
+    }
+
+    private static Replicator.WriteConsistency defaultWriteConsistency() {
+        return new Replicator.WriteAll(Duration.ofSeconds(25L));
     }
 }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/AbstractRequest.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/AbstractRequest.java
@@ -25,17 +25,14 @@ abstract class AbstractRequest implements Request {
 
     private final Set<String> topics;
     private final ActorRef subscriber;
-    private final Replicator.WriteConsistency writeConsistency;
     private final boolean acknowledge;
 
     protected AbstractRequest(final Collection<String> topics,
             final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
             final boolean acknowledge) {
 
         this.topics = Set.copyOf(topics);
         this.subscriber = subscriber;
-        this.writeConsistency = writeConsistency;
         this.acknowledge = acknowledge;
     }
 
@@ -54,13 +51,6 @@ abstract class AbstractRequest implements Request {
     }
 
     /**
-     * @return write consistency for the request.
-     */
-    public Replicator.WriteConsistency getWriteConsistency() {
-        return writeConsistency;
-    }
-
-    /**
      * @return whether acknowledgement is expected.
      */
     public boolean shouldAcknowledge() {
@@ -72,7 +62,6 @@ abstract class AbstractRequest implements Request {
         return getClass().getSimpleName() + " [" +
                 "topics=" + topics +
                 ", subscriber=" + subscriber +
-                ", writeConsistency=" + writeConsistency +
                 ", acknowledge=" + acknowledge +
                 "]";
     }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/RemoveSubscriber.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/RemoveSubscriber.java
@@ -15,31 +15,25 @@ package org.eclipse.ditto.internal.utils.pubsub.api;
 import java.util.Collections;
 
 import akka.actor.ActorRef;
-import akka.cluster.ddata.Replicator;
 
 /**
  * Request to remove a subscriber.
  */
 public final class RemoveSubscriber extends AbstractRequest {
 
-    private RemoveSubscriber(final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
-            final boolean acknowledge) {
-        super(Collections.emptySet(), subscriber, writeConsistency, acknowledge);
+    private RemoveSubscriber(final ActorRef subscriber, final boolean acknowledge) {
+        super(Collections.emptySet(), subscriber, acknowledge);
     }
 
     /**
      * Create an "unsubscribe" request.
      *
      * @param subscriber who is subscribing.
-     * @param writeConsistency with which write consistency should this subscription be updated.
      * @param acknowledge whether acknowledgement is desired.
      * @return the request.
      */
-    public static RemoveSubscriber of(final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
-            final boolean acknowledge) {
-        return new RemoveSubscriber(subscriber, writeConsistency, acknowledge);
+    public static RemoveSubscriber of(final ActorRef subscriber, final boolean acknowledge) {
+        return new RemoveSubscriber(subscriber, acknowledge);
     }
 
 }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Request.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Request.java
@@ -27,11 +27,6 @@ public interface Request {
     Set<String> getTopics();
 
     /**
-     * @return write consistency for the request.
-     */
-    Replicator.WriteConsistency getWriteConsistency();
-
-    /**
      * @return whether acknowledgement is expected.
      */
     boolean shouldAcknowledge();

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Subscribe.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Subscribe.java
@@ -19,7 +19,6 @@ import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 import akka.actor.ActorRef;
-import akka.cluster.ddata.Replicator;
 
 /**
  * Request to subscribe to topics.
@@ -32,12 +31,11 @@ public final class Subscribe extends AbstractRequest {
 
     private Subscribe(final Collection<String> topics,
             final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
             final boolean acknowledge,
             @Nullable final Predicate<Collection<String>> filter,
             @Nullable final String group,
             final boolean resubscribe) {
-        super(topics, subscriber, writeConsistency, acknowledge);
+        super(topics, subscriber, acknowledge);
         this.filter = filter;
         this.group = group;
         this.resubscribe = resubscribe;
@@ -48,17 +46,15 @@ public final class Subscribe extends AbstractRequest {
      *
      * @param topics the topics to subscribe to.
      * @param subscriber who is subscribing.
-     * @param writeConsistency with which write consistency should this subscription be updated.
      * @param acknowledge whether acknowledgement is desired.
      * @param group any group the subscriber belongs to, or null.
      * @return the request.
      */
     public static Subscribe of(final Collection<String> topics,
             final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
             final boolean acknowledge,
             @Nullable final String group) {
-        return new Subscribe(topics, subscriber, writeConsistency, acknowledge, null, group, false);
+        return new Subscribe(topics, subscriber, acknowledge, null, group, false);
     }
 
     /**
@@ -66,7 +62,6 @@ public final class Subscribe extends AbstractRequest {
      *
      * @param topics the topics to subscribe to.
      * @param subscriber who is subscribing.
-     * @param writeConsistency with which write consistency should this subscription be updated.
      * @param acknowledge whether acknowledgement is desired.
      * @param filter local filter for incoming messages.
      * @param group any group the subscriber belongs to, or null.
@@ -74,12 +69,11 @@ public final class Subscribe extends AbstractRequest {
      */
     public static Subscribe of(final Collection<String> topics,
             final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
             final boolean acknowledge,
             @Nullable final Predicate<Collection<String>> filter,
             @Nullable final String group,
             final boolean resubscribe) {
-        return new Subscribe(topics, subscriber, writeConsistency, acknowledge, filter, group, resubscribe);
+        return new Subscribe(topics, subscriber, acknowledge, filter, group, resubscribe);
     }
 
     /**

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Unsubscribe.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/api/Unsubscribe.java
@@ -15,18 +15,14 @@ package org.eclipse.ditto.internal.utils.pubsub.api;
 import java.util.Collection;
 
 import akka.actor.ActorRef;
-import akka.cluster.ddata.Replicator;
 
 /**
  * Request to unsubscribe to topics.
  */
 public final class Unsubscribe extends AbstractRequest {
 
-    private Unsubscribe(final Collection<String> topics,
-            final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
-            final boolean acknowledge) {
-        super(topics, subscriber, writeConsistency, acknowledge);
+    private Unsubscribe(final Collection<String> topics, final ActorRef subscriber, final boolean acknowledge) {
+        super(topics, subscriber, acknowledge);
     }
 
     /**
@@ -34,14 +30,11 @@ public final class Unsubscribe extends AbstractRequest {
      *
      * @param topics the set of topics to subscribe.
      * @param subscriber who is subscribing.
-     * @param writeConsistency with which write consistency should this subscription be updated.
      * @param acknowledge whether acknowledgement is desired.
      * @return the request.
      */
-    public static Unsubscribe of(final Collection<String> topics,
-            final ActorRef subscriber,
-            final Replicator.WriteConsistency writeConsistency,
+    public static Unsubscribe of(final Collection<String> topics, final ActorRef subscriber,
             final boolean acknowledge) {
-        return new Unsubscribe(topics, subscriber, writeConsistency, acknowledge);
+        return new Unsubscribe(topics, subscriber, acknowledge);
     }
 }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DData.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/DData.java
@@ -12,6 +12,8 @@
  */
 package org.eclipse.ditto.internal.utils.pubsub.ddata;
 
+import org.eclipse.ditto.internal.utils.ddata.DistributedDataConfig;
+
 /**
  * A package of ddata reader, writer, and creator of local subscriptions to plug into a pub-sub framework.
  *
@@ -30,5 +32,11 @@ public interface DData<K, R, W extends DDataUpdate<?>> {
      * @return the distributed data writer.
      */
     DDataWriter<K, W> getWriter();
+
+    /**
+     * @return the config of the distributed data.
+     * @since 3.0.0
+     */
+    DistributedDataConfig getConfig();
 
 }

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/compressed/CompressedDData.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/compressed/CompressedDData.java
@@ -68,6 +68,11 @@ public final class CompressedDData implements DData<ActorRef, String, LiteralUpd
         return handler;
     }
 
+    @Override
+    public DistributedDataConfig getConfig() {
+        return handler.getConfig();
+    }
+
     /**
      * Get the hash seeds of the compressed DData.
      *

--- a/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/literal/LiteralDData.java
+++ b/internal/utils/pubsub/src/main/java/org/eclipse/ditto/internal/utils/pubsub/ddata/literal/LiteralDData.java
@@ -12,6 +12,7 @@
  */
 package org.eclipse.ditto.internal.utils.pubsub.ddata.literal;
 
+import org.eclipse.ditto.internal.utils.ddata.DistributedDataConfig;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.DData;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataReader;
 import org.eclipse.ditto.internal.utils.pubsub.ddata.DDataWriter;
@@ -60,6 +61,11 @@ public final class LiteralDData implements DData<Address, String, LiteralUpdate>
     @Override
     public DDataWriter<Address, LiteralUpdate> getWriter() {
         return handler;
+    }
+
+    @Override
+    public DistributedDataConfig getConfig() {
+        return handler.getConfig();
     }
 
 }

--- a/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
+++ b/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.ditto.internal.utils.pubsub.actors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.eclipse.ditto.internal.utils.pubsub.actors.ClusterMemberRemovedAware.writeLocal;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
@@ -107,7 +106,7 @@ public final class SubUpdaterTest {
             final ActorRef underTest = system.actorOf(SubUpdater.props(config, subscriberRef, ddata));
 
             // GIVEN: local subscriptions are not empty
-            final var subscribe = Subscribe.of(List.of("topic"), subscriberRef, writeLocal(), true, null);
+            final var subscribe = Subscribe.of(List.of("topic"), subscriberRef, true, null);
             underTest.tell(subscribe, getRef());
             expectMsgClass(SubAck.class);
 
@@ -132,14 +131,14 @@ public final class SubUpdaterTest {
             final var addressMap = Map.of(subscriberRef, "unknown-value");
             final CompressedDData ddata = mockDistributedData(addressMap);
             final ActorRef underTest = system.actorOf(SubUpdater.props(config, subscriberRef, ddata));
-            final var subscribe = Subscribe.of(List.of("topic"), subscriberRef, writeLocal(), true, null);
+            final var subscribe = Subscribe.of(List.of("topic"), subscriberRef, true, null);
             underTest.tell(subscribe, getRef());
             expectMsgClass(SubAck.class);
 
             // WHEN: SubUpdater is requested to resubscribe
             final var writer = ddata.getWriter();
             Mockito.when(writer.reset(any(), any(), any())).thenReturn(CompletableFuture.completedStage(null));
-            final var resubscribe = Subscribe.of(List.of("topic"), subscriberRef, writeLocal(), true, null, null, true);
+            final var resubscribe = Subscribe.of(List.of("topic"), subscriberRef, true, null, null, true);
             underTest.tell(resubscribe, getRef());
 
             // THEN: SubAck confirms consistency.
@@ -161,7 +160,7 @@ public final class SubUpdaterTest {
             // WHEN: SubUpdater is requested to resubscribe
             final var writer = ddata.getWriter();
             Mockito.when(writer.reset(any(), any(), any())).thenReturn(CompletableFuture.completedStage(null));
-            final var resubscribe = Subscribe.of(List.of("topic"), subscriberRef, writeLocal(), true, null, null, true);
+            final var resubscribe = Subscribe.of(List.of("topic"), subscriberRef, true, null, null, true);
             underTest.tell(resubscribe, getRef());
 
             // THEN: SubAck denies consistency.

--- a/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
+++ b/internal/utils/pubsub/src/test/java/org/eclipse/ditto/internal/utils/pubsub/actors/SubUpdaterTest.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 
+import org.eclipse.ditto.internal.utils.ddata.DefaultDistributedDataConfig;
+import org.eclipse.ditto.internal.utils.ddata.DistributedDataConfig;
 import org.eclipse.ditto.internal.utils.pubsub.api.SubAck;
 import org.eclipse.ditto.internal.utils.pubsub.api.Subscribe;
 import org.eclipse.ditto.internal.utils.pubsub.config.PubSubConfig;
@@ -180,7 +182,8 @@ public final class SubUpdaterTest {
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
-    private static CompressedDData mockDistributedData(final Map<ActorRef, String> result) {
+    private CompressedDData mockDistributedData(final Map<ActorRef, String> result) {
+        final DistributedDataConfig ddataConfig = DefaultDistributedDataConfig.of(getTestConf().getConfig("ditto"));
         final ORMultiMap map = Mockito.mock(ORMultiMap.class);
         Mockito.when(map.getEntries()).thenReturn(result);
         final var mock = Mockito.mock(CompressedDData.class);
@@ -189,6 +192,7 @@ public final class SubUpdaterTest {
         Mockito.when(mock.getReader()).thenReturn(reader);
         Mockito.when(mock.getWriter()).thenReturn(writer);
         Mockito.when(mock.getSeeds()).thenReturn(List.of(1, 2));
+        Mockito.when(mock.getConfig()).thenReturn(ddataConfig);
         Mockito.when(reader.get(any(), any())).thenReturn(CompletableFuture.completedStage(Optional.of(map)));
         Mockito.when(reader.getAllShards(any())).thenReturn(CompletableFuture.completedStage(List.of(map)));
         Mockito.when(writer.put(any(), any(), any())).thenReturn(CompletableFuture.completedStage(null));

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -29,7 +29,6 @@ import org.bson.BsonDocument;
 import org.eclipse.ditto.base.api.common.ShutdownReasonType;
 import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
-import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
 import org.eclipse.ditto.base.service.actors.ShutdownBehaviour;
 import org.eclipse.ditto.base.service.config.supervision.ExponentialBackOff;
 import org.eclipse.ditto.internal.models.streaming.IdentifiableStreamingMessage;
@@ -247,7 +246,6 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
     private FSMStateFunctionBuilder<State, Data> persisting() {
         return matchEvent(Result.class, this::onResult)
                 .event(Done.class, this::onDone)
-                .event(ThingEvent.class, this::onEventWhenPersisting)
                 .event(ShutdownTrigger.class, this::shutdown)
                 .event(SHUTDOWN_CLASS, this::shutdownNow)
                 .event(DistributedPubSubMediator.SubscribeAck.class, this::subscribeAck)
@@ -301,11 +299,6 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
                 default -> cancelTimer(Control.TICK.name());
             }
         }
-    }
-
-    private FSM.State<State, Data> onEventWhenPersisting(final ThingEvent<?> event, final Data data) {
-        computeEventMetadata(event, data).ifPresent(eventMetadata -> getSelf().tell(eventMetadata, getSelf()));
-        return stay();
     }
 
     private FSM.State<State, Data> onResult(final Result result, final Data data) {

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -305,7 +305,7 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
         killSwitch = null;
         final var writeResultAndErrors = result.resultAndErrors();
         final var pair = BulkWriteResultAckFlow.checkBulkWriteResult(writeResultAndErrors);
-        pair.second().forEach(log::info);
+        pair.second().forEach(log::debug);
         if (shuttingDown) {
             log.info("Shutting down after completing persistence operation");
             return stop();

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdater.java
@@ -463,13 +463,11 @@ public final class ThingUpdater extends AbstractFSMWithStash<ThingUpdater.State,
                             + "equal to the current sequence number <{}> of the update actor.", thingId,
                     thingEvent.getRevision(), data.metadata().getThingRevision());
             if (shouldAcknowledge) {
-                final String hint = String.format("Thing event with revision <%d> for thing <%s> dropped.",
-                        thingEvent.getRevision(),
-                        thingId);
-                exportMetadataWithSender(true, thingEvent, getSender(), null, data)
-                        .sendWeakAck(JsonValue.of(hint));
+                // add sender to pending acknowledgements
+                return Optional.of(data.metadata().export().withSender(getSender()));
+            } else {
+                return Optional.empty();
             }
-            return Optional.empty();
         }
 
         l.debug("Applying thing event <{}>.", thingEvent);

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/ThingUpdaterTest.java
@@ -28,7 +28,6 @@ import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.acks.DittoAcknowledgementLabel;
 import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
-import org.eclipse.ditto.base.model.signals.acks.Acknowledgement;
 import org.eclipse.ditto.internal.utils.akka.ActorSystemResource;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.json.JsonPointer;
@@ -88,6 +87,7 @@ public final class ThingUpdaterTest {
                       ditto {
                         search {
                             updater.stream.thing-deletion-timeout = 3s
+                            updater.stream.write-interval = 1ms
                         }
                         mongodb.uri = "mongodb://localhost:27017/test"
                       }


### PR DESCRIPTION
- Use the configured write consistency for all Ditto pubsub updates
- Remove write consistency field from Ditto pubsub requests
- ThingUpdater: delay weak acknowledgements to the end of the next persistence operation
- Do not terminate ThingUpdater after max-idle-time when the actor is not idle
- Do not schedule clock ticks in ThingUpdater in the absence of incoming updates