### PR TITLE
Add random interval for policy announcements

### DIFF
--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -6576,6 +6576,7 @@ components:
                 labels:
                   - 'my-connection-id:my-issued-acknowledgement'
                 timeout: 30s
+              randomizationInterval: 5m
       description: Optional request payload for `activateTokenIntegration` policy action.
       required: false
   responses:
@@ -7531,9 +7532,13 @@ components:
             labels:
               - 'my-connection-id:my-issued-acknowledgement'
             timeout: 5s
+        randomizationInterval:
+          type: string
+          description: Interval in which the announcement can be sent earlier in effort to prevent announcement peaks.
       example:
         beforeExpiry: 5m
         whenDeleted: true
+        randomizationInterval: 5m
     Features:
       type: object
       description: |-

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -7535,7 +7535,7 @@ components:
         randomizationInterval:
           type: string
           minimum: 0ms
-          maximum: 2562047788015215h
+          maximum: 999_999_999s
           default: 5m
           description: 'Interval in which the announcement can be sent earlier than the configured `beforeExpiry`. The actual point in time when the announcement will be sent is `beforeExpire` plus a randomly chosen time within the `randomizationInterval`. E.g assuming `beforeExpiry` is set to 5m and `randomizationInterval` is set to 1m, the announcements will be sent between 5 and 6 minutes before the subject expires. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
       example:

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -7534,7 +7534,10 @@ components:
             timeout: 5s
         randomizationInterval:
           type: string
-          description: Interval in which the announcement can be sent earlier in effort to prevent announcement peaks.
+          minimum: 0ms
+          maximum: 2562047788015215h
+          default: 5m
+          description: 'Interval in which the announcement can be sent earlier in effort to prevent announcement peaks. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
       example:
         beforeExpiry: 5m
         whenDeleted: true

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -7537,7 +7537,7 @@ components:
           minimum: 0ms
           maximum: 2562047788015215h
           default: 5m
-          description: 'Interval in which the announcement can be sent earlier in effort to prevent announcement peaks. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
+          description: 'Interval in which the announcement can be sent earlier than the configured `beforeExpiry`. The actual point in time when the announcement will be sent is `beforeExpire` plus a randomly chosen time within the `randomizationInterval`. E.g assuming `beforeExpiry` is set to 5m and `randomizationInterval` is set to 1m, the announcements will be sent between 5 and 6 minutes before the subject expires. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.'
       example:
         beforeExpiry: 5m
         whenDeleted: true

--- a/documentation/src/main/resources/openapi/sources/package-lock.json
+++ b/documentation/src/main/resources/openapi/sources/package-lock.json
@@ -236,6 +236,12 @@
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
+    "node_modules/openapi-types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
+      "peer": true
+    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -623,6 +629,12 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
       "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+    },
+    "openapi-types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.0.0.tgz",
+      "integrity": "sha512-6Wd9k8nmGQHgCbehZCP6wwWcfXcvinhybUTBatuhjRsCxUIujuYFZc9QnGeae75CyHASewBtxs0HX/qwREReUw==",
+      "peer": true
     },
     "p-limit": {
       "version": "2.3.0",

--- a/documentation/src/main/resources/openapi/sources/requests/policies/actions/activateTokenIntegration.yml
+++ b/documentation/src/main/resources/openapi/sources/requests/policies/actions/activateTokenIntegration.yml
@@ -21,5 +21,6 @@ content:
         requestedAcks:
           labels: ["my-connection-id:my-issued-acknowledgement"]
           timeout: "30s"
+        randomizationInterval: "5m"
 description: Optional request payload for `activateTokenIntegration` policy action.
 required: false

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/subjectAnnouncement.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/subjectAnnouncement.yml
@@ -34,6 +34,10 @@ properties:
     example:
       labels: ["my-connection-id:my-issued-acknowledgement"]
       timeout: "5s"
+  randomizationInterval:
+    type: string
+    description: Interval in which the announcement can be sent earlier in effort to prevent announcement peaks.
 example:
   beforeExpiry: "5m"
   whenDeleted: true
+  randomizationInterval: "5m"

--- a/documentation/src/main/resources/openapi/sources/schemas/policies/subjectAnnouncement.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/policies/subjectAnnouncement.yml
@@ -36,7 +36,10 @@ properties:
       timeout: "5s"
   randomizationInterval:
     type: string
-    description: Interval in which the announcement can be sent earlier in effort to prevent announcement peaks.
+    minimum: "0ms"
+    maximum: "999_999_999s"
+    default: "5m"
+    description: Interval in which the announcement can be sent earlier in effort to prevent announcement peaks. If omitted, the default value will be applied. If set to minimum, no randomization will be applied.
 example:
   beforeExpiry: "5m"
   whenDeleted: true

--- a/policies/model/pom.xml
+++ b/policies/model/pom.xml
@@ -156,6 +156,7 @@
                             <exclude>org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers#throughputOptimizedEvaluator(org.eclipse.ditto.policies.model.Policy)</exclude>
                             <exclude>org.eclipse.ditto.policies.model.enforcers.tree.TreeBasedPolicyEnforcer#createInstance(org.eclipse.ditto.policies.model.Policy)</exclude>
                             <exclude>org.eclipse.ditto.policies.model.enforcers.trie.TrieBasedPolicyEnforcer#newInstance(org.eclipse.ditto.policies.model.Policy)</exclude>
+                            <exclude>org.eclipse.ditto.policies.model.SubjectAnnouncement#of(org.eclipse.ditto.base.model.common.DittoDuration, boolean, java.util.List, org.eclipse.ditto.base.model.common.DittoDuration)</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/Subject.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/Subject.java
@@ -120,8 +120,11 @@ public interface Subject extends Jsonifiable.WithFieldSelectorAndPredicate<JsonF
      * @throws NullPointerException if the {@code subjectId} or {@code subjectType} argument is {@code null}.
      * @since 2.0.0
      */
-    static Subject newInstance(final SubjectId subjectId, final SubjectType subjectType,
-            @Nullable final SubjectExpiry subjectExpiry, @Nullable final SubjectAnnouncement subjectAnnouncement) {
+    static Subject newInstance(final SubjectId subjectId,
+            final SubjectType subjectType,
+            @Nullable final SubjectExpiry subjectExpiry,
+            @Nullable final SubjectAnnouncement subjectAnnouncement) {
+
         return ImmutableSubject.of(subjectId, subjectType, subjectExpiry, subjectAnnouncement);
     }
 

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/SubjectAnnouncement.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/SubjectAnnouncement.java
@@ -45,7 +45,7 @@ public interface SubjectAnnouncement extends Jsonifiable<JsonObject> {
      */
     static SubjectAnnouncement of(@Nullable final DittoDuration beforeExpiry, final boolean whenDeleted) {
         return new ImmutableSubjectAnnouncement(beforeExpiry, whenDeleted, Collections.emptyList(),
-                null);
+                null, null);
     }
 
     /**
@@ -56,14 +56,17 @@ public interface SubjectAnnouncement extends Jsonifiable<JsonObject> {
      * @param whenDeleted whether an announcement should be sent when the subject is deleted.
      * @param requestedAcksLabels acknowledgement requests for subject deletion announcements.
      * @param requestedAcksTimeout timeout of acknowledgement requests.
+     * @param randomizationInterval interval for randomizing the announcement timing.
      * @return the new {@link SubjectAnnouncement}.
      */
     static SubjectAnnouncement of(@Nullable final DittoDuration beforeExpiry,
             final boolean whenDeleted,
             final List<AcknowledgementRequest> requestedAcksLabels,
-            @Nullable final DittoDuration requestedAcksTimeout) {
+            @Nullable final DittoDuration requestedAcksTimeout,
+            @Nullable final DittoDuration randomizationInterval) {
+
         return new ImmutableSubjectAnnouncement(beforeExpiry, whenDeleted, requestedAcksLabels,
-                requestedAcksTimeout);
+                requestedAcksTimeout, randomizationInterval);
     }
 
     /**
@@ -109,6 +112,15 @@ public interface SubjectAnnouncement extends Jsonifiable<JsonObject> {
     Optional<DittoDuration> getRequestedAcksTimeout();
 
     /**
+     * Returns interval in which the announcement can be sent earlier in effort to prevent announcement
+     * peaks.
+     *
+     * @return the interval.
+     * @since 3.0.0
+     */
+    Optional<DittoDuration> getRandomizationInterval();
+
+    /**
      * Returns a copy of this object with the field {@code beforeExpiry} replaced.
      *
      * @param beforeExpiry the new value.
@@ -147,6 +159,14 @@ public interface SubjectAnnouncement extends Jsonifiable<JsonObject> {
          */
         public static final JsonFieldDefinition<String> REQUESTED_ACKS_TIMEOUT =
                 JsonFactory.newStringFieldDefinition("requestedAcks/timeout");
+
+        /**
+         * Field to store interval in which the announcement can be sent earlier in effort to prevent announcement
+         * peaks.
+         * @since 3.0.0
+         */
+        public static final JsonFieldDefinition<String> RANDOMIZATION_INTERVAL =
+                JsonFactory.newStringFieldDefinition("randomizationInterval");
 
         private JsonFields() {}
     }

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableSubjectAnnouncementTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableSubjectAnnouncementTest.java
@@ -23,12 +23,11 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
+import org.eclipse.ditto.base.model.common.DittoDuration;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
-import org.eclipse.ditto.base.model.common.DittoDuration;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -42,12 +41,14 @@ public final class ImmutableSubjectAnnouncementTest {
     private static final String BEFORE_EXPIRY_STRING = BEFORE_EXPIRY.toString();
     private static final JsonArray REQUESTED_ACKS = JsonArray.of("[\"integration:connection\"]");
     private static final DittoDuration ACKS_TIMEOUT = DittoDuration.parseDuration("10s");
+    private static final DittoDuration RANDOMIZATION_INTERVAL = DittoDuration.parseDuration("5m");
 
     static final JsonObject KNOWN_JSON = JsonObject.newBuilder()
             .set(SubjectAnnouncement.JsonFields.BEFORE_EXPIRY, BEFORE_EXPIRY_STRING)
             .set(SubjectAnnouncement.JsonFields.WHEN_DELETED, true)
             .set(SubjectAnnouncement.JsonFields.REQUESTED_ACKS_LABELS, REQUESTED_ACKS)
             .set(SubjectAnnouncement.JsonFields.REQUESTED_ACKS_TIMEOUT, ACKS_TIMEOUT.toString())
+            .set(SubjectAnnouncement.JsonFields.RANDOMIZATION_INTERVAL, RANDOMIZATION_INTERVAL.toString())
             .build();
 
     @Test
@@ -66,7 +67,7 @@ public final class ImmutableSubjectAnnouncementTest {
         final List<AcknowledgementRequest> requestedAcks =
                 Collections.singletonList(AcknowledgementRequest.parseAcknowledgementRequest("integration:connection"));
         final SubjectAnnouncement underTest =
-                SubjectAnnouncement.of(BEFORE_EXPIRY, true, requestedAcks, ACKS_TIMEOUT);
+                SubjectAnnouncement.of(BEFORE_EXPIRY, true, requestedAcks, ACKS_TIMEOUT, RANDOMIZATION_INTERVAL);
 
         final JsonObject subjectAnnouncementJson = underTest.toJson();
         final SubjectAnnouncement deserialized = SubjectAnnouncement.fromJson(subjectAnnouncementJson);
@@ -76,7 +77,7 @@ public final class ImmutableSubjectAnnouncementTest {
     }
 
     @Test
-    public void testToAndFromSubjectAnnouncementWithoutExpiryAndNotWhenDeleted() {
+    public void testToAndFromSubjectAnnouncementWithoutExpiryAndNotWhenDeletedAndRandomization() {
         final SubjectAnnouncement underTest = SubjectAnnouncement.of(null, false);
         final JsonObject emptyJson = underTest.toJson();
         final SubjectAnnouncement emptyAnnouncement = SubjectAnnouncement.fromJson(emptyJson);
@@ -109,5 +110,34 @@ public final class ImmutableSubjectAnnouncementTest {
                         .build()
                 )
         );
+
+        assertThatExceptionOfType(SubjectAnnouncementInvalidException.class).isThrownBy(() ->
+                SubjectAnnouncement.fromJson(JsonObject.newBuilder()
+                        .set(SubjectAnnouncement.JsonFields.REQUESTED_ACKS_TIMEOUT, "PT5h")
+                        .build()
+                )
+        );
+
+        assertThatExceptionOfType(SubjectAnnouncementInvalidException.class).isThrownBy(() ->
+                SubjectAnnouncement.fromJson(JsonObject.newBuilder()
+                        .set(SubjectAnnouncement.JsonFields.REQUESTED_ACKS_TIMEOUT, "-2h")
+                        .build()
+                )
+        );
+
+        assertThatExceptionOfType(SubjectAnnouncementInvalidException.class).isThrownBy(() ->
+                SubjectAnnouncement.fromJson(JsonObject.newBuilder()
+                        .set(SubjectAnnouncement.JsonFields.RANDOMIZATION_INTERVAL, "PT5h")
+                        .build()
+                )
+        );
+
+        assertThatExceptionOfType(SubjectAnnouncementInvalidException.class).isThrownBy(() ->
+                SubjectAnnouncement.fromJson(JsonObject.newBuilder()
+                        .set(SubjectAnnouncement.JsonFields.RANDOMIZATION_INTERVAL, "-2h")
+                        .build()
+                )
+        );
+
     }
 }

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableSubjectTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/ImmutableSubjectTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import org.eclipse.ditto.base.model.acks.AcknowledgementRequest;
 import org.eclipse.ditto.base.model.common.DittoDuration;
 import org.eclipse.ditto.json.JsonObject;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -77,7 +76,7 @@ public final class ImmutableSubjectTest {
                 SubjectAnnouncement.of(DittoDuration.parseDuration("5m"), true,
                         Collections.singletonList(
                                 AcknowledgementRequest.parseAcknowledgementRequest("integration:connection")),
-                        DittoDuration.parseDuration("10s")
+                        DittoDuration.parseDuration("10s"), DittoDuration.parseDuration("5m")
                 ));
 
         final Subject subject1 = ImmutableSubject.fromJson(SubjectIssuer.GOOGLE + ":myself",
@@ -85,7 +84,6 @@ public final class ImmutableSubjectTest {
 
         assertThat(subject).isEqualTo(subject1);
     }
-
 
     @Test(expected = NullPointerException.class)
     public void createSubjectWithNullSubjectIssuer() {

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/DefaultPolicyAnnouncementConfig.java
@@ -35,6 +35,8 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
     private final Duration gracePeriod;
     private final Duration maxTimeout;
     private final boolean enableAnnouncementsWhenDeleted;
+
+    private final Duration defaultRandomizationInterval;
     private final ExponentialBackOffConfig exponentialBackOffConfig;
 
     private DefaultPolicyAnnouncementConfig(final ScopedConfig scopedConfig) {
@@ -42,6 +44,7 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
         maxTimeout = scopedConfig.getDuration(ConfigValue.MAX_TIMEOUT.getConfigPath());
         enableAnnouncementsWhenDeleted =
                 scopedConfig.getBoolean(ConfigValue.ENABLE_ANNOUNCEMENTS_WHEN_DELETED.getConfigPath());
+        defaultRandomizationInterval = scopedConfig.getDuration(ConfigValue.DEFAULT_RANDOMIZATION_INTERVAL.getConfigPath());
         exponentialBackOffConfig = DefaultExponentialBackOffConfig.of(scopedConfig);
     }
 
@@ -67,6 +70,11 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
     }
 
     @Override
+    public Duration getDefaultRandomizationInterval() {
+        return defaultRandomizationInterval;
+    }
+
+    @Override
     public ExponentialBackOffConfig getExponentialBackOffConfig() {
         return exponentialBackOffConfig;
     }
@@ -83,12 +91,14 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
         return Objects.equals(gracePeriod, that.gracePeriod) &&
                 Objects.equals(maxTimeout, that.maxTimeout) &&
                 enableAnnouncementsWhenDeleted == that.enableAnnouncementsWhenDeleted &&
+                Objects.equals(defaultRandomizationInterval, that.defaultRandomizationInterval) &&
                 Objects.equals(exponentialBackOffConfig, that.exponentialBackOffConfig);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(gracePeriod, maxTimeout, enableAnnouncementsWhenDeleted, exponentialBackOffConfig);
+        return Objects.hash(gracePeriod, maxTimeout, enableAnnouncementsWhenDeleted, defaultRandomizationInterval,
+                exponentialBackOffConfig);
     }
 
     @Override
@@ -97,6 +107,7 @@ final class DefaultPolicyAnnouncementConfig implements PolicyAnnouncementConfig 
                 "gracePeriod=" + gracePeriod +
                 ", maxTimeout=" + maxTimeout +
                 ", enableAnnouncementsWhenDeleted=" + enableAnnouncementsWhenDeleted +
+                ", defaultRandomizationInterval=" + defaultRandomizationInterval +
                 ", exponentialBackOffConfig" + exponentialBackOffConfig +
                 "]";
     }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyAnnouncementConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyAnnouncementConfig.java
@@ -50,6 +50,14 @@ public interface PolicyAnnouncementConfig {
     boolean isEnableAnnouncementsWhenDeleted();
 
     /**
+     * Returns the default randomization interval.
+     *
+     * @return the default interval in which an announcement is sent earlier.
+     * @since 3.0.0
+     */
+    Duration getDefaultRandomizationInterval();
+
+    /**
      * Returns the config for the exponential back-off strategy of announcement redelivery.
      *
      * @return the config.
@@ -82,6 +90,11 @@ public interface PolicyAnnouncementConfig {
          * The maximum timeout.
          */
         MAX_TIMEOUT("max-timeout", Duration.ofMinutes(1L)),
+
+        /**
+         * The maximum duration of randomization.
+         */
+        DEFAULT_RANDOMIZATION_INTERVAL("default-randomization-interval", Duration.ofMinutes(5)),
 
         /**
          * Whether when-deleted announcements are enabled.

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -84,7 +84,6 @@ public final class PolicyPersistenceActor
         this.policyConfig = policyConfig;
     }
 
-    @SuppressWarnings("unused")
     private PolicyPersistenceActor(final PolicyId policyId,
             final ActorRef pubSubMediator,
             final ActorRef announcementManager) {

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/PolicyAnnouncementManager.java
@@ -205,6 +205,6 @@ public final class PolicyAnnouncementManager extends AbstractActor {
 
         return minuend.stream()
                 .filter(subject -> !subtrahend.contains(subject))
-                .collect(Collectors.toList());
+                .toList();
     }
 }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActor.java
@@ -21,7 +21,9 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
 
+import org.eclipse.ditto.base.model.common.DittoDuration;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
@@ -77,6 +79,8 @@ public final class SubjectExpiryActor extends AbstractFSM<SubjectExpiryState, No
     private final Duration persistenceTimeout;
     private final ActorRef commandForwarder;
     private final boolean enableAnnouncementsWhenDeleted;
+    private final Duration defaultRandomizationInterval;
+
 
     private final Duration maxBackOff;
     private final double backOffRandomFactor;
@@ -100,13 +104,15 @@ public final class SubjectExpiryActor extends AbstractFSM<SubjectExpiryState, No
         this.gracePeriod = gracePeriod;
         this.policyAnnouncementPub = policyAnnouncementPub;
         enableAnnouncementsWhenDeleted = config.isEnableAnnouncementsWhenDeleted();
+        defaultRandomizationInterval = config.getDefaultRandomizationInterval();
 
         ackregatorStarter =
                 AcknowledgementAggregatorActorStarter.of(getContext(), maxTimeout, HeaderTranslator.empty(),
                         null, List.of(), List.of());
         this.commandForwarder = commandForwarder;
         sudoDeleteExpiredSubject =
-                SudoDeleteExpiredSubject.of(policyId, subject, DittoHeaders.newBuilder().responseRequired(false).build());
+                SudoDeleteExpiredSubject.of(policyId, subject,
+                        DittoHeaders.newBuilder().responseRequired(false).build());
         persistenceTimeout = maxTimeout;
 
         final var backOffConfig = config.getExponentialBackOffConfig();
@@ -498,11 +504,31 @@ public final class SubjectExpiryActor extends AbstractFSM<SubjectExpiryState, No
         return builder.build();
     }
 
+    /**
+     * Gets the instant when the announcement should be sent (instant of expiry - time before expiry that the
+     * announcement should be sent)
+     */
     private Optional<Instant> getAnnouncementInstant() {
         return subject.getAnnouncement()
                 .flatMap(SubjectAnnouncement::getBeforeExpiry)
                 .flatMap(beforeExpiry -> subject.getExpiry()
-                        .map(expiry -> expiry.getTimestamp().minus(beforeExpiry.getDuration())));
+                        .map(expiry -> expiry.getTimestamp().minus(beforeExpiry.getDuration())))
+                .flatMap(this::subtractRandomFactor);
+    }
+
+    /**
+     * subtract a random factor from the announcement instant in effort to prevent policy announcement bulks, which
+     * could cause to dropped messages in connections not consuming fast enough.
+     */
+    private Optional<Instant> subtractRandomFactor(final Instant announcementInstant) {
+        return subject.getAnnouncement()
+                .map(a -> a.getRandomizationInterval().orElse(DittoDuration.of(defaultRandomizationInterval)))
+                .map(interval -> announcementInstant.minusMillis(getRandomMillis(interval)));
+    }
+
+    private long getRandomMillis(final DittoDuration interval) {
+        final long intervalMillis = interval.getDuration().toMillis();
+        return intervalMillis > 0 ? ThreadLocalRandom.current().nextLong(intervalMillis) : intervalMillis;
     }
 
     private static Duration truncateToOneDay(final Duration duration) {

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -83,6 +83,9 @@ ditto {
         enable-announcements-when-deleted = true
         enable-announcements-when-deleted = ${?POLICY_ENABLE_ANNOUNCEMENTS_WHEN_DELETED}
 
+        default-randomization-interval = 5m
+        default-randomization-interval = ${?POLICY_ANNOUNCEMENT_DEFAULT_RANDOMIZATION_INTERVAL}
+
         exponential-backoff {
           # minimum backoff for announcement redelivery
           min = 1s

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActorTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActorTest.java
@@ -112,7 +112,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(null,
                     null,
                     true,
-                    null
+                    null,
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -130,7 +131,6 @@ public final class SubjectExpiryActorTest {
             assertThat(subjectDeletionAnnouncement.getSubjectIds())
                     .containsExactly(SUBJECT_DITTO_DITTO);
             assertThat(subjectDeletionAnnouncement.getDittoHeaders().getAcknowledgementRequests()).isEmpty();
-
             expectTerminated(underTest);
             expectNoMessage();
             verifyNoMoreInteractions(policiesPub);
@@ -144,7 +144,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(null,
                     null,
                     true,
-                    null
+                    null,
+                    Duration.ofSeconds(0)
             );
 
             final var disabledConfig = PolicyAnnouncementConfig.of(ConfigFactory.parseMap(
@@ -173,6 +174,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -211,6 +213,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -258,6 +261,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofMillis(1),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -286,8 +290,9 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     null,
                     false,
-                    Duration.ofSeconds(30)
-            );
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
+                    );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
                     maxTimeout, getTestActor(), config);
@@ -313,7 +318,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     null,
                     true,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    null
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -350,6 +356,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -389,6 +396,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -423,6 +431,7 @@ public final class SubjectExpiryActorTest {
                     null,
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -448,7 +457,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     Duration.ofMillis(500),
                     false,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -480,7 +490,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(10)),
                     Duration.ofSeconds(7),
                     false,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -503,7 +514,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     Duration.ofMillis(500),
                     false,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -528,7 +540,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     Duration.ofMillis(500),
                     false,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props =
@@ -566,6 +579,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -603,6 +617,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -632,6 +647,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -661,6 +677,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(9000),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -690,6 +707,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(1500),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -727,6 +745,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(1500),
                     false,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -758,7 +777,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     Duration.ofMillis(500),
                     true,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -790,7 +810,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(160)),
                     Duration.ofMillis(500),
                     true,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -812,7 +833,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(60)),
                     Duration.ofSeconds(57),
                     true,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
@@ -833,7 +855,8 @@ public final class SubjectExpiryActorTest {
             final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(3)),
                     Duration.ofMillis(500),
                     true,
-                    Duration.ofSeconds(30)
+                    Duration.ofSeconds(30),
+                    Duration.ofSeconds(0)
             );
 
             final Props props =
@@ -859,6 +882,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -896,6 +920,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -925,6 +950,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -954,6 +980,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(9500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -983,6 +1010,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1020,6 +1048,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1050,6 +1079,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1087,6 +1117,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1117,6 +1148,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(9500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1156,6 +1188,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(9500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1195,6 +1228,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1232,6 +1266,7 @@ public final class SubjectExpiryActorTest {
                     Duration.ofMillis(500),
                     true,
                     Duration.ofSeconds(30),
+                    Duration.ofSeconds(0),
                     ACK_LABEL_CONNECTION_ACK
             );
 
@@ -1255,11 +1290,96 @@ public final class SubjectExpiryActorTest {
         }};
     }
 
+    @Test
+    public void testRandomization() {
+        new TestKit(system) {{
+            final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(5)),
+                    Duration.ofSeconds(0),
+                    false,
+                    null,
+                    Duration.ofDays(20)
+            );
+
+            final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
+                    maxTimeout, getTestActor(), config);
+            final ActorRef underTest = watch(childActorOf(props));
+
+            underTest.tell(SUBJECT_DELETED, ActorRef.noSender());
+
+            verify(policiesPub, timeout(4_000))
+                    .publishWithAcks(announcementCaptor.capture(), any(), senderCaptor.capture());
+            final var announcement = announcementCaptor.getValue();
+
+            assertThat(announcement).isInstanceOf(SubjectDeletionAnnouncement.class);
+            final var subjectDeletionAnnouncement = (SubjectDeletionAnnouncement) announcement;
+            assertThat(subjectDeletionAnnouncement.getSubjectIds())
+                    .containsExactly(SUBJECT_DITTO_DITTO);
+            assertThat(subjectDeletionAnnouncement.getDittoHeaders().getAcknowledgementRequests()).isEmpty();
+            expectTerminated(underTest);
+            expectNoMessage();
+            verifyNoMoreInteractions(policiesPub);
+        }};
+    }
+
+    @Test
+    public void testNoRandomization() {
+        new TestKit(system) {{
+            final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(5)),
+                    Duration.ofSeconds(0),
+                    false,
+                    null,
+                    Duration.ZERO
+            );
+
+            final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
+                    maxTimeout, getTestActor(), config);
+            final ActorRef underTest = watch(childActorOf(props));
+
+            underTest.tell(SUBJECT_DELETED, ActorRef.noSender());
+
+            expectTerminated(underTest);
+            expectNoMessage();
+        }};
+    }
+
+    @Test
+    public void testDefaultRandomization() {
+        new TestKit(system) {{
+            final Subject subject = createSubject(Instant.now().plus(Duration.ofSeconds(5)),
+                    Duration.ofSeconds(0),
+                    false,
+                    null,
+                    null
+            );
+
+            final Props props = SubjectExpiryActor.props(policyId, subject, Duration.ofHours(4), policiesPub,
+                    maxTimeout, getTestActor(), config);
+            final ActorRef underTest = watch(childActorOf(props));
+
+            underTest.tell(SUBJECT_DELETED, ActorRef.noSender());
+
+            verify(policiesPub, timeout(4_000))
+                    .publishWithAcks(announcementCaptor.capture(), any(), senderCaptor.capture());
+            final var announcement = announcementCaptor.getValue();
+
+            assertThat(announcement).isInstanceOf(SubjectDeletionAnnouncement.class);
+            final var subjectDeletionAnnouncement = (SubjectDeletionAnnouncement) announcement;
+            assertThat(subjectDeletionAnnouncement.getSubjectIds())
+                    .containsExactly(SUBJECT_DITTO_DITTO);
+            assertThat(subjectDeletionAnnouncement.getDittoHeaders().getAcknowledgementRequests()).isEmpty();
+            expectTerminated(underTest);
+            expectNoMessage();
+            verifyNoMoreInteractions(policiesPub);
+        }};
+    }
+
     private static Subject createSubject(@Nullable final Instant expiry,
             @Nullable final Duration beforeExpiry,
             final boolean whenDeleted,
             @Nullable final Duration ackTimeout,
+            @Nullable final Duration randomizationInterval,
             final String... ackLabels) {
+
         return Subject.newInstance(SUBJECT_DITTO_DITTO,
                 SubjectType.UNKNOWN,
                 expiry != null ? PoliciesModelFactory.newSubjectExpiry(expiry) : null,
@@ -1269,7 +1389,8 @@ public final class SubjectExpiryActorTest {
                         Arrays.stream(ackLabels)
                                 .map(AcknowledgementRequest::parseAcknowledgementRequest)
                                 .collect(Collectors.toList()),
-                        ackTimeout != null ? DittoDuration.of(ackTimeout) : null
+                        ackTimeout != null ? DittoDuration.of(ackTimeout) : null,
+                        randomizationInterval != null ?DittoDuration.of(randomizationInterval) : null
                 )
         );
     }


### PR DESCRIPTION
Announcement peaks can lead to dropped announcement in connections. (i.e. if policy activation is triggered via a script for many policies in a short time-frame)
To prevent announcement peaks a random interval in which the announcements are sent earlier is added.
The interval is either configurable via the subject-announcement API or (if not set) a default interval is applied.

Should be part of Ditto 3.0.0 (Contains API break)