### PR TITLE
Add support for JsonWebTokens with an EC keyType

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwkException.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwkException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.security.authentication.jwt;
+
+public interface JwkException {
+
+    /**
+     * Error code prefix of errors related to JWK.
+     */
+    String ERROR_CODE_PREFIX = "jwk" + ":";
+
+}

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwkInvalidException.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwkInvalidException.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.gateway.service.security.authentication.jwt;
+
+import java.net.URI;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.base.model.common.HttpStatus;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
+import org.eclipse.ditto.base.model.exceptions.DittoRuntimeExceptionBuilder;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.base.model.json.JsonParsableException;
+import org.eclipse.ditto.json.JsonObject;
+
+@JsonParsableException(errorCode = JwkInvalidException.ERROR_CODE)
+public final class JwkInvalidException extends DittoRuntimeException implements JwkException {
+
+    /**
+     * Error code of this exception.
+     */
+    static final String ERROR_CODE =  ERROR_CODE_PREFIX + "invalid";
+
+    private static final String MESSAGE = "The JSON Web Key is not valid.";
+    private static final String DESCRIPTION = "The provided JSON Web Key did not have the expected format.";
+
+    private static final long serialVersionUID = 5855341686469407357L;
+
+    private JwkInvalidException(final DittoHeaders dittoHeaders,
+            @Nullable final String message,
+            @Nullable final String description,
+            @Nullable final Throwable cause,
+            @Nullable final URI href) {
+        super(ERROR_CODE, HttpStatus.BAD_REQUEST, dittoHeaders, message, description, cause, href);
+    }
+
+    /**
+     * A mutable builder for this exception.
+     *
+     * @return the builder.
+     */
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    /**
+     * Constructs a new {@code JwkInvalidException} object with the exception message extracted from the
+     * given JSON object.
+     *
+     * @param jsonObject the JSON to read the {@link org.eclipse.ditto.base.model.exceptions.DittoRuntimeException.JsonFields#MESSAGE} field from.
+     * @param dittoHeaders the headers of the command which resulted in this exception.
+     * @return the new JwkInvalidException.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws org.eclipse.ditto.json.JsonMissingFieldException if this JsonObject did not contain an error message.
+     * @throws org.eclipse.ditto.json.JsonParseException if the passed in {@code jsonObject} was not in the expected
+     * format.
+     */
+    public static JwkInvalidException fromJson(final JsonObject jsonObject, final DittoHeaders dittoHeaders) {
+        return DittoRuntimeException.fromJson(jsonObject, dittoHeaders, new Builder());
+    }
+
+    @Override
+    public DittoRuntimeException setDittoHeaders(final DittoHeaders dittoHeaders) {
+        return new Builder()
+                .message(getMessage())
+                .description(getDescription().orElse(null))
+                .cause(getCause())
+                .href(getHref().orElse(null))
+                .dittoHeaders(dittoHeaders)
+                .build();
+    }
+
+    /**
+     * A mutable builder with a fluent API for a {@link org.eclipse.ditto.gateway.service.security.authentication.jwt.JwkInvalidException}.
+     */
+    @NotThreadSafe
+    public static final class Builder extends DittoRuntimeExceptionBuilder<JwkInvalidException> {
+
+        private Builder() {
+            message(MESSAGE).description(DESCRIPTION);
+        }
+
+        @Override
+        protected JwkInvalidException doBuild(final DittoHeaders dittoHeaders,
+                @Nullable final String message,
+                @Nullable final String description,
+                @Nullable final Throwable cause,
+                @Nullable final URI href) {
+            return new JwkInvalidException(dittoHeaders, message, description, cause, href);
+        }
+
+    }
+
+}

--- a/jwt/model/pom.xml
+++ b/jwt/model/pom.xml
@@ -121,7 +121,11 @@
                     <parameter>
                         <excludes>
                             <!-- Don't add excludes here before checking with the whole Ditto team -->
-                            <!--<exclude></exclude>-->
+                            <exclude>org.eclipse.ditto.jwt.model.ImmutableJsonWebKey#getExponent()</exclude>
+                            <exclude>org.eclipse.ditto.jwt.model.ImmutableJsonWebKey#getModulus()</exclude>
+                            <exclude>org.eclipse.ditto.jwt.model.JsonWebKey#getModulus()</exclude>
+                            <exclude>org.eclipse.ditto.jwt.model.JsonWebKey#getExponent()</exclude>
+                            <exclude>org.eclipse.ditto.jwt.model.ImmutableJsonWebKey#of(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.math.BigInteger,java.math.BigInteger)</exclude>
                         </excludes>
                     </parameter>
                 </configuration>

--- a/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/ImmutableJsonWebKey.java
+++ b/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/ImmutableJsonWebKey.java
@@ -44,6 +44,7 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
     @Nullable private final BigInteger exponent;
     @Nullable private final BigInteger xCoordinate;
     @Nullable private final BigInteger yCoordinate;
+    @Nullable private final String curveType;
 
     private ImmutableJsonWebKey(final String type,
             @Nullable final String algorithm,
@@ -52,7 +53,8 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
             @Nullable final BigInteger modulus,
             @Nullable final BigInteger exponent,
             @Nullable final BigInteger xCoordinate,
-            @Nullable final BigInteger yCoordinate) {
+            @Nullable final BigInteger yCoordinate,
+            @Nullable final String curveType) {
 
         this.type = type;
         this.algorithm = algorithm;
@@ -62,6 +64,7 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
         this.exponent = exponent;
         this.xCoordinate = xCoordinate;
         this.yCoordinate = yCoordinate;
+        this.curveType = curveType;
     }
 
     /**
@@ -76,6 +79,7 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
      * @param exponent the optional exponent of the JWK.
      * @param xCoordinate the optional EC X coordinate.
      * @param yCoordinate the optional EC Y coordinate.
+     * @param curveType the optional type of the used curve.
      * @return the JsonWebKey.
      * @throws NullPointerException if any argument but {@code algorithm} or {@code usage} is {@code null}.
      * @throws IllegalArgumentException if any {@code String} argument is empty.
@@ -87,12 +91,14 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
             @Nullable final BigInteger modulus,
             @Nullable final BigInteger exponent,
             @Nullable final BigInteger xCoordinate,
-            @Nullable final BigInteger yCoordinate) {
+            @Nullable final BigInteger yCoordinate,
+            @Nullable final String curveType) {
 
         argumentNotEmpty(type);
         argumentNotEmpty(id);
 
-        return new ImmutableJsonWebKey(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate);
+        return new ImmutableJsonWebKey(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate,
+                curveType);
     }
 
     /**
@@ -122,10 +128,11 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
         final Optional<BigInteger> exponent = getOptionalValueFromJson(JsonFields.KEY_EXPONENT, jsonObject);
         final Optional<BigInteger> xCoordinate = getOptionalValueFromJson(JsonFields.KEY_X_COORDINATE, jsonObject);
         final Optional<BigInteger> yCoordinate = getOptionalValueFromJson(JsonFields.KEY_Y_COORDINATE, jsonObject);
+        final Optional<String> curveType = jsonObject.getValue(JsonFields.KEY_CURVE);
 
 
         return of(type, algorithm, usage, id, modulus.orElse(null), exponent.orElse(null),
-                xCoordinate.orElse(null), yCoordinate.orElse(null));
+                xCoordinate.orElse(null), yCoordinate.orElse(null), curveType.orElse(null));
     }
 
     private static Optional<BigInteger> getOptionalValueFromJson(final JsonFieldDefinition<String> field,
@@ -178,6 +185,11 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
     }
 
     @Override
+    public Optional<String> getCurveType() {
+        return Optional.ofNullable(curveType);
+    }
+
+    @Override
     @SuppressWarnings({"squid:MethodCyclomaticComplexity", "squid:S1067"})
     public boolean equals(final Object o) {
         if (this == o) {
@@ -194,12 +206,13 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
                 Objects.equals(modulus, that.modulus) &&
                 Objects.equals(exponent, that.exponent) &&
                 Objects.equals(xCoordinate, that.xCoordinate) &&
-                Objects.equals(yCoordinate, that.yCoordinate);
+                Objects.equals(yCoordinate, that.yCoordinate) &&
+                Objects.equals(curveType, that.curveType);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate);
+        return Objects.hash(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate, curveType);
     }
 
     @Override
@@ -213,6 +226,7 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
                 ", exponent=" + exponent +
                 ", xCoordinate=" + xCoordinate +
                 ", yCoordinate=" + yCoordinate +
+                ", curveType=" + curveType +
                 ']';
     }
 

--- a/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/ImmutableJsonWebKey.java
+++ b/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/ImmutableJsonWebKey.java
@@ -13,7 +13,6 @@
 package org.eclipse.ditto.jwt.model;
 
 import static org.eclipse.ditto.base.model.common.ConditionChecker.argumentNotEmpty;
-import static org.eclipse.ditto.base.model.common.ConditionChecker.argumentNotNull;
 
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
@@ -25,6 +24,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonMissingFieldException;
 import org.eclipse.ditto.json.JsonObject;
 
@@ -40,15 +40,19 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
     @Nullable private final String algorithm;
     @Nullable private final String usage;
     private final String id;
-    private final BigInteger modulus;
-    private final BigInteger exponent;
+    @Nullable private final BigInteger modulus;
+    @Nullable private final BigInteger exponent;
+    @Nullable private final BigInteger xCoordinate;
+    @Nullable private final BigInteger yCoordinate;
 
     private ImmutableJsonWebKey(final String type,
             @Nullable final String algorithm,
             @Nullable final String usage,
             final String id,
-            final BigInteger modulus,
-            final BigInteger exponent) {
+            @Nullable final BigInteger modulus,
+            @Nullable final BigInteger exponent,
+            @Nullable final BigInteger xCoordinate,
+            @Nullable final BigInteger yCoordinate) {
 
         this.type = type;
         this.algorithm = algorithm;
@@ -56,6 +60,8 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
         this.id = id;
         this.modulus = modulus;
         this.exponent = exponent;
+        this.xCoordinate = xCoordinate;
+        this.yCoordinate = yCoordinate;
     }
 
     /**
@@ -66,8 +72,10 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
      * @param algorithm the algorithm of the JWK or {@code null}.
      * @param usage the usage of the JWK or {@code null}.
      * @param id the ID of the JWK.
-     * @param modulus the modulus of the JWK.
-     * @param exponent the exponent of the JWK.
+     * @param modulus the optional modulus of the JWK.
+     * @param exponent the optional exponent of the JWK.
+     * @param xCoordinate the optional EC X coordinate.
+     * @param yCoordinate the optional EC Y coordinate.
      * @return the JsonWebKey.
      * @throws NullPointerException if any argument but {@code algorithm} or {@code usage} is {@code null}.
      * @throws IllegalArgumentException if any {@code String} argument is empty.
@@ -76,15 +84,15 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
             @Nullable final String algorithm,
             @Nullable final String usage,
             final String id,
-            final BigInteger modulus,
-            final BigInteger exponent) {
+            @Nullable final BigInteger modulus,
+            @Nullable final BigInteger exponent,
+            @Nullable final BigInteger xCoordinate,
+            @Nullable final BigInteger yCoordinate) {
 
         argumentNotEmpty(type);
         argumentNotEmpty(id);
-        argumentNotNull(modulus);
-        argumentNotNull(exponent);
 
-        return new ImmutableJsonWebKey(type, algorithm, usage, id, modulus, exponent);
+        return new ImmutableJsonWebKey(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate);
     }
 
     /**
@@ -109,18 +117,24 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
         final String algorithm = jsonObject.getValue(JsonFields.KEY_ALGORITHM).orElse(null);
         final String usage = jsonObject.getValue(JsonFields.KEY_USAGE).orElse(null);
         final String id = jsonObject.getValueOrThrow(JsonFields.KEY_ID);
-        final BigInteger modulus = jsonObject.getValue(JsonFields.KEY_MODULUS)
-                .map(string -> string.getBytes(StandardCharsets.UTF_8))
-                .map(DECODER::decode)
-                .map(bytes -> new BigInteger(1, bytes))
-                .orElseThrow(() -> new JsonMissingFieldException(JsonFields.KEY_MODULUS.getPointer()));
-        final BigInteger exponent = jsonObject.getValue(JsonFields.KEY_EXPONENT)
-                .map(string -> string.getBytes(StandardCharsets.UTF_8))
-                .map(DECODER::decode)
-                .map(bytes -> new BigInteger(1, bytes))
-                .orElseThrow(() -> new JsonMissingFieldException(JsonFields.KEY_EXPONENT.getPointer()));
 
-        return of(type, algorithm, usage, id, modulus, exponent);
+        final Optional<BigInteger> modulus = getOptionalValueFromJson(JsonFields.KEY_MODULUS, jsonObject);
+        final Optional<BigInteger> exponent = getOptionalValueFromJson(JsonFields.KEY_EXPONENT, jsonObject);
+        final Optional<BigInteger> xCoordinate = getOptionalValueFromJson(JsonFields.KEY_X_COORDINATE, jsonObject);
+        final Optional<BigInteger> yCoordinate = getOptionalValueFromJson(JsonFields.KEY_Y_COORDINATE, jsonObject);
+
+
+        return of(type, algorithm, usage, id, modulus.orElse(null), exponent.orElse(null),
+                xCoordinate.orElse(null), yCoordinate.orElse(null));
+    }
+
+    private static Optional<BigInteger> getOptionalValueFromJson(final JsonFieldDefinition<String> field,
+            final JsonObject jsonObject) {
+
+        return jsonObject.getValue(field)
+                .map(string -> string.getBytes(StandardCharsets.UTF_8))
+                .map(DECODER::decode)
+                .map(bytes -> new BigInteger(1, bytes));
     }
 
     @Override
@@ -144,13 +158,23 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
     }
 
     @Override
-    public BigInteger getModulus() {
-        return modulus;
+    public Optional<BigInteger> getModulus() {
+        return Optional.ofNullable(modulus);
     }
 
     @Override
-    public BigInteger getExponent() {
-        return exponent;
+    public Optional<BigInteger> getExponent() {
+        return Optional.ofNullable(exponent);
+    }
+
+    @Override
+    public Optional<BigInteger> getXCoordinate() {
+        return Optional.ofNullable(xCoordinate);
+    }
+
+    @Override
+    public Optional<BigInteger> getYCoordinate() {
+        return Optional.ofNullable(yCoordinate);
     }
 
     @Override
@@ -163,21 +187,33 @@ public final class ImmutableJsonWebKey implements JsonWebKey {
             return false;
         }
         final ImmutableJsonWebKey that = (ImmutableJsonWebKey) o;
-        return Objects.equals(type, that.type) && Objects.equals(algorithm, that.algorithm)
-                && Objects.equals(usage, that.usage) && Objects.equals(id, that.id) &&
-                Objects.equals(modulus, that.modulus)
-                && Objects.equals(exponent, that.exponent);
+        return Objects.equals(type, that.type) &&
+                Objects.equals(algorithm, that.algorithm) &&
+                Objects.equals(usage, that.usage) &&
+                Objects.equals(id, that.id) &&
+                Objects.equals(modulus, that.modulus) &&
+                Objects.equals(exponent, that.exponent) &&
+                Objects.equals(xCoordinate, that.xCoordinate) &&
+                Objects.equals(yCoordinate, that.yCoordinate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(type, algorithm, usage, id, modulus, exponent);
+        return Objects.hash(type, algorithm, usage, id, modulus, exponent, xCoordinate, yCoordinate);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + "type=" + type + ", algorithm=" + algorithm + ", usage=" + usage
-                + ", id=" + id + ", modulus=" + modulus + ", exponent=" + exponent + ']';
+        return getClass().getSimpleName() + " [" +
+                "type=" + type +
+                ", algorithm=" + algorithm +
+                ", usage=" + usage +
+                ", id=" + id +
+                ", modulus=" + modulus +
+                ", exponent=" + exponent +
+                ", xCoordinate=" + xCoordinate +
+                ", yCoordinate=" + yCoordinate +
+                ']';
     }
 
 }

--- a/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/JsonWebKey.java
+++ b/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/JsonWebKey.java
@@ -60,15 +60,33 @@ public interface JsonWebKey {
      * Returns the modulus parameter.
      *
      * @return the modulus.
+     * @since 3.0.0
      */
-    BigInteger getModulus();
+    Optional<BigInteger> getModulus();
 
     /**
      * Returns the exponent parameter.
      *
      * @return the exponent.
+     * @since 3.0.0
      */
-    BigInteger getExponent();
+    Optional<BigInteger> getExponent();
+
+    /**
+     * Returns the EC X coordinate.
+     *
+     * @return the exponent.
+     * @since 3.0.0
+     */
+    Optional<BigInteger> getXCoordinate();
+
+    /**
+     * Returns the EC Y coordinate.
+     *
+     * @return the exponent.
+     * @since 3.0.0
+     */
+    Optional<BigInteger> getYCoordinate();
 
     /**
      * An enumeration of the known {@link org.eclipse.ditto.json.JsonField}s of a JSON Web Key.
@@ -111,6 +129,20 @@ public interface JsonWebKey {
          */
         public static final JsonFieldDefinition<String> KEY_EXPONENT =
                 JsonFactory.newStringFieldDefinition("e", FieldType.REGULAR);
+
+        /**
+         * JSON field containing the key's EC X coordinate.
+         * @since 3.0.0
+         */
+        public static final JsonFieldDefinition<String> KEY_X_COORDINATE =
+                JsonFactory.newStringFieldDefinition("x", FieldType.REGULAR);
+
+        /**
+         * JSON field containing the key's EC Y coordinate.
+         * @since 3.0.0
+         */
+        public static final JsonFieldDefinition<String> KEY_Y_COORDINATE =
+                JsonFactory.newStringFieldDefinition("y", FieldType.REGULAR);
 
         private JsonFields() {
             throw new AssertionError();

--- a/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/JsonWebKey.java
+++ b/jwt/model/src/main/java/org/eclipse/ditto/jwt/model/JsonWebKey.java
@@ -17,9 +17,9 @@ import java.util.Optional;
 
 import javax.annotation.concurrent.Immutable;
 
+import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonFieldDefinition;
-import org.eclipse.ditto.base.model.json.FieldType;
 
 /**
  * Representation for a JSON Web Key.
@@ -75,7 +75,7 @@ public interface JsonWebKey {
     /**
      * Returns the EC X coordinate.
      *
-     * @return the exponent.
+     * @return the EC X coordinate.
      * @since 3.0.0
      */
     Optional<BigInteger> getXCoordinate();
@@ -83,10 +83,18 @@ public interface JsonWebKey {
     /**
      * Returns the EC Y coordinate.
      *
-     * @return the exponent.
+     * @return the EC Y coordinate.
      * @since 3.0.0
      */
     Optional<BigInteger> getYCoordinate();
+
+    /**
+     * Returns the curve type.
+     *
+     * @return the curve type.
+     * @since 3.0.0
+     */
+    Optional<String> getCurveType();
 
     /**
      * An enumeration of the known {@link org.eclipse.ditto.json.JsonField}s of a JSON Web Key.
@@ -143,6 +151,13 @@ public interface JsonWebKey {
          */
         public static final JsonFieldDefinition<String> KEY_Y_COORDINATE =
                 JsonFactory.newStringFieldDefinition("y", FieldType.REGULAR);
+
+        /**
+         * JSON field containing the key's EC curve.
+         * @since 3.0.0
+         */
+        public static final JsonFieldDefinition<String> KEY_CURVE =
+                JsonFactory.newStringFieldDefinition("crv", FieldType.REGULAR);
 
         private JsonFields() {
             throw new AssertionError();


### PR DESCRIPTION
Prior the deserialization of an Eliptic Curve JsonWebToken failed, because Ditto assumed it to be an RSA token and missed the modulus and exponent information.

Signed-off-by: David Schwilk <david.schwilk@bosch.io>