### PR TITLE
Fix edge command forwarder ordering

### DIFF
--- a/base/service/src/main/java/org/eclipse/ditto/base/service/signaltransformer/SignalTransformers.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/signaltransformer/SignalTransformers.java
@@ -20,11 +20,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.akka.logging.ThreadSafeDittoLogger;
 import org.eclipse.ditto.internal.utils.extension.DittoExtensionIds;
 import org.eclipse.ditto.internal.utils.extension.DittoExtensionPoint;
 import org.eclipse.ditto.internal.utils.extension.DittoExtensionPoint.ExtensionId.ExtensionIdConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
@@ -33,7 +33,7 @@ import akka.actor.ActorSystem;
 
 public final class SignalTransformers implements DittoExtensionPoint, SignalTransformer {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(SignalTransformers.class);
+    private static final ThreadSafeDittoLogger LOGGER = DittoLoggerFactory.getThreadSafeLogger(SignalTransformers.class);
     private static final String SIGNAL_TRANSFORMERS = "signal-transformers";
     private final List<SignalTransformer> transformers;
 
@@ -63,9 +63,11 @@ public final class SignalTransformers implements DittoExtensionPoint, SignalTran
         }
         return prior.whenComplete((result, error) -> {
             if (error != null) {
-                LOGGER.debug("Error happened during signal transforming.", error);
+                LOGGER.withCorrelationId(signal)
+                        .debug("Error happened during signal transforming.", error);
             } else {
-                LOGGER.debug("Signal transforming of <{}> resulted in <{}>.", signal, result);
+                LOGGER.withCorrelationId(signal)
+                        .debug("Signal transforming of <{}> resulted in <{}>.", signal, result);
             }
         });
     }

--- a/edge/service/pom.xml
+++ b/edge/service/pom.xml
@@ -99,6 +99,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.typesafe.akka</groupId>
+            <artifactId>akka-testkit_${scala.version}</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
             <scope>test</scope>

--- a/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/EntityTaskResultSequentializer.java
+++ b/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/EntityTaskResultSequentializer.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.edge.service.dispatching;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.entity.id.EntityId;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoDiagnosticLoggingAdapter;
+import org.eclipse.ditto.internal.utils.akka.logging.DittoLoggerFactory;
+import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
+import org.eclipse.ditto.internal.utils.metrics.instruments.counter.Counter;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.Props;
+import akka.japi.pf.ReceiveBuilder;
+
+/**
+ * This class allows chaining futures related for a single entity.
+ * This means that you can be sure that previous tasks for the entity are completed when you're reiving the TaskResult
+ * as response.
+ */
+final class EntityTaskResultSequentializer extends AbstractActor {
+
+    static final String ACTOR_NAME = "entity-task-scheduler";
+
+    /**
+     * Remembers running tasks for a certain entity ID. May contain an already completed future.
+     */
+    private final Map<EntityId, CompletionStage<?>> taskCsPerEntityId;
+    private final DittoDiagnosticLoggingAdapter log;
+    private final Counter scheduledTasks;
+    private final Counter completedTasks;
+
+    private EntityTaskResultSequentializer() {
+        taskCsPerEntityId = new HashMap<>();
+        log = DittoLoggerFactory.getDiagnosticLoggingAdapter(this);
+        scheduledTasks = DittoMetrics.counter("scheduled_tasks");
+        completedTasks = DittoMetrics.counter("completed_tasks");
+    }
+
+    static Props props() {
+        return Props.create(EntityTaskResultSequentializer.class);
+    }
+
+    @Override
+    public Receive createReceive() {
+        return ReceiveBuilder.create()
+                .match(Task.class, this::scheduleTask)
+                .match(TaskComplete.class, this::taskComplete)
+                .matchAny(message -> log.warning("UnknownMessage <{}>", message))
+                .build();
+    }
+
+    private void scheduleTask(final Task<?> task) {
+        final ActorRef sender = sender();
+        final CompletionStage<?> taskCs = taskCsPerEntityId.compute(task.entityId(), (entityId, previousTaskCS) -> {
+            final CompletionStage<?> previous =
+                    previousTaskCS != null ? previousTaskCS : CompletableFuture.completedStage(null);
+            return scheduleTaskAfter(previous, task);
+        });
+        scheduledTasks.increment();
+
+        taskCs.whenComplete((result, error) -> {
+            final TaskResult<?> taskResult = new TaskResult<>(result, error);
+            sender.tell(taskResult, ActorRef.noSender());
+        });
+    }
+
+    private void taskComplete(final TaskComplete taskComplete) {
+        taskCsPerEntityId.compute(taskComplete.entityId(), (entityId, previousTaskCs) -> {
+            if (previousTaskCs == null) {
+                log.warning("PreviousTaskCs must never be null on task completion. We at least expect the cs for " +
+                        "the task which is completed by this message.");
+                return null;
+            } else if (previousTaskCs.toCompletableFuture().isDone()) {
+                return null;
+            } else {
+                return previousTaskCs;
+            }
+        });
+        completedTasks.increment();
+    }
+
+    /**
+     * Schedule an enforcement task based on previous completion stage of a task for an entity.
+     * Informs self about completion by sending TaskComplete to self when the scheduled task has been completed.
+     *
+     * @param previousTaskCompletion in-flight tasks for the same entity.
+     * @param task the task to schedule.
+     * @return the next in-flight task, including the scheduled task.
+     * Completes after all previous tasks are completed as well.
+     */
+    private CompletionStage<?> scheduleTaskAfter(final CompletionStage<?> previousTaskCompletion, final Task<?> task) {
+        return previousTaskCompletion
+                .exceptionally(error -> null) //future tasks should ignore failures of previous tasks
+                .thenCompose(lastResult -> task.startedStage()
+                        .whenComplete((result, error) ->
+                                self().tell(new TaskComplete(task.entityId()), ActorRef.noSender())));
+    }
+
+    record Task<R>(EntityId entityId, CompletionStage<R> startedStage) {}
+
+    record TaskResult<R>(@Nullable R result, @Nullable Throwable error) {}
+
+    private record TaskComplete(EntityId entityId) {}
+
+}

--- a/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActorTest.java
+++ b/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.edge.service.dispatching;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.things.model.Thing;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
+import org.eclipse.ditto.things.model.signals.commands.modify.ModifyAttribute;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.TestProbe;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Unit tests for {@link EdgeCommandForwarderActor}.
+ */
+public final class EdgeCommandForwarderActorTest {
+
+    public static final PolicyId POLICY_ID = PolicyId.of("foo:bar");
+    public static final ThingId THING_ID = ThingId.of("foo:bar");
+    @Nullable private static ActorSystem actorSystem;
+
+    @BeforeClass
+    public static void init() {
+        actorSystem = ActorSystem.create("AkkaTestSystem", ConfigFactory.load("test"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (actorSystem != null) {
+            TestKit.shutdownActorSystem(actorSystem);
+        }
+    }
+
+    @Test
+    public void ensureCommandOrderIsMaintainedForSlowSignalTransformations() {
+        assert actorSystem != null;
+        new TestKit(actorSystem) {{
+            final ShardRegions shardRegionsMock = Mockito.mock(ShardRegions.class);
+            final TestProbe thingsProbe = new TestProbe(actorSystem);
+            Mockito.when(shardRegionsMock.things()).thenReturn(thingsProbe.ref());
+
+            final Props props = EdgeCommandForwarderActor.props(getRef(), shardRegionsMock);
+            final ActorRef underTest = actorSystem.actorOf(props);
+
+            final CreateThing createThing = CreateThing.of(Thing.newBuilder()
+                            .setId(THING_ID)
+                            .setPolicyId(POLICY_ID)
+                            .build(),
+                    null,
+                    DittoHeaders.newBuilder().correlationId("cid-1-create").build()
+            );
+            final ModifyAttribute modifyAttribute = ModifyAttribute.of(THING_ID,
+                    JsonPointer.of("foo"),
+                    JsonValue.of(42),
+                    DittoHeaders.newBuilder().correlationId("cid-2-modify").build()
+            );
+
+            underTest.tell(createThing, getRef());
+            underTest.tell(modifyAttribute, getRef());
+
+            thingsProbe.expectMsg(createThing);
+            thingsProbe.expectMsg(modifyAttribute);
+        }};
+    }
+}

--- a/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActorTestSignalTransformer.java
+++ b/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EdgeCommandForwarderActorTestSignalTransformer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.edge.service.dispatching;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.base.service.signaltransformer.SignalTransformer;
+import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
+
+import com.typesafe.config.Config;
+
+import akka.actor.ActorSystem;
+
+/**
+ * Signal transformer used for {@link EdgeCommandForwarderActorTest} to artificially delay certain commands in their
+ * signal transformation.
+ */
+public final class EdgeCommandForwarderActorTestSignalTransformer implements SignalTransformer {
+
+    private static final Duration CREATE_THING_TRANSFORMATION_DURATION = Duration.ofMillis(200);
+
+    EdgeCommandForwarderActorTestSignalTransformer(final ActorSystem actorSystem, final Config config) {
+    }
+
+    @Override
+    public CompletionStage<Signal<?>> apply(final Signal<?> signal) {
+        if (signal instanceof CreateThing) {
+            return new CompletableFuture<Signal<?>>()
+                    .completeOnTimeout(signal, CREATE_THING_TRANSFORMATION_DURATION.toMillis(), TimeUnit.MILLISECONDS);
+        } else {
+            return CompletableFuture.completedStage(signal);
+        }
+    }
+
+}

--- a/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EntityTaskSchedulerTest.java
+++ b/edge/service/src/test/java/org/eclipse/ditto/edge/service/dispatching/EntityTaskSchedulerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.edge.service.dispatching;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.things.model.ThingId;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.testkit.javadsl.TestKit;
+
+/**
+ * Unit tests for {@link EntityTaskScheduler}.
+ */
+public final class EntityTaskSchedulerTest {
+
+    public static final ThingId THING_ID = ThingId.of("foo:bar");
+    public static final ThingId THING_ID_2 = ThingId.of("foo:bar2");
+    public static final ThingId THING_ID_3 = ThingId.of("foo:bar3");
+    @Nullable private static ActorSystem actorSystem;
+
+    @BeforeClass
+    public static void init() {
+        actorSystem = ActorSystem.create("AkkaTestSystem", ConfigFactory.load("test"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (actorSystem != null) {
+            TestKit.shutdownActorSystem(actorSystem);
+        }
+    }
+
+    @Test
+    public void ensureOrderForSameEntityId() {
+        assert actorSystem != null;
+        new TestKit(actorSystem) {{
+            final Props props = EntityTaskScheduler.props("test");
+            final ActorRef underTest = actorSystem.actorOf(props);
+
+            underTest.tell(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<>().completeOnTimeout(1, 50, TimeUnit.MILLISECONDS)), getRef());
+            underTest.tell(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<>().completeOnTimeout(2, 0, TimeUnit.MILLISECONDS)), getRef());
+            underTest.tell(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<>().completeOnTimeout(3, 10, TimeUnit.MILLISECONDS)), getRef());
+
+            expectMsg(new EntityTaskScheduler.TaskResult<>(1, null));
+            expectMsg(new EntityTaskScheduler.TaskResult<>(2, null));
+            expectMsg(new EntityTaskScheduler.TaskResult<>(3, null));
+        }};
+    }
+
+    @Test
+    public void ensureMessagesForDifferentEntityIdsAreProcessedInParallelWhileEnsuringOrder() {
+        assert actorSystem != null;
+        new TestKit(actorSystem) {{
+            final Props props = EntityTaskScheduler.props("test");
+            final ActorRef underTest = actorSystem.actorOf(props);
+
+            final List<EntityTaskScheduler.Task<Double>> oneTasks = new ArrayList<>();
+            oneTasks.add(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(1.1, 20, TimeUnit.MILLISECONDS)));
+            oneTasks.add(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(1.2, 0, TimeUnit.MILLISECONDS)));
+            oneTasks.add(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(1.3, 50, TimeUnit.MILLISECONDS)));
+            oneTasks.add(new EntityTaskScheduler.Task<>(THING_ID,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(1.4, 10, TimeUnit.MILLISECONDS)));
+
+            final List<EntityTaskScheduler.Task<Double>> twoTasks = new ArrayList<>();
+            twoTasks.add(new EntityTaskScheduler.Task<>(THING_ID_2,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(2.1, 0, TimeUnit.MILLISECONDS)));
+            twoTasks.add(new EntityTaskScheduler.Task<>(THING_ID_2,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(2.2, 0, TimeUnit.MILLISECONDS)));
+            twoTasks.add(new EntityTaskScheduler.Task<>(THING_ID_2,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(2.3, 0, TimeUnit.MILLISECONDS)));
+
+            final List<EntityTaskScheduler.Task<Double>> threeTasks = new ArrayList<>();
+            threeTasks.add(new EntityTaskScheduler.Task<>(THING_ID_3,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(3.1, 50, TimeUnit.MILLISECONDS)));
+            threeTasks.add(new EntityTaskScheduler.Task<>(THING_ID_3,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(3.2, 0, TimeUnit.MILLISECONDS)));
+            threeTasks.add(new EntityTaskScheduler.Task<>(THING_ID_3,
+                    () -> new CompletableFuture<Double>().completeOnTimeout(3.3, 20, TimeUnit.MILLISECONDS)));
+
+            final List<EntityTaskScheduler.Task<Double>> allTasks = new ArrayList<>();
+            allTasks.addAll(oneTasks);
+            allTasks.addAll(twoTasks);
+            allTasks.addAll(threeTasks);
+            allTasks.forEach(task -> underTest.tell(task, getRef()));
+
+            final List<Double> oneResults = new ArrayList<>();
+            final List<Double> twoResults = new ArrayList<>();
+            final List<Double> threeResults = new ArrayList<>();
+
+            allTasks.forEach(task -> {
+                    final EntityTaskScheduler.TaskResult<Double> taskResult =
+                            expectMsgClass(EntityTaskScheduler.TaskResult.class);
+                    final Double result = taskResult.result();
+                    assertThat(result).isNotNull();
+                    switch (result.intValue()) {
+                        case 1 -> oneResults.add(result);
+                        case 2 -> {
+                            twoResults.add(result);
+                            if (twoResults.size() == twoTasks.size()) {
+                                // twos are finished - ensure that they are first and the others still wait for results:
+                                assertThat(oneResults)
+                                        .hasSizeLessThan(oneTasks.size());
+                                assertThat(threeResults)
+                                        .hasSizeLessThan(threeTasks.size());
+                            }
+                        }
+                        case 3 -> threeResults.add(result);
+                        default -> throw new AssertionError("Not expected result");
+                    }
+            });
+
+            assertThat(oneResults).isSorted();
+            assertThat(twoResults).isSorted();
+            assertThat(threeResults).isSorted();
+        }};
+    }
+
+}

--- a/edge/service/src/test/resources/logback-test.xml
+++ b/edge/service/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] [%X{x-correlation-id}] %logger{15} - %msg%n%rEx</pattern>
+        </encoder>
+    </appender>
+
+
+    <logger name="org.eclipse.ditto" level="DEBUG"/>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+
+</configuration>

--- a/edge/service/src/test/resources/logback-test.xml
+++ b/edge/service/src/test/resources/logback-test.xml
@@ -1,4 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
+  ~
+  ~ See the NOTICE file(s) distributed with this work for additional
+  ~ information regarding copyright ownership.
+  ~
+  ~ This program and the accompanying materials are made available under the
+  ~ terms of the Eclipse Public License 2.0 which is available at
+  ~ http://www.eclipse.org/legal/epl-2.0
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
 <configuration>
 
     <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">

--- a/edge/service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/edge/service/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/edge/service/src/test/resources/test.conf
+++ b/edge/service/src/test/resources/test.conf
@@ -1,0 +1,19 @@
+akka {
+  loggers = ["akka.event.slf4j.Slf4jLogger"]
+  loglevel = "DEBUG"
+  logging-filter = "akka.event.DefaultLoggingFilter"
+  logger-startup-timeout = 60s
+
+  # for log messages during the actor system is starting up and shutting down:
+  stdout-loglevel = "INFO"
+}
+
+ditto.extensions {
+  edge-command-forwarder-extension = org.eclipse.ditto.edge.service.dispatching.NoOpEdgeCommandForwarderExtension
+  signal-transformers-provider {
+    extension-class = org.eclipse.ditto.base.service.signaltransformer.SignalTransformers
+    extension-config.signal-transformers = [
+      "org.eclipse.ditto.edge.service.dispatching.EdgeCommandForwarderActorTestSignalTransformer"
+    ]
+  }
+}


### PR DESCRIPTION
After #1416 we found a bug that the order of commands might be mixed up in `EdgeCommandForwarderActor` when applying the `SignalTransformer` in order to modify passed through signals.

As this is a regression (Ditto always ensures that for a single device/thing) all commands are processed in the same order they "arrive", this PR fixes the bug.