### PR TITLE
fixed that latest Ditto Docker images could not be started

### DIFF
--- a/.github/workflows/docker-nightly.yml
+++ b/.github/workflows/docker-nightly.yml
@@ -62,6 +62,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-policies-service
             SERVICE_VERSION=0-SNAPSHOT
+            MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
           tags: |
@@ -76,6 +77,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-things-service
             SERVICE_VERSION=0-SNAPSHOT
+            MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
           tags: |
@@ -90,6 +92,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-gateway-service
             SERVICE_VERSION=0-SNAPSHOT
+            MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
           tags: |
@@ -104,6 +107,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-thingsearch-service
             SERVICE_VERSION=0-SNAPSHOT
+            MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
           tags: |
@@ -118,6 +122,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-connectivity-service
             SERVICE_VERSION=0-SNAPSHOT
+            MAIN_CLASS=org.eclipse.ditto.connectivity.service.ConnectivityService
           pull: true
           push: true
           tags: |

--- a/.github/workflows/push-dockerhub.yml
+++ b/.github/workflows/push-dockerhub.yml
@@ -70,6 +70,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-policies-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
           tags: |
@@ -88,6 +89,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-things-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
           tags: |
@@ -106,6 +108,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-gateway-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
           tags: |
@@ -124,6 +127,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-thingsearch-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
           tags: |
@@ -142,6 +146,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-connectivity-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.connectivity.service.ConnectivityService
           pull: true
           push: true
           tags: |
@@ -172,6 +177,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-policies-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.policies.service.starter.PoliciesService
           pull: true
           push: true
           tags: |
@@ -187,6 +193,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-things-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.things.service.starter.ThingsService
           pull: true
           push: true
           tags: |
@@ -202,6 +209,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-gateway-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.gateway.service.starter.GatewayService
           pull: true
           push: true
           tags: |
@@ -217,6 +225,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-thingsearch-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.thingsearch.service.starter.SearchService
           pull: true
           push: true
           tags: |
@@ -232,6 +241,7 @@ jobs:
           build-args: |
             SERVICE_STARTER=ditto-connectivity-service
             SERVICE_VERSION=${{ env.IMAGE_TAG }}
+            MAIN_CLASS=org.eclipse.ditto.connectivity.service.ConnectivityService
           pull: true
           push: true
           tags: |

--- a/dockerfile-release
+++ b/dockerfile-release
@@ -21,7 +21,7 @@ ENV HTTP_PORT=8080 \
     HOSTING_ENVIRONMENT=Docker \
     DITTO_HOME=/opt/ditto \
     DITTO_LOGS=/var/log/ditto \
-    JVM_CMD_ARGS_ENV=${JVM_CMD_ARGS}\
+    JVM_CMD_ARGS_ENV=${JVM_CMD_ARGS} \
     MAIN_CLASS_ENV=${MAIN_CLASS} \
     CLASSPATH=/opt/ditto/*
 
@@ -33,10 +33,9 @@ RUN set -x \
     && apt-get install -y tini \
     && apt-get install -y wget \
     && mkdir -p $DITTO_HOME \
+    && mkdir -p $DITTO_LOGS \
     && groupadd --system --gid 1000 ditto \
     && useradd --no-log-init --system --home-dir $DITTO_HOME --shell /bin/sh --gid ditto --uid 1000 ditto \
-    && mkdir -p $DITTO_HOME \
-    && mkdir -p $DITTO_LOGS \
     && cd $DITTO_HOME \
     && wget -q --show-progress -O ${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar "${MAVEN_REPO}?r=ditto&g=org.eclipse.ditto&a=${SERVICE_STARTER}&v=${SERVICE_VERSION}&c=allinone" \
     && chown -R ditto:ditto $DITTO_HOME \
@@ -47,4 +46,4 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["sh", "-c", "java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]
+CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]

--- a/dockerfile-release
+++ b/dockerfile-release
@@ -46,4 +46,4 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]
+CMD ["sh", "-c", "exec java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]

--- a/dockerfile-snapshot
+++ b/dockerfile-snapshot
@@ -31,10 +31,10 @@ EXPOSE 8080
 RUN set -x \
     && apt-get update \
     && apt-get install -y tini \
-    && groupadd --system --gid 1000 ditto \
-    && useradd --no-log-init --system --home-dir $DITTO_HOME --shell /bin/sh --gid ditto --uid 1000 ditto \
     && mkdir -p $DITTO_HOME \
     && mkdir -p $DITTO_LOGS \
+    && groupadd --system --gid 1000 ditto \
+    && useradd --no-log-init --system --home-dir $DITTO_HOME --shell /bin/sh --gid ditto --uid 1000 ditto \
     && cd $DITTO_HOME \
     && chown -R ditto:ditto $DITTO_HOME \
     && cd $DITTO_LOGS \
@@ -43,6 +43,6 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["sh", "-c", "java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]
+CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]
 
 COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME

--- a/dockerfile-snapshot
+++ b/dockerfile-snapshot
@@ -43,6 +43,6 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]
+CMD ["sh", "-c", "exec java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]
 
 COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME

--- a/dockerfile-snapshot-arm64
+++ b/dockerfile-snapshot-arm64
@@ -21,7 +21,7 @@ ENV HTTP_PORT=8080 \
     HOSTING_ENVIRONMENT=Docker \
     DITTO_HOME=/opt/ditto \
     DITTO_LOGS=/var/log/ditto \
-    JVM_CMD_ARGS_ENV=${JVM_CMD_ARGS}\
+    JVM_CMD_ARGS_ENV=${JVM_CMD_ARGS} \
     MAIN_CLASS_ENV=${MAIN_CLASS} \
     CLASSPATH=/opt/ditto/*
 
@@ -31,10 +31,10 @@ EXPOSE 8080
 RUN set -x \
     && apt-get update \
     && apt-get install -y tini \
-    && groupadd --system --gid 1000 ditto \
-    && useradd --no-log-init --system --home-dir $DITTO_HOME --shell /bin/sh --gid ditto --uid 1000 ditto \
     && mkdir -p $DITTO_HOME \
     && mkdir -p $DITTO_LOGS \
+    && groupadd --system --gid 1000 ditto \
+    && useradd --no-log-init --system --home-dir $DITTO_HOME --shell /bin/sh --gid ditto --uid 1000 ditto \
     && cd $DITTO_HOME \
     && chown -R ditto:ditto $DITTO_HOME \
     && cd $DITTO_LOGS \
@@ -43,6 +43,6 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["sh", "-c", "java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]
+CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]
 
 COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME

--- a/dockerfile-snapshot-arm64
+++ b/dockerfile-snapshot-arm64
@@ -43,6 +43,6 @@ RUN set -x \
 USER ditto
 WORKDIR $DITTO_HOME
 ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["java", "${JVM_CMD_ARGS_ENV}", "${MAIN_CLASS_ENV}"]
+CMD ["sh", "-c", "exec java ${JVM_CMD_ARGS_ENV} ${MAIN_CLASS_ENV}"]
 
 COPY ${TARGET_DIR}/${SERVICE_STARTER}-${SERVICE_VERSION}-allinone.jar $DITTO_HOME


### PR DESCRIPTION
* added missing Main classname for starting Ditto services
* configured "tini" to not start "sh" but instead "java" in order to correctly forward signals to the java process (e.g. in order to gracefully shutdown)
