### PR TITLE
Apply WoT Ditto extension in skeleton and TD generation

### DIFF
--- a/deployment/docker/sandbox/html/index.html
+++ b/deployment/docker/sandbox/html/index.html
@@ -119,6 +119,11 @@
         <p>
             Choose "ditto_sandbox" from the environment drop-down at the top right in order to explore the things in the sandbox.
         </p>
+        <h2>Ditto WoT Extension Ontology</h2>
+        <p>
+            The Ditto WoT Extension Ontology can be found here:
+            <a href="https://ditto.eclipseprojects.io/wot/ditto-extension#">https://ditto.eclipseprojects.io/wot/ditto-extension#</a>
+        </p>
         <h2>Authentication</h2>
         <p>
             When using the <a href="/apidoc">HTTP API</a> you can authenticate with your Google account in order to use

--- a/internal/utils/config/src/main/resources/ditto-devops.conf
+++ b/internal/utils/config/src/main/resources/ditto-devops.conf
@@ -14,7 +14,7 @@ ditto.devops {
     merge-things-enabled = ${?DITTO_DEVOPS_FEATURE_MERGE_THINGS_ENABLED}
 
     // enables/disables the WoT (Web of Things) integration feature
-    wot-integration-enabled = false
+    wot-integration-enabled = true
     wot-integration-enabled = ${?DITTO_DEVOPS_FEATURE_WOT_INTEGRATION_ENABLED}
   }
 }

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -672,10 +672,8 @@ public final class MongoReadJournal {
         final RestartSettings restartSettings = RestartSettings.create(minBackOff,
                         MongoReadJournal.MAX_BACK_OFF_DURATION, randomFactor)
                 .withMaxRestarts(maxRestarts, minBackOff);
-        return RestartSource.onFailuresWithBackoff(restartSettings, () -> {
-                    LOGGER.warn("Ran into failure when listing latest journal entries with tag <{}>.", tag);
-                    return Source.fromPublisher(journal.aggregate(pipeline));
-                }
+        return RestartSource.onFailuresWithBackoff(restartSettings, () ->
+                Source.fromPublisher(journal.aggregate(pipeline))
         );
     }
 

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ImmutableFeatureDefinition.java
@@ -45,6 +45,18 @@ final class ImmutableFeatureDefinition implements FeatureDefinition {
     }
 
     /**
+     * Creates a new instance of {@code ImmutableFeatureDefinition} based on the passed {@code definitionIdentifiers}.
+     *
+     * @param definitionIdentifiers the Identifiers of the FeatureDefinition to be returned.
+     * @return the instance.
+     * @throws NullPointerException if {@code definitionIdentifiers} is {@code null}.
+     * @since 3.0.0
+     */
+    public static ImmutableFeatureDefinition of(final Collection<DefinitionIdentifier> definitionIdentifiers) {
+        return new ImmutableFeatureDefinition(checkNotNull(definitionIdentifiers, "definitionIdentifiers"));
+    }
+
+    /**
      * Parses the specified JsonArray and returns an instance of {@code ImmutableFeatureDefinition}.
      *
      * @param featureDefinitionEntriesAsJsonArray JSON array containing the Identifiers of the FeatureDefinition to

--- a/things/model/src/main/java/org/eclipse/ditto/things/model/ThingsModelFactory.java
+++ b/things/model/src/main/java/org/eclipse/ditto/things/model/ThingsModelFactory.java
@@ -172,6 +172,18 @@ public final class ThingsModelFactory {
     }
 
     /**
+     * Creates a new instance of {@code ImmutableFeatureDefinition} based on the passed {@code definitionIdentifiers}.
+     *
+     * @param definitionIdentifiers the Identifiers of the FeatureDefinition to be returned.
+     * @return the instance.
+     * @throws NullPointerException if {@code definitionIdentifiers} is {@code null}.
+     * @since 3.0.0
+     */
+    public static FeatureDefinition newFeatureDefinition(final Collection<DefinitionIdentifier> definitionIdentifiers) {
+        return ImmutableFeatureDefinition.of(definitionIdentifiers);
+    }
+
+    /**
      * Parses the specified JsonArray and returns an immutable instance of {@code FeatureDefinition} which is
      * initialised with the values of the given JSON array.
      *

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateThingStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/CreateThingStrategy.java
@@ -109,7 +109,8 @@ final class CreateThingStrategy extends AbstractThingCommandStrategy<CreateThing
         final Thing finalNewThing = newThing;
         newThing = wotThingDescriptionProvider.provideThingSkeletonForCreation(
                         command.getEntityId(),
-                        newThing.getDefinition().orElse(null), commandHeaders
+                        newThing.getDefinition().orElse(null),
+                        commandHeaders
                 )
                 .map(wotBasedThingSkeleton ->
                         JsonFactory.mergeJsonValues(finalNewThing.toJson(), wotBasedThingSkeleton.toJson())

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategy.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategy.java
@@ -12,27 +12,39 @@
  */
 package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.base.model.entity.metadata.Metadata;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.base.model.headers.WithDittoHeaders;
 import org.eclipse.ditto.base.model.headers.entitytag.EntityTag;
+import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
+import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
+import org.eclipse.ditto.json.JsonFactory;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.things.model.DefinitionIdentifier;
+import org.eclipse.ditto.things.model.FeatureDefinition;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.internal.utils.persistentactors.results.Result;
-import org.eclipse.ditto.internal.utils.persistentactors.results.ResultFactory;
+import org.eclipse.ditto.things.model.ThingsModelFactory;
 import org.eclipse.ditto.things.model.signals.commands.ThingCommandSizeValidator;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeatures;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeaturesResponse;
 import org.eclipse.ditto.things.model.signals.events.FeaturesCreated;
 import org.eclipse.ditto.things.model.signals.events.FeaturesModified;
 import org.eclipse.ditto.things.model.signals.events.ThingEvent;
+import org.eclipse.ditto.wot.integration.provider.WotThingDescriptionProvider;
+
+import akka.actor.ActorSystem;
 
 /**
  * This strategy handles the {@link org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeatures} command.
@@ -40,11 +52,16 @@ import org.eclipse.ditto.things.model.signals.events.ThingEvent;
 @Immutable
 final class ModifyFeaturesStrategy extends AbstractThingCommandStrategy<ModifyFeatures> {
 
+    private final WotThingDescriptionProvider wotThingDescriptionProvider;
+
     /**
      * Constructs a new {@code ModifyFeaturesStrategy} object.
+     *
+     * @param actorSystem the actor system to use for loading the WoT extension.
      */
-    ModifyFeaturesStrategy() {
+    ModifyFeaturesStrategy(final ActorSystem actorSystem) {
         super(ModifyFeatures.class);
+        wotThingDescriptionProvider = WotThingDescriptionProvider.get(actorSystem);
     }
 
     @Override
@@ -94,8 +111,47 @@ final class ModifyFeaturesStrategy extends AbstractThingCommandStrategy<ModifyFe
     private Result<ThingEvent<?>> getCreateResult(final Context<ThingId> context, final long nextRevision,
             final ModifyFeatures command, @Nullable final Thing thing, @Nullable final Metadata metadata) {
 
-        final Features features = command.getFeatures();
         final DittoHeaders dittoHeaders = command.getDittoHeaders();
+
+        final Features features = ThingsModelFactory.newFeatures(command.getFeatures()
+                .stream()
+                .map(feature -> wotThingDescriptionProvider.provideFeatureSkeletonForCreation(
+                                feature.getId(),
+                                feature.getDefinition().orElse(null),
+                                dittoHeaders
+                        )
+                        .map(wotBasedFeatureSkeleton -> {
+                                final Optional<FeatureDefinition> mergedDefinition =
+                                        wotBasedFeatureSkeleton.getDefinition()
+                                                .map(def -> {
+                                                    final Set<DefinitionIdentifier> identifiers = Stream.concat(
+                                                            wotBasedFeatureSkeleton.getDefinition()
+                                                                    .map(FeatureDefinition::stream)
+                                                                    .orElse(Stream.empty()),
+                                                            feature.getDefinition()
+                                                                    .map(FeatureDefinition::stream)
+                                                                    .orElse(Stream.empty())
+                                                    ).collect(Collectors.toCollection(LinkedHashSet::new));
+                                                    return ThingsModelFactory.newFeatureDefinition(identifiers);
+                                                })
+                                                .or(feature::getDefinition);
+
+                                return mergedDefinition.map(definitionIdentifiers -> JsonFactory.mergeJsonValues(
+                                        feature.setDefinition(definitionIdentifiers).toJson(),
+                                        wotBasedFeatureSkeleton.toJson()
+                                )).orElseGet(() -> JsonFactory.mergeJsonValues(feature.toJson(),
+                                        wotBasedFeatureSkeleton.toJson())
+                                );
+
+                        })
+                        .filter(JsonValue::isObject)
+                        .map(JsonValue::asObject)
+                        .map(ThingsModelFactory::newFeatureBuilder)
+                        .map(b -> b.useId(feature.getId()).build())
+                        .orElse(feature)
+                )
+                .toList()
+        );
 
         final ThingEvent<?> event =
                 FeaturesCreated.of(command.getEntityId(), features, nextRevision, getEventTimestamp(),

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingCommandStrategies.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ThingCommandStrategies.java
@@ -111,8 +111,8 @@ public final class ThingCommandStrategies
     }
 
     private void addFeaturesStrategies(final ActorSystem system) {
-        addStrategy(new ModifyFeaturesStrategy());
-        addStrategy(new ModifyFeatureStrategy());
+        addStrategy(new ModifyFeaturesStrategy(system));
+        addStrategy(new ModifyFeatureStrategy(system));
         addStrategy(new RetrieveFeaturesStrategy());
         addStrategy(new RetrieveFeatureStrategy(system));
         addStrategy(new DeleteFeaturesStrategy());

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -145,9 +145,9 @@ ditto {
         placeholders {
           # add arbitrary placeholders to be resolved, e.g.:
           # FOO = "bar"
-          # TM_REQUIRED = [
-          #  "#/properties/status",
-          #  "#/actions/toggle"
+          # TM_OPTIONAL = [
+          #  "/properties/status",
+          #  "/actions/toggle"
           # ]
         }
 

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeatureStrategyTest.java
@@ -13,22 +13,27 @@
 package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.TestConstants;
 import org.eclipse.ditto.things.model.ThingId;
-import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeature;
 import org.eclipse.ditto.things.model.signals.events.FeatureCreated;
 import org.eclipse.ditto.things.model.signals.events.FeatureModified;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
+import org.eclipse.ditto.wot.integration.provider.WotThingDescriptionProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorSystem;
 
 /**
  * Unit test for {@link ModifyFeatureStrategy}.
@@ -46,12 +51,14 @@ public final class ModifyFeatureStrategyTest extends AbstractCommandStrategyTest
 
     @Before
     public void setUp() {
-        underTest = new ModifyFeatureStrategy();
+        final ActorSystem system = ActorSystem.create("test", ConfigFactory.load("test"));
+        underTest = new ModifyFeatureStrategy(system);
     }
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(ModifyFeatureStrategy.class, areImmutable());
+        assertInstancesOf(ModifyFeatureStrategy.class, areImmutable(),
+                provided(WotThingDescriptionProvider.class).areAlsoImmutable());
     }
 
     @Test

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategyTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/strategies/commands/ModifyFeaturesStrategyTest.java
@@ -14,11 +14,13 @@ package org.eclipse.ditto.things.service.persistence.actors.strategies.commands;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.eclipse.ditto.things.model.TestConstants.Thing.THING_V2;
+import static org.mutabilitydetector.unittesting.AllowedReason.provided;
 import static org.mutabilitydetector.unittesting.MutabilityAssert.assertInstancesOf;
 import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable;
 
-import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
+import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.things.model.Feature;
 import org.eclipse.ditto.things.model.Features;
 import org.eclipse.ditto.things.model.TestConstants;
@@ -26,16 +28,19 @@ import org.eclipse.ditto.things.model.Thing;
 import org.eclipse.ditto.things.model.ThingId;
 import org.eclipse.ditto.things.model.ThingTooLargeException;
 import org.eclipse.ditto.things.model.ThingsModelFactory;
-import org.eclipse.ditto.internal.utils.persistentactors.commands.CommandStrategy;
 import org.eclipse.ditto.things.model.signals.commands.modify.CreateThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyFeatures;
 import org.eclipse.ditto.things.model.signals.events.FeaturesCreated;
 import org.eclipse.ditto.things.model.signals.events.FeaturesModified;
 import org.eclipse.ditto.things.service.persistence.actors.ETagTestUtils;
+import org.eclipse.ditto.wot.integration.provider.WotThingDescriptionProvider;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+import akka.actor.ActorSystem;
 
 /**
  * Unit test for {@link ModifyFeaturesStrategy}.
@@ -57,12 +62,14 @@ public final class ModifyFeaturesStrategyTest extends AbstractCommandStrategyTes
 
     @Before
     public void setUp() {
-        underTest = new ModifyFeaturesStrategy();
+        final ActorSystem system = ActorSystem.create("test", ConfigFactory.load("test"));
+        underTest = new ModifyFeaturesStrategy(system);
     }
 
     @Test
     public void assertImmutability() {
-        assertInstancesOf(ModifyFeaturesStrategy.class, areImmutable());
+        assertInstancesOf(ModifyFeaturesStrategy.class, areImmutable(),
+                provided(WotThingDescriptionProvider.class).areAlsoImmutable());
     }
 
     @Test

--- a/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/generator/DittoWotExtension.java
+++ b/wot/integration/src/main/java/org/eclipse/ditto/wot/integration/generator/DittoWotExtension.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.wot.integration.generator;
+
+import org.eclipse.ditto.wot.model.SingleUriAtContext;
+
+/**
+ * Contains the specifics of Ditto's WoT Extension Ontology.
+ *
+ * @see <a href="https://ditto.eclipseprojects.io/wot/ditto-extension#">Ditto - WoT Extension Ontology</a>
+ * @since 3.0.0
+ */
+final class DittoWotExtension {
+
+    /**
+     * The {@code SingleUriAtContext} (being an IRI) of the Ditto WoT Extension.
+     */
+    static final SingleUriAtContext DITTO_WOT_EXTENSION = SingleUriAtContext.DITTO_WOT_EXTENSION;
+
+    /**
+     * Contains a category with which WoT property affordances may optionally be categorized.
+     * This category will be used by Ditto in order to provide an additional "nesting level" for properties.
+     *
+     * @see <a href="https://ditto.eclipseprojects.io/wot/ditto-extension#category">Property category</a>
+     */
+    static final String DITTO_WOT_EXTENSION_CATEGORY = "category";
+
+
+    private DittoWotExtension() {
+        throw new AssertionError();
+    }
+}

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtContext.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.wot.model;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * AtContext represents the JSON-LD context which is included in the Json document as {@code "@context"}.
@@ -33,5 +34,23 @@ public interface AtContext {
 
     static MultipleAtContext newMultipleAtContext(final Collection<SingleAtContext> contexts) {
         return MultipleAtContext.of(contexts);
+    }
+
+    /**
+     * Determines the {@code @context} prefix of the passed IRI in {@code singleUriAtContext}.
+     * If this {@code AtContext} instance is of type {@code MultipleAtContext} AND contains such an IRI, the prefix
+     * for that context entry is returned.
+     *
+     * @param singleUriAtContext the IRI to determine the context prefix for.
+     * @return the determined context prefix if the IRI was part of this {@code AtContext} instance or an empty optional
+     * instead.
+     * @since 3.0.0
+     */
+    default Optional<String> determinePrefixFor(final SingleUriAtContext singleUriAtContext) {
+        if (this instanceof MultipleAtContext) {
+            return ((MultipleAtContext) this).determinePrefixForSingleUriAtContext(singleUriAtContext);
+        } else {
+            return Optional.empty();
+        }
     }
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtContext.java
@@ -14,6 +14,7 @@ package org.eclipse.ditto.wot.model;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -52,5 +53,24 @@ public interface MultipleAtContext extends AtContext, Iterable<SingleAtContext>,
 
     default Stream<SingleAtContext> stream() {
         return StreamSupport.stream(spliterator(), false);
+    }
+
+    /**
+     * Determines the {@code @context} prefix of the passed IRI in {@code singleUriAtContext}.
+     * If this {@code MultipleAtContext} contains such an IRI, the prefix for that context entry is returned.
+     *
+     * @param singleUriAtContext the IRI to determine the context prefix for.
+     * @return the determined context prefix if the IRI was part of this {@code MultipleAtContext} instance or an
+     * empty optional instead.
+     * @since 3.0.0
+     */
+    default Optional<String> determinePrefixForSingleUriAtContext(final SingleUriAtContext singleUriAtContext) {
+        return stream()
+                .filter(SinglePrefixedAtContext.class::isInstance)
+                .map(SinglePrefixedAtContext.class::cast)
+                .filter(singlePrefixedAtContext -> singlePrefixedAtContext
+                        .getDelegateContext().equals(singleUriAtContext))
+                .map(SinglePrefixedAtContext::getPrefix)
+                .findFirst();
     }
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleUriAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleUriAtContext.java
@@ -13,7 +13,7 @@
 package org.eclipse.ditto.wot.model;
 
 /**
- * A SingleAtContext is a single String {@link AtContext}.
+ * A SingleAtContext is a single IRI {@link AtContext}.
  *
  * @since 2.4.0
  */
@@ -24,6 +24,8 @@ public interface SingleUriAtContext extends SingleAtContext, IRI {
     SingleUriAtContext W3ORG_2022_WOT_TD_V11 = of("https://www.w3.org/2022/wot/td/v1.1");
 
     SingleUriAtContext W3ORG_NS_TD = of("http://www.w3.org/ns/td");
+
+    SingleUriAtContext DITTO_WOT_EXTENSION = of("https://ditto.eclipseprojects.io/wot/ditto-extension#");
 
     static SingleUriAtContext of(final CharSequence context) {
         if (context instanceof SingleUriAtContext) {


### PR DESCRIPTION
The Ditto WoT extension located at [https://ditto.eclipseprojects.io/wot/ditto-extension#](https://ditto.eclipseprojects.io/wot/ditto-extension#) can now be made use of in Ditto's WoT integration.

The "category" which can be used to categorise WoT properties is now used to provide an optional JSON object wrapper in the generated target JSON and also in generated TDs.

In addition to that, when creating new features now also a JSON skeletton is generated from the linked "definition"'s ThingModel.