### PR TITLE
Make it possible to provide multiple OIDC issuer urls for a single configured openid-connect "prefix"

### DIFF
--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -87,12 +87,17 @@ proxy_set_header              x-ditto-pre-authenticated "nginx:${remote_user}";
 
 ### OpenID Connect
 
-The authentication provider must be added to the ditto-gateway configuration.
-`auth-subjects`, an optional field, takes a list of placeholders that will be
-evaluated against incoming JWTs.
-For each entry in `auth-subjects` and authorization subject will be generated.
+The authentication provider must be added to the ditto-gateway configuration with unique configuration key 
+(e.g. `myprovier` in the example below).
+
+Either `issuer` as single supported JWT `"iss"` claim or `issuers` (as a list of supported JWT `"iss"` claims) has to be 
+configured. If `issuers` is configured, this list has priority and the value configured in `issuer` will be ignored.
+
+The configured `auth-subjects`, an optional field, takes a list of placeholders that will be
+evaluated against incoming JWTs.  
+For each entry in `auth-subjects` an authorization subject will be generated.
 If the entry contains unresolvable placeholders, it will be ignored in full.
-When `auth-subjects` is not provided, the “sub” claim (`{%raw%}{{ jwt:sub }}{%endraw%}`) is used by default.
+When `auth-subjects` is not provided, the `"sub"` claim (`{%raw%}{{ jwt:sub }}{%endraw%}`) is used by default.
 
 Please read [more details on the OpenId Connect configuration placeholder](basic-placeholders.html#scope-openid-connect-configuration)
 to find out what is possible when defining the `auth-subjects`.
@@ -104,6 +109,10 @@ ditto.gateway.authentication {
       openid-connect-issuers = {
         myprovider = {
           issuer = "localhost:9000"
+          #issuers = [
+          #  "localhost:9000/one"
+          #  "localhost:9000/two"
+          #]
           auth-subjects = [
             "{%raw%}{{ jwt:sub }}{%endraw%}",
             "{%raw%}{{ jwt:sub }}/{{ jwt:scp }}{%endraw%}",

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProvider.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProvider.java
@@ -174,20 +174,24 @@ public final class DittoPublicKeyProvider implements PublicKeyProvider {
         final String keyId = publicKeyIdWithIssuer.getKeyId();
         LOGGER.debug("Loading public key with id <{}> from issuer <{}>.", keyId, issuer);
 
-        final Optional<JwtSubjectIssuerConfig> subjectIssuerConfigOpt = jwtSubjectIssuersConfig.getConfigItem(issuer);
+        final Optional<JwtSubjectIssuerConfig> subjectIssuerConfigOpt = jwtSubjectIssuersConfig
+                .getConfigItem(issuer);
         if (subjectIssuerConfigOpt.isEmpty()) {
             LOGGER.info("The JWT issuer <{}> is not included in Ditto's gateway configuration at " +
                             "'ditto.gateway.authentication.oauth.openid-connect-issuers', supported are: <{}>",
                     issuer, jwtSubjectIssuersConfig);
 
-            return CompletableFuture.failedFuture(GatewayJwtIssuerNotSupportedException.newBuilder(issuer).build());
+            return CompletableFuture
+                    .failedFuture(GatewayJwtIssuerNotSupportedException.newBuilder(issuer).build());
         }
 
+        final String issuerWithoutProtocol = issuer.replaceFirst("http(s)?://", "");
         final String discoveryEndpoint = getDiscoveryEndpoint(subjectIssuerConfigOpt.get().getIssuers()
                 .stream()
-                .filter(configuredIssuer -> configuredIssuer.contains(issuer))
+                .filter(configuredIssuer -> configuredIssuer.equals(issuerWithoutProtocol))
                 .findAny()
-                .orElse(issuer));
+                .orElse(issuerWithoutProtocol)
+        );
         final CompletionStage<HttpResponse> responseFuture = getPublicKeysFromDiscoveryEndpoint(discoveryEndpoint);
         final CompletionStage<JsonArray> publicKeysFuture = responseFuture.thenCompose(this::mapResponseToJsonArray);
 
@@ -196,12 +200,12 @@ public final class DittoPublicKeyProvider implements PublicKeyProvider {
                 .toCompletableFuture();
     }
 
-    private String getDiscoveryEndpoint(final String issuer) {
+    private String getDiscoveryEndpoint(final String issuerWithoutProtocolPrefix) {
         final String iss;
-        if (issuer.endsWith("/")) {
-            iss = issuer.substring(0, issuer.length() - 1);
+        if (issuerWithoutProtocolPrefix.endsWith("/")) {
+            iss = issuerWithoutProtocolPrefix.substring(0, issuerWithoutProtocolPrefix.length() - 1);
         } else {
-            iss = issuer;
+            iss = issuerWithoutProtocolPrefix;
         }
 
         return jwtSubjectIssuersConfig.getProtocolPrefix() + iss + OPENID_CONNECT_DISCOVERY_PATH;

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProvider.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProvider.java
@@ -183,7 +183,11 @@ public final class DittoPublicKeyProvider implements PublicKeyProvider {
             return CompletableFuture.failedFuture(GatewayJwtIssuerNotSupportedException.newBuilder(issuer).build());
         }
 
-        final String discoveryEndpoint = getDiscoveryEndpoint(subjectIssuerConfigOpt.get().getIssuer());
+        final String discoveryEndpoint = getDiscoveryEndpoint(subjectIssuerConfigOpt.get().getIssuers()
+                .stream()
+                .filter(configuredIssuer -> configuredIssuer.contains(issuer))
+                .findAny()
+                .orElse(issuer));
         final CompletionStage<HttpResponse> responseFuture = getPublicKeysFromDiscoveryEndpoint(discoveryEndpoint);
         final CompletionStage<JsonArray> publicKeysFuture = responseFuture.thenCompose(this::mapResponseToJsonArray);
 

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuerConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuerConfig.java
@@ -15,6 +15,7 @@ package org.eclipse.ditto.gateway.service.security.authentication.jwt;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -31,7 +32,7 @@ import org.eclipse.ditto.policies.model.SubjectIssuer;
 public final class JwtSubjectIssuerConfig {
 
     private final SubjectIssuer subjectIssuer;
-    private final String issuer;
+    private final List<String> issuers;
     private final List<String> authSubjectTemplates;
 
     private static final List<String> DEFAULT_AUTH_SUBJECT = Collections.singletonList("{{jwt:sub}}");
@@ -40,34 +41,36 @@ public final class JwtSubjectIssuerConfig {
      * Constructs a new {@code JwtSubjectIssuerConfig}.
      *
      * @param subjectIssuer the subject issuer.
-     * @param issuer the issuer.
+     * @param issuers the issuer.
      *
      */
-    public JwtSubjectIssuerConfig(final SubjectIssuer subjectIssuer, final String issuer) {
-        this(subjectIssuer, issuer, DEFAULT_AUTH_SUBJECT);
+    public JwtSubjectIssuerConfig(final SubjectIssuer subjectIssuer, final Collection<String> issuers) {
+        this(subjectIssuer, issuers, DEFAULT_AUTH_SUBJECT);
     }
 
     /**
      * Constructs a new {@code JwtSubjectIssuerConfig}.
      *
      * @param subjectIssuer the subject issuer.
-     * @param issuer        the issuer.
+     * @param issuers        the list of issuers.
      * @param authSubjectTemplates  the authorization subject templates
      *
      */
-    public JwtSubjectIssuerConfig(final SubjectIssuer subjectIssuer, final String issuer, final List<String> authSubjectTemplates) {
+    public JwtSubjectIssuerConfig(final SubjectIssuer subjectIssuer,
+            final Collection<String> issuers,
+            final Collection<String> authSubjectTemplates) {
         this.subjectIssuer = requireNonNull(subjectIssuer);
-        this.issuer = requireNonNull(issuer);
+        this.issuers = Collections.unmodifiableList(new ArrayList<>(requireNonNull(issuers)));
         this.authSubjectTemplates = Collections.unmodifiableList(new ArrayList<>(requireNonNull(authSubjectTemplates)));
     }
 
     /**
-     * Returns the issuer.
+     * Returns the issuers.
      *
-     * @return the issuer.
+     * @return the issuers.
      */
-    public String getIssuer() {
-        return issuer;
+    public List<String> getIssuers() {
+        return issuers;
     }
 
     /**
@@ -93,21 +96,21 @@ public final class JwtSubjectIssuerConfig {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         final JwtSubjectIssuerConfig that = (JwtSubjectIssuerConfig) o;
-        return Objects.equals(issuer, that.issuer) &&
+        return Objects.equals(issuers, that.issuers) &&
                 Objects.equals(subjectIssuer, that.subjectIssuer) &&
                 Objects.equals(authSubjectTemplates, that.authSubjectTemplates);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(issuer, subjectIssuer, authSubjectTemplates);
+        return Objects.hash(issuers, subjectIssuer, authSubjectTemplates);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
                 "subjectIssuer=" + subjectIssuer +
-                ", issuer=" + issuer +
+                ", issuers=" + issuers +
                 ", authSubjectTemplates=" + authSubjectTemplates +
                 "]";
     }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfig.java
@@ -66,7 +66,7 @@ public final class JwtSubjectIssuersConfig {
                 // merge the default and extension config
                 Stream.concat(config.getOpenIdConnectIssuers().entrySet().stream(),
                         config.getOpenIdConnectIssuersExtension().entrySet().stream())
-                        .map(entry -> new JwtSubjectIssuerConfig(entry.getKey(), entry.getValue().getIssuer(),
+                        .map(entry -> new JwtSubjectIssuerConfig(entry.getKey(), entry.getValue().getIssuers(),
                                 entry.getValue().getAuthorizationSubjectTemplates()))
                         .collect(Collectors.toSet());
         return new JwtSubjectIssuersConfig(configItems, config.getProtocol());
@@ -75,8 +75,12 @@ public final class JwtSubjectIssuersConfig {
     private static void addConfigToMap(final JwtSubjectIssuerConfig config,
             final Map<String, JwtSubjectIssuerConfig> map,
             final String protocolPrefix) {
-        map.put(config.getIssuer(), config);
-        map.put(protocolPrefix + config.getIssuer(), config);
+
+        config.getIssuers()
+                .forEach(issuer -> {
+                    map.put(issuer, config);
+                    map.put(protocolPrefix + issuer, config);
+                });
     }
 
     public String getProtocolPrefix() {
@@ -97,7 +101,9 @@ public final class JwtSubjectIssuersConfig {
     private Optional<JwtSubjectIssuerConfig> getConfigItemByIssuer(final String issuer) {
         return subjectIssuerConfigMap.values()
                 .stream()
-                .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getIssuer().equals(issuer))
+                .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getIssuers().stream()
+                        .anyMatch(configuredIssuer -> configuredIssuer.equals(issuer))
+                )
                 .findFirst();
     }
 
@@ -122,7 +128,7 @@ public final class JwtSubjectIssuersConfig {
 
         return subjectIssuerConfigMap.values().stream()
                 .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getSubjectIssuer().equals(subjectIssuer))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     @Override

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfig.java
@@ -17,7 +17,7 @@ import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public final class JwtSubjectIssuersConfig {
     private JwtSubjectIssuersConfig(final Iterable<JwtSubjectIssuerConfig> configItems, final String protocol) {
         protocolPrefix = protocol + "://";
         requireNonNull(configItems);
-        final Map<String, JwtSubjectIssuerConfig> modifiableSubjectIssuerConfigMap = new HashMap<>();
+        final Map<String, JwtSubjectIssuerConfig> modifiableSubjectIssuerConfigMap = new LinkedHashMap<>();
 
         configItems.forEach(configItem ->
                 addConfigToMap(configItem, modifiableSubjectIssuerConfigMap, protocolPrefix));
@@ -95,14 +95,16 @@ public final class JwtSubjectIssuersConfig {
      * for this issuer
      */
     public Optional<JwtSubjectIssuerConfig> getConfigItem(final String issuer) {
-        return Optional.ofNullable(getConfigItemByIssuer(issuer).orElse(subjectIssuerConfigMap.get(issuer)));
+        return getConfigItemByIssuer(issuer)
+                .or(() -> Optional.ofNullable(subjectIssuerConfigMap.get(issuer)));
     }
 
     private Optional<JwtSubjectIssuerConfig> getConfigItemByIssuer(final String issuer) {
         return subjectIssuerConfigMap.values()
                 .stream()
                 .filter(jwtSubjectIssuerConfig -> jwtSubjectIssuerConfig.getIssuers().stream()
-                        .anyMatch(configuredIssuer -> configuredIssuer.equals(issuer))
+                        .anyMatch(configuredIssuer -> configuredIssuer.equals(issuer) ||
+                                protocolPrefix.concat(configuredIssuer).equals(issuer))
                 )
                 .findFirst();
     }

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfig.java
@@ -154,7 +154,7 @@ public final class DefaultOAuthConfig implements OAuthConfig {
         @Override
         public BiConsumer<Map<SubjectIssuer, SubjectIssuerConfig>, Map.Entry<String, ConfigValue>> accumulator() {
             return (map, entry) -> map.put(SubjectIssuer.newInstance(entry.getKey()),
-                    DefaultSubjectIssuerConfig.of(ConfigFactory.empty().withFallback(entry.getValue())));
+                    DefaultSubjectIssuerConfig.of(entry.getKey(), ConfigFactory.empty().withFallback(entry.getValue())));
         }
 
         @Override

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/SubjectIssuerConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/security/SubjectIssuerConfig.java
@@ -26,11 +26,11 @@ import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 public interface SubjectIssuerConfig {
 
     /**
-     * Returns the issuer endpoint.
+     * Returns the issuer endpoints.
      *
-     * @return the token issuer endpoint.
+     * @return the token issuer endpoints.
      */
-    String getIssuer();
+    List<String> getIssuers();
 
     /**
      * Returns the authorization subject templates.
@@ -42,6 +42,7 @@ public interface SubjectIssuerConfig {
 
     enum SubjectIssuerConfigValue implements KnownConfigValue {
         ISSUER("issuer", ""),
+        ISSUERS("issuers", List.of()),
         AUTH_SUBJECTS("auth-subjects", List.of("{{jwt:sub}}"));
 
         private final String path;

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -243,6 +243,10 @@ ditto {
         openid-connect-issuers = {
           # auth0 = {
           #   issuer = "<your-domain>.<region>.auth0.com/"
+          #   issuers = [
+          #     "<your-domain>.<region>.auth0.com/"
+          #     "<your-domain-2>.<region>.auth0.com/"
+          #   ]
           #}
           google = {
             issuer = "accounts.google.com"

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoJwtAuthorizationSubjectsProviderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoJwtAuthorizationSubjectsProviderTest.java
@@ -300,7 +300,7 @@ public final class DittoJwtAuthorizationSubjectsProviderTest {
             final List<String> subjectTemplates) {
         final JwtSubjectIssuerConfig subjectIssuerConfig = new JwtSubjectIssuerConfig(
                 SubjectIssuer.newInstance(subjectIssuer),
-                JwtTestConstants.ISSUER,
+                List.of(JwtTestConstants.ISSUER),
                 subjectTemplates);
         return JwtSubjectIssuersConfig.fromJwtSubjectIssuerConfigs(List.of(subjectIssuerConfig));
     }
@@ -308,7 +308,7 @@ public final class DittoJwtAuthorizationSubjectsProviderTest {
     private static JwtSubjectIssuersConfig createSubjectIssuersConfig(final String subjectIssuer) {
         final JwtSubjectIssuerConfig subjectIssuerConfig = new JwtSubjectIssuerConfig(
                 SubjectIssuer.newInstance(subjectIssuer),
-                JwtTestConstants.ISSUER);
+                List.of(JwtTestConstants.ISSUER));
         return JwtSubjectIssuersConfig.fromJwtSubjectIssuerConfigs(List.of(subjectIssuerConfig));
     }
 

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProviderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProviderTest.java
@@ -78,7 +78,7 @@ public final class DittoPublicKeyProviderTest {
         actorSystem = ActorSystem.create(getClass().getSimpleName());
         when(httpClientMock.getActorSystem()).thenReturn(actorSystem);
         final JwtSubjectIssuersConfig subjectIssuersConfig = JwtSubjectIssuersConfig.fromJwtSubjectIssuerConfigs(
-                Collections.singleton(new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, List.of("google.com"))));
+                Collections.singleton(new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, List.of("google.com", "http://google.com"))));
         when(oauthConfigMock.getAllowedClockSkew()).thenReturn(Duration.ofSeconds(1));
         underTest = new DittoPublicKeyProvider(subjectIssuersConfig, httpClientMock,
                 oauthConfigMock, DittoPublicKeyProviderTest::thisThreadCache);
@@ -120,7 +120,7 @@ public final class DittoPublicKeyProviderTest {
         mockECSuccessfulPublicKeysRequest();
 
         final Optional<PublicKeyWithParser> publicKeyFromEndpoint =
-                underTest.getPublicKeyWithParser("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+                underTest.getPublicKeyWithParser("http://google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
         assertThat(publicKeyFromEndpoint).isNotEmpty();
         verify(httpClientMock).createSingleHttpRequest(DISCOVERY_ENDPOINT_REQUEST);
         verify(httpClientMock).createSingleHttpRequest(PUBLIC_KEYS_REQUEST);
@@ -128,7 +128,7 @@ public final class DittoPublicKeyProviderTest {
         Mockito.clearInvocations(httpClientMock);
 
         final Optional<PublicKeyWithParser> publicKeyFromCache =
-                underTest.getPublicKeyWithParser("google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
+                underTest.getPublicKeyWithParser("http://google.com", KEY_ID).get(LATCH_TIMEOUT, TimeUnit.SECONDS);
         assertThat(publicKeyFromCache).contains(publicKeyFromEndpoint.get());
         assertThat(publicKeyFromCache).isNotEmpty();
         verifyNoMoreInteractions(httpClientMock);

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProviderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/DittoPublicKeyProviderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -77,7 +78,7 @@ public final class DittoPublicKeyProviderTest {
         actorSystem = ActorSystem.create(getClass().getSimpleName());
         when(httpClientMock.getActorSystem()).thenReturn(actorSystem);
         final JwtSubjectIssuersConfig subjectIssuersConfig = JwtSubjectIssuersConfig.fromJwtSubjectIssuerConfigs(
-                Collections.singleton(new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, "google.com")));
+                Collections.singleton(new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, List.of("google.com"))));
         when(oauthConfigMock.getAllowedClockSkew()).thenReturn(Duration.ofSeconds(1));
         underTest = new DittoPublicKeyProvider(subjectIssuersConfig, httpClientMock,
                 oauthConfigMock, DittoPublicKeyProviderTest::thisThreadCache);

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/security/authentication/jwt/JwtSubjectIssuersConfigTest.java
@@ -38,15 +38,19 @@ public final class JwtSubjectIssuersConfigTest {
 
     private static final JwtSubjectIssuerConfig JWT_SUBJECT_ISSUER_CONFIG_GOOGLE;
     private static final JwtSubjectIssuerConfig JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_DE;
+    private static final JwtSubjectIssuerConfig JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_COMBINED;
     private static final Set<JwtSubjectIssuerConfig> JWT_SUBJECT_ISSUER_CONFIGS;
     private static final JwtSubjectIssuersConfig JWT_SUBJECT_ISSUERS_CONFIG;
 
     static {
         JWT_SUBJECT_ISSUER_CONFIG_GOOGLE = new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, List.of("accounts.google.com"));
         JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_DE = new JwtSubjectIssuerConfig(SubjectIssuer.GOOGLE, List.of("accounts.google.de"));
+        JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_COMBINED = new JwtSubjectIssuerConfig(
+                SubjectIssuer.newInstance("google-foobar"), List.of("accounts.google.foo", "accounts.google.bar"));
         JWT_SUBJECT_ISSUER_CONFIGS = new HashSet<>();
         JWT_SUBJECT_ISSUER_CONFIGS.add(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE);
         JWT_SUBJECT_ISSUER_CONFIGS.add(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_DE);
+        JWT_SUBJECT_ISSUER_CONFIGS.add(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_COMBINED);
         JWT_SUBJECT_ISSUERS_CONFIG = JwtSubjectIssuersConfig.fromJwtSubjectIssuerConfigs(JWT_SUBJECT_ISSUER_CONFIGS);
     }
 
@@ -77,7 +81,7 @@ public final class JwtSubjectIssuersConfigTest {
     }
 
     @Test
-    public void issuerWithMultipleIssuerUrisWorks() {
+    public void multipleIssuerWithSingleIssuerUriWorks() {
         final Optional<JwtSubjectIssuerConfig> configItem =
                 JWT_SUBJECT_ISSUERS_CONFIG.getConfigItem("accounts.google.com");
         assertThat(configItem).hasValue(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE);
@@ -85,6 +89,17 @@ public final class JwtSubjectIssuersConfigTest {
         final Optional<JwtSubjectIssuerConfig> configItem2 =
                 JWT_SUBJECT_ISSUERS_CONFIG.getConfigItem("accounts.google.de");
         assertThat(configItem2).hasValue(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_DE);
+    }
+
+    @Test
+    public void singleIssuerWithMultipleIssuerUrisWorks() {
+        final Optional<JwtSubjectIssuerConfig> configItem =
+                JWT_SUBJECT_ISSUERS_CONFIG.getConfigItem("accounts.google.foo");
+        assertThat(configItem).hasValue(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_COMBINED);
+
+        final Optional<JwtSubjectIssuerConfig> configItem2 =
+                JWT_SUBJECT_ISSUERS_CONFIG.getConfigItem("https://accounts.google.bar");
+        assertThat(configItem2).hasValue(JWT_SUBJECT_ISSUER_CONFIG_GOOGLE_COMBINED);
     }
 
     @Test
@@ -117,7 +132,7 @@ public final class JwtSubjectIssuersConfigTest {
             SubjectIssuer.newInstance("some-other"),
             List.of(
                     "https://one.com",
-                    "https://two.com",
+                    "two.com",
                     "https://three.com"
             ),
             List.of(

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
@@ -20,11 +20,11 @@ import static org.mutabilitydetector.unittesting.MutabilityMatchers.areImmutable
 import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.eclipse.ditto.policies.model.SubjectIssuer;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -96,23 +96,40 @@ public final class DefaultOAuthConfigTest {
         softly.assertThat(underTest.getOpenIdConnectIssuers())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS.getConfigPath())
                 .isEqualTo(
-                        Collections.singletonMap(
+                        Map.of(
                                 SubjectIssuer.newInstance("google"),
                                 DefaultSubjectIssuerConfig.of(
-                                        "https://accounts.google.com",
+                                        List.of("https://accounts.google.com"),
                                         List.of(
                                                 "{{ jwt:sub }}",
                                                 "{{ jwt:sub }}/{{ jwt:scope }}",
                                                 "{{ jwt:sub }}/{{ jwt:scope }}@{{ jwt:client_id }}",
                                                 "{{ jwt:sub }}/{{ jwt:scope }}@{{ jwt:non_existing }}",
                                                 "{{ jwt:roles/support }}"
-                                        ))));
+                                        )
+                                ),
+                                SubjectIssuer.newInstance("some-other"),
+                                DefaultSubjectIssuerConfig.of(
+                                        List.of(
+                                                "https://one.com",
+                                                "https://two.com",
+                                                "https://three.com"
+                                        ),
+                                        List.of(
+                                                "{{ jwt:sub }}"
+                                        )
+                                )
+                        ));
 
         softly.assertThat(underTest.getOpenIdConnectIssuersExtension())
                 .as(OAuthConfig.OAuthConfigValue.OPENID_CONNECT_ISSUERS_EXTENSION.getConfigPath())
                 .isEqualTo(Collections.singletonMap(
                         SubjectIssuer.newInstance("additional"),
-                        DefaultSubjectIssuerConfig.of("https://additional.google.com", List.of("{{ jwt:sub }}"))));
+                        DefaultSubjectIssuerConfig.of(
+                                List.of("https://additional.google.com"),
+                                List.of("{{ jwt:sub }}")
+                        )
+                ));
 
         softly.assertThat(underTest.getTokenIntegrationSubject()).isEqualTo("ditto:ditto");
     }

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
@@ -112,7 +112,7 @@ public final class DefaultOAuthConfigTest {
                                 DefaultSubjectIssuerConfig.of(
                                         List.of(
                                                 "https://one.com",
-                                                "https://two.com",
+                                                "two.com",
                                                 "https://three.com"
                                         ),
                                         List.of(

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/util/config/security/DefaultOAuthConfigTest.java
@@ -89,7 +89,7 @@ public final class DefaultOAuthConfigTest {
     public void underTestReturnsValuesOfConfigFile() {
         final DefaultOAuthConfig underTest = DefaultOAuthConfig.of(oauthConfig);
 
-        softly.assertThat(underTest.getProtocol()).isEqualTo("http");
+        softly.assertThat(underTest.getProtocol()).isEqualTo("https");
 
         softly.assertThat(underTest.getAllowedClockSkew()).isEqualTo(Duration.ofSeconds(20));
 

--- a/gateway/service/src/test/resources/oauth-test.conf
+++ b/gateway/service/src/test/resources/oauth-test.conf
@@ -13,6 +13,18 @@ oauth {
         "{{ jwt:roles/support }}"
       ]
     }
+
+    some-other {
+      issuer = "https://zero.com"
+      issuers = [
+        "https://one.com"
+        "https://two.com"
+        "https://three.com"
+      ]
+      auth-subjects = [
+        "{{ jwt:sub }}"
+      ]
+    }
   }
   openid-connect-issuers-extension = {
     additional = {

--- a/gateway/service/src/test/resources/oauth-test.conf
+++ b/gateway/service/src/test/resources/oauth-test.conf
@@ -1,5 +1,5 @@
 oauth {
-  protocol = http
+  protocol = https
   allowed-clock-skew = 20s
   token-integration-subject = "ditto:ditto"
   openid-connect-issuers = {
@@ -18,7 +18,7 @@ oauth {
       issuer = "https://zero.com"
       issuers = [
         "https://one.com"
-        "https://two.com"
+        "two.com"
         "https://three.com"
       ]
       auth-subjects = [


### PR DESCRIPTION
Up to now exactly one "issuer" URL could be configured.
Now, while maintaining backwards compatibility, also a list of "issuers" may be configured. If the list of "issuers" is configured, it takes priority over a configured single "issuer" URL.