### PR TITLE
skip hostname verfication check with self signed in kafka

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/PropertiesFactory.java
@@ -132,7 +132,8 @@ final class PropertiesFactory {
     private Map<String, String> getTrustedSelfSignedCertificates() {
         if (connection.isValidateCertificates() && connection.getTrustedCertificates().isPresent()) {
             return Map.of(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, "PEM",
-                    SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, connection.getTrustedCertificates().orElse(""));
+                    SslConfigs.SSL_TRUSTSTORE_CERTIFICATES_CONFIG, connection.getTrustedCertificates().orElse(""),
+                    SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG, "");
         }
         return Map.of();
     }


### PR DESCRIPTION
Added the SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG in order to skip hostname verification checks as in general we don't expect self signed certs to necessarily match the container host name.

Signed-off-by: Kalin Kostashki <kalin.kostashki@bosch.io>