### PR TITLE
adjust log levels of BaseClientActor and AmqpConsumerActor

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -815,7 +815,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         }
 
         if (message instanceof Throwable throwable) {
-            logger.error(throwable, "received Exception {} in state {} - status: {} - sender: {}",
+            logger.warning(throwable, "received Exception {} in state {} - status: {} - sender: {}",
                     message,
                     stateName(),
                     state.getConnectionStatus() + ": " + state.getConnectionStatusDetails().orElse(""),

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
@@ -449,6 +449,9 @@ final class AmqpConsumerActor extends LegacyBaseConsumerActor
                 inboundAcknowledgedMonitor.exception(externalMessageHeaders,
                         "Sending negative acknowledgement: <{0}>", ackTypeName);
             }
+        } catch (final IllegalStateException e) {
+            logger.withCorrelationId(correlationId.orElse(null))
+                    .warning(e, "Failed to ack an AMQP message because of server side issues");
         } catch (final Exception e) {
             logger.withCorrelationId(correlationId.orElse(null)).error(e, "Failed to ack an AMQP message");
         }


### PR DESCRIPTION
changed loggers to WARN where appropriate to avoid logging errors for problems on client side backends

Signed-off-by: Kalin Kostashki <kalin.kostashki@bosch.io>