### PR TITLE
Make it possible to retrieve disabled loggers via devops API

### DIFF
--- a/base/api/src/main/java/org/eclipse/ditto/base/api/devops/LoggingFacade.java
+++ b/base/api/src/main/java/org/eclipse/ditto/base/api/devops/LoggingFacade.java
@@ -32,7 +32,7 @@ public interface LoggingFacade {
      *
      * @return the LoggerConfig for all known loggers.
      */
-    List<LoggerConfig> getLoggerConfig();
+    List<LoggerConfig> getLoggerConfig(boolean includeDisabledLoggers);
 
     /**
      * Returns the {@code LoggerConfig}s for the specified {@code loggerNames}.

--- a/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/RetrieveLoggerConfig.java
+++ b/base/api/src/main/java/org/eclipse/ditto/base/api/devops/signals/commands/RetrieveLoggerConfig.java
@@ -53,6 +53,10 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      */
     public static final String TYPE = TYPE_PREFIX + NAME;
 
+    static final JsonFieldDefinition<Boolean> JSON_INCLUDE_DISABLED_LOGGERS =
+            JsonFactory.newBooleanFieldDefinition("includeDisabledLoggers", FieldType.REGULAR,
+                    JsonSchemaVersion.V_2);
+
     static final JsonFieldDefinition<Boolean> JSON_ALL_KNOWN_LOGGERS =
             JsonFactory.newBooleanFieldDefinition("allKnownLoggers", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
@@ -61,12 +65,15 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
             JsonFactory.newJsonArrayFieldDefinition("specificLoggers", FieldType.REGULAR,
                     JsonSchemaVersion.V_2);
 
+    private final boolean includeDisabledLoggers;
     private final boolean allKnownLoggers;
     private final List<String> specificLoggers;
 
     private RetrieveLoggerConfig(@Nullable final String serviceName, @Nullable final String instance,
-            final boolean allKnownLoggers, final List<String> specificLoggers, final DittoHeaders dittoHeaders) {
+            final boolean includeDisabledLoggers, final boolean allKnownLoggers, final List<String> specificLoggers,
+            final DittoHeaders dittoHeaders) {
         super(TYPE, serviceName, instance, dittoHeaders);
+        this.includeDisabledLoggers = includeDisabledLoggers;
         this.allKnownLoggers = allKnownLoggers;
         this.specificLoggers = Collections.unmodifiableList(new ArrayList<>(specificLoggers));
     }
@@ -74,11 +81,12 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
     /**
      * Returns a new instance of {@code RetrieveLoggerConfig}.
      *
+     * @param includeDisabledLoggers whether to include disabled loggers or not.
      * @param dittoHeaders the headers of the request.
      * @return a new RetrieveLoggerConfig command.
      */
-    public static RetrieveLoggerConfig ofAllKnownLoggers(final DittoHeaders dittoHeaders) {
-        return new RetrieveLoggerConfig(null, null, true, Collections.emptyList(), dittoHeaders);
+    public static RetrieveLoggerConfig ofAllKnownLoggers(final boolean includeDisabledLoggers, final DittoHeaders dittoHeaders) {
+        return new RetrieveLoggerConfig(null, null, includeDisabledLoggers, true, Collections.emptyList(), dittoHeaders);
     }
 
     /**
@@ -90,7 +98,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      */
     public static RetrieveLoggerConfig ofAllKnownLoggers(@Nullable final String serviceName,
             final DittoHeaders dittoHeaders) {
-        return new RetrieveLoggerConfig(serviceName, null, true, Collections.emptyList(), dittoHeaders);
+        return new RetrieveLoggerConfig(serviceName, null, false, true, Collections.emptyList(), dittoHeaders);
     }
 
     /**
@@ -98,13 +106,15 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      *
      * @param serviceName the service name to which to send the DevOpsCommand.
      * @param instance the instance index of the serviceName to which to send the DevOpsCommand.
+     * @param includeDisabledLoggers whether to include disabled loggers in the response or not.
      * @param dittoHeaders the headers of the request.
      * @return a new RetrieveLoggerConfig command.
      */
     public static RetrieveLoggerConfig ofAllKnownLoggers(@Nullable final String serviceName,
             @Nullable final String instance,
+            final boolean includeDisabledLoggers,
             final DittoHeaders dittoHeaders) {
-        return new RetrieveLoggerConfig(serviceName, instance, true, Collections.emptyList(), dittoHeaders);
+        return new RetrieveLoggerConfig(serviceName, instance, includeDisabledLoggers, true, Collections.emptyList(), dittoHeaders);
     }
 
     /**
@@ -115,7 +125,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      * @return a new RetrieveLoggerConfig command.
      */
     public static RetrieveLoggerConfig of(final DittoHeaders dittoHeaders, final String... specificLoggers) {
-        return new RetrieveLoggerConfig(null, null, false,
+        return new RetrieveLoggerConfig(null, null, false, false,
                 specificLoggers == null ? Collections.emptyList() : Arrays.asList(specificLoggers), dittoHeaders);
     }
 
@@ -127,7 +137,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      * @return a new RetrieveLoggerConfig command.
      */
     public static RetrieveLoggerConfig of(final DittoHeaders dittoHeaders, final List<String> specificLoggers) {
-        return new RetrieveLoggerConfig(null, null, false, specificLoggers, dittoHeaders);
+        return new RetrieveLoggerConfig(null, null, false, false, specificLoggers, dittoHeaders);
     }
 
     /**
@@ -140,7 +150,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      */
     public static RetrieveLoggerConfig of(@Nullable final String serviceName, final DittoHeaders dittoHeaders,
             final String... specificLoggers) {
-        return new RetrieveLoggerConfig(serviceName, null, false,
+        return new RetrieveLoggerConfig(serviceName, null, false, false,
                 specificLoggers == null ? Collections.emptyList() : Arrays.asList(specificLoggers), dittoHeaders);
     }
 
@@ -155,7 +165,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      */
     public static RetrieveLoggerConfig of(@Nullable final String serviceName, @Nullable final String instance,
             final DittoHeaders dittoHeaders, final String... specificLoggers) {
-        return new RetrieveLoggerConfig(serviceName, instance, false,
+        return new RetrieveLoggerConfig(serviceName, instance, false, false,
                 specificLoggers == null ? Collections.emptyList() : Arrays.asList(specificLoggers), dittoHeaders);
     }
 
@@ -169,7 +179,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      */
     public static RetrieveLoggerConfig of(@Nullable final String serviceName, final DittoHeaders dittoHeaders,
             final List<String> specificLoggers) {
-        return new RetrieveLoggerConfig(serviceName, null, false, specificLoggers, dittoHeaders);
+        return new RetrieveLoggerConfig(serviceName, null, false, false, specificLoggers, dittoHeaders);
     }
 
     /**
@@ -177,14 +187,16 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
      *
      * @param serviceName the service name to which to send the DevOpsCommand.
      * @param instance the instance index of the serviceName to which to send the DevOpsCommand.
+     * @param includeDisabledLoggers whether to include disabled loggers or not.
      * @param dittoHeaders the headers of the request.
      * @param specificLoggers one or more loggers to be retrieved.
      * @return a new RetrieveLoggerConfig command.
      */
     public static RetrieveLoggerConfig of(@Nullable final String serviceName, @Nullable final String instance,
+            final boolean includeDisabledLoggers,
             final DittoHeaders dittoHeaders,
             final List<String> specificLoggers) {
-        return new RetrieveLoggerConfig(serviceName, instance, false, specificLoggers, dittoHeaders);
+        return new RetrieveLoggerConfig(serviceName, instance, includeDisabledLoggers, false, specificLoggers, dittoHeaders);
     }
 
     /**
@@ -216,9 +228,10 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
             final String serviceName = jsonObject.getValue(DevOpsCommand.JsonFields.JSON_SERVICE_NAME).orElse(null);
             final String instance = jsonObject.getValue(DevOpsCommand.JsonFields.JSON_INSTANCE).orElse(null);
             final boolean isAllKnownLoggers = jsonObject.getValueOrThrow(JSON_ALL_KNOWN_LOGGERS);
+            final boolean includeDisabledLoggers = jsonObject.getValueOrThrow(JSON_INCLUDE_DISABLED_LOGGERS);
 
             if (isAllKnownLoggers) {
-                return ofAllKnownLoggers(dittoHeaders);
+                return ofAllKnownLoggers(includeDisabledLoggers, dittoHeaders);
             } else {
                 final JsonArray loggersJsonArray = jsonObject.getValueOrThrow(JSON_SPECIFIC_LOGGERS);
                 final List<String> extractedSpecificLoggers = loggersJsonArray.stream()
@@ -226,7 +239,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
                         .map(JsonValue::asString)
                         .toList();
 
-                return of(serviceName, instance, dittoHeaders, extractedSpecificLoggers);
+                return of(serviceName, instance, includeDisabledLoggers, dittoHeaders, extractedSpecificLoggers);
             }
         });
     }
@@ -238,7 +251,16 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
 
     @Override
     public RetrieveLoggerConfig setDittoHeaders(final DittoHeaders dittoHeaders) {
-        return of(getServiceName().orElse(null), getInstance().orElse(null), dittoHeaders, specificLoggers);
+        return of(getServiceName().orElse(null), getInstance().orElse(null), includeDisabledLoggers, dittoHeaders, specificLoggers);
+    }
+
+    /**
+     * Returns whether all disabled loggers to include or not.
+     *
+     * @return whether all disabled loggers to include or not.
+     */
+    public boolean includeDisabledLoggers() {
+        return includeDisabledLoggers;
     }
 
     /**
@@ -267,6 +289,7 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
 
         final Predicate<JsonField> predicate = schemaVersion.and(thePredicate);
         jsonObjectBuilder.set(JSON_ALL_KNOWN_LOGGERS, allKnownLoggers, predicate);
+        jsonObjectBuilder.set(JSON_INCLUDE_DISABLED_LOGGERS, includeDisabledLoggers, predicate);
 
         if (specificLoggers.size() > 0) {
             jsonObjectBuilder.set(JSON_SPECIFIC_LOGGERS, specificLoggers.stream()
@@ -285,8 +308,9 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
             return false;
         }
         final RetrieveLoggerConfig that = (RetrieveLoggerConfig) o;
-        return that.canEqual(this) && Objects.equals(allKnownLoggers, that.allKnownLoggers) && Objects
-                .equals(specificLoggers, that.specificLoggers) && super.equals(that);
+        return that.canEqual(this) && Objects.equals(includeDisabledLoggers, that.includeDisabledLoggers)
+                && Objects.equals(allKnownLoggers, that.allKnownLoggers)
+                && Objects.equals(specificLoggers, that.specificLoggers) && super.equals(that);
     }
 
     @Override
@@ -296,13 +320,13 @@ public final class RetrieveLoggerConfig extends AbstractDevOpsCommand<RetrieveLo
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), allKnownLoggers, specificLoggers);
+        return Objects.hash(super.hashCode(), includeDisabledLoggers, allKnownLoggers, specificLoggers);
     }
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + " [" + super.toString() + "allKnownLoggers=" + allKnownLoggers
-                + ", specificLoggers=" + specificLoggers + "]";
+        return getClass().getSimpleName() + " [" + super.toString() + "includeDisabledLoggers=" + includeDisabledLoggers
+                + "allKnownLoggers=" + allKnownLoggers + ", specificLoggers=" + specificLoggers + "]";
     }
 
 }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/devops/DevOpsCommandsActor.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/devops/DevOpsCommandsActor.java
@@ -326,7 +326,7 @@ public final class DevOpsCommandsActor extends AbstractActor implements Retrieve
         final List<LoggerConfig> loggerConfigs;
 
         if (command.isAllKnownLoggers()) {
-            loggerConfigs = loggingFacade.getLoggerConfig();
+            loggerConfigs = loggingFacade.getLoggerConfig(command.includeDisabledLoggers());
         } else {
             loggerConfigs = loggingFacade.getLoggerConfig(command.getSpecificLoggers());
         }

--- a/base/service/src/main/java/org/eclipse/ditto/base/service/devops/LogbackLoggingFacade.java
+++ b/base/service/src/main/java/org/eclipse/ditto/base/service/devops/LogbackLoggingFacade.java
@@ -73,7 +73,7 @@ public final class LogbackLoggingFacade implements LoggingFacade {
                 .map(logger -> (Logger) LoggerFactory.getLogger(logger))
                 .toList();
 
-        return loggerConfigsFor(loggerList, true);
+        return loggerConfigsFor(loggerList, false);
     }
 
     private List<LoggerConfig> loggerConfigsFor(final Iterable<Logger> loggers, final boolean includeDisabledLoggers) {

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/routes/devops/DevOpsRoute.java
@@ -72,6 +72,11 @@ public final class DevOpsRoute extends AbstractRoute {
      */
     private static final String PATH_PARAMETER = "path";
 
+    /**
+     * Path parameter for retrieving disabled loggers.
+     */
+    private static final String INCLUDE_DISABLED_LOGGERS_PARAMETER = "includeDisabledLoggers";
+
     private final HttpConfig httpConfig;
     private final DevopsAuthenticationDirective devOpsAuthenticationDirective;
 
@@ -189,12 +194,12 @@ public final class DevOpsRoute extends AbstractRoute {
             final DittoHeaders dittoHeaders) {
 
         return concat(
-                get(() ->
+                get(() -> parameterOptional(INCLUDE_DISABLED_LOGGERS_PARAMETER, idl ->
                         handlePerRequest(ctx,
-                                RetrieveLoggerConfig.ofAllKnownLoggers(serviceName, instance, dittoHeaders),
+                                RetrieveLoggerConfig.ofAllKnownLoggers(serviceName, instance, idl.map(Boolean::valueOf).orElse(false), dittoHeaders),
                                 transformResponse(serviceName, instance)
                         )
-                ),
+                )),
                 put(() ->
                         extractDataBytes(payloadSource ->
                                 handlePerRequest(ctx, dittoHeaders, payloadSource,


### PR DESCRIPTION
The current implementation filters all loggers set to "off". Add query parameter to control that behaviour.