### PR TITLE
Explorer UI: URL parameters for environments

### DIFF
--- a/ui/index.css
+++ b/ui/index.css
@@ -24,6 +24,13 @@
     --bs-table-hover-color: white;
 }
 
+td {
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+    max-width: 300px;
+}
+
 thead {
     position: sticky;
     top: 0;

--- a/ui/index.css
+++ b/ui/index.css
@@ -28,7 +28,7 @@ td {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
-    max-width: 300px;
+    max-width: 15em;
 }
 
 thead {

--- a/ui/index.html
+++ b/ui/index.html
@@ -101,16 +101,7 @@
         </div>
     </div>
     <!-- Notifications to user ----------------------------------------------------------------->
-    <div class="position-fixed bottom-0 end-0 p-3" style="z-index: 5; right: 0; bottom: 0">
-        <div class="toast hide" data-bs-delay="5000" id="errorToast">
-            <div class="toast-header alert-danger">
-                <i class="bi me-2 bi-exclamation-triangle-fill"></i>
-                <strong class="me-auto" id="errorHeader"></strong>
-                <small id="errorStatus"></small>
-                <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
-            </div>
-            <div class="toast-body" id="errorBody"></div>
-        </div>
+    <div class="toast-container position-fixed bottom-0 end-0 p-3" style="z-index: 5; right: 0; bottom: 0" id="toastContainer">      
         <div class="toast hide bg-success" data-bs-delay="2000" id="successToast">
             <div class="toast-header" id="successHeader">
             </div>

--- a/ui/main.js
+++ b/ui/main.js
@@ -52,7 +52,7 @@ document.addEventListener('DOMContentLoaded', async function() {
   Policies.ready();
   Connections.ready();
   Authorization.ready();
-  Environments.ready();
+  await Environments.ready();
 
   const thingDescription = WoTDescription({
     itemsId: 'tabItemsThing',

--- a/ui/modules/api.js
+++ b/ui/modules/api.js
@@ -301,8 +301,9 @@ export function setAuthHeader(forDevOps) {
  * @return {Object} result as json object
  */
 export async function callDittoREST(method, path, body, additionalHeaders) {
+  let response;
   try {
-    const response = await fetch(Environments.current().api_uri + '/api/2' + path, {
+    response = await fetch(Environments.current().api_uri + '/api/2' + path, {
       method: method,
       headers: {
         'Content-Type': 'application/json',
@@ -311,24 +312,24 @@ export async function callDittoREST(method, path, body, additionalHeaders) {
       },
       ...(body) && {body: JSON.stringify(body)},
     });
-    if (!response.ok) {
-      response.json()
-          .then((dittoErr) => {
-            Utils.showError(dittoErr.message, dittoErr.error, dittoErr.status);
-          })
-          .catch((err) => {
-            Utils.showError('No error details from Ditto', response.statusText, response.status);
-          });
-      throw new Error('An error occurred: ' + response.status);
-    }
-    if (response.status !== 204) {
-      return response.json();
-    } else {
-      return null;
-    }
   } catch (err) {
     Utils.showError(err);
     throw err;
+  }
+  if (!response.ok) {
+    response.json()
+        .then((dittoErr) => {
+          Utils.showError(dittoErr.message, dittoErr.error, dittoErr.status);
+        })
+        .catch((err) => {
+          Utils.showError('No error details from Ditto', response.statusText, response.status);
+        });
+    throw new Error('An error occurred: ' + response.status);
+  }
+  if (response.status !== 204) {
+    return response.json();
+  } else {
+    return null;
   }
 }
 

--- a/ui/modules/connections/connections.html
+++ b/ui/modules/connections/connections.html
@@ -15,7 +15,7 @@
 </h5>
 <hr />
 <div class="collapse show" id="connectionsEdit">
-    <div class="row resizable_pane" style="height: 600px;">
+    <div class="row resizable_pane" style="height: 80vh;">
         <div class="col-md-4 resizable_flex_column">
             <div class="input-group input-group-sm mt-1 mb-1" role="group">
                 <div style="flex-grow: 1;"></div>
@@ -92,7 +92,7 @@
 </h5>
 <hr />
 <div class="collapse show" id="tabConnectionHelper">
-    <div class="row resizable_pane" style="height: 600px;">
+    <div class="row resizable_pane" style="height: 80vh;">
         <div class="col-md-4 resizable_flex_column">
             <ul class="nav nav-tabs">
                 <li class="nav-item">

--- a/ui/modules/environments/environments.html
+++ b/ui/modules/environments/environments.html
@@ -53,7 +53,10 @@
                 </div>
                 <div class="input-group input-group-sm mt-1">
                     <label class="input-group-text">Ditto Version</label>
-                    <input type="number" class="form-control form-control-sm" id="inputDittoVersion"></input>
+                    <select class="form-select form-select-sm" id="selectDittoVersion">
+                        <option selecte value="3">3</option>
+                        <option value="2">2</option>
+                    </select>
                 </div>
             </div>
             <div class="tab-pane container no-margin" id="tabEnvJson">

--- a/ui/modules/environments/environments.html
+++ b/ui/modules/environments/environments.html
@@ -12,7 +12,7 @@
   -->
 <h5>Environments</h5>
 <hr />
-<div class="row resizable_pane" style="height:600px">
+<div class="row resizable_pane" style="height: 80vh">
     <div class="col-md-4 resizable_flex_column">
         <div class="table-wrap">
             <table class="table table-striped table-hover table-sm">

--- a/ui/modules/environments/environments.js
+++ b/ui/modules/environments/environments.js
@@ -34,7 +34,7 @@ let dom = {
   buttonUpdateJson: null,
   inputEnvironmentName: null,
   inputApiUri: null,
-  inputDittoVersion: null,
+  selectDittoVersion: null,
   tbodyEnvironments: null,
 };
 
@@ -96,7 +96,7 @@ export async function ready() {
 
   dom.buttonUpdateFields.onclick = () => {
     environments[dom.inputEnvironmentName.value].api_uri = dom.inputApiUri.value;
-    environments[dom.inputEnvironmentName.value].ditto_version = dom.inputDittoVersion.value;
+    environments[dom.inputEnvironmentName.value].ditto_version = dom.selectDittoVersion.value;
     environmentsJsonChanged();
   };
 
@@ -112,7 +112,7 @@ export async function ready() {
     Utils.assert(!environments[dom.inputEnvironmentName.value], 'Name already used', dom.inputEnvironmentName);
     environments[dom.inputEnvironmentName.value] = new Environment({
       api_uri: dom.inputApiUri.value ? dom.inputApiUri.value : '',
-      ditto_version: dom.inputDittoVersion.value ? dom.inputDittoVersion.value : '3',
+      ditto_version: dom.selectDittoVersion.value ? dom.selectDittoVersion.value : '3',
     });
     environmentsJsonChanged();
   };
@@ -175,12 +175,12 @@ function updateEnvEditors() {
   if (selectedEnvironment) {
     settingsEditor.setValue(JSON.stringify(selectedEnvironment, null, 2), -1);
     dom.inputApiUri.value = selectedEnvironment.api_uri;
-    dom.inputDittoVersion.value = selectedEnvironment.ditto_version ? selectedEnvironment.ditto_version : '3';
+    dom.selectDittoVersion.value = selectedEnvironment.ditto_version ? selectedEnvironment.ditto_version : '3';
   } else {
     dom.inputEnvironmentName.value = null;
     settingsEditor.setValue('');
     dom.inputApiUri.value = null;
-    dom.inputDittoVersion.value = null;
+    dom.selectDittoVersion.value = 3;
   }
 }
 

--- a/ui/modules/environments/environments.js
+++ b/ui/modules/environments/environments.js
@@ -17,6 +17,10 @@
 import * as Authorization from '../environments/authorization.js';
 import * as Utils from '../utils.js';
 
+const URL_PRIMARY_ENVIRONMENT_NAME = 'primaryEnvironmentName';
+const URL_ENVIRONMENTS = 'environmentsURL';
+const STORAGE_KEY = 'ditto-ui-env';
+
 let urlSearchParams;
 let environments;
 
@@ -126,7 +130,9 @@ export async function ready() {
     settingsEditor.renderer.updateFull();
   });
 
-  document.getElementById('environmentSelector').onchange = () => {
+  dom.environmentSelector.onchange = () => {
+    urlSearchParams.set(URL_PRIMARY_ENVIRONMENT_NAME, dom.environmentSelector.value);
+    window.history.replaceState({}, '', `${window.location.pathname}?${urlSearchParams}`);
     notifyAll();
   };
 
@@ -134,7 +140,7 @@ export async function ready() {
 }
 
 export function environmentsJsonChanged(modifiedField) {
-  localStorage.setItem('ditto-ui-env', JSON.stringify(environments));
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(environments));
 
   updateEnvSelector();
   updateEnvEditors();
@@ -145,7 +151,7 @@ export function environmentsJsonChanged(modifiedField) {
   function updateEnvSelector() {
     let activeEnvironment = dom.environmentSelector.value;
     if (!activeEnvironment) {
-      activeEnvironment = urlSearchParams.get('primaryEnvironmentName');
+      activeEnvironment = urlSearchParams.get(URL_PRIMARY_ENVIRONMENT_NAME);
     }
     if (!activeEnvironment || !environments[activeEnvironment]) {
       activeEnvironment = Object.keys(environments)[0];
@@ -183,7 +189,7 @@ async function loadEnvironmentTemplates() {
   let fromURL;
   let fromLocalStorage;
 
-  let environmentsURL = urlSearchParams.get('environmentsURL');
+  let environmentsURL = urlSearchParams.get(URL_ENVIRONMENTS);
   if (environmentsURL) {
     try {
       let response = await fetch(environmentsURL);
@@ -200,7 +206,7 @@ async function loadEnvironmentTemplates() {
     }
   }
 
-  const restoredEnv = localStorage.getItem('ditto-ui-env');
+  const restoredEnv = localStorage.getItem(STORAGE_KEY);
   if (restoredEnv) {
     fromLocalStorage = JSON.parse(restoredEnv);
   }

--- a/ui/modules/policies/policies.html
+++ b/ui/modules/policies/policies.html
@@ -1,7 +1,7 @@
 <div>
     <h5>Overview</h5>
     <hr />
-    <div class="row resizable_pane" style="height: 200px;">
+    <div class="row resizable_pane" style="height: 30vh;">
         <div class="col-md-6 resizable_flex_column">
             <h6>Load a policy</h6>
             <div class="input-group input-group-sm mb-1 mt-1 has-validation" role="group">
@@ -25,7 +25,7 @@
     </div>
     <h5>Policy Entries</h5>
     <hr />
-    <div class="row resizable_pane" style="height: 400px;">
+    <div class="row resizable_pane" style="height: 50vh;">
         <div class="col-md-4 resizable_flex_column">
             <div class="input-group input-group-sm mb-1 mt-1 has-validation">
                 <label class="input-group-text">Entry</label>

--- a/ui/modules/things/features.html
+++ b/ui/modules/things/features.html
@@ -14,7 +14,7 @@
     Features <span class="badge badge-info" id="featureCount"></span></h5>
 <hr />
 <div class="collapse show" id="collapseFeatures">
-    <div class="row resizable_pane" style="height:500px;">
+    <div class="row resizable_pane" style="height: 45vh;">
         <div class="col-md-4 resizable_flex_column">
             <div class="input-group has-validation">
                 <input class="form-control" id="tableValidationFeature" hidden="true"></input>

--- a/ui/modules/things/searchFilter.js
+++ b/ui/modules/things/searchFilter.js
@@ -117,6 +117,7 @@ function searchTriggered(filter) {
 function pinnedTriggered() {
   lastSearch = 'pinned';
   dom.searchFilterEdit.value = null;
+  dom.favIcon.classList.replace('bi-star-fill', 'bi-star');
   Things.getThings(Environments.current()['pinnedThings']);
 }
 

--- a/ui/modules/things/things.html
+++ b/ui/modules/things/things.html
@@ -14,7 +14,7 @@
     <h5>Things</h5>
     <hr />
     <div>
-        <div class="row resizable_pane" style="height:300px;">
+        <div class="row resizable_pane" style="height: 30vh;">
             <div class="col-md-6 resizable_flex_column">
                 <div class="input-group input-group-sm mb-1 mt-1">
                     <div class="btn-group dropend">

--- a/ui/modules/utils.js
+++ b/ui/modules/utils.js
@@ -16,6 +16,7 @@
 const dom = {
   modalBodyConfirm: null,
   buttonConfirmed: null,
+  toastContainer: null,
 };
 
 /**
@@ -36,9 +37,9 @@ export function ready() {
 export const addTableRow = function(table, key, selected, withClipBoardCopy, ...columnValues) {
   const row = table.insertRow();
   row.id = key;
-  row.insertCell(0).innerHTML = key;
+  addCellToRow(row, key, key, 0);
   columnValues.forEach((value) => {
-    row.insertCell().innerHTML = value;
+    addCellToRow(row, value);
   });
   if (selected) {
     row.classList.add('table-active');
@@ -64,6 +65,20 @@ export function addCheckboxToRow(row, id, checked, onToggle) {
   checkBox.checked = checked;
   checkBox.onchange = onToggle;
   td.append(checkBox);
+}
+
+/**
+ * Adds a cell to the row including a tooltip
+ * @param {HTMRTableRowElement} row target row
+ * @param {String} cellContent content of new cell
+ * @param {String} cellTooltip tooltip for new cell
+ * @param {integer} position optional, default -1 (add to the end)
+ */
+export function addCellToRow(row, cellContent, cellTooltip, position) {
+  const cell = row.insertCell(position ?? -1);
+  cell.innerHTML = cellContent;
+  cell.setAttribute('data-bs-toggle', 'tooltip');
+  cell.title = cellTooltip ?? cellContent;
 }
 
 /**
@@ -186,8 +201,6 @@ export function getAllElementsById(domObjects) {
   });
 }
 
-let errorToast = null;
-
 /**
  * Show an error toast
  * @param {String} message Message for toast
@@ -195,13 +208,22 @@ let errorToast = null;
  * @param {String} status Status text for toas
  */
 export function showError(message, header, status) {
-  if (!errorToast) {
-    errorToast = new bootstrap.Toast(document.getElementById('errorToast'));
-  }
-  document.getElementById('errorHeader').innerText = header ? header : 'Error';
-  document.getElementById('errorBody').innerText = message;
-  document.getElementById('errorStatus').innerText = status ? status : '';
-  errorToast.show();
+  const domToast = document.createElement('div');
+  domToast.classList.add('toast');
+  domToast.innerHTML = `<div class="toast-header alert-danger">
+  <i class="bi me-2 bi-exclamation-triangle-fill"></i>
+  <strong class="me-auto">${header ?? 'Error'}</strong>
+  <small>${status ?? ''}</small>
+  <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+  </div>
+  <div class="toast-body">${message}</div>`;
+
+  dom.toastContainer.appendChild(domToast);
+  domToast.addEventListener("hidden.bs.toast", () => {
+    domToast.remove();
+  });
+  const bsToast = new bootstrap.Toast(domToast);
+  bsToast.show();
 }
 
 /**

--- a/ui/templates/environmentTemplates.json
+++ b/ui/templates/environmentTemplates.json
@@ -1,0 +1,32 @@
+{
+  "local_ditto": {
+    "api_uri": "http://localhost:8080",
+    "ditto_version": 3,
+    "bearer": null,
+    "defaultUsernamePassword": "ditto:ditto",
+    "defaultUsernamePasswordDevOps": "devops:foobar",
+    "useBasicAuth": true,
+    "useDittoPreAuthenticatedAuth": false,
+    "defaultDittoPreAuthenticatedUsername": null
+  },
+  "local_ditto_ide": {
+    "api_uri": "http://localhost:8080",
+    "ditto_version": 3,
+    "bearer": null,
+    "defaultUsernamePassword": null,
+    "defaultUsernamePasswordDevOps": null,
+    "useBasicAuth": false,
+    "useDittoPreAuthenticatedAuth": true,
+    "defaultDittoPreAuthenticatedUsername": "pre:ditto"
+  },
+  "ditto_sandbox": {
+    "api_uri": "https://ditto.eclipseprojects.io",
+    "ditto_version": 3,
+    "bearer": null,
+    "defaultUsernamePassword": "ditto:ditto",
+    "defaultUsernamePasswordDevOps": null,
+    "useBasicAuth": true,
+    "useDittoPreAuthenticatedAuth": false,
+    "defaultDittoPreAuthenticatedUsername": null
+  }
+}


### PR DESCRIPTION
Hi ditto team,

please find this PR that addresses issue: #1449 

I allows to
* load environments via `environmentsURL` parameter
* select an environment via `primaryEnvironmentName`

Additional improvements:
* Stacking for (multiple) error toasts (because invalid URL parameters can cause additional errors that were not visible)
* Avoid errors to be thrown twice in ditto rest call
* Optimized layout for long thingIds in tables. Multi-line cells are avoided in general by ellipsis and tooltip. Hidden experimental: you can set `shortenUUID` to true and define a `defaultNamespace` in the environment to get better readable thingIds
* fixed some eslint issues in things.js
* Small fix to de-select favorite filter in case of pinned things

Looking forward to your feedback, Thomas
