### PR TITLE
Add reading/writing AMQP 1.0 message annotations from/to AMQP messages

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
@@ -481,8 +481,8 @@ final class AmqpConsumerActor extends LegacyBaseConsumerActor
         return builder;
     }
 
-    private Map<String, String> extractHeadersMapFromJmsMessage(final JmsMessage message) {
-        return JMSPropertyMapper.getPropertiesAndApplicationProperties(message);
+    private static Map<String, String> extractHeadersMapFromJmsMessage(final JmsMessage message) {
+        return JMSPropertyMapper.getHeadersFromProperties(message);
     }
 
     @Override

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/JMSPropertyMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/JMSPropertyMapper.java
@@ -360,9 +360,7 @@ final class JMSPropertyMapper {
             wrap(msg -> {
                 facade.filterTracingAnnotations((key, value) -> {
                     if (value != null) {
-                        final var headerName = isDefinedAmqpProperty(key)
-                                ? AMQP.MESSAGE_ANNOTATION_PREFIX + key
-                                : key;
+                        final var headerName = AMQP.MESSAGE_ANNOTATION_PREFIX + key;
                         headers.put(headerName, value.toString());
                     }
                 });

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/JMSPropertyMapper.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/JMSPropertyMapper.java
@@ -56,6 +56,7 @@ final class JMSPropertyMapper {
     private static final class AMQP {
 
         private static final String APPLICATION_PROPERTY_PREFIX = "amqp.application.property:";
+        private static final String MESSAGE_ANNOTATION_PREFIX = "amqp.message.annotation:";
 
         // 13 defined properties in total
         private static final String MESSAGE_ID = "message-id";
@@ -123,15 +124,17 @@ final class JMSPropertyMapper {
     }
 
     /**
-     * Extract headers from properties and application properties of an AMQP JMS message to be mapped.
+     * Extract headers from properties, application properties and message annotations of an AMQP JMS message to be
+     * mapped.
      *
      * @param message the message.
      * @return the headers to be mapped.
      */
-    static Map<String, String> getPropertiesAndApplicationProperties(final Message message) {
+    static Map<String, String> getHeadersFromProperties(final Message message) {
         final Map<String, String> headers = new HashMap<>();
         readDefinedAmqpPropertiesFromMessage(message, headers);
         readAmqpApplicationPropertiesFromMessage(message, headers);
+        readAmqpMessageAnnotationsFromMessage(message, headers);
         return Collections.unmodifiableMap(headers);
     }
 
@@ -333,6 +336,24 @@ final class JMSPropertyMapper {
                     headers.put(headerName, value.toString());
                 }
             }
+        });
+    }
+
+    private static void readAmqpMessageAnnotationsFromMessage(final Message message,
+            final Map<String, String> theHeaders) {
+
+        wrapFacadeBiConsumer(message, theHeaders, (facade, headers) -> {
+            wrap(msg -> {
+                facade.filterTracingAnnotations((key, value) -> {
+                    if (value != null) {
+                        final var headerName = isDefinedAmqpProperty(key)
+                                ? AMQP.MESSAGE_ANNOTATION_PREFIX + key
+                                : key;
+                        headers.put(headerName, value.toString());
+                    }
+                });
+                return null;
+            }).apply(message);
         });
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpPublisherActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpPublisherActorTest.java
@@ -448,7 +448,7 @@ public final class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             verify(messageProducer, timeout(2000)).send(messageCaptor.capture(), any(CompletionListener.class));
             final Message message = messageCaptor.getValue();
             final Map<String, String> receivedHeaders =
-                    JMSPropertyMapper.getPropertiesAndApplicationProperties(message);
+                    JMSPropertyMapper.getHeadersFromProperties(message);
 
             assertThat(message.getJMSTimestamp()).isEqualTo(-1L);
             assertThat(message.getJMSType()).isEqualTo("subjective");

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpPublisherActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpPublisherActorTest.java
@@ -466,7 +466,7 @@ public final class AmqpPublisherActorTest extends AbstractPublisherActorTest {
             assertThat(receivedHeaders).containsEntry("amqp.application.property:to", "value1");
             assertThat(receivedHeaders).containsEntry("anotherApplicationProperty", "value2");
             // group-sequence is an AMQP prop of type "int", therefore it must not be contained in the headers here
-            assertThat(receivedHeaders).containsEntry("message-annotation", "value3");
+            assertThat(receivedHeaders).containsEntry("amqp.message.annotation:message-annotation", "value3");
             assertThat(receivedHeaders).doesNotContainKey("group-sequence");
         }};
 

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
@@ -73,8 +73,8 @@ the message annotation `to` to the value of the Ditto protocol header `reply-to`
 }
 ```
 
-To read a message annotation whose name is identical to an AMQP 1.0 property, prefix it by `amqp.message.
-annotation:`. The following [source header mapping](basic-connections.html#source-header-mapping) sets
+To read a message annotation, prefix it by `amqp.message.annotation:`. 
+The following [source header mapping](basic-connections.html#source-header-mapping) sets
 the Ditto protocol header `reply-to` to the value of the message annotation `to`:
 ```json
 {

--- a/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
+++ b/documentation/src/main/resources/pages/ditto/connectivity-protocol-bindings-amqp10.md
@@ -20,7 +20,7 @@ application/vnd.eclipse.ditto+json
 If messages, which are not in Ditto Protocol, should be processed, a [payload mapping](connectivity-mapping.html) must
 be configured for the AMQP 1.0 connection in order to transform the messages. 
 
-## AMQP 1.0 properties and application properties
+## AMQP 1.0 properties, application properties and message annotations
 
 When set as external headers by outgoing payload or header mapping, the properties defined by AMQP 1.0 specification are
 set to the corresponding header value. Conversely, the values of AMQP 1.0 properties are available for incoming payload
@@ -58,6 +58,28 @@ the Ditto protocol header `reply-to` to the value of the application property `t
 {
   "headerMapping": {
     "reply-to": "{%raw%}{{ header:amqp.application.property:to }}{%endraw%}"
+  }
+}
+```
+
+To set a message annotation, prefix it by `amqp.message.annotation:`. 
+The following [target header mapping](basic-connections.html#target-header-mapping) sets
+the message annotation `to` to the value of the Ditto protocol header `reply-to`:
+```json
+{
+  "headerMapping": {
+    "amqp.message.annotation:to": "{%raw%}{{ header:reply-to }}{%endraw%}"
+  }
+}
+```
+
+To read a message annotation whose name is identical to an AMQP 1.0 property, prefix it by `amqp.message.
+annotation:`. The following [source header mapping](basic-connections.html#source-header-mapping) sets
+the Ditto protocol header `reply-to` to the value of the message annotation `to`:
+```json
+{
+  "headerMapping": {
+    "reply-to": "{%raw%}{{ header:amqp.message.annotation:to }}{%endraw%}"
   }
 }
 ```


### PR DESCRIPTION
Adds the possibility to use AMQP message annotations via header placeholders.
Additionally allows to set message annotations to outbound messages via header-mapping.
Fixes #1390