### PR TITLE
Accept and test TextMessage with null payload

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActor.java
@@ -461,7 +461,11 @@ final class AmqpConsumerActor extends LegacyBaseConsumerActor
             final ExternalMessageBuilder builder, @Nullable final String correlationId) throws JMSException {
         if (message instanceof TextMessage textMessage) {
             final String payload = textMessage.getText();
-            builder.withTextAndBytes(payload, payload.getBytes());
+            if (payload == null) {
+                builder.withText(null);
+            } else {
+                builder.withTextAndBytes(payload, payload.getBytes());
+            }
         } else if (message instanceof BytesMessage bytesMessage) {
             final long bodyLength = bytesMessage.getBodyLength();
             if (bodyLength >= Integer.MIN_VALUE && bodyLength <= Integer.MAX_VALUE) {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
@@ -238,7 +238,7 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
                 assertThat(((ModifyAttribute) command).getAttributePointer())
                         .isEqualTo(JsonPointer.of("/foo"));
                 assertThat(((ModifyAttribute) command).getAttributeValue())
-                        .isEqualTo(JsonValue.of(plainPayload));
+                        .isEqualTo(JsonValue.nullLiteral());
             }
         };
     }
@@ -323,7 +323,7 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
     }
 
     @SafeVarargs // varargs array is not modified or passed around
-    private JmsMessage getJmsMessage(final String plainPayload, final String correlationId,
+    private JmsMessage getJmsMessage(@Nullable final String plainPayload, final String correlationId,
             final Map.Entry<String, ?>... headers) {
         try {
             final AmqpJmsTextMessageFacade messageFacade = new AmqpJmsTextMessageFacade();

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
@@ -198,6 +198,52 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
     }
 
     @Test
+    public void nullPayloadMappingTest() {
+        new TestKit(actorSystem) {
+            {
+                final MappingContext mappingContext = ConnectivityModelFactory.newMappingContextBuilder(
+                        "JavaScript",
+                        JavaScriptMessageMapperFactory
+                                .createJavaScriptMessageMapperConfigurationBuilder(
+                                        "plainStringMapping",
+                                        Collections.emptyMap())
+                                .incomingScript(TestConstants.Mapping.INCOMING_MAPPING_SCRIPT)
+                                .outgoingScript(TestConstants.Mapping.OUTGOING_MAPPING_SCRIPT)
+                                .build()
+                                .getPropertiesAsJson())
+                        .build();
+
+                final Sink<Object, NotUsed> mappingSink = setupMappingSink(getRef(), mappingContext,
+                        actorSystem);
+
+                final Source source = mock(Source.class);
+                when(source.getAuthorizationContext())
+                        .thenReturn(TestConstants.Authorization.AUTHORIZATION_CONTEXT);
+                when(source.getPayloadMapping())
+                        .thenReturn(ConnectivityModelFactory.newPayloadMapping("test"));
+                final ActorRef underTest = actorSystem.actorOf(AmqpConsumerActor.props(CONNECTION,
+                        consumerData("foo", mock(MessageConsumer.class), source), mappingSink,
+                        getRef(),
+                        mock(ConnectivityStatusResolver.class),
+                        CONNECTIVITY_CONFIG));
+
+                final String plainPayload = null;
+                final String correlationId = "cor-";
+
+                underTest.tell(getJmsMessage(plainPayload, correlationId), null);
+
+                final Command<?> command = expectMsgClass(Command.class);
+                assertThat(command.getType()).isEqualTo(ModifyAttribute.TYPE);
+                assertThat(command.getDittoHeaders().getCorrelationId()).contains(correlationId);
+                assertThat(((ModifyAttribute) command).getAttributePointer())
+                        .isEqualTo(JsonPointer.of("/foo"));
+                assertThat(((ModifyAttribute) command).getAttributeValue())
+                        .isEqualTo(JsonValue.of(plainPayload));
+            }
+        };
+    }
+
+    @Test
     public void plainStringMappingTest() {
         new TestKit(actorSystem) {{
             final MappingContext mappingContext = ConnectivityModelFactory.newMappingContextBuilder(
@@ -283,8 +329,10 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
             final AmqpJmsTextMessageFacade messageFacade = new AmqpJmsTextMessageFacade();
             // give it a connection returning null for all methods to set any AMQP properties at all
             messageFacade.initialize(mock(AmqpConnection.class));
-            messageFacade.setText(plainPayload);
-            messageFacade.setContentType(Symbol.getSymbol("text/plain"));
+            if (plainPayload != null) {
+                messageFacade.setText(plainPayload);
+                messageFacade.setContentType(Symbol.getSymbol("text/plain"));
+            }
             messageFacade.setCorrelationId(correlationId);
 
             final JmsMessage message = messageFacade.asJmsMessage();


### PR DESCRIPTION
Adds the ability to handle TextMessage with null payload, from issue #1503 

Signed-off-by: Tobias Månsson <tobias@zept.io>