### PR TITLE
fix: Parse full certificate chain for client certificates

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/KeyManagerFactoryFactory.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/KeyManagerFactoryFactory.java
@@ -66,9 +66,9 @@ public final class KeyManagerFactoryFactory implements CredentialsVisitor<KeyMan
 
         final KeyStore keystore = keyStoreFactory.newKeystore();
         final PrivateKey privateKey = Keys.getPrivateKey(clientKeyPem, exceptionMapper);
-        final Certificate certificate = Keys.getCertificate(clientCertificatePem, exceptionMapper);
+        final Certificate[] certificate = Keys.getCertificateChain(clientCertificatePem, exceptionMapper);
         keyStoreFactory.setPrivateKey(keystore, privateKey, certificate);
-        keyStoreFactory.setCertificate(keystore, certificate);
+        keyStoreFactory.setCertificate(keystore, certificate[0]);
 
         try {
             final KeyManagerFactory keyManagerFactory =

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/TestConstants.java
@@ -504,7 +504,7 @@ public final class TestConstants {
         public static final String SERVER_KEY = getCert("server.key");
         public static final String SERVER_CRT = getCert("server.crt");
         public static final String SERVER_PUB = getCert("server.pub");
-        public static final PublicKey SERVER_PUBLIC_KEY = TestCertificates.getCertificate(SERVER_CRT).getPublicKey();
+        public static final PublicKey SERVER_PUBLIC_KEY = TestCertificates.getCertificate(SERVER_CRT)[0].getPublicKey();
         public static final String SERVER_PUBKEY_FINGERPRINT_SHA256 =
                 "SHA256:MEULjymCqsBH6TkmQzKmA+G2qd+AJwarKwr84vUsQ+Y";
         public static final String SERVER_PUBKEY_FINGERPRINT_MD5 =

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/KeysTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/KeysTest.java
@@ -37,6 +37,6 @@ public class KeysTest {
 
     @Test
     public void loadCertificate() {
-        Keys.getCertificate(TestConstants.Certificates.SERVER_CRT, EXCEPTION_MAPPER);
+        Keys.getCertificateChain(TestConstants.Certificates.SERVER_CRT, EXCEPTION_MAPPER);
     }
 }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/TestCertificates.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/internal/ssl/TestCertificates.java
@@ -28,8 +28,8 @@ public class TestCertificates {
         return Keys.getPublicKey(publicKey, ExceptionMapper.forSshPublicKeyCredentials(DittoHeaders.empty()));
     }
 
-    public static Certificate getCertificate(final String certificate) {
-        return Keys.getCertificate(certificate, ExceptionMapper.forTrustedCertificates(DittoHeaders.empty()));
+    public static Certificate[] getCertificate(final String certificate) {
+        return Keys.getCertificateChain(certificate, ExceptionMapper.forTrustedCertificates(DittoHeaders.empty()));
     }
 
     public static void main(String[] args) {


### PR DESCRIPTION
Previously the code for parsing the certificate chain for use in connection's client certificate based authentication only parsed the very first certificate of what the user submitted (the client certificate itself), and disregarded all other certificates.

This works when the validation path doesn't include any intermediate certificates. However, as soon as an intermediate certificate is introduced everything stops working, because when the server requests a certificate for it's configured client certificate authority, no path can be made and client certificate authentication fails.

This PR fixes this issue by properly parsing the full certificate chain.