### PR TITLE
support silent token refresh

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-auth.md
+++ b/documentation/src/main/resources/pages/ditto/basic-auth.md
@@ -53,6 +53,46 @@ for the following browser based requests:
   browser
    * passing the `withCredentials: true` option when creating the SSE in the browser
 
+#### Silent Token Refresh
+
+The Ditto UI supports automatic silent token refresh to provide a seamless user experience without frequent redirects to the OIDC provider. This feature:
+
+* **Automatically refreshes JWT tokens** before they expire using refresh tokens
+* **Retries failed API calls** after successful token refresh
+* **Works transparently** without user interaction
+
+**Configuration Requirements:**
+
+The OIDC provider must support:
+- `offline_access` scope for refresh tokens
+- `refresh_token` grant type
+- Silent refresh callback endpoint
+
+**OIDC Provider Configuration:**
+
+Configure your OIDC provider in the environment settings:
+
+```json
+{
+  "oidc": {
+    "providers": {
+      "your-provider": {
+        "displayName": "Your OIDC Provider",
+        "extractBearerTokenFrom": "access_token",
+        "authority": "https://your-oidc-provider.com",
+        "client_id": "your-client-id",
+        "redirect_uri": "https://your-ditto-ui.com",
+        "post_logout_redirect_uri": "https://your-ditto-ui.com",
+        "silent_redirect_uri": "https://your-ditto-ui.com/silent-callback.html",
+        "response_type": "code",
+        "scope": "openid groups email offline_access",
+        "automaticSilentRenew": true
+      }
+    }
+  }
+}
+```
+
 ## Authorization
 
 Authorization is implemented with a <a href="#" data-toggle="tooltip" data-original-title="{{site.data.glossary.policy}}">Policy</a>

--- a/ui/modules/environments/environmentTemplates.json
+++ b/ui/modules/environments/environmentTemplates.json
@@ -173,8 +173,11 @@
             "authority": "http://localhost:9900/fake",
             "client_id": "some-client-id",
             "redirect_uri": "http://localhost:8000",
+            "post_logout_redirect_uri": "http://localhost:8000",
+            "silent_redirect_uri": "http://localhost:8000/silent-callback.html",
             "response_type": "code",
-            "scope": "openid"
+            "scope": "openid offline_access",
+            "automaticSilentRenew": true
           }
         }
       }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,7 +17,7 @@
         "dompurify": "^3.2.4",
         "event-source-polyfill": "^1.0.31",
         "jsonpath-plus": "^10.3.0",
-        "oidc-client-ts": "^3.0.1"
+        "oidc-client-ts": "^3.3.0"
       },
       "devDependencies": {
         "@types/ace": "^0.0.52",
@@ -4406,9 +4406,9 @@
       }
     },
     "node_modules/oidc-client-ts": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.0.1.tgz",
-      "integrity": "sha512-xX8unZNtmtw3sOz4FPSqDhkLFnxCDsdo2qhFEH2opgWnF/iXMFoYdBQzkwCxAZVgt3FT3DnuBY3k80EZHT0RYg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.3.0.tgz",
+      "integrity": "sha512-t13S540ZwFOEZKLYHJwSfITugupW4uYLwuQSSXyKH/wHwZ+7FvgHE7gnNJh1YQIZ1Yd1hKSRjqeXGSUtS0r9JA==",
       "dependencies": {
         "jwt-decode": "^4.0.0"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -33,6 +33,6 @@
     "dompurify": "^3.2.4",
     "event-source-polyfill": "^1.0.31",
     "jsonpath-plus": "^10.3.0",
-    "oidc-client-ts": "^3.0.1"
+    "oidc-client-ts": "^3.3.0"
   }
 }

--- a/ui/silent-callback.html
+++ b/ui/silent-callback.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Silent Refresh Callback</title>
+</head>
+<body>
+    <script>
+        try {
+            import('oidc-client-ts').then(({ UserManager }) => {
+                const userManager = new UserManager();
+                
+                userManager.signinSilentCallback()
+                    .then(() => {
+                        if (window.opener) {
+                            window.close();
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Silent refresh callback failed:', error);
+                    });
+            }).catch(error => {
+                console.error('Failed to load oidc-client-ts:', error);
+            });
+        } catch (error) {
+            console.error('Silent callback error:', error);
+        }
+    </script>
+</body>
+</html>
+
+


### PR DESCRIPTION
This PR adds support for silent token refresh to the Ditto UI when using OIDC/SSO authentication.
Users no longer need to manually re-login once their token expires; the session will be refreshed in the background.