### PR TITLE
#2233: fix policy unable to be updated in case expired subject exists inside the policy

### DIFF
--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/announcements/SubjectExpiryActor.java
@@ -23,6 +23,13 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.AbstractFSM;
+import org.apache.pekko.actor.ActorRef;
+import org.apache.pekko.actor.Address;
+import org.apache.pekko.actor.Props;
+import org.apache.pekko.cluster.Cluster;
+import org.apache.pekko.japi.pf.FSMStateFunctionBuilder;
 import org.eclipse.ditto.base.model.common.DittoDuration;
 import org.eclipse.ditto.base.model.common.HttpStatus;
 import org.eclipse.ditto.base.model.exceptions.DittoRuntimeException;
@@ -45,13 +52,6 @@ import org.eclipse.ditto.policies.model.signals.announcements.SubjectDeletionAnn
 import org.eclipse.ditto.policies.service.common.config.PolicyAnnouncementConfig;
 import org.eclipse.ditto.policies.service.persistence.actors.strategies.commands.SudoDeleteExpiredSubject;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.AbstractFSM;
-import org.apache.pekko.actor.ActorRef;
-import org.apache.pekko.actor.Address;
-import org.apache.pekko.actor.Props;
-import org.apache.pekko.cluster.Cluster;
-import org.apache.pekko.japi.pf.FSMStateFunctionBuilder;
 import scala.util.Random$;
 
 /**
@@ -176,8 +176,7 @@ public final class SubjectExpiryActor extends AbstractFSM<SubjectExpiryState, No
             scheduleAnnouncement(now, getAnnouncementInstant().orElse(now));
         } else {
             log.debug("Starting in <{}>", TO_DELETE);
-            startWith(TO_DELETE, NULL);
-            subject.getExpiry().ifPresent(this::scheduleDeleteExpiredSubject);
+            startWith(subject.getExpiry().map(this::scheduleDeleteExpiredSubject).orElse(TO_DELETE), NULL);
         }
         initialize();
     }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifyPolicyEntryStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifyPolicyEntryStrategy.java
@@ -75,7 +75,7 @@ final class ModifyPolicyEntryStrategy extends AbstractPolicyCommandStrategy<Modi
         final Policy newPolicy = nonNullPolicy.setEntry(adjustedPolicyEntry);
 
         final Optional<Result<PolicyEvent<?>>> alreadyExpiredSubject =
-                checkForAlreadyExpiredSubject(newPolicy, commandHeaders, command);
+                checkForAlreadyExpiredSubject(adjustedPolicyEntry.getSubjects(), commandHeaders, command);
         if (alreadyExpiredSubject.isPresent()) {
             return alreadyExpiredSubject.get();
         }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifySubjectStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifySubjectStrategy.java
@@ -82,7 +82,7 @@ final class ModifySubjectStrategy extends AbstractPolicyCommandStrategy<ModifySu
             final Policy newPolicy = nonNullPolicy.setSubjectFor(label, adjustedSubject);
 
             final Optional<Result<PolicyEvent<?>>> alreadyExpiredSubject =
-                    checkForAlreadyExpiredSubject(newPolicy, commandHeaders, command);
+                    checkForAlreadyExpiredSubject(adjustedSubject, commandHeaders, command);
             if (alreadyExpiredSubject.isPresent()) {
                 return alreadyExpiredSubject.get();
             }

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifySubjectsStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ModifySubjectsStrategy.java
@@ -79,7 +79,7 @@ final class ModifySubjectsStrategy extends AbstractPolicyCommandStrategy<ModifyS
             final Policy newPolicy = nonNullPolicy.setSubjectsFor(label, adjustedSubjects);
 
             final Optional<Result<PolicyEvent<?>>> alreadyExpiredSubject =
-                    checkForAlreadyExpiredSubject(newPolicy, commandHeaders, command);
+                    checkForAlreadyExpiredSubject(adjustedSubjects, commandHeaders, command);
             if (alreadyExpiredSubject.isPresent()) {
                 return alreadyExpiredSubject.get();
             }

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/TestConstants.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/TestConstants.java
@@ -199,6 +199,16 @@ public final class TestConstants {
                         .setPolicyImports(POLICY_IMPORTS_WITH_ENTRIES)
                         .build();
 
+        /**
+         * Expired subject to be used in persistence tests.
+         */
+
+        public static final Label EXPIRED_POLICY_LABEL = Label.of("expired");
+
+        public static final Subject EXPIRED_SUBJECT = Subject.newInstance(SubjectId.newInstance("foo:expired"),
+                SubjectType.GENERATED,
+                SubjectExpiry.newInstance(Instant.now().minusSeconds(30)));
+
         public static PolicyImport policyImportWithId(final String importedPolicyId) {
             return PolicyImport.newInstance(PolicyId.of("com.example", importedPolicyId), EffectedImports.newInstance(null));
         }


### PR DESCRIPTION
- currently, updating single subject, subjects or policy entry only validates the updated parts, not the entire policy

- fix SubjectExpiryActor not retrying to delete subject on startup

Fixes: #2233