### PR TITLE
fix configuring missing cluster sharding healthcheck names

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -1151,6 +1151,10 @@ pekko {
         # default is "default-idle-strategy" with "idle-entity.timeout = 120s":
         strategy = "off"
       }
+
+      healthcheck {
+        names = [ "connection" ]
+      }
     }
 
     roles = [

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -246,6 +246,10 @@ pekko {
         # default is "default-idle-strategy" with "idle-entity.timeout = 120s":
         strategy = "off"
       }
+
+      healthcheck {
+        names = [ "policy" ]
+      }
     }
 
     roles = [

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -547,6 +547,10 @@ pekko {
         # default is "default-idle-strategy" with "idle-entity.timeout = 120s":
         strategy = "off"
       }
+
+      healthcheck {
+        names = [ "thing", "wot-validation-config" ]
+      }
     }
 
     roles = [

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -386,6 +386,10 @@ pekko {
         # default is "default-idle-strategy" with "idle-entity.timeout = 120s":
         strategy = "off"
       }
+
+      healthcheck {
+        names = [ "search-updater" ]
+      }
     }
 
     roles = [


### PR DESCRIPTION
This follows the practice to check for shard allocations before declaring a pod "ready":  
https://pekko.apache.org/docs/pekko/current/typed/cluster-sharding.html#health-check

> An [Pekko Management compatible health check](https://pekko.apache.org/docs/pekko-management/current/healthchecks.html) is included that returns healthy once the local shard region has registered with the coordinator. This health check should be used in cases where you don’t want to receive production traffic until the local shard region is ready to retrieve locations for shards.

This should improve rolling updates, as far as I understand from the docs - it was missing from Ditto config until now.