### PR TITLE
fixed exceptions during providePolicyEnforcer loading being silently treated as "empty enforcer"

### DIFF
--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/DefaultPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/DefaultPolicyEnforcerProvider.java
@@ -58,14 +58,13 @@ final class DefaultPolicyEnforcerProvider extends AbstractPolicyEnforcerProvider
         } else {
             try {
                 return policyEnforcerCacheLoader.asyncLoad(policyId, cacheDispatcher)
-                        .thenApply(Entry::get)
-                        .exceptionally(error -> Optional.empty());
+                        .thenApply(Entry::get);
             } catch (final Exception e) {
                 LOGGER.warn(
                         "Got exception when trying to load the policy enforcer via cache loader. This is " +
                                 "unexpected", e
                 );
-                return CompletableFuture.completedFuture(Optional.empty());
+                return CompletableFuture.failedFuture(e);
             }
         }
     }


### PR DESCRIPTION
This could lead to errors like:
```
ThingNotModifiableException [message='The Thing with ID 'org.eclipse.ditto:thing-1' could not be accessed as its Policy with ID 'org.eclipse.ditto:policy-1' is not or no longer existing.'
```
Even though the policy was not deleted - just e.g. cannot be retrieved at the moment (e.g. because of timeouts during a rolling restart).

Instead, now an `DittoInternalErrorException` should be thrown and returned not "hiding" the root cause - also providing more clarity in logs.