### PR TITLE
fix wrong CBOR upper bound calculation

### DIFF
--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonArray.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonArray.java
@@ -493,14 +493,17 @@ final class ImmutableJsonArray extends AbstractJsonValue implements JsonArray {
         }
 
         public long upperBoundForStringSize() {
+            long max = 0L;
             if (jsonArrayStringRepresentation != null) {
-                return jsonArrayStringRepresentation.length();
+                max = jsonArrayStringRepresentation.length();
             }
             if (cborArrayRepresentation != null) {
-                return cborArrayRepresentation.length * CBOR_MAX_COMPRESSION_RATIO;
+                final long cborSize = cborArrayRepresentation.length * CBOR_MAX_COMPRESSION_RATIO;
+                if (cborSize > max) {
+                    max = cborSize;
+                }
             }
-            assert false; // this should never happen
-            return Long.MAX_VALUE;
+            return max;
         }
     }
 

--- a/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
+++ b/json/src/main/java/org/eclipse/ditto/json/ImmutableJsonObject.java
@@ -607,6 +607,7 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
                     .orElseGet(NoopCborFactory::new); // when no Service could be found -> CBOR not available
         }
 
+
         private String jsonObjectStringRepresentation;
         private byte[] cborObjectRepresentation;
         private int hashCode;
@@ -815,16 +816,18 @@ final class ImmutableJsonObject extends AbstractJsonValue implements JsonObject 
         }
 
         public long upperBoundForStringSize() {
+            long max = 0L;
             if (jsonObjectStringRepresentation != null) {
-                return jsonObjectStringRepresentation.length();
+                max = jsonObjectStringRepresentation.length();
             }
             if (cborObjectRepresentation != null) {
-                return cborObjectRepresentation.length * CBOR_MAX_COMPRESSION_RATIO;
+                final long cborSize = cborObjectRepresentation.length * CBOR_MAX_COMPRESSION_RATIO;
+                if (cborSize > max) {
+                    max = cborSize;
+                }
             }
-            assert false; // this should never happen
-            return Long.MAX_VALUE;
+            return max;
         }
-
     }
 
     /**


### PR DESCRIPTION
* in case CBOR representation is bigger than jsonString representation
* made JacksonCborFactory.toByteBuffer more error-proof by handling BufferOverflowException, doubling the buffer

The latest improvements in Ditto 3.8.4 / 3.8.5 caused potential `BufferOverflowException` (depending on the validated payload) when using WoT based validation.

Reason was a wrongly determined "upper bound" for a ByteBuffer allocation.  
This fix also introduces an additional safeguard, increasing the allocated buffer on an exception instead of failing with `BufferOverflowException`.