### PR TITLE
improve stability of ThingsAggregatorProxy in "things" service during restart

### DIFF
--- a/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/ThingsAggregatorProxyActor.java
+++ b/edge/service/src/main/java/org/eclipse/ditto/edge/service/dispatching/ThingsAggregatorProxyActor.java
@@ -198,7 +198,7 @@ public final class ThingsAggregatorProxyActor extends AbstractActorWithShutdownB
 
         final CompletionStage<List<PlainJson>> o =
                 provideSource(sourceRef, thingNotAccessibleExceptionSource, thingPlainJsonSupplier)
-                        .log("retrieve-thing-response", log)
+                        .log("things-aggregator-proxy-response", log)
                         .recoverWithRetries(5, new PFBuilder<Throwable, Source<PlainJson, NotUsed>>()
                                 .match(NoSuchElementException.class, nsee -> Source.single(PlainJson.empty()))
                                 .match(RemoteStreamRefActorTerminatedException.class, rsrate -> {

--- a/internal/utils/config/src/main/resources/ditto-things-aggregator.conf
+++ b/internal/utils/config/src/main/resources/ditto-things-aggregator.conf
@@ -1,10 +1,33 @@
 ditto.things-aggregator {
-
-  single-retrieve-thing-timeout = 30s
-  single-retrieve-thing-timeout = ${?THINGS_AGGREGATOR_SINGLE_RETRIEVE_THING_TIMEOUT}
-
   max-parallelism = 20
   max-parallelism = ${?THINGS_AGGREGATOR_MAX_PARALLELISM}
+}
+
+# ask-with-retry is used in ThingsAggregatorActor to more reliably retrieve things from ThingShardRegions
+ditto.ask-with-retry {
+  # maximum duration to wait for answers from thing shard region
+  ask-timeout = 10s
+  ask-timeout = ${?THINGS_ASK_WITH_RETRY_ASK_TIMEOUT}
+
+  # one of: OFF, NO_DELAY, FIXED_DELAY, BACKOFF_DELAY
+  retry-strategy = BACKOFF_DELAY
+  retry-strategy = ${?THINGS_ASK_WITH_RETRY_ASK_RETRY_STRATEGY}
+
+  retry-attempts = 3
+  retry-attempts = ${?THINGS_ASK_WITH_RETRY_ASK_TIMEOUT_RETRIES}
+
+  fixed-delay = 5s
+  fixed-delay = ${?THINGS_ASK_WITH_RETRY_ASK_FIXED_DELAY}
+
+  backoff-delay {
+    min = 100ms
+    min = ${?THINGS_ASK_WITH_RETRY_ASK_BACKOFF_DELAY_MIN}
+    max = 10s
+    max = ${?THINGS_ASK_WITH_RETRY_ASK_BACKOFF_DELAY_MAX}
+    # must be between 0.0 and 1.0:
+    random-factor = 0.5
+    random-factor = ${?THINGS_ASK_WITH_RETRY_ASK_BACKOFF_DELAY_RANDOM_FACTOR}
+  }
 }
 
 aggregator-internal-dispatcher {

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/aggregation/DefaultThingsAggregatorConfig.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/aggregation/DefaultThingsAggregatorConfig.java
@@ -12,7 +12,6 @@
  */
 package org.eclipse.ditto.things.service.aggregation;
 
-import java.time.Duration;
 import java.util.Objects;
 
 import javax.annotation.concurrent.Immutable;
@@ -30,12 +29,9 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
 
     private static final String CONFIG_PATH = "things-aggregator";
 
-    private final Duration singleRetrieveThingTimeout;
     private final int maxParallelism;
 
     private DefaultThingsAggregatorConfig(final ScopedConfig config) {
-        singleRetrieveThingTimeout =
-                config.getNonNegativeAndNonZeroDurationOrThrow(ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT);
         maxParallelism = config.getPositiveIntOrThrow(ThingsAggregatorConfigValue.MAX_PARALLELISM);
     }
 
@@ -52,11 +48,6 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
     }
 
     @Override
-    public Duration getSingleRetrieveThingTimeout() {
-        return singleRetrieveThingTimeout;
-    }
-
-    @Override
     public int getMaxParallelism() {
         return maxParallelism;
     }
@@ -70,20 +61,18 @@ public final class DefaultThingsAggregatorConfig implements ThingsAggregatorConf
             return false;
         }
         final DefaultThingsAggregatorConfig that = (DefaultThingsAggregatorConfig) o;
-        return maxParallelism == that.maxParallelism &&
-                Objects.equals(singleRetrieveThingTimeout, that.singleRetrieveThingTimeout);
+        return maxParallelism == that.maxParallelism;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(singleRetrieveThingTimeout, maxParallelism);
+        return Objects.hash(maxParallelism);
     }
 
     @Override
     public String toString() {
         return getClass().getSimpleName() + " [" +
-                "singleRetrieveThingTimeout=" + singleRetrieveThingTimeout +
-                ", maxParallelism=" + maxParallelism +
+                "maxParallelism=" + maxParallelism +
                 "]";
     }
 

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/aggregation/ThingsAggregatorConfig.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/aggregation/ThingsAggregatorConfig.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.things.service.aggregation;
 
-import java.time.Duration;
-
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
@@ -23,13 +21,6 @@ import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
  */
 @Immutable
 public interface ThingsAggregatorConfig {
-
-    /**
-     * Returns the timeout how long the {@code ThingsAggregatorActor} should wait for a single retrieve thing.
-     *
-     * @return the timeout.
-     */
-    Duration getSingleRetrieveThingTimeout();
 
     /**
      * Returns the maximum parallelism, that is how many {@code RetrieveThing} commands can be "in flight" at the
@@ -44,11 +35,6 @@ public interface ThingsAggregatorConfig {
      * {@code ThingsAggregatorConfig}.
      */
     enum ThingsAggregatorConfigValue implements KnownConfigValue {
-
-        /**
-         * The timeout how long the {@code ThingsAggregatorActor} should wait for a single retrieve thing.
-         */
-        SINGLE_RETRIEVE_THING_TIMEOUT("single-retrieve-thing-timeout", Duration.ofSeconds(30L)),
 
         /**
          * The maximum parallelism.

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/aggregation/DefaultThingsAggregatorConfigTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/aggregation/DefaultThingsAggregatorConfigTest.java
@@ -12,8 +12,6 @@
  */
 package org.eclipse.ditto.things.service.aggregation;
 
-import java.time.Duration;
-
 import org.assertj.core.api.JUnitSoftAssertions;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -50,10 +48,6 @@ public final class DefaultThingsAggregatorConfigTest {
     public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
         final DefaultThingsAggregatorConfig underTest = DefaultThingsAggregatorConfig.of(ConfigFactory.empty());
 
-        softly.assertThat(underTest.getSingleRetrieveThingTimeout())
-                .as(ThingsAggregatorConfig.ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT.getConfigPath())
-                .isEqualTo(ThingsAggregatorConfig.ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT.getDefaultValue());
-
         softly.assertThat(underTest.getMaxParallelism())
                 .as(ThingsAggregatorConfig.ThingsAggregatorConfigValue.MAX_PARALLELISM.getConfigPath())
                 .isEqualTo(ThingsAggregatorConfig.ThingsAggregatorConfigValue.MAX_PARALLELISM.getDefaultValue());
@@ -62,10 +56,6 @@ public final class DefaultThingsAggregatorConfigTest {
     @Test
     public void underTestReturnsValuesOfConfigFile() {
         final DefaultThingsAggregatorConfig underTest = DefaultThingsAggregatorConfig.of(thingsAggregatorTestConf);
-
-        softly.assertThat(underTest.getSingleRetrieveThingTimeout())
-                .as(ThingsAggregatorConfig.ThingsAggregatorConfigValue.SINGLE_RETRIEVE_THING_TIMEOUT.getConfigPath())
-                .isEqualTo(Duration.ofSeconds(60L));
 
         softly.assertThat(underTest.getMaxParallelism())
                 .as(ThingsAggregatorConfig.ThingsAggregatorConfigValue.MAX_PARALLELISM.getConfigPath())

--- a/things/service/src/test/resources/things-aggregator-test.conf
+++ b/things/service/src/test/resources/things-aggregator-test.conf
@@ -1,6 +1,4 @@
 things-aggregator {
-  single-retrieve-thing-timeout = 60s
-  single-retrieve-thing-timeout = ${?THINGS_AGGREGATOR_SINGLE_RETRIEVE_THING_TIMEOUT}
   max-parallelism = 10
   max-parallelism = ${?THINGS_AGGREGATOR_MAX_PARALLELISM}
 }


### PR DESCRIPTION
* right now it fails when encountering ask timeouts (e.g. because shard proxy is not available)
* improve this by using "ask-with-retry" instead