### PR TITLE
add possibility to configure tracing tick-interval and queue-size

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.6  # chart version is effectively set by release-job
+version: 3.8.7  # chart version is effectively set by release-job
 appVersion: 3.8.6
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/connectivity-deployment.yaml
+++ b/deployment/helm/ditto/templates/connectivity-deployment.yaml
@@ -101,6 +101,10 @@ spec:
               value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_TICK_INTERVAL
+              value: "{{ .Values.global.tracing.tickInterval }}"
+            - name: DITTO_TRACING_REPORTER_QUEUE_SIZE
+              value: "{{ .Values.global.tracing.reporterQueueSize }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
               value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/deployment/helm/ditto/templates/gateway-deployment.yaml
+++ b/deployment/helm/ditto/templates/gateway-deployment.yaml
@@ -101,6 +101,10 @@ spec:
               value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_TICK_INTERVAL
+              value: "{{ .Values.global.tracing.tickInterval }}"
+            - name: DITTO_TRACING_REPORTER_QUEUE_SIZE
+              value: "{{ .Values.global.tracing.reporterQueueSize }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
               value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/deployment/helm/ditto/templates/policies-deployment.yaml
+++ b/deployment/helm/ditto/templates/policies-deployment.yaml
@@ -101,6 +101,10 @@ spec:
               value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_TICK_INTERVAL
+              value: "{{ .Values.global.tracing.tickInterval }}"
+            - name: DITTO_TRACING_REPORTER_QUEUE_SIZE
+              value: "{{ .Values.global.tracing.reporterQueueSize }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
               value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/deployment/helm/ditto/templates/things-deployment.yaml
+++ b/deployment/helm/ditto/templates/things-deployment.yaml
@@ -101,6 +101,10 @@ spec:
               value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_TICK_INTERVAL
+              value: "{{ .Values.global.tracing.tickInterval }}"
+            - name: DITTO_TRACING_REPORTER_QUEUE_SIZE
+              value: "{{ .Values.global.tracing.reporterQueueSize }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
               value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -101,6 +101,10 @@ spec:
               value: "{{ .Values.global.metrics.systemMetrics.enabled }}"
             - name: DITTO_TRACING_ENABLED
               value: "{{ .Values.global.tracing.enabled }}"
+            - name: DITTO_TRACING_TICK_INTERVAL
+              value: "{{ .Values.global.tracing.tickInterval }}"
+            - name: DITTO_TRACING_REPORTER_QUEUE_SIZE
+              value: "{{ .Values.global.tracing.reporterQueueSize }}"
             - name: DITTO_TRACING_OTEL_TRACE_REPORTER_ENABLED
               value: "{{ .Values.global.tracing.otelTraceReporterEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -195,6 +195,12 @@ global:
   tracing:
     # enabled whether tracing (via OpenTelemetry) is enabled
     enabled: false
+    # tickInterval the interval at which tracing metrics are reported
+    tickInterval: 10s
+    # reporterQueueSize size of the internal queue where sampled spans will stay until they get flushed.
+    #  If the queue becomes full then sampled finished spans will be dropped in order to avoid consuming excessive
+    #  amounts of memory. Each configured reporter has a separate queue.
+    reporterQueueSize: 4096
     # otelTraceReporterEnabled whether reporting traces via the OLTP endpoint should be activated
     otelTraceReporterEnabled: false
     # otelExporterOtlpEndpoint the OTLP endpoint to report traces to

--- a/internal/utils/config/src/main/resources/ditto-kamon.conf
+++ b/internal/utils/config/src/main/resources/ditto-kamon.conf
@@ -82,6 +82,14 @@ kamon {
   }
 
   trace {
+    tick-interval = 10s
+    tick-interval = ${?DITTO_TRACING_TICK_INTERVAL}
+    tick-interval = ${?OTEL_BSP_SCHEDULE_DELAY} # this is the OTEL default env var - specified as milliseconds
+
+    reporter-queue-size = 4096
+    reporter-queue-size = ${?DITTO_TRACING_REPORTER_QUEUE_SIZE}
+    reporter-queue-size = ${?OTEL_BSP_MAX_QUEUE_SIZE} # this is the OTEL default env var
+
     # disable reporting by default
     #   - always: report all traces.
     #   - never:  don't report any trace.
@@ -99,6 +107,11 @@ kamon {
 
     # must be double for w3c trace context
     identifier-scheme = double
+
+    span-metric-tags {
+      upstream-service = no
+      parent-operation = no
+    }
   }
 
   propagation {


### PR DESCRIPTION
This is e.g. needed if not all spans are reaching the OTEL tracing backend.

Kamon documents for the `reporterQueueSize`:
> If the queue becomes full then sampled finished spans will be dropped in order to avoid consuming excessive
> amounts of memory. Each configured reporter has a separate queue.