### PR TITLE
fix wrong exceptions being thrown when duplicates occur in WoT parsing

### DIFF
--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/resolver/DefaultWotThingModelResolver.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/resolver/DefaultWotThingModelResolver.java
@@ -16,6 +16,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.AbstractMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -130,7 +131,11 @@ final class DefaultWotThingModelResolver implements WotThingModelResolver {
         return CompletableFuture.allOf(futureList.toArray(CompletableFuture<?>[]::new))
                 .thenApplyAsync(aVoid -> futureList.stream()
                         .map(CompletableFuture::join) // joining does not block anything here as "allOf" already guaranteed that all futures are ready
-                        .collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue))
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (u, v) -> {
+                            throw WotThingModelInvalidException.newBuilder(String.format("Thing submodels: Duplicate key %s", u))
+                                    .dittoHeaders(dittoHeaders)
+                                    .build();
+                        }, LinkedHashMap::new))
                 );
     }
 

--- a/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
+++ b/wot/api/src/main/java/org/eclipse/ditto/wot/api/validator/DefaultWotThingModelValidator.java
@@ -53,6 +53,7 @@ import org.eclipse.ditto.things.model.signals.commands.modify.MergeThing;
 import org.eclipse.ditto.wot.api.resolver.ThingSubmodel;
 import org.eclipse.ditto.wot.api.resolver.WotThingModelResolver;
 import org.eclipse.ditto.wot.model.ThingModel;
+import org.eclipse.ditto.wot.model.WotThingModelInvalidException;
 import org.eclipse.ditto.wot.validation.JsonSchemaCacheKey;
 import org.eclipse.ditto.wot.validation.ValidationContext;
 import org.eclipse.ditto.wot.validation.WotThingModelPayloadValidationException;
@@ -991,7 +992,11 @@ public final class DefaultWotThingModelValidator implements WotThingModelValidat
                 .filter(subModel ->
                         affectedFeatures.contains(subModel.getKey().instanceName())
                 )
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (u, v) -> {
+                    throw WotThingModelInvalidException.newBuilder(String.format("Thing submodels: Duplicate key %s", u))
+                            .dittoHeaders(context.dittoHeaders())
+                            .build();
+                }, LinkedHashMap::new));
         final Features filteredFeatures = thing.getFeatures()
                 .map(features -> Features.newBuilder()
                         .setAll(features.stream()

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Actions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Actions.java
@@ -34,7 +34,8 @@ public interface Actions extends Map<String, Action>, Jsonifiable<JsonObject> {
                 field -> field.getKey().toString(),
                 field -> Action.fromJson(field.getKey().toString(), field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Actions: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));
@@ -45,7 +46,8 @@ public interface Actions extends Map<String, Action>, Jsonifiable<JsonObject> {
                 Action::getActionName,
                 a -> a,
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Actions: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Descriptions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Descriptions.java
@@ -33,7 +33,8 @@ public interface Descriptions extends Map<Locale, Description>, Jsonifiable<Json
                 field -> new Locale(field.getKey().toString()),
                 field -> Description.of(field.getValue().asString()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Descriptions: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Events.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Events.java
@@ -34,7 +34,8 @@ public interface Events extends Map<String, Event>, Jsonifiable<JsonObject> {
                 field -> field.getKey().toString(),
                 field -> Event.fromJson(field.getKey().toString(), field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Events: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));
@@ -45,7 +46,8 @@ public interface Events extends Map<String, Event>, Jsonifiable<JsonObject> {
                 Event::getEventName,
                 e -> e,
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Events: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ImmutableObjectSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ImmutableObjectSchema.java
@@ -52,7 +52,8 @@ final class ImmutableObjectSchema extends AbstractSingleDataSchema implements Ob
                         f -> f.getKey().toString(),
                         f -> SingleDataSchema.fromJson(f.getValue().asObject()),
                         (u, v) -> {
-                            throw new IllegalStateException(String.format("Duplicate key %s", u));
+                            throw WotThingModelInvalidException.newBuilder(String.format("Object properties: Duplicate key %s", u))
+                                    .build();
                         },
                         LinkedHashMap::new
                 ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Properties.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Properties.java
@@ -34,7 +34,8 @@ public interface Properties extends Map<String, Property>, Jsonifiable<JsonObjec
                 field -> field.getKey().toString(),
                 field -> Property.fromJson(field.getKey().toString(), field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Properties: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));
@@ -45,7 +46,8 @@ public interface Properties extends Map<String, Property>, Jsonifiable<JsonObjec
                 Property::getPropertyName,
                 p -> p,
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Properties: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SchemaDefinitions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SchemaDefinitions.java
@@ -33,7 +33,8 @@ public interface SchemaDefinitions extends Map<String, SingleDataSchema>, Jsonif
                 field -> field.getKey().toString(),
                 field -> SingleDataSchema.fromJson(field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("SingleDataSchemas: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityDefinitions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityDefinitions.java
@@ -33,7 +33,8 @@ public interface SecurityDefinitions extends Map<String, SecurityScheme>, Jsonif
                 field -> field.getKey().toString(),
                 field -> SecurityScheme.fromJson(field.getKey().toString(), field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("SecuritySchemes: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));
@@ -44,7 +45,8 @@ public interface SecurityDefinitions extends Map<String, SecurityScheme>, Jsonif
                 SecurityScheme::getSecuritySchemeName,
                 s -> s,
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("SecuritySchemes: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Titles.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Titles.java
@@ -34,7 +34,8 @@ public interface Titles extends Map<Locale, Title>, Jsonifiable<JsonObject> {
                 field -> new Locale(field.getKey().toString()),
                 field -> Title.of(field.getValue().asString()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Titles: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/UriVariables.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/UriVariables.java
@@ -32,7 +32,8 @@ public interface UriVariables extends Map<String, SingleDataSchema>, Jsonifiable
                 field -> field.getKey().toString(),
                 field -> SingleDataSchema.fromJson(field.getValue().asObject()),
                 (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("SingleDataSchemas: Duplicate key %s", u))
+                            .build();
                 },
                 LinkedHashMap::new)
         ));

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/InternalValidation.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/InternalValidation.java
@@ -41,6 +41,7 @@ import org.eclipse.ditto.wot.model.SingleDataSchema;
 import org.eclipse.ditto.wot.model.SingleUriAtContext;
 import org.eclipse.ditto.wot.model.ThingModel;
 import org.eclipse.ditto.wot.model.TmOptionalElement;
+import org.eclipse.ditto.wot.model.WotThingModelInvalidException;
 
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.output.OutputUnit;
@@ -465,7 +466,9 @@ final class InternalValidation {
                                 .filter(entry -> !entry.getValue().isValid())
                                 .stream()
                 ).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (u, v) -> {
-                    throw new IllegalStateException(String.format("Duplicate key %s", u));
+                    throw WotThingModelInvalidException.newBuilder(String.format("Invalid properties: Duplicate key %s", u))
+                            .dittoHeaders(context.dittoHeaders())
+                            .build();
                 }, LinkedHashMap::new));
     }
 


### PR DESCRIPTION
* replace IllegalStateException with WotThingModelInvalidException to avoid "WoT internal server" errors with status code 500 and not useful error description