### PR TITLE
fixed still missed out hard-coded "local ask timeouts" of 5 seconds to be dependent on recovery

### DIFF
--- a/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
+++ b/internal/utils/persistent-actors/src/main/java/org/eclipse/ditto/internal/utils/persistentactors/AbstractPersistenceSupervisor.java
@@ -584,7 +584,7 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
         }
     }
 
-    private Duration determineAskTimeoutForPersistenceActorForwarding(final boolean shouldSendResponse) {
+    protected Duration determineAskTimeoutForPersistenceActorForwarding(final boolean shouldSendResponse) {
         if (shouldSendResponse) {
             if (paRecovered) {
                 return localAskTimeout;
@@ -636,6 +636,9 @@ public abstract class AbstractPersistenceSupervisor<E extends EntityId, S extend
     private void paRecovered(final Control paRecoveredTrigger) {
         log.debug("Persistence actor for entity with ID <{}> signaled it was recovered", entityId);
         paRecovered = true;
+        if (enforcerChild != null) {
+            enforcerChild.tell(Control.PA_RECOVERED, getSender());
+        }
     }
 
     private void startChildren(final Control startChild) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyLoadingEnforcerActor.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyLoadingEnforcerActor.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 import org.eclipse.ditto.base.model.entity.id.EntityId;
 import org.eclipse.ditto.base.model.signals.Signal;
 import org.eclipse.ditto.base.model.signals.commands.CommandResponse;
+import org.eclipse.ditto.base.service.config.supervision.LocalAskTimeoutConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAccessibleException;
 
@@ -40,8 +41,10 @@ public abstract class AbstractPolicyLoadingEnforcerActor<I extends EntityId, S e
 
     protected AbstractPolicyLoadingEnforcerActor(final I entityId,
             final E enforcement,
-            final PolicyEnforcerProvider policyEnforcerProvider) {
-        super(entityId, enforcement);
+            final PolicyEnforcerProvider policyEnforcerProvider,
+            final LocalAskTimeoutConfig localAskTimeoutConfig
+    ) {
+        super(entityId, enforcement, localAskTimeoutConfig);
         this.policyEnforcerProvider = policyEnforcerProvider;
     }
 

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
@@ -19,6 +19,7 @@ import java.util.function.Function;
 
 import org.apache.pekko.actor.Props;
 import org.eclipse.ditto.base.model.signals.Signal;
+import org.eclipse.ditto.base.service.config.supervision.LocalAskTimeoutConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
 import org.eclipse.ditto.policies.enforcement.AbstractPolicyLoadingEnforcerActor;
 import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
@@ -39,9 +40,12 @@ public final class PolicyEnforcerActor extends
         AbstractPolicyLoadingEnforcerActor<PolicyId, Signal<?>, PolicyCommandResponse<?>, PolicyCommandEnforcement> {
 
     @SuppressWarnings("unused")
-    private PolicyEnforcerActor(final PolicyId policyId, final PolicyCommandEnforcement policyCommandEnforcement,
-            final PolicyEnforcerProvider policyEnforcerProvider) {
-        super(policyId, policyCommandEnforcement, policyEnforcerProvider);
+    private PolicyEnforcerActor(final PolicyId policyId,
+            final PolicyCommandEnforcement policyCommandEnforcement,
+            final PolicyEnforcerProvider policyEnforcerProvider,
+            final LocalAskTimeoutConfig localAskTimeoutConfig
+    ) {
+        super(policyId, policyCommandEnforcement, policyEnforcerProvider, localAskTimeoutConfig);
     }
 
     /**
@@ -50,12 +54,14 @@ public final class PolicyEnforcerActor extends
      * @param policyId the PolicyId this enforcer actor is responsible for.
      * @param policyCommandEnforcement the policy command enforcement logic to apply in the enforcer.
      * @param policyEnforcerProvider the policy enforcer provider.
+     * @param localAskTimeoutConfig the configuration for determining local "ask" timeouts.
      * @return the {@link Props} to create this actor.
      */
     public static Props props(final PolicyId policyId, final PolicyCommandEnforcement policyCommandEnforcement,
-            final PolicyEnforcerProvider policyEnforcerProvider) {
-        return Props.create(PolicyEnforcerActor.class, policyId, policyCommandEnforcement, policyEnforcerProvider)
-                .withDispatcher(ENFORCEMENT_DISPATCHER);
+            final PolicyEnforcerProvider policyEnforcerProvider, final LocalAskTimeoutConfig localAskTimeoutConfig) {
+        return Props.create(PolicyEnforcerActor.class, policyId, policyCommandEnforcement, policyEnforcerProvider,
+                        localAskTimeoutConfig
+                ).withDispatcher(ENFORCEMENT_DISPATCHER);
     }
 
     @Override

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
@@ -114,7 +114,9 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
 
     @Override
     protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
-        return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider);
+        return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
+                policiesConfig.getPolicyConfig().getSupervisorConfig().getLocalAskTimeoutConfig()
+        );
     }
 
     @Override

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
@@ -47,6 +47,7 @@ import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.base.model.signals.commands.streaming.SubscribeForPersistedEvents;
 import org.eclipse.ditto.base.model.signals.events.Event;
 import org.eclipse.ditto.base.service.actors.ShutdownBehaviour;
+import org.eclipse.ditto.base.service.config.supervision.DefaultLocalAskTimeoutConfig;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.internal.utils.persistentactors.AbstractPersistenceSupervisor;
@@ -808,7 +809,8 @@ public final class PolicyCommandEnforcementTest {
 
         @Override
         protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
-            return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider);
+            return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
+                    DefaultLocalAskTimeoutConfig.of(ConfigFactory.empty()));
         }
 
         @Override

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/ThingSupervisorActor.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/persistence/actors/ThingSupervisorActor.java
@@ -310,7 +310,8 @@ public final class ThingSupervisorActor extends AbstractPersistenceSupervisor<Th
         } else if (message instanceof ThingQueryCommand<?> thingQueryCommand &&
                 Signal.isChannelSmart(thingQueryCommand)) {
 
-            return smartChannelDispatching.dispatchSmartChannelThingQueryCommand(thingQueryCommand, sender);
+            return smartChannelDispatching.dispatchSmartChannelThingQueryCommand(thingQueryCommand, sender,
+                    determineAskTimeoutForPersistenceActorForwarding(true));
         } else if (message instanceof ThingQueryCommand<?> thingQueryCommand &&
                 Command.isLiveCommand(thingQueryCommand)) {
 
@@ -334,7 +335,8 @@ public final class ThingSupervisorActor extends AbstractPersistenceSupervisor<Th
                     if (pair.command() instanceof RetrieveThing retrieveThing &&
                             SupervisorInlinePolicyEnrichment.shouldRetrievePolicyWithThing(retrieveThing) &&
                             pair.response() instanceof RetrieveThingResponse retrieveThingResponse) {
-                        return inlinePolicyEnrichment.enrichPolicy(retrieveThing, retrieveThingResponse)
+                        return inlinePolicyEnrichment.enrichPolicy(retrieveThing, retrieveThingResponse,
+                                        determineAskTimeoutForPersistenceActorForwarding(true))
                                 .map(Object.class::cast);
                     } else if (RollbackCreatedPolicy.shouldRollbackBasedOnTargetActorResponse(pair.command(),
                             pair.response())) {
@@ -430,7 +432,10 @@ public final class ThingSupervisorActor extends AbstractPersistenceSupervisor<Th
                 new ThingEnforcement(policiesShardRegion, system, enforcementConfig);
 
         return ThingEnforcerActor.props(entityId, thingsConfig, thingEnforcement,
-                enforcementConfig.getAskWithRetryConfig(), policiesShardRegion, thingsShardRegion, policyEnforcerProvider);
+                enforcementConfig.getAskWithRetryConfig(),
+                thingsConfig.getThingConfig().getSupervisorConfig().getLocalAskTimeoutConfig(),
+                policiesShardRegion, thingsShardRegion, policyEnforcerProvider
+        );
     }
 
     @Override


### PR DESCRIPTION
* during recovery, use much higher ask timeouts
* after recovery, fall back to lower one
* use configured values instead of hardcoded ones