### PR TITLE
add possibility to add custom annotations to serviceaccount.yaml

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.10  # chart version is effectively set by release-job
+version: 3.8.11  # chart version is effectively set by release-job
 appVersion: 3.8.10
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/serviceaccount.yaml
+++ b/deployment/helm/ditto/templates/serviceaccount.yaml
@@ -21,5 +21,8 @@ metadata:
     {{- if .Values.serviceAccount.assumeAwsIamRole }}
     eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.assumedAwsRoleArn }}
     {{- end }}
+    {{- if .Values.serviceAccount.annotations }}
+    {{ toYaml .Values.serviceAccount.annotations }}
+    {{- end }}
 {{ include "ditto.labels" . | indent 4 }}
 {{- end -}}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -19,6 +19,10 @@ serviceAccount:
   # name is the name of the service account to use
   #  If not set and create is true, a name is generated using the fullname template
   name:
+  # Additional annotations to add to the service account.
+  # Useful when using GitOps tooling like Argo or Flux in order to add sync-wave annotations that ensure
+  # the service account is created before other resources depending on it like the pre-upgrade hook.
+  annotations: {}
   # assumeAwsIamRole specifies whether to assume an AWS IAM Role for Service Accounts (IRSA).
   # Set to true to use IRSA, which allows the pod to assume an IAM role.
   # When set to true, ensure that awsRoleArn is specified.


### PR DESCRIPTION
 - GitOps tools like ArgoCD or Flux may cause problems on first install when creating pre-upgrade hooks -> job needs service account, but it doesn't exist
 - this way sync-wave annotations can be added in argo for example to ensure service account is actually present when creating Ditto for the first time