### PR TITLE
#2053: add configurable slow query logging to search service

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.13  # chart version is effectively set by release-job
+version: 3.8.14  # chart version is effectively set by release-job
 appVersion: 3.8.10
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/templates/thingssearch-deployment.yaml
+++ b/deployment/helm/ditto/templates/thingssearch-deployment.yaml
@@ -259,6 +259,10 @@ spec:
               value: "{{ .Values.thingsSearch.config.updater.stream.retrievalParallelism }}"
             - name: THINGS_SEARCH_UPDATER_STREAM_PERSISTENCE_PARALLELISM
               value: "{{ .Values.thingsSearch.config.updater.stream.persistence.parallelism }}"
+            - name: THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_ENABLED
+              value: "{{ .Values.thingsSearch.config.query.slowQueryLog.enabled }}"
+            - name: THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_THRESHOLD
+              value: "{{ .Values.thingsSearch.config.query.slowQueryLog.threshold }}"
             - name: THINGS_SEARCH_OPERATOR_METRICS_ENABLED
               value: "{{ .Values.thingsSearch.config.operatorMetrics.enabled }}"
             - name: THINGS_SEARCH_OPERATOR_METRICS_SCRAPE_INTERVAL

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -1631,6 +1631,14 @@ thingsSearch:
         interval: 1s
         # limit is the maximum number of updates allowed within each throttling interval
         limit: 100
+    # query contains configuration for the search query handling
+    query:
+      # slowQueryLog contains configuration for logging slow search queries
+      slowQueryLog:
+        # enabled controls whether slow query logging is enabled
+        enabled: true
+        # threshold defines the duration above which queries are considered slow and logged
+        threshold: "1s"
     # updater contains configuration for the "Things Updater" of things-search service
     updater:
       # activityCheckInterval configures to keep thing updaters for that amount of time in memory when no update did happen:

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSlowQueryLogConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSlowQueryLogConfig.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class is the default implementation for {@link SlowQueryLogConfig}.
+ */
+@Immutable
+public final class DefaultSlowQueryLogConfig implements SlowQueryLogConfig {
+
+    /**
+     * Path where the slow query log config values are expected.
+     */
+    static final String CONFIG_PATH = "slow-query-log";
+
+    private final boolean enabled;
+    private final Duration threshold;
+
+    private DefaultSlowQueryLogConfig(final ConfigWithFallback configWithFallback) {
+        enabled = configWithFallback.getBoolean(SlowQueryLogConfigValue.ENABLED.getConfigPath());
+        threshold = configWithFallback.getNonNegativeDurationOrThrow(SlowQueryLogConfigValue.THRESHOLD);
+    }
+
+    /**
+     * Returns an instance of DefaultSlowQueryLogConfig based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the settings of the slow query log config at {@value #CONFIG_PATH}.
+     * @return the instance.
+     * @throws org.eclipse.ditto.internal.utils.config.DittoConfigError if {@code config} is invalid.
+     */
+    public static DefaultSlowQueryLogConfig of(final Config config) {
+        return new DefaultSlowQueryLogConfig(
+                ConfigWithFallback.newInstance(config, CONFIG_PATH, SlowQueryLogConfigValue.values()));
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public Duration getThreshold() {
+        return threshold;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultSlowQueryLogConfig that = (DefaultSlowQueryLogConfig) o;
+        return enabled == that.enabled &&
+                Objects.equals(threshold, that.threshold);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(enabled, threshold);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "enabled=" + enabled +
+                ", threshold=" + threshold +
+                "]";
+    }
+
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/DittoSearchConfig.java
@@ -84,6 +84,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
     private final List<NamespaceSearchIndexConfig> namespaceIndexedFields;
     private final DefaultOperatorMetricsConfig operatorMetricsConfig;
     private final Map<String, CustomSearchIndexConfig> customIndexes;
+    private final SlowQueryLogConfig slowQueryLogConfig;
 
     private DittoSearchConfig(final ScopedConfig dittoScopedConfig) {
         dittoServiceConfig = DittoServiceConfig.of(dittoScopedConfig, CONFIG_PATH);
@@ -102,6 +103,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
                 ? configWithFallback.getConfig(QUERY_PATH)
                 : ConfigFactory.empty();
         queryPersistenceConfig = DefaultSearchPersistenceConfig.of(queryConfig);
+        slowQueryLogConfig = DefaultSlowQueryLogConfig.of(queryConfig);
         simpleFieldMappings =
                 convertToMap(configWithFallback.getConfig(SearchConfigValue.SIMPLE_FIELD_MAPPINGS.getConfigPath()));
         namespaceIndexedFields = loadNamespaceSearchIndexList(configWithFallback);
@@ -182,6 +184,11 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
     }
 
     @Override
+    public SlowQueryLogConfig getSlowQueryLogConfig() {
+        return slowQueryLogConfig;
+    }
+
+    @Override
     public ClusterConfig getClusterConfig() {
         return dittoServiceConfig.getClusterConfig();
     }
@@ -252,6 +259,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
                 Objects.equals(queryPersistenceConfig, that.queryPersistenceConfig) &&
                 Objects.equals(simpleFieldMappings, that.simpleFieldMappings) &&
                 Objects.equals(operatorMetricsConfig, that.operatorMetricsConfig) &&
+                Objects.equals(slowQueryLogConfig, that.slowQueryLogConfig) &&
                 Objects.equals(namespaceIndexedFields, that.namespaceIndexedFields) &&
                 Objects.equals(customIndexes, that.customIndexes);
     }
@@ -260,8 +268,8 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
     public int hashCode() {
         return Objects.hash(mongoHintsByNamespace, mongoCountHintIndexName, updaterConfig, dittoServiceConfig,
                 healthCheckConfig, indexInitializationConfig, persistenceOperationsConfig, mongoDbConfig,
-                queryPersistenceConfig, simpleFieldMappings, operatorMetricsConfig, namespaceIndexedFields,
-                customIndexes);
+                queryPersistenceConfig, simpleFieldMappings, operatorMetricsConfig, slowQueryLogConfig,
+                namespaceIndexedFields, customIndexes);
     }
 
     @Override
@@ -280,6 +288,7 @@ public final class DittoSearchConfig implements SearchConfig, WithConfigPath {
                 ", namespaceIndexedFields=" + namespaceIndexedFields +
                 ", operatorMetricsConfig=" + operatorMetricsConfig +
                 ", customIndexes=" + customIndexes +
+                ", slowQueryLogConfig=" + slowQueryLogConfig +
                 "]";
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SearchConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SearchConfig.java
@@ -92,6 +92,13 @@ public interface SearchConfig extends ServiceSpecificConfig, WithHealthCheckConf
     OperatorMetricsConfig getOperatorMetricsConfig();
 
     /**
+     * Returns the slow query log configuration for logging queries that exceed a configurable threshold.
+     *
+     * @return the slow query log configuration.
+     */
+    SlowQueryLogConfig getSlowQueryLogConfig();
+
+    /**
      * Returns a map of fields scoped by namespaces that will be explicitly included in the search index.
      *
      * @return the search projection fields.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SlowQueryLogConfig.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/common/config/SlowQueryLogConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+/**
+ * Provides configuration settings for slow query logging.
+ */
+@Immutable
+public interface SlowQueryLogConfig {
+
+    /**
+     * Returns whether slow query logging is enabled.
+     *
+     * @return true if enabled, false otherwise.
+     */
+    boolean isEnabled();
+
+    /**
+     * Returns the threshold duration above which queries are considered slow and will be logged.
+     *
+     * @return the threshold duration.
+     */
+    Duration getThreshold();
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values for
+     * SlowQueryLogConfig.
+     */
+    enum SlowQueryLogConfigValue implements KnownConfigValue {
+
+        /**
+         * Whether slow query logging is enabled.
+         */
+        ENABLED("enabled", true),
+
+        /**
+         * The threshold duration above which queries are considered slow.
+         */
+        THRESHOLD("threshold", Duration.ofSeconds(1));
+
+        private final String path;
+        private final Object defaultValue;
+
+        SlowQueryLogConfigValue(final String thePath, final Object theDefaultValue) {
+            path = thePath;
+            defaultValue = theDefaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return path;
+        }
+
+    }
+
+}

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchRootActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchRootActor.java
@@ -131,7 +131,8 @@ public final class SearchRootActor extends DittoRootActor {
     private ActorRef initializeSearchActor(final SearchConfig searchConfig,
             final ThingsSearchPersistence thingsSearchPersistence, final ActorRef pubSubMediator) {
         final var queryParser = getQueryParser(searchConfig, getContext().getSystem());
-        final var props = SearchActor.props(queryParser, thingsSearchPersistence, pubSubMediator);
+        final var slowQueryLogConfig = searchConfig.getSlowQueryLogConfig();
+        final var props = SearchActor.props(queryParser, thingsSearchPersistence, pubSubMediator, slowQueryLogConfig);
         return startChildActor(SearchActor.ACTOR_NAME, props);
     }
 

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -123,6 +123,16 @@ ditto {
         readConcern = ${ditto.mongodb.options.readConcern}
         readConcern = ${?QUERY_PERSISTENCE_MONGO_DB_READ_CONCERN}
       }
+
+      slow-query-log {
+        # whether slow query logging is enabled
+        enabled = true
+        enabled = ${?THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_ENABLED}
+
+        # queries exceeding this threshold will be logged
+        threshold = 1s
+        threshold = ${?THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_THRESHOLD}
+      }
     }
 
     # How simple fields (root level, primitive type) are mapped during query parsing

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSlowQueryLogConfigTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/common/config/DefaultSlowQueryLogConfigTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.common.config;
+
+import java.time.Duration;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit tests for {@link DefaultSlowQueryLogConfig}.
+ */
+public final class DefaultSlowQueryLogConfigTest {
+
+    private static Config config;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @BeforeClass
+    public static void initTestFixture() {
+        config = ConfigFactory.load("slow-query-log-test");
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultSlowQueryLogConfig.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final SlowQueryLogConfig underTest = DefaultSlowQueryLogConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.isEnabled())
+                .as(SlowQueryLogConfig.SlowQueryLogConfigValue.ENABLED.getConfigPath())
+                .isEqualTo(SlowQueryLogConfig.SlowQueryLogConfigValue.ENABLED.getDefaultValue());
+
+        softly.assertThat(underTest.getThreshold())
+                .as(SlowQueryLogConfig.SlowQueryLogConfigValue.THRESHOLD.getConfigPath())
+                .isEqualTo(SlowQueryLogConfig.SlowQueryLogConfigValue.THRESHOLD.getDefaultValue());
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final SlowQueryLogConfig underTest = DefaultSlowQueryLogConfig.of(config);
+
+        softly.assertThat(underTest.isEnabled())
+                .as(SlowQueryLogConfig.SlowQueryLogConfigValue.ENABLED.getConfigPath())
+                .isFalse();
+
+        softly.assertThat(underTest.getThreshold())
+                .as(SlowQueryLogConfig.SlowQueryLogConfigValue.THRESHOLD.getConfigPath())
+                .isEqualTo(Duration.ofMillis(500));
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/starter/actors/SearchActorTest.java
@@ -43,6 +43,7 @@ import org.eclipse.ditto.thingsearch.model.signals.commands.query.CountThingsRes
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.QueryThings;
 import org.eclipse.ditto.thingsearch.model.signals.commands.query.QueryThingsResponse;
 import org.eclipse.ditto.thingsearch.service.common.config.DittoSearchConfig;
+import org.eclipse.ditto.thingsearch.service.common.config.SlowQueryLogConfig;
 import org.eclipse.ditto.thingsearch.service.common.model.ResultListImpl;
 import org.eclipse.ditto.thingsearch.service.persistence.query.QueryParser;
 import org.eclipse.ditto.thingsearch.service.persistence.read.ThingsSearchPersistence;
@@ -71,17 +72,19 @@ public final class SearchActorTest {
 
     private final ThingsSearchPersistence persistence = Mockito.mock(ThingsSearchPersistence.class);
     private QueryParser queryParser;
+    private SlowQueryLogConfig slowQueryLogConfig;
 
     @Before
     public void init() {
         final var searchConfig = DittoSearchConfig.of(DefaultScopedConfig.dittoScoped(CONFIG));
         queryParser = SearchRootActor.getQueryParser(searchConfig, actorSystemResource.getActorSystem());
+        slowQueryLogConfig = searchConfig.getSlowQueryLogConfig();
     }
 
     @Test
     public void unbindAndStopWithoutQuery() {
         new TestKit(actorSystemResource.getActorSystem()) {{
-            final var props = SearchActor.props(queryParser, persistence, getRef());
+            final var props = SearchActor.props(queryParser, persistence, getRef(), slowQueryLogConfig);
             final var underTest = childActorOf(props, SearchActor.ACTOR_NAME);
 
             final var expectedSubscribe =
@@ -108,7 +111,7 @@ public final class SearchActorTest {
     @Test
     public void waitForQueries() {
         new TestKit(actorSystemResource.getActorSystem()) {{
-            final var props = SearchActor.props(queryParser, persistence, getRef());
+            final var props = SearchActor.props(queryParser, persistence, getRef(), slowQueryLogConfig);
             final var underTest = childActorOf(props, SearchActor.ACTOR_NAME);
 
             final var expectedSubscribe =

--- a/thingsearch/service/src/test/resources/slow-query-log-test.conf
+++ b/thingsearch/service/src/test/resources/slow-query-log-test.conf
@@ -1,0 +1,4 @@
+slow-query-log {
+  enabled = false
+  threshold = 500ms
+}


### PR DESCRIPTION
Adds a new feature to log slow search queries that exceed a configurable threshold. When enabled, queries exceeding the threshold will be logged with details including duration, namespaces, RQL filter, and the corresponding MongoDB BSON filter.

Configuration:
- ditto.search.query.slow-query-log.enabled (default: true)
- ditto.search.query.slow-query-log.threshold (default: 1s)

Environment variables:
- THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_ENABLED
- THINGS_SEARCH_QUERY_SLOW_QUERY_LOG_THRESHOLD

Fixes: #2053