### PR TITLE
#2280: Add per-namespace activity check configuration

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.13  # chart version is effectively set by release-job
+version: 3.8.14  # chart version is effectively set by release-job
 appVersion: 3.8.10
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/service-config/policies-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/policies-extension.conf.tpl
@@ -38,6 +38,15 @@ ditto {
   }
   policies {
     policy {
+      namespace-activity-check = [
+      {{- range $index, $nsActivityCheck := .Values.policies.config.persistence.namespaceActivityCheckOverrides }}
+        {
+          namespace-pattern = "{{$nsActivityCheck.namespacePattern}}"
+          inactive-interval = "{{$nsActivityCheck.inactiveInterval}}"
+          deleted-interval = "{{$nsActivityCheck.deletedInterval}}"
+        }
+      {{- end }}
+      ]
       event {
         historical-headers-to-persist = [
         {{- range $index, $header := .Values.policies.config.persistence.events.historicalHeadersToPersist }}

--- a/deployment/helm/ditto/service-config/things-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/things-extension.conf.tpl
@@ -56,6 +56,15 @@ ditto {
   }
   things {
     thing {
+      namespace-activity-check = [
+      {{- range $index, $nsActivityCheck := .Values.things.config.persistence.namespaceActivityCheckOverrides }}
+        {
+          namespace-pattern = "{{$nsActivityCheck.namespacePattern}}"
+          inactive-interval = "{{$nsActivityCheck.inactiveInterval}}"
+          deleted-interval = "{{$nsActivityCheck.deletedInterval}}"
+        }
+      {{- end }}
+      ]
       event {
         historical-headers-to-persist = [
         {{- range $index, $header := .Values.things.config.persistence.events.historicalHeadersToPersist }}

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -871,6 +871,13 @@ policies:
     persistence:
       # activityCheckInterval configures to keep policies for that amount of time in memory when no other use did happen:
       activityCheckInterval: 2d
+      # namespaceActivityCheckOverrides allows configuring different passivation intervals for policies in specific namespaces
+      #  First match wins - namespace patterns are evaluated in order.
+      #  Supports SQL-LIKE wildcard patterns: '*' matches any number of characters, '?' matches single character.
+      namespaceActivityCheckOverrides: []
+      # - namespacePattern: "org.example.low-frequency*"
+      #   inactiveInterval: "5m"
+      #   deletedInterval: "1m"
       # pingRate used to throttle pinging of PolicyPersistenceActors, so that not all PolicyPersistenceActors are recovered at the same time:
       pingRate:
         # frequency the frequency of sent "pings" to PolicyPersistenceActors
@@ -1212,6 +1219,13 @@ things:
     persistence:
       # activityCheckInterval configures to keep things for that amount of time in memory when no other use did happen
       activityCheckInterval: 2d
+      # namespaceActivityCheckOverrides allows configuring different passivation intervals for things in specific namespaces
+      #  First match wins - namespace patterns are evaluated in order.
+      #  Supports SQL-LIKE wildcard patterns: '*' matches any number of characters, '?' matches single character.
+      namespaceActivityCheckOverrides: []
+      # - namespacePattern: "org.example.low-frequency*"
+      #   inactiveInterval: "5m"
+      #   deletedInterval: "1m"
       # events contains event journal specific configuration
       events:
         # historicalHeadersToPersist define the DittoHeaders to persist when persisting events to the journal

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultNamespaceActivityCheckConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultNamespaceActivityCheckConfig.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.ConfigWithFallback;
+
+import com.typesafe.config.Config;
+
+/**
+ * This class is the default implementation of the NamespaceActivityCheckConfig.
+ * It is instantiated for each namespace activity check entry containing the namespace pattern
+ * and the activity check intervals.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+public final class DefaultNamespaceActivityCheckConfig implements NamespaceActivityCheckConfig {
+
+    private final String namespacePattern;
+    private final Duration inactiveInterval;
+    private final Duration deletedInterval;
+
+    private DefaultNamespaceActivityCheckConfig(final ConfigWithFallback configWithFallback) {
+        this.namespacePattern = configWithFallback.getString(
+                NamespaceActivityCheckConfigValue.NAMESPACE_PATTERN.getConfigPath());
+        this.inactiveInterval = configWithFallback.getDuration(
+                NamespaceActivityCheckConfigValue.INACTIVE_INTERVAL.getConfigPath());
+        this.deletedInterval = configWithFallback.getDuration(
+                NamespaceActivityCheckConfigValue.DELETED_INTERVAL.getConfigPath());
+    }
+
+    /**
+     * Returns an instance of {@code DefaultNamespaceActivityCheckConfig} based on the settings of the specified Config.
+     *
+     * @param config is supposed to provide the config for the namespace activity check at its current level.
+     * @return the instance.
+     */
+    public static DefaultNamespaceActivityCheckConfig of(final Config config) {
+        return new DefaultNamespaceActivityCheckConfig(
+                ConfigWithFallback.newInstance(config, NamespaceActivityCheckConfigValue.values()));
+    }
+
+    @Override
+    public String getNamespacePattern() {
+        return namespacePattern;
+    }
+
+    @Override
+    public Duration getInactiveInterval() {
+        return inactiveInterval;
+    }
+
+    @Override
+    public Duration getDeletedInterval() {
+        return deletedInterval;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final DefaultNamespaceActivityCheckConfig that = (DefaultNamespaceActivityCheckConfig) o;
+        return Objects.equals(namespacePattern, that.namespacePattern) &&
+                Objects.equals(inactiveInterval, that.inactiveInterval) &&
+                Objects.equals(deletedInterval, that.deletedInterval);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(namespacePattern, inactiveInterval, deletedInterval);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "namespacePattern=" + namespacePattern +
+                ", inactiveInterval=" + inactiveInterval +
+                ", deletedInterval=" + deletedInterval +
+                "]";
+    }
+}

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import java.time.Duration;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+
+/**
+ * Provides configuration settings for namespace-scoped activity checks.
+ * This allows different passivation intervals to be configured for entities in specific namespaces.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+public interface NamespaceActivityCheckConfig extends ActivityCheckConfig {
+
+    /**
+     * Returns the namespace pattern definition.
+     * Supports SQL-LIKE wildcard patterns using '*' (matches any number of characters)
+     * and '?' (matches any single character).
+     *
+     * @return the namespace pattern definition.
+     */
+    String getNamespacePattern();
+
+    /**
+     * An enumeration of the known config path expressions and their associated default values for
+     * {@code NamespaceActivityCheckConfig}.
+     */
+    enum NamespaceActivityCheckConfigValue implements KnownConfigValue {
+
+        /**
+         * The namespace pattern to apply the activity check configuration.
+         */
+        NAMESPACE_PATTERN("namespace-pattern", ""),
+
+        /**
+         * The interval of how long to keep an "inactive" entity in memory.
+         */
+        INACTIVE_INTERVAL("inactive-interval", Duration.ofHours(2L)),
+
+        /**
+         * The interval of how long to keep a deleted entity in memory.
+         */
+        DELETED_INTERVAL("deleted-interval", Duration.ofMinutes(5L));
+
+        private final String configPath;
+        private final Object defaultValue;
+
+        NamespaceActivityCheckConfigValue(final String configPath, final Object defaultValue) {
+            this.configPath = configPath;
+            this.defaultValue = defaultValue;
+        }
+
+        @Override
+        public Object getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getConfigPath() {
+            return configPath;
+        }
+    }
+}

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfigProvider.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfigProvider.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import static org.eclipse.ditto.base.model.common.ConditionChecker.checkNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.common.LikeHelper;
+
+/**
+ * Provider for namespace-specific activity check configurations.
+ * Compiles namespace patterns to regex at construction time and provides the appropriate
+ * configuration for a given namespace.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+public final class NamespaceActivityCheckConfigProvider {
+
+    private final List<CompiledNamespaceConfig> compiledConfigs;
+    private final ActivityCheckConfig defaultConfig;
+
+    private NamespaceActivityCheckConfigProvider(
+            final List<CompiledNamespaceConfig> compiledConfigs,
+            final ActivityCheckConfig defaultConfig) {
+        this.compiledConfigs = compiledConfigs;
+        this.defaultConfig = defaultConfig;
+    }
+
+    /**
+     * Creates a new instance of {@code NamespaceActivityCheckConfigProvider}.
+     *
+     * @param namespaceConfigs the list of namespace-specific activity check configurations.
+     * @param defaultConfig the default activity check configuration to use when no namespace pattern matches.
+     * @return the new instance.
+     */
+    public static NamespaceActivityCheckConfigProvider of(
+            final List<NamespaceActivityCheckConfig> namespaceConfigs,
+            final ActivityCheckConfig defaultConfig) {
+
+        checkNotNull(namespaceConfigs, "namespaceConfigs");
+        checkNotNull(defaultConfig, "defaultConfig");
+
+        final List<CompiledNamespaceConfig> compiledConfigs = new ArrayList<>(namespaceConfigs.size());
+        for (final NamespaceActivityCheckConfig config : namespaceConfigs) {
+            final String pattern = config.getNamespacePattern();
+            if (pattern != null && !pattern.isEmpty()) {
+                final String regex = LikeHelper.convertToRegexSyntax(pattern);
+                if (regex != null) {
+                    compiledConfigs.add(new CompiledNamespaceConfig(Pattern.compile(regex), config));
+                }
+            }
+        }
+
+        return new NamespaceActivityCheckConfigProvider(List.copyOf(compiledConfigs), defaultConfig);
+    }
+
+    /**
+     * Returns the activity check configuration for the given namespace.
+     * Evaluates namespace patterns in order and returns the first matching configuration.
+     * If no pattern matches, returns the default configuration.
+     *
+     * @param namespace the namespace to get the configuration for.
+     * @return the activity check configuration for the namespace.
+     */
+    public ActivityCheckConfig getConfigForNamespace(@Nullable final String namespace) {
+        if (namespace == null || namespace.isEmpty()) {
+            return defaultConfig;
+        }
+
+        for (final CompiledNamespaceConfig compiledConfig : compiledConfigs) {
+            if (compiledConfig.pattern.matcher(namespace).matches()) {
+                return compiledConfig.config;
+            }
+        }
+
+        return defaultConfig;
+    }
+
+    @Immutable
+    private static final class CompiledNamespaceConfig {
+
+        private final Pattern pattern;
+        private final NamespaceActivityCheckConfig config;
+
+        private CompiledNamespaceConfig(final Pattern pattern, final NamespaceActivityCheckConfig config) {
+            this.pattern = pattern;
+            this.config = config;
+        }
+    }
+}

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultNamespaceActivityCheckConfigTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/DefaultNamespaceActivityCheckConfigTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import java.time.Duration;
+
+import org.assertj.core.api.JUnitSoftAssertions;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Unit test for {@link DefaultNamespaceActivityCheckConfig}.
+ */
+public final class DefaultNamespaceActivityCheckConfigTest {
+
+    private static Config namespaceActivityCheckTestConf;
+
+    @Rule
+    public final JUnitSoftAssertions softly = new JUnitSoftAssertions();
+
+    @BeforeClass
+    public static void initTestFixture() {
+        namespaceActivityCheckTestConf = ConfigFactory.load("namespace-activity-check-test");
+    }
+
+    @Test
+    public void testHashCodeAndEquals() {
+        EqualsVerifier.forClass(DefaultNamespaceActivityCheckConfig.class)
+                .usingGetClass()
+                .verify();
+    }
+
+    @Test
+    public void underTestReturnsDefaultValuesIfBaseConfigWasEmpty() {
+        final DefaultNamespaceActivityCheckConfig underTest =
+                DefaultNamespaceActivityCheckConfig.of(ConfigFactory.empty());
+
+        softly.assertThat(underTest.getNamespacePattern())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.NAMESPACE_PATTERN.getConfigPath())
+                .isEqualTo(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.NAMESPACE_PATTERN.getDefaultValue());
+        softly.assertThat(underTest.getInactiveInterval())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.INACTIVE_INTERVAL.getConfigPath())
+                .isEqualTo(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.INACTIVE_INTERVAL.getDefaultValue());
+        softly.assertThat(underTest.getDeletedInterval())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.DELETED_INTERVAL.getConfigPath())
+                .isEqualTo(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.DELETED_INTERVAL.getDefaultValue());
+    }
+
+    @Test
+    public void underTestReturnsValuesOfConfigFile() {
+        final DefaultNamespaceActivityCheckConfig underTest =
+                DefaultNamespaceActivityCheckConfig.of(namespaceActivityCheckTestConf);
+
+        softly.assertThat(underTest.getNamespacePattern())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.NAMESPACE_PATTERN.getConfigPath())
+                .isEqualTo("org.example*");
+        softly.assertThat(underTest.getInactiveInterval())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.INACTIVE_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofMinutes(30L));
+        softly.assertThat(underTest.getDeletedInterval())
+                .as(NamespaceActivityCheckConfig.NamespaceActivityCheckConfigValue.DELETED_INTERVAL.getConfigPath())
+                .isEqualTo(Duration.ofMinutes(10L));
+    }
+}

--- a/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfigProviderTest.java
+++ b/internal/utils/persistence/src/test/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/NamespaceActivityCheckConfigProviderTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.internal.utils.persistence.mongo.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.List;
+
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit test for {@link NamespaceActivityCheckConfigProvider}.
+ */
+public final class NamespaceActivityCheckConfigProviderTest {
+
+    private static final Duration DEFAULT_INACTIVE_INTERVAL = Duration.ofHours(2L);
+    private static final Duration DEFAULT_DELETED_INTERVAL = Duration.ofMinutes(5L);
+
+    private static final Duration CUSTOM_INACTIVE_INTERVAL = Duration.ofMinutes(30L);
+    private static final Duration CUSTOM_DELETED_INTERVAL = Duration.ofMinutes(10L);
+
+    @Test
+    public void returnsDefaultConfigWhenNoNamespaceConfigsExist() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.eclipse.ditto");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(DEFAULT_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(DEFAULT_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsDefaultConfigWhenNamespaceIsNull() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example*");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace(null);
+
+        assertThat(result.getInactiveInterval()).isEqualTo(DEFAULT_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(DEFAULT_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsDefaultConfigWhenNamespaceIsEmpty() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example*");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(DEFAULT_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(DEFAULT_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsDefaultConfigWhenNoPatternMatches() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example*");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("com.other.namespace");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(DEFAULT_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(DEFAULT_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsCustomConfigWhenExactPatternMatches() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example.myapp");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.myapp");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(CUSTOM_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(CUSTOM_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsCustomConfigWhenWildcardPatternMatches() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example*");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.myapp.subpackage");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(CUSTOM_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(CUSTOM_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsCustomConfigWhenSingleCharWildcardMatches() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example.app?");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.app1");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(CUSTOM_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(CUSTOM_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void returnsDefaultConfigWhenSingleCharWildcardDoesNotMatch() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig customConfig = createCustomConfig("org.example.app?");
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(customConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.app12");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(DEFAULT_INACTIVE_INTERVAL);
+        assertThat(result.getDeletedInterval()).isEqualTo(DEFAULT_DELETED_INTERVAL);
+    }
+
+    @Test
+    public void firstMatchWins() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig firstConfig = createCustomConfig("org.example.first*",
+                Duration.ofMinutes(10L), Duration.ofMinutes(1L));
+        final NamespaceActivityCheckConfig secondConfig = createCustomConfig("org.example*",
+                Duration.ofMinutes(20L), Duration.ofMinutes(2L));
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(firstConfig, secondConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.first.app");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(Duration.ofMinutes(10L));
+        assertThat(result.getDeletedInterval()).isEqualTo(Duration.ofMinutes(1L));
+    }
+
+    @Test
+    public void secondPatternMatchesWhenFirstDoesNot() {
+        final ActivityCheckConfig defaultConfig = createDefaultConfig();
+        final NamespaceActivityCheckConfig firstConfig = createCustomConfig("org.example.first*",
+                Duration.ofMinutes(10L), Duration.ofMinutes(1L));
+        final NamespaceActivityCheckConfig secondConfig = createCustomConfig("org.example*",
+                Duration.ofMinutes(20L), Duration.ofMinutes(2L));
+        final NamespaceActivityCheckConfigProvider underTest =
+                NamespaceActivityCheckConfigProvider.of(List.of(firstConfig, secondConfig), defaultConfig);
+
+        final ActivityCheckConfig result = underTest.getConfigForNamespace("org.example.second.app");
+
+        assertThat(result.getInactiveInterval()).isEqualTo(Duration.ofMinutes(20L));
+        assertThat(result.getDeletedInterval()).isEqualTo(Duration.ofMinutes(2L));
+    }
+
+    private static ActivityCheckConfig createDefaultConfig() {
+        return DefaultActivityCheckConfig.of(ConfigFactory.parseString(
+                "activity-check { inactive-interval = 2h, deleted-interval = 5m }"
+        ));
+    }
+
+    private static NamespaceActivityCheckConfig createCustomConfig(final String namespacePattern) {
+        return createCustomConfig(namespacePattern, CUSTOM_INACTIVE_INTERVAL, CUSTOM_DELETED_INTERVAL);
+    }
+
+    private static NamespaceActivityCheckConfig createCustomConfig(final String namespacePattern,
+            final Duration inactiveInterval, final Duration deletedInterval) {
+        return DefaultNamespaceActivityCheckConfig.of(ConfigFactory.parseString(
+                "namespace-pattern = \"" + namespacePattern + "\"\n" +
+                        "inactive-interval = " + inactiveInterval.toMinutes() + "m\n" +
+                        "deleted-interval = " + deletedInterval.toMinutes() + "m"
+        ));
+    }
+}

--- a/internal/utils/persistence/src/test/resources/namespace-activity-check-test.conf
+++ b/internal/utils/persistence/src/test/resources/namespace-activity-check-test.conf
@@ -1,0 +1,3 @@
+namespace-pattern = "org.example*"
+inactive-interval = 30m
+deleted-interval = 10m

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyConfig.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/common/config/PolicyConfig.java
@@ -13,12 +13,14 @@
 package org.eclipse.ditto.policies.service.common.config;
 
 import java.time.Duration;
+import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.service.config.supervision.WithSupervisorConfig;
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.EventConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.NamespaceActivityCheckConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.WithActivityCheckConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.WithSnapshotConfig;
 import org.eclipse.ditto.internal.utils.persistentactors.cleanup.WithCleanupConfig;
@@ -74,6 +76,15 @@ public interface PolicyConfig extends WithSupervisorConfig, WithActivityCheckCon
      * @return the policy announcement config.
      */
     PolicyAnnouncementConfig getPolicyAnnouncementConfig();
+
+    /**
+     * Returns the list of namespace-specific activity check configurations.
+     * These allow different passivation intervals to be configured for policies in specific namespaces.
+     *
+     * @return the list of namespace activity check configurations.
+     * @since 3.9.0
+     */
+    List<NamespaceActivityCheckConfig> getNamespaceActivityCheckConfigs();
 
     /**
      * An enumeration of the known config path expressions and their associated default values for {@code PolicyConfig}.

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceActor.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.base.model.signals.commands.Command;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.config.DefaultScopedConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.ActivityCheckConfig;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.NamespaceActivityCheckConfigProvider;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.SnapshotConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJournal;
 import org.eclipse.ditto.internal.utils.persistentactors.AbstractPersistenceActor;
@@ -72,6 +73,7 @@ public final class PolicyPersistenceActor
 
     private final ActorRef pubSubMediator;
     private final PolicyConfig policyConfig;
+    private final NamespaceActivityCheckConfigProvider activityCheckConfigProvider;
     private final ActorRef announcementManager;
     private final ActorRef supervisor;
 
@@ -86,6 +88,10 @@ public final class PolicyPersistenceActor
         this.pubSubMediator = pubSubMediator;
         this.announcementManager = announcementManager;
         this.policyConfig = policyConfig;
+        this.activityCheckConfigProvider = NamespaceActivityCheckConfigProvider.of(
+                policyConfig.getNamespaceActivityCheckConfigs(),
+                policyConfig.getActivityCheckConfig()
+        );
         this.supervisor = getContext().getParent();
     }
 
@@ -104,6 +110,10 @@ public final class PolicyPersistenceActor
                 DefaultScopedConfig.dittoScoped(getContext().getSystem().settings().config())
         );
         this.policyConfig = policiesConfig.getPolicyConfig();
+        this.activityCheckConfigProvider = NamespaceActivityCheckConfigProvider.of(
+                policyConfig.getNamespaceActivityCheckConfigs(),
+                policyConfig.getActivityCheckConfig()
+        );
     }
 
     /**
@@ -179,7 +189,7 @@ public final class PolicyPersistenceActor
 
     @Override
     protected ActivityCheckConfig getActivityCheckConfig() {
-        return policyConfig.getActivityCheckConfig();
+        return activityCheckConfigProvider.getConfigForNamespace(entityId.getNamespace());
     }
 
     @Override

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -87,6 +87,17 @@ ditto {
         deleted-interval = ${?POLICY_ACTIVITY_CHECK_DELETED_INTERVAL}
       }
 
+      # Per-namespace activity check overrides (first match wins).
+      # Allows configuring different passivation intervals for policies in specific namespaces.
+      # Supports SQL-LIKE wildcard patterns: '*' matches any number of characters, '?' matches single character.
+      namespace-activity-check = [
+        # {
+        #   namespace-pattern = "org.example.low-frequency*"
+        #   inactive-interval = 5m
+        #   deleted-interval = 1m
+        # }
+      ]
+
       snapshot {
         # the interval when to do snapshot for a Policy which had changes to it
         interval = 15m

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/common/config/ThingConfig.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/common/config/ThingConfig.java
@@ -13,11 +13,13 @@
 package org.eclipse.ditto.things.service.common.config;
 
 import java.time.Duration;
+import java.util.List;
 
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.base.service.config.supervision.WithSupervisorConfig;
 import org.eclipse.ditto.internal.utils.config.KnownConfigValue;
+import org.eclipse.ditto.internal.utils.persistence.mongo.config.NamespaceActivityCheckConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.WithActivityCheckConfig;
 import org.eclipse.ditto.internal.utils.persistence.mongo.config.WithSnapshotConfig;
 import org.eclipse.ditto.internal.utils.persistentactors.cleanup.WithCleanupConfig;
@@ -49,6 +51,15 @@ public interface ThingConfig extends WithSupervisorConfig, WithActivityCheckConf
      * @return The timeout.
      */
     Duration getShutdownTimeout();
+
+    /**
+     * Returns the list of namespace-specific activity check configurations.
+     * These allow different passivation intervals to be configured for things in specific namespaces.
+     *
+     * @return the list of namespace activity check configurations.
+     * @since 3.9.0
+     */
+    List<NamespaceActivityCheckConfig> getNamespaceActivityCheckConfigs();
 
     /**
      * Indicates whether empty JSON objects should be removed from merge payloads when patch conditions filter out all content.

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -136,6 +136,17 @@ ditto {
         deleted-interval = ${?THING_ACTIVITY_CHECK_DELETED_INTERVAL}
       }
 
+      # Per-namespace activity check overrides (first match wins).
+      # Allows configuring different passivation intervals for things in specific namespaces.
+      # Supports SQL-LIKE wildcard patterns: '*' matches any number of characters, '?' matches single character.
+      namespace-activity-check = [
+        # {
+        #   namespace-pattern = "org.example.low-frequency*"
+        #   inactive-interval = 5m
+        #   deleted-interval = 1m
+        # }
+      ]
+
       snapshot {
         # the interval when to do snapshot for a Thing which had changes to it
         interval = 15m


### PR DESCRIPTION
Makes `activity-check.inactive-interval` and
`deleted-interval `configurable per namespace, allowing different entity passivation times based on namespace patterns.

Resolves: #2280