### PR TITLE
Add comprehensive JavaDoc to WoT model public interfaces

### DIFF
--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Action.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Action.java
@@ -25,60 +25,190 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * An Action is an {@link Interaction} describing a function which can be invoked on a Thing.
+ * <p>
+ * Actions allow Consumers to invoke functions on a Thing, potentially passing input data and receiving output data
+ * as a result. Unlike Properties, Actions may take time to complete and may have side effects.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance</a>
  * @since 2.4.0
  */
 public interface Action extends Interaction<Action, ActionFormElement, ActionForms> {
 
+    /**
+     * Creates a new Action from the specified JSON object.
+     *
+     * @param actionName the name of the action (the key in the actions map).
+     * @param jsonObject the JSON object representing the action affordance.
+     * @return the Action.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Action fromJson(final CharSequence actionName, final JsonObject jsonObject) {
         return new ImmutableAction(checkNotNull(actionName, "actionName").toString(), jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an Action.
+     *
+     * @param actionName the name of the action.
+     * @return the builder.
+     * @throws NullPointerException if {@code actionName} is {@code null}.
+     */
     static Action.Builder newBuilder(final CharSequence actionName) {
         return Action.Builder.newBuilder(actionName);
     }
 
+    /**
+     * Creates a new builder for building an Action, initialized with the values from the specified JSON object.
+     *
+     * @param actionName the name of the action.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Action.Builder newBuilder(final CharSequence actionName, final JsonObject jsonObject) {
         return Action.Builder.newBuilder(actionName, jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building an Action, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default Action.Builder toBuilder() {
         return Builder.newBuilder(getActionName(), toJson());
     }
 
+    /**
+     * Returns the name of this action as defined in the Thing Description's actions map.
+     *
+     * @return the action name.
+     */
     String getActionName();
 
+    /**
+     * Returns the optional data schema describing the input data accepted by this action.
+     *
+     * @return the optional input schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (input)</a>
+     */
     Optional<SingleDataSchema> getInput();
 
+    /**
+     * Returns the optional data schema describing the output data returned by this action.
+     *
+     * @return the optional output schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (output)</a>
+     */
     Optional<SingleDataSchema> getOutput();
 
+    /**
+     * Returns whether this action is safe, meaning it does not change the state of the Thing.
+     * <p>
+     * Safe actions can be called without risk of unintended side effects. The default is {@code false}.
+     * </p>
+     *
+     * @return {@code true} if the action is safe, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (safe)</a>
+     */
     boolean isSafe();
 
+    /**
+     * Returns whether this action is idempotent, meaning repeated invocations with the same input
+     * produce the same result without additional side effects.
+     * <p>
+     * The default is {@code false}.
+     * </p>
+     *
+     * @return {@code true} if the action is idempotent, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (idempotent)</a>
+     */
     boolean isIdempotent();
 
+    /**
+     * Returns the optional indication of whether the action is synchronous.
+     * <p>
+     * A synchronous action completes within a single request-response interaction,
+     * while an asynchronous action may take longer and require polling for completion.
+     * </p>
+     *
+     * @return the optional synchronous indicator.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (synchronous)</a>
+     */
     Optional<Boolean> isSynchronous();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link Action}.
+     */
     interface Builder extends Interaction.Builder<Builder, Action, ActionFormElement, ActionForms> {
 
+        /**
+         * Creates a new builder for building an Action.
+         *
+         * @param actionName the name of the action.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence actionName) {
             return new MutableActionBuilder(checkNotNull(actionName, "actionName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an Action, initialized with the values from the specified JSON object.
+         *
+         * @param actionName the name of the action.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence actionName, final JsonObject jsonObject) {
             return new MutableActionBuilder(checkNotNull(actionName, "actionName").toString(), jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the input data schema for this action.
+         *
+         * @param input the input schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (input)</a>
+         */
         Builder setInput(@Nullable SingleDataSchema input);
 
+        /**
+         * Sets the output data schema for this action.
+         *
+         * @param output the output schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (output)</a>
+         */
         Builder setOutput(@Nullable SingleDataSchema output);
 
+        /**
+         * Sets whether this action is safe.
+         *
+         * @param safe whether the action is safe, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (safe)</a>
+         */
         Builder setSafe(@Nullable Boolean safe);
 
+        /**
+         * Sets whether this action is idempotent.
+         *
+         * @param idempotent whether the action is idempotent, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (idempotent)</a>
+         */
         Builder setIdempotent(@Nullable Boolean idempotent);
 
+        /**
+         * Sets whether this action is synchronous.
+         *
+         * @param synchronous whether the action is synchronous, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance (synchronous)</a>
+         */
         Builder setSynchronous(@Nullable Boolean synchronous);
     }
 
@@ -88,18 +218,33 @@ public interface Action extends Interaction<Action, ActionFormElement, ActionFor
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the input data schema.
+         */
         public static final JsonFieldDefinition<JsonObject> INPUT = JsonFactory.newJsonObjectFieldDefinition(
                 "input");
 
+        /**
+         * JSON field definition for the output data schema.
+         */
         public static final JsonFieldDefinition<JsonObject> OUTPUT = JsonFactory.newJsonObjectFieldDefinition(
                 "output");
 
+        /**
+         * JSON field definition for the safe flag.
+         */
         public static final JsonFieldDefinition<Boolean> SAFE = JsonFactory.newBooleanFieldDefinition(
                 "safe");
 
+        /**
+         * JSON field definition for the idempotent flag.
+         */
         public static final JsonFieldDefinition<Boolean> IDEMPOTENT = JsonFactory.newBooleanFieldDefinition(
                 "idempotent");
 
+        /**
+         * JSON field definition for the synchronous flag.
+         */
         public static final JsonFieldDefinition<Boolean> SYNCHRONOUS = JsonFactory.newBooleanFieldDefinition(
                 "synchronous");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ActionFormElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ActionFormElement.java
@@ -23,14 +23,34 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface ActionFormElement extends FormElement<ActionFormElement> {
 
+    /**
+     * Creates a new ActionFormElement from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the form element.
+     * @return the ActionFormElement.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ActionFormElement fromJson(final JsonObject jsonObject) {
         return new ImmutableActionFormElement(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an ActionFormElement.
+     *
+     * @return the builder.
+     */
     static ActionFormElement.Builder newBuilder() {
         return ActionFormElement.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an ActionFormElement, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ActionFormElement.Builder newBuilder(final JsonObject jsonObject) {
         return ActionFormElement.Builder.newBuilder(jsonObject);
     }
@@ -40,18 +60,45 @@ public interface ActionFormElement extends FormElement<ActionFormElement> {
         return ActionFormElement.Builder.newBuilder(toJson());
     }
 
+    /**
+     * Returns the operation type(s) this form element supports for action affordances.
+     *
+     * @return the action operation type(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (op)</a>
+     */
     ActionFormElementOp<SingleActionFormElementOp> getOp();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link ActionFormElement}.
+     */
     interface Builder extends FormElement.Builder<Builder, ActionFormElement> {
 
+        /**
+         * Creates a new builder for building an ActionFormElement.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableActionFormElementBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an ActionFormElement, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableActionFormElementBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the operation type(s) for this form element.
+         *
+         * @param op the operation type(s), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setOp(@Nullable ActionFormElementOp<SingleActionFormElementOp> op);
 
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ActionForms.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ActionForms.java
@@ -27,6 +27,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface ActionForms extends Forms<ActionFormElement> {
 
+    /**
+     * Creates ActionForms from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of form element objects.
+     * @return the ActionForms.
+     */
     static ActionForms fromJson(final JsonArray jsonArray) {
         final List<ActionFormElement> actionFormElements = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -37,6 +43,12 @@ public interface ActionForms extends Forms<ActionFormElement> {
         return of(actionFormElements);
     }
 
+    /**
+     * Creates ActionForms from the specified collection of form elements.
+     *
+     * @param formElements the collection of form elements.
+     * @return the ActionForms.
+     */
     static ActionForms of(final Collection<ActionFormElement> formElements) {
         return new ImmutableActionForms(formElements);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Actions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Actions.java
@@ -29,6 +29,13 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Actions extends Map<String, Action>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new Actions container from the specified JSON object.
+     *
+     * @param jsonObject the JSON object containing action definitions.
+     * @return the Actions container.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static Actions fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -41,6 +48,13 @@ public interface Actions extends Map<String, Action>, Jsonifiable<JsonObject> {
         ));
     }
 
+    /**
+     * Creates a new Actions container from the specified collection of actions.
+     *
+     * @param actions the collection of actions.
+     * @return the Actions container.
+     * @throws NullPointerException if {@code actions} is {@code null}.
+     */
     static Actions from(final Collection<Action> actions) {
         return of(actions.stream().collect(Collectors.toMap(
                 Action::getActionName,
@@ -53,10 +67,23 @@ public interface Actions extends Map<String, Action>, Jsonifiable<JsonObject> {
         ));
     }
 
+    /**
+     * Creates a new Actions container from the specified map of action name to action.
+     *
+     * @param actions the map of actions.
+     * @return the Actions container.
+     * @throws NullPointerException if {@code actions} is {@code null}.
+     */
     static Actions of(final Map<String, Action> actions) {
         return new ImmutableActions(actions);
     }
 
+    /**
+     * Returns the action with the specified name if it exists.
+     *
+     * @param actionName the name of the action.
+     * @return the optional action.
+     */
     Optional<Action> getAction(CharSequence actionName);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AdditionalSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AdditionalSecurityScheme.java
@@ -26,23 +26,58 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface AdditionalSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new AdditionalSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the AdditionalSecurityScheme.
+     */
     static AdditionalSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableAdditionalSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an AdditionalSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param contextExtensionScopedScheme the context extension scoped scheme identifier.
+     * @return the builder.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static AdditionalSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
             final CharSequence contextExtensionScopedScheme) {
         return AdditionalSecurityScheme.Builder.newBuilder(securitySchemeName, contextExtensionScopedScheme);
     }
 
+    /**
+     * Creates a new builder for building an AdditionalSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param contextExtensionScopedScheme the context extension scoped scheme identifier.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static AdditionalSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
             final CharSequence contextExtensionScopedScheme,
             final JsonObject jsonObject) {
         return AdditionalSecurityScheme.Builder.newBuilder(securitySchemeName, contextExtensionScopedScheme, jsonObject);
     }
 
+    /**
+     * A mutable builder with a fluent API for building an {@link AdditionalSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<AdditionalSecurityScheme.Builder, AdditionalSecurityScheme> {
 
+        /**
+         * Creates a new builder for building an AdditionalSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param contextExtensionScopedScheme the context extension scoped scheme identifier.
+         * @return the builder.
+         */
         static AdditionalSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
                 final CharSequence contextExtensionScopedScheme) {
             final SecuritySchemeScheme scheme = SecuritySchemeScheme.of(
@@ -55,6 +90,15 @@ public interface AdditionalSecurityScheme extends SecurityScheme {
             return additionalSecuritySchemeBuilder.setScheme(scheme);
         }
 
+        /**
+         * Creates a new builder for building an AdditionalSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param contextExtensionScopedScheme the context extension scoped scheme identifier.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static AdditionalSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
                 final CharSequence contextExtensionScopedScheme, final JsonObject jsonObject) {
             return new MutableAdditionalSecuritySchemeBuilder(

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AllOfComboSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AllOfComboSecurityScheme.java
@@ -33,14 +33,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface AllOfComboSecurityScheme extends ComboSecurityScheme {
 
+    /**
+     * Creates a new AllOfComboSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the AllOfComboSecurityScheme.
+     */
     static AllOfComboSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableAllOfComboSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an AllOfComboSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static AllOfComboSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return AllOfComboSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an AllOfComboSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static AllOfComboSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
             final JsonObject jsonObject) {
         return AllOfComboSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
@@ -51,17 +74,40 @@ public interface AllOfComboSecurityScheme extends ComboSecurityScheme {
         return SecuritySchemeScheme.COMBO;
     }
 
+    /**
+     * Returns the list of security scheme names that must all be applied.
+     *
+     * @return the list of security scheme names.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme">WoT TD ComboSecurityScheme (allOf)</a>
+     */
     List<String> getAllOf();
 
 
+    /**
+     * A mutable builder with a fluent API for building an {@link AllOfComboSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, AllOfComboSecurityScheme> {
 
+        /**
+         * Creates a new builder for building an AllOfComboSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableAllOfComboSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an AllOfComboSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName,
                 final JsonObject jsonObject) {
             return new MutableAllOfComboSecuritySchemeBuilder(
@@ -69,16 +115,25 @@ public interface AllOfComboSecurityScheme extends ComboSecurityScheme {
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the security schemes that must all be applied.
+         *
+         * @param securitySchemes the security schemes, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setAllOf(@Nullable Collection<SecurityScheme> securitySchemes);
 
     }
 
     /**
-     * An enumeration of the known {@link org.eclipse.ditto.json.JsonFieldDefinition}s of a AllOfComboSecurityScheme.
+     * An enumeration of the known {@link org.eclipse.ditto.json.JsonFieldDefinition}s of an AllOfComboSecurityScheme.
      */
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the array of security scheme names that must all apply.
+         */
         public static final JsonFieldDefinition<JsonArray> ALL_OF = JsonFactory.newJsonArrayFieldDefinition(
                 "allOf");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ApiKeySecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ApiKeySecurityScheme.java
@@ -26,20 +26,46 @@ import org.eclipse.ditto.json.JsonObject;
 /**
  * An ApiKeySecurityScheme is a {@link SecurityScheme} indicating to use an API key / API token, "for example when a key
  * in an unknown or proprietary format is provided by a cloud service provider."
+ * <p>
+ * API key authentication is commonly used for simple service-to-service authentication.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#apikeysecurityscheme">WoT TD APIKeySecurityScheme</a>
  * @since 2.4.0
  */
 public interface ApiKeySecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new ApiKeySecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the ApiKeySecurityScheme.
+     */
     static ApiKeySecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableApiKeySecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an ApiKeySecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static ApiKeySecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return ApiKeySecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an ApiKeySecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static ApiKeySecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return ApiKeySecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -49,27 +75,71 @@ public interface ApiKeySecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.APIKEY;
     }
 
+    /**
+     * Returns the optional location where the API key should be provided.
+     * <p>
+     * Possible values are "header", "query", "body", or "cookie". The default is "query".
+     * </p>
+     *
+     * @return the optional location for the API key.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#apikeysecurityscheme">WoT TD APIKeySecurityScheme (in)</a>
+     */
     Optional<SecuritySchemeIn> getIn();
 
+    /**
+     * Returns the optional name of the header, query parameter, or cookie where the API key should be provided.
+     *
+     * @return the optional API key parameter name.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#apikeysecurityscheme">WoT TD APIKeySecurityScheme (name)</a>
+     */
     Optional<String> getName();
 
 
+    /**
+     * A mutable builder with a fluent API for building an {@link ApiKeySecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, ApiKeySecurityScheme> {
 
+        /**
+         * Creates a new builder for building an ApiKeySecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableApiKeySecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an ApiKeySecurityScheme, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
             return new MutableApiKeySecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the location where the API key should be provided.
+         *
+         * @param in the location (e.g., "header", "query", "body", "cookie"), or {@code null} to remove.
+         * @return this builder.
+         */
         ApiKeySecurityScheme.Builder setIn(@Nullable String in);
 
+        /**
+         * Sets the name of the API key parameter.
+         *
+         * @param name the parameter name, or {@code null} to remove.
+         * @return this builder.
+         */
         ApiKeySecurityScheme.Builder setName(@Nullable String name);
 
     }
@@ -80,9 +150,15 @@ public interface ApiKeySecurityScheme extends SecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the location of the API key.
+         */
         public static final JsonFieldDefinition<String> IN = JsonFactory.newStringFieldDefinition(
                 "in");
 
+        /**
+         * JSON field definition for the API key parameter name.
+         */
         public static final JsonFieldDefinition<String> NAME = JsonFactory.newStringFieldDefinition(
                 "name");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ArraySchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ArraySchema.java
@@ -25,22 +25,47 @@ import org.eclipse.ditto.json.JsonObject;
 /**
  * An ArraySchema is a {@link SingleDataSchema} describing the JSON data type {@code array}.
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema</a>
  * @since 2.4.0
  */
 public interface ArraySchema extends SingleDataSchema {
 
+    /**
+     * Creates a new ArraySchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the array schema.
+     * @return the ArraySchema.
+     */
     static ArraySchema fromJson(final JsonObject jsonObject) {
         return new ImmutableArraySchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an ArraySchema.
+     *
+     * @return the builder.
+     */
     static ArraySchema.Builder newBuilder() {
         return ArraySchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an ArraySchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static ArraySchema.Builder newBuilder(final JsonObject jsonObject) {
         return ArraySchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building an ArraySchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default ArraySchema.Builder toBuilder() {
         return ArraySchema.Builder.newBuilder(toJson());
     }
@@ -50,26 +75,80 @@ public interface ArraySchema extends SingleDataSchema {
         return Optional.of(DataSchemaType.ARRAY);
     }
 
+    /**
+     * Returns the optional data schema describing the elements of the array.
+     * <p>
+     * May be a single schema (all elements have the same type) or a multiple schema (tuple validation).
+     * </p>
+     *
+     * @return the optional items schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema (items)</a>
+     */
     Optional<DataSchema> getItems();
 
+    /**
+     * Returns the optional minimum number of items the array must contain.
+     *
+     * @return the optional minimum items count.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema (minItems)</a>
+     */
     Optional<Integer> getMinItems();
 
+    /**
+     * Returns the optional maximum number of items the array may contain.
+     *
+     * @return the optional maximum items count.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema (maxItems)</a>
+     */
     Optional<Integer> getMaxItems();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link ArraySchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, ArraySchema> {
 
+        /**
+         * Creates a new builder for building an ArraySchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableArraySchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an ArraySchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableArraySchemaBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the items schema.
+         *
+         * @param items the items schema, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setItems(@Nullable DataSchema items);
 
+        /**
+         * Sets the minimum items constraint.
+         *
+         * @param minItems the minimum items count, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMinItems(@Nullable Integer minItems);
 
+        /**
+         * Sets the maximum items constraint.
+         *
+         * @param maxItems the maximum items count, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMaxItems(@Nullable Integer maxItems);
 
     }
@@ -80,15 +159,27 @@ public interface ArraySchema extends SingleDataSchema {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the items schema (single schema).
+         */
         public static final JsonFieldDefinition<JsonObject> ITEMS = JsonFactory.newJsonObjectFieldDefinition(
                 "items");
 
+        /**
+         * JSON field definition for the items schema (multiple schemas for tuple validation).
+         */
         public static final JsonFieldDefinition<JsonArray> ITEMS_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "items");
 
+        /**
+         * JSON field definition for the minimum items count.
+         */
         public static final JsonFieldDefinition<Integer> MIN_ITEMS = JsonFactory.newIntFieldDefinition(
                 "minItems");
 
+        /**
+         * JSON field definition for the maximum items count.
+         */
         public static final JsonFieldDefinition<Integer> MAX_ITEMS = JsonFactory.newIntFieldDefinition(
                 "minItems");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtContext.java
@@ -23,15 +23,37 @@ import java.util.Optional;
  */
 public interface AtContext {
 
+    /**
+     * Creates a new single URI context entry.
+     *
+     * @param context the context URI.
+     * @return the SingleUriAtContext.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (@context)</a>
+     */
     static SingleUriAtContext newSingleUriAtContext(final CharSequence context) {
         return SingleUriAtContext.of(context);
     }
 
+    /**
+     * Creates a new single prefixed context entry with a prefix and a URI.
+     *
+     * @param prefix the prefix to use for the context.
+     * @param context the context URI.
+     * @return the SinglePrefixedAtContext.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (@context)</a>
+     */
     static SinglePrefixedAtContext newSinglePrefixedAtContext(final CharSequence prefix,
             final SingleUriAtContext context) {
         return SinglePrefixedAtContext.of(prefix, context);
     }
 
+    /**
+     * Creates a new multiple context containing multiple single context entries.
+     *
+     * @param contexts the collection of single context entries.
+     * @return the MultipleAtContext.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (@context)</a>
+     */
     static MultipleAtContext newMultipleAtContext(final Collection<SingleAtContext> contexts) {
         return MultipleAtContext.of(contexts);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtType.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AtType.java
@@ -22,10 +22,24 @@ import java.util.Collection;
  */
 public interface AtType {
 
+    /**
+     * Creates a new single type annotation.
+     *
+     * @param type the semantic type.
+     * @return the SingleAtType.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (@type)</a>
+     */
     static SingleAtType newSingleAtType(final CharSequence type) {
         return SingleAtType.of(type);
     }
 
+    /**
+     * Creates a new multiple type annotation containing multiple single types.
+     *
+     * @param types the collection of semantic types.
+     * @return the MultipleAtType.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (@type)</a>
+     */
     static MultipleAtType newMultipleAtType(final Collection<SingleAtType> types) {
         return MultipleAtType.of(types);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/AutoSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/AutoSecurityScheme.java
@@ -25,14 +25,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface AutoSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new AutoSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the AutoSecurityScheme.
+     */
     static AutoSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableAutoSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an AutoSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static AutoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return AutoSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an AutoSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static AutoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return AutoSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -42,14 +65,31 @@ public interface AutoSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.AUTO;
     }
 
+    /**
+     * A mutable builder with a fluent API for building an {@link AutoSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<AutoSecurityScheme.Builder, AutoSecurityScheme> {
 
+        /**
+         * Creates a new builder for building an AutoSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static AutoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableAutoSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an AutoSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static AutoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
                 final JsonObject jsonObject) {
             return new MutableAutoSecuritySchemeBuilder(

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/BaseLink.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/BaseLink.java
@@ -25,6 +25,10 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * A BaseLink "can be viewed as a statement of the form link context has a relation type resource at link target".
+ * <p>
+ * Links provide a way to connect the Thing Description to related resources, following the Web Linking model
+ * defined in RFC 8288.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link</a>
  * @see <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA</a>
@@ -33,8 +37,18 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface BaseLink<L extends BaseLink<L>> extends TypedJsonObject<L>, Jsonifiable<JsonObject> {
 
+    /**
+     * The relation type for icon links.
+     */
     String REL_ICON = "icon";
 
+    /**
+     * Creates a BaseLink from the specified JSON object, automatically determining whether it is
+     * an {@link IconLink} or a regular {@link Link} based on the {@code rel} field.
+     *
+     * @param jsonObject the JSON object representing the link.
+     * @return the appropriate BaseLink subtype.
+     */
     static BaseLink<?> fromJson(final JsonObject jsonObject) {
         if (jsonObject.getValue(BaseLinkJsonFields.REL)
                 .filter(REL_ICON::equals)
@@ -45,35 +59,115 @@ public interface BaseLink<L extends BaseLink<L>> extends TypedJsonObject<L>, Jso
         }
     }
 
+    /**
+     * Creates a new builder for building a {@link Link}.
+     *
+     * @return the builder.
+     */
     static Link.Builder newLinkBuilder() {
         return Link.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link IconLink}.
+     *
+     * @return the builder.
+     */
     static IconLink.Builder newIconLinkBuilder() {
         return IconLink.newBuilder();
     }
 
+    /**
+     * Returns the target IRI of the link.
+     *
+     * @return the target href IRI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link (href)</a>
+     */
     IRI getHref();
 
+    /**
+     * Returns the optional hint indicating the expected MIME type of the target resource.
+     *
+     * @return the optional media type hint.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link (type)</a>
+     */
     Optional<String> getType();
 
+    /**
+     * Returns the optional relation type that identifies the semantics of the link.
+     * <p>
+     * Common values include "alternate", "describedby", "item", "collection", etc.
+     * </p>
+     *
+     * @return the optional link relation type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link (rel)</a>
+     * @see <a href="https://www.iana.org/assignments/link-relations">IANA Link Relations</a>
+     */
     Optional<String> getRel();
 
+    /**
+     * Returns the optional anchor IRI that overrides the default context IRI for the link relation.
+     *
+     * @return the optional anchor IRI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link (anchor)</a>
+     */
     Optional<IRI> getAnchor();
 
+    /**
+     * Returns the optional language tag(s) indicating the language of the target resource.
+     *
+     * @return the optional language tag(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link (hreflang)</a>
+     */
     Optional<Hreflang> getHreflang();
 
 
+    /**
+     * A mutable builder for creating {@link BaseLink} instances.
+     *
+     * @param <B> the type of the Builder.
+     * @param <L> the type of the BaseLink.
+     */
     interface Builder<B extends Builder<B, L>, L extends BaseLink<L>> extends TypedJsonObjectBuilder<B, L> {
 
+        /**
+         * Sets the target href IRI.
+         *
+         * @param href the target IRI, or {@code null} to remove.
+         * @return this builder.
+         */
         B setHref(@Nullable IRI href);
 
+        /**
+         * Sets the media type hint.
+         *
+         * @param type the media type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setType(@Nullable String type);
 
+        /**
+         * Sets the link relation type.
+         *
+         * @param rel the relation type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setRel(@Nullable String rel);
 
+        /**
+         * Sets the anchor IRI.
+         *
+         * @param anchor the anchor IRI, or {@code null} to remove.
+         * @return this builder.
+         */
         B setAnchor(@Nullable IRI anchor);
 
+        /**
+         * Sets the language tag(s).
+         *
+         * @param hreflang the language tag(s), or {@code null} to remove.
+         * @return this builder.
+         */
         B setHreflang(@Nullable Hreflang hreflang);
 
     }
@@ -84,21 +178,39 @@ public interface BaseLink<L extends BaseLink<L>> extends TypedJsonObject<L>, Jso
     @Immutable
     final class BaseLinkJsonFields {
 
+        /**
+         * JSON field definition for the target href IRI.
+         */
         public static final JsonFieldDefinition<String> HREF = JsonFactory.newStringFieldDefinition(
                 "href");
 
+        /**
+         * JSON field definition for the media type hint.
+         */
         public static final JsonFieldDefinition<String> TYPE = JsonFactory.newStringFieldDefinition(
                 "type");
 
+        /**
+         * JSON field definition for the link relation type.
+         */
         public static final JsonFieldDefinition<String> REL = JsonFactory.newStringFieldDefinition(
                 "rel");
 
+        /**
+         * JSON field definition for the anchor IRI.
+         */
         public static final JsonFieldDefinition<String> ANCHOR = JsonFactory.newStringFieldDefinition(
                 "anchor");
 
+        /**
+         * JSON field definition for the language tag (single value).
+         */
         public static final JsonFieldDefinition<String> HREFLANG = JsonFactory.newStringFieldDefinition(
                 "hreflang");
 
+        /**
+         * JSON field definition for the language tags (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> HREFLANG_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "hreflang");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/BasicSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/BasicSecurityScheme.java
@@ -24,8 +24,11 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * A BasicSecurityScheme is a {@link SecurityScheme} indicating to use {@code Basic} Authentication, using an unencryped
+ * A BasicSecurityScheme is a {@link SecurityScheme} indicating to use {@code Basic} Authentication, using an unencrypted
  * username and password.
+ * <p>
+ * Basic authentication transmits credentials as base64-encoded strings and should only be used over HTTPS.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bib-rfc7617">RFC7617 - Basic Authentication</a>
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">WoT TD BasicSecurityScheme</a>
@@ -33,14 +36,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface BasicSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new BasicSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the BasicSecurityScheme.
+     */
     static BasicSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableBasicSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a BasicSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static BasicSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return BasicSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a BasicSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static BasicSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return BasicSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -50,19 +76,51 @@ public interface BasicSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.BASIC;
     }
 
+    /**
+     * Returns the optional location where the credentials should be provided.
+     * <p>
+     * Possible values are "header", "query", "body", or "cookie". The default is "header".
+     * </p>
+     *
+     * @return the optional location for credentials.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">WoT TD BasicSecurityScheme (in)</a>
+     */
     Optional<SecuritySchemeIn> getIn();
 
+    /**
+     * Returns the optional name of the header, query parameter, or cookie where credentials should be provided.
+     *
+     * @return the optional credential parameter name.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">WoT TD BasicSecurityScheme (name)</a>
+     */
     Optional<String> getName();
 
 
+    /**
+     * A mutable builder with a fluent API for building a {@link BasicSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<BasicSecurityScheme.Builder, BasicSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a BasicSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static BasicSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableBasicSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a BasicSecurityScheme, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static BasicSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
                 final JsonObject jsonObject) {
             return new MutableBasicSecuritySchemeBuilder(
@@ -70,8 +128,20 @@ public interface BasicSecurityScheme extends SecurityScheme {
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the location where credentials should be provided.
+         *
+         * @param in the location (e.g., "header", "query", "body", "cookie"), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setIn(@Nullable String in);
 
+        /**
+         * Sets the name of the credential parameter.
+         *
+         * @param name the parameter name, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setName(@Nullable String name);
 
     }
@@ -82,9 +152,15 @@ public interface BasicSecurityScheme extends SecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the location of credentials.
+         */
         public static final JsonFieldDefinition<String> IN = JsonFactory.newStringFieldDefinition(
                 "in");
 
+        /**
+         * JSON field definition for the credential parameter name.
+         */
         public static final JsonFieldDefinition<String> NAME = JsonFactory.newStringFieldDefinition(
                 "name");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/BearerSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/BearerSecurityScheme.java
@@ -25,6 +25,9 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * A BearerSecurityScheme is a {@link SecurityScheme} indicating to use {@code Bearer Tokens} "independently of OAuth2".
+ * <p>
+ * Bearer token authentication is commonly used with JWT tokens or other token formats.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bib-rfc6750">RFC6750 - Bearer Token</a>
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme</a>
@@ -32,14 +35,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface BearerSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new BearerSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the BearerSecurityScheme.
+     */
     static BearerSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableBearerSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a BearerSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static BearerSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return BearerSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a BearerSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static BearerSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return BearerSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -49,39 +75,119 @@ public interface BearerSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.BEARER;
     }
 
+    /**
+     * Returns the optional URI of the authorization server for obtaining tokens.
+     *
+     * @return the optional authorization URI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme (authorization)</a>
+     */
     Optional<IRI> getAuthorization();
 
+    /**
+     * Returns the optional encoding algorithm used for signing the token (e.g., "ES256", "ES512-256").
+     *
+     * @return the optional algorithm identifier.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme (alg)</a>
+     */
     Optional<String> getAlg();
 
+    /**
+     * Returns the optional token format (e.g., "jwt", "cwt", "jwe").
+     *
+     * @return the optional format identifier.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme (format)</a>
+     */
     Optional<String> getFormat();
 
+    /**
+     * Returns the optional location where the token should be provided.
+     * <p>
+     * Possible values are "header", "query", "body", or "cookie". The default is "header".
+     * </p>
+     *
+     * @return the optional location for the token.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme (in)</a>
+     */
     Optional<SecuritySchemeIn> getIn();
 
+    /**
+     * Returns the optional name of the header, query parameter, or cookie where the token should be provided.
+     *
+     * @return the optional token parameter name.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme (name)</a>
+     */
     Optional<String> getName();
 
 
+    /**
+     * A mutable builder with a fluent API for building a {@link BearerSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, BearerSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a BearerSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableBearerSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a BearerSecurityScheme, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
             return new MutableBearerSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the authorization endpoint URI.
+         *
+         * @param authorization the authorization URI, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setAuthorization(@Nullable IRI authorization);
 
+        /**
+         * Sets the signing algorithm identifier.
+         *
+         * @param alg the algorithm, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setAlg(@Nullable String alg);
 
+        /**
+         * Sets the token format.
+         *
+         * @param format the format, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setFormat(@Nullable String format);
 
+        /**
+         * Sets the location where the token should be provided.
+         *
+         * @param in the location (e.g., "header", "query", "body", "cookie"), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setIn(@Nullable String in);
 
+        /**
+         * Sets the name of the token parameter.
+         *
+         * @param name the parameter name, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setName(@Nullable String name);
 
     }
@@ -92,18 +198,33 @@ public interface BearerSecurityScheme extends SecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the authorization endpoint URI.
+         */
         public static final JsonFieldDefinition<String> AUTHORIZATION = JsonFactory.newStringFieldDefinition(
                 "authorization");
 
+        /**
+         * JSON field definition for the signing algorithm.
+         */
         public static final JsonFieldDefinition<String> ALG = JsonFactory.newStringFieldDefinition(
                 "alg");
 
+        /**
+         * JSON field definition for the token format.
+         */
         public static final JsonFieldDefinition<String> FORMAT = JsonFactory.newStringFieldDefinition(
                 "format");
 
+        /**
+         * JSON field definition for the location of the token.
+         */
         public static final JsonFieldDefinition<String> IN = JsonFactory.newStringFieldDefinition(
                 "in");
 
+        /**
+         * JSON field definition for the token parameter name.
+         */
         public static final JsonFieldDefinition<String> NAME = JsonFactory.newStringFieldDefinition(
                 "name");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/BooleanSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/BooleanSchema.java
@@ -18,33 +18,76 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * A BooleanSchema is a {@link SingleDataSchema} describing the JSON data type {@code boolean}.
+ * <p>
+ * Boolean values can only be {@code true} or {@code false}.
+ * </p>
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#booleanschema">WoT TD BooleanSchema</a>
  * @since 2.4.0
  */
 public interface BooleanSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new BooleanSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the boolean schema.
+     * @return the BooleanSchema.
+     */
     static BooleanSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableBooleanSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a BooleanSchema.
+     *
+     * @return the builder.
+     */
     static BooleanSchema.Builder newBuilder() {
         return BooleanSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a BooleanSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static BooleanSchema.Builder newBuilder(final JsonObject jsonObject) {
         return BooleanSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a BooleanSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default BooleanSchema.Builder toBuilder() {
         return BooleanSchema.Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link BooleanSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, BooleanSchema> {
 
+        /**
+         * Creates a new builder for building a BooleanSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableBooleanSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a BooleanSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableBooleanSchemaBuilder(jsonObject.toBuilder());
         }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ComboSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ComboSecurityScheme.java
@@ -22,6 +22,17 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface ComboSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new ComboSecurityScheme from the specified JSON object.
+     * <p>
+     * Automatically determines whether this is a "oneOf" or "allOf" combo scheme based on the JSON content.
+     * </p>
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the ComboSecurityScheme (either {@link OneOfComboSecurityScheme} or {@link AllOfComboSecurityScheme}).
+     * @throws IllegalArgumentException if the JSON object contains neither "oneOf" nor "allOf".
+     */
     static ComboSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         if (jsonObject.getValue(OneOfComboSecurityScheme.JsonFields.ONE_OF).isPresent()) {
             return OneOfComboSecurityScheme.fromJson(securitySchemeName, jsonObject);
@@ -31,10 +42,22 @@ public interface ComboSecurityScheme extends SecurityScheme {
         throw new IllegalArgumentException("Unsupported ComboSecurityScheme config");
     }
 
+    /**
+     * Creates a new builder for building a {@link OneOfComboSecurityScheme}.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     */
     static OneOfComboSecurityScheme.Builder newOneOfBuilder(final CharSequence securitySchemeName) {
         return OneOfComboSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link AllOfComboSecurityScheme}.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     */
     static AllOfComboSecurityScheme.Builder newAllOfBuilder(final CharSequence securitySchemeName) {
         return AllOfComboSecurityScheme.Builder.newBuilder(securitySchemeName);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/DataSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/DataSchema.java
@@ -16,42 +16,92 @@ import java.util.Collection;
 
 /**
  * A DataSchema describes a used data format which can be used for validation.
- * It may present itself as {@link SingleDataSchema} or as {@link MultipleDataSchema} containing multiple
- * {@link SingleDataSchema}s.
+ * <p>
+ * It may present itself as {@link SingleDataSchema} (a single type definition) or as {@link MultipleDataSchema}
+ * containing multiple {@link SingleDataSchema}s for union types.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema</a>
  * @since 2.4.0
  */
 public interface DataSchema {
 
+    /**
+     * Creates a new builder for building a {@link BooleanSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#booleanschema">WoT TD BooleanSchema</a>
+     */
     static BooleanSchema.Builder newBooleanSchemaBuilder() {
         return BooleanSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link IntegerSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema</a>
+     */
     static IntegerSchema.Builder newSingleIntegerSchemaBuilder() {
         return IntegerSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link NumberSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema</a>
+     */
     static NumberSchema.Builder newSingleNumberSchemaBuilder() {
         return NumberSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link StringSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema</a>
+     */
     static StringSchema.Builder newSingleStringSchemaBuilder() {
         return StringSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link ObjectSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#objectschema">WoT TD ObjectSchema</a>
+     */
     static ObjectSchema.Builder newSingleObjectSchemaBuilder() {
         return ObjectSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link ArraySchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema</a>
+     */
     static ArraySchema.Builder newSingleArraySchemaBuilder() {
         return ArraySchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link NullSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#nullschema">WoT TD NullSchema</a>
+     */
     static NullSchema.Builder newSingleNullSchemaBuilder() {
         return NullSchema.newBuilder();
     }
 
+    /**
+     * Creates a new {@link MultipleDataSchema} containing the given collection of schemas.
+     *
+     * @param dataSchemas the collection of data schemas to include.
+     * @return the MultipleDataSchema.
+     */
     static MultipleDataSchema newMultipleDataSchema(final Collection<SingleDataSchema> dataSchemas) {
         return MultipleDataSchema.of(dataSchemas);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/DataSchemaType.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/DataSchemaType.java
@@ -23,12 +23,33 @@ import java.util.Optional;
  * @since 2.4.0
  */
 public enum DataSchemaType implements CharSequence {
+    /**
+     * Boolean data type (true/false).
+     */
     BOOLEAN("boolean"),
+    /**
+     * Integer data type (whole numbers).
+     */
     INTEGER("integer"),
+    /**
+     * Number data type (floating-point numbers).
+     */
     NUMBER("number"),
+    /**
+     * String data type (text).
+     */
     STRING("string"),
+    /**
+     * Object data type (JSON object with properties).
+     */
     OBJECT("object"),
+    /**
+     * Array data type (ordered list of items).
+     */
     ARRAY("array"),
+    /**
+     * Null data type (absence of value).
+     */
     NULL("null");
 
     private final String name;
@@ -37,6 +58,11 @@ public enum DataSchemaType implements CharSequence {
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this data schema type.
+     *
+     * @return the type name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Description.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Description.java
@@ -15,10 +15,17 @@ package org.eclipse.ditto.wot.model;
 /**
  * A Description "provides additional (human-readable) information based on a default language."
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#titles-descriptions-serialization-json">WoT TD Human-Readable Metadata</a>
  * @since 2.4.0
  */
 public interface Description extends CharSequence {
 
+    /**
+     * Creates a Description from the specified character sequence.
+     *
+     * @param charSequence the description text.
+     * @return the Description.
+     */
     static Description of(final CharSequence charSequence) {
         if (charSequence instanceof Description) {
             return (Description) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Descriptions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Descriptions.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Descriptions extends Map<Locale, Description>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a Descriptions from the specified JSON object.
+     *
+     * @param jsonObject the JSON object mapping language tags to descriptions.
+     * @return the Descriptions.
+     */
     static Descriptions fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> new Locale(field.getKey().toString()),
@@ -40,6 +46,12 @@ public interface Descriptions extends Map<Locale, Description>, Jsonifiable<Json
         ));
     }
 
+    /**
+     * Creates a Descriptions from the specified map of locale to description.
+     *
+     * @param descriptions the map of locales to descriptions.
+     * @return the Descriptions.
+     */
     static Descriptions of(final Map<Locale, Description> descriptions) {
         return new ImmutableDescriptions(descriptions);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/DigestSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/DigestSecurityScheme.java
@@ -33,14 +33,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface DigestSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new DigestSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the DigestSecurityScheme.
+     */
     static DigestSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableDigestSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a DigestSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static DigestSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return DigestSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a DigestSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static DigestSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return DigestSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -50,21 +73,59 @@ public interface DigestSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.DIGEST;
     }
 
+    /**
+     * Returns the optional quality of protection (qop) parameter for digest authentication.
+     *
+     * @return the optional qop value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme (qop)</a>
+     */
     Optional<Qop> getQop();
 
+    /**
+     * Returns the optional location where the credentials should be provided.
+     * <p>
+     * Possible values are "header", "query", "body", or "cookie". The default is "header".
+     * </p>
+     *
+     * @return the optional location for credentials.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme (in)</a>
+     */
     Optional<SecuritySchemeIn> getIn();
-    
+
+    /**
+     * Returns the optional name of the header, query parameter, or cookie where credentials should be provided.
+     *
+     * @return the optional credential parameter name.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme (name)</a>
+     */
     Optional<String> getName();
 
 
+    /**
+     * A mutable builder with a fluent API for building a {@link DigestSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, DigestSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a DigestSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableDigestSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a DigestSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName,
                 final JsonObject jsonObject) {
             return new MutableDigestSecuritySchemeBuilder(
@@ -72,16 +133,45 @@ public interface DigestSecurityScheme extends SecurityScheme {
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the quality of protection (qop) parameter.
+         *
+         * @param qop the qop value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setQop(@Nullable Qop qop);
 
+        /**
+         * Sets the location where credentials should be provided.
+         *
+         * @param in the location (e.g., "header", "query", "body", "cookie"), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setIn(@Nullable String in);
 
+        /**
+         * Sets the name of the credential parameter.
+         *
+         * @param name the parameter name, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setName(@Nullable String name);
 
     }
-    
+
+    /**
+     * Enumeration of quality of protection (qop) values for digest authentication.
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme (qop)</a>
+     */
     enum Qop implements CharSequence {
+        /**
+         * Authentication only.
+         */
         AUTH("auth"),
+        /**
+         * Authentication with integrity protection.
+         */
         AUTH_INT("auth-int");
 
         private final String name;
@@ -90,6 +180,11 @@ public interface DigestSecurityScheme extends SecurityScheme {
             this.name = name;
         }
 
+        /**
+         * Returns the string representation of this qop value.
+         *
+         * @return the qop name.
+         */
         public String getName() {
             return name;
         }
@@ -134,12 +229,21 @@ public interface DigestSecurityScheme extends SecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the quality of protection (qop).
+         */
         public static final JsonFieldDefinition<String> QOP = JsonFactory.newStringFieldDefinition(
                 "qop");
 
+        /**
+         * JSON field definition for the location of credentials.
+         */
         public static final JsonFieldDefinition<String> IN = JsonFactory.newStringFieldDefinition(
                 "in");
 
+        /**
+         * JSON field definition for the credential parameter name.
+         */
         public static final JsonFieldDefinition<String> NAME = JsonFactory.newStringFieldDefinition(
                 "name");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Event.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Event.java
@@ -25,56 +25,162 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * An Event is an {@link Interaction} describing an event source which can push events to consumers.
+ * <p>
+ * Events enable a mechanism for Things to asynchronously notify Consumers about changes or occurrences.
+ * Unlike Properties that are polled, Events are pushed from the Thing to subscribed Consumers.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance</a>
  * @since 2.4.0
  */
 public interface Event extends Interaction<Event, EventFormElement, EventForms> {
 
+    /**
+     * Creates a new Event from the specified JSON object.
+     *
+     * @param eventName the name of the event (the key in the events map).
+     * @param jsonObject the JSON object representing the event affordance.
+     * @return the Event.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Event fromJson(final CharSequence eventName, final JsonObject jsonObject) {
         return new ImmutableEvent(checkNotNull(eventName, "eventName").toString(), jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an Event.
+     *
+     * @param eventName the name of the event.
+     * @return the builder.
+     * @throws NullPointerException if {@code eventName} is {@code null}.
+     */
     static Event.Builder newBuilder(final CharSequence eventName) {
         return Event.Builder.newBuilder(eventName);
     }
 
+    /**
+     * Creates a new builder for building an Event, initialized with the values from the specified JSON object.
+     *
+     * @param eventName the name of the event.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Event.Builder newBuilder(final CharSequence eventName, final JsonObject jsonObject) {
         return Event.Builder.newBuilder(eventName, jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building an Event, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default Event.Builder toBuilder() {
         return Event.Builder.newBuilder(getEventName(), toJson());
     }
 
+    /**
+     * Returns the name of this event as defined in the Thing Description's events map.
+     *
+     * @return the event name.
+     */
     String getEventName();
 
+    /**
+     * Returns the optional data schema describing the data that a Consumer sends to subscribe to the event.
+     *
+     * @return the optional subscription schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (subscription)</a>
+     */
     Optional<SingleDataSchema> getSubscription();
 
+    /**
+     * Returns the optional data schema describing the data that the Thing sends when the event occurs.
+     *
+     * @return the optional event data schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (data)</a>
+     */
     Optional<SingleDataSchema> getData();
 
+    /**
+     * Returns the optional data schema describing the data that the Thing sends as a response to an event subscription.
+     *
+     * @return the optional data response schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (dataResponse)</a>
+     */
     Optional<SingleDataSchema> getDataResponse();
 
+    /**
+     * Returns the optional data schema describing the data that a Consumer sends to cancel an event subscription.
+     *
+     * @return the optional cancellation schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (cancellation)</a>
+     */
     Optional<SingleDataSchema> getCancellation();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link Event}.
+     */
     interface Builder extends Interaction.Builder<Builder, Event, EventFormElement, EventForms> {
 
+        /**
+         * Creates a new builder for building an Event.
+         *
+         * @param eventName the name of the event.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence eventName) {
             return new MutableEventBuilder(checkNotNull(eventName, "eventName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an Event, initialized with the values from the specified JSON object.
+         *
+         * @param eventName the name of the event.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence eventName, final JsonObject jsonObject) {
             return new MutableEventBuilder(checkNotNull(eventName, "eventName").toString(), jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the subscription data schema for this event.
+         *
+         * @param subscription the subscription schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (subscription)</a>
+         */
         Builder setSubscription(@Nullable SingleDataSchema subscription);
 
+        /**
+         * Sets the event data schema describing the data sent when the event occurs.
+         *
+         * @param data the event data schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (data)</a>
+         */
         Builder setData(@Nullable SingleDataSchema data);
 
+        /**
+         * Sets the data response schema for this event.
+         *
+         * @param dataResponse the data response schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (dataResponse)</a>
+         */
         Builder setDataResponse(@Nullable SingleDataSchema dataResponse);
 
+        /**
+         * Sets the cancellation data schema for this event.
+         *
+         * @param cancellation the cancellation schema, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance (cancellation)</a>
+         */
         Builder setCancellation(@Nullable SingleDataSchema cancellation);
 
     }
@@ -85,15 +191,27 @@ public interface Event extends Interaction<Event, EventFormElement, EventForms> 
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the subscription data schema.
+         */
         public static final JsonFieldDefinition<JsonObject> SUBSCRIPTION = JsonFactory.newJsonObjectFieldDefinition(
                 "subscription");
 
+        /**
+         * JSON field definition for the event data schema.
+         */
         public static final JsonFieldDefinition<JsonObject> DATA = JsonFactory.newJsonObjectFieldDefinition(
                 "data");
 
+        /**
+         * JSON field definition for the data response schema.
+         */
         public static final JsonFieldDefinition<JsonObject> DATA_RESPONSE = JsonFactory.newJsonObjectFieldDefinition(
                 "dataResponse");
 
+        /**
+         * JSON field definition for the cancellation data schema.
+         */
         public static final JsonFieldDefinition<JsonObject> CANCELLATION = JsonFactory.newJsonObjectFieldDefinition(
                 "cancellation");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/EventFormElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/EventFormElement.java
@@ -23,14 +23,34 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface EventFormElement extends FormElement<EventFormElement> {
 
+    /**
+     * Creates a new EventFormElement from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the form element.
+     * @return the EventFormElement.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static EventFormElement fromJson(final JsonObject jsonObject) {
         return new ImmutableEventFormElement(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an EventFormElement.
+     *
+     * @return the builder.
+     */
     static EventFormElement.Builder newBuilder() {
         return EventFormElement.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an EventFormElement, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static EventFormElement.Builder newBuilder(final JsonObject jsonObject) {
         return EventFormElement.Builder.newBuilder(jsonObject);
     }
@@ -40,18 +60,45 @@ public interface EventFormElement extends FormElement<EventFormElement> {
         return EventFormElement.Builder.newBuilder(toJson());
     }
 
+    /**
+     * Returns the operation type(s) this form element supports for event affordances.
+     *
+     * @return the event operation type(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (op)</a>
+     */
     EventFormElementOp<SingleEventFormElementOp> getOp();
-    
+
+    /**
+     * A mutable builder with a fluent API for building an {@link EventFormElement}.
+     */
     interface Builder extends FormElement.Builder<Builder, EventFormElement> {
 
+        /**
+         * Creates a new builder for building an EventFormElement.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableEventFormElementBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an EventFormElement, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableEventFormElementBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the operation type(s) for this form element.
+         *
+         * @param op the operation type(s), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setOp(@Nullable EventFormElementOp<?> op);
 
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/EventForms.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/EventForms.java
@@ -27,16 +27,28 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface EventForms extends Forms<EventFormElement> {
 
+    /**
+     * Creates EventForms from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of form element objects.
+     * @return the EventForms.
+     */
     static EventForms fromJson(final JsonArray jsonArray) {
         final List<EventFormElement> eventFormElements = jsonArray.stream()
                 .filter(JsonValue::isObject)
                 .map(JsonValue::asObject)
                 .map(EventFormElement::fromJson)
                 .collect(Collectors.toList());
-        
+
         return of(eventFormElements);
     }
 
+    /**
+     * Creates EventForms from the specified collection of form elements.
+     *
+     * @param formElements the collection of form elements.
+     * @return the EventForms.
+     */
     static EventForms of(final Collection<EventFormElement> formElements) {
         return new ImmutableEventForms(formElements);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Events.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Events.java
@@ -29,6 +29,13 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Events extends Map<String, Event>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new Events container from the specified JSON object.
+     *
+     * @param jsonObject the JSON object containing event definitions.
+     * @return the Events container.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static Events fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -41,6 +48,13 @@ public interface Events extends Map<String, Event>, Jsonifiable<JsonObject> {
         ));
     }
 
+    /**
+     * Creates a new Events container from the specified collection of events.
+     *
+     * @param events the collection of events.
+     * @return the Events container.
+     * @throws NullPointerException if {@code events} is {@code null}.
+     */
     static Events from(final Collection<Event> events) {
         return of(events.stream().collect(Collectors.toMap(
                 Event::getEventName,
@@ -53,10 +67,23 @@ public interface Events extends Map<String, Event>, Jsonifiable<JsonObject> {
         ));
     }
 
+    /**
+     * Creates a new Events container from the specified map of event name to event.
+     *
+     * @param events the map of events.
+     * @return the Events container.
+     * @throws NullPointerException if {@code events} is {@code null}.
+     */
     static Events of(final Map<String, Event> events) {
         return new ImmutableEvents(events);
     }
 
+    /**
+     * Returns the event with the specified name if it exists.
+     *
+     * @param eventName the name of the event.
+     * @return the optional event.
+     */
     Optional<Event> getEvent(CharSequence eventName);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElement.java
@@ -24,7 +24,11 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * A FormElement is a "hypermedia control that describe how an operation can be performed".
+ * A FormElement is a "hypermedia control that describes how an operation can be performed".
+ * <p>
+ * Forms provide the protocol binding information for interacting with a Thing's affordances,
+ * including the target URI, content type, and security requirements.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form</a>
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form-serialization-json">WoT TD Form serialization as JSON</a>
@@ -33,39 +37,141 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface FormElement<F extends FormElement<F>> extends TypedJsonObject<F>, Jsonifiable<JsonObject> {
 
+    /**
+     * Returns the target IRI of the form submission, identifying the resource to interact with.
+     *
+     * @return the target href IRI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (href)</a>
+     */
     IRI getHref();
 
+    /**
+     * Returns the content type (MIME type) of the request/response body (default: "application/json").
+     *
+     * @return the content type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (contentType)</a>
+     */
     String getContentType();
 
+    /**
+     * Returns the optional content coding indicating the encoding of the payload (e.g., "gzip").
+     *
+     * @return the optional content coding.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (contentCoding)</a>
+     */
     Optional<String> getContentCoding();
 
+    /**
+     * Returns the optional subprotocol identifier for the communication (e.g., "longpoll", "websub", "sse").
+     *
+     * @return the optional subprotocol.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (subprotocol)</a>
+     */
     Optional<FormElementSubprotocol> getSubprotocol();
 
+    /**
+     * Returns the optional security configuration overriding the Thing-level security for this form.
+     *
+     * @return the optional security configuration.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (security)</a>
+     */
     Optional<Security> getSecurity();
 
+    /**
+     * Returns the optional OAuth2 scopes required for this form when using OAuth2 security.
+     *
+     * @return the optional OAuth2 scopes.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (scopes)</a>
+     */
     Optional<OAuth2Scopes> getScopes();
 
+    /**
+     * Returns the optional expected response metadata when the operation succeeds.
+     *
+     * @return the optional expected response.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#expectedresponse">WoT TD ExpectedResponse</a>
+     */
     Optional<FormElementExpectedResponse> getExpectedResponse();
 
+    /**
+     * Returns the optional collection of additional expected responses for error cases or alternative outcomes.
+     *
+     * @return the optional additional responses.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#additionalexpectedresponse">WoT TD AdditionalExpectedResponse</a>
+     */
     Optional<FormElementAdditionalResponses> getAdditionalResponses();
 
+    /**
+     * A mutable builder for creating {@link FormElement} instances.
+     *
+     * @param <B> the type of the Builder.
+     * @param <E> the type of the FormElement.
+     */
     interface Builder<B extends Builder<B, E>, E extends FormElement<E>>
             extends TypedJsonObjectBuilder<B, E> {
 
+        /**
+         * Sets the target href IRI.
+         *
+         * @param href the target IRI, or {@code null} to remove.
+         * @return this builder.
+         */
         B setHref(@Nullable IRI href);
 
+        /**
+         * Sets the content type (MIME type).
+         *
+         * @param contentType the content type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setContentType(@Nullable String contentType);
 
+        /**
+         * Sets the content coding (e.g., "gzip").
+         *
+         * @param contentCoding the content coding, or {@code null} to remove.
+         * @return this builder.
+         */
         B setContentCoding(@Nullable String contentCoding);
 
+        /**
+         * Sets the subprotocol identifier.
+         *
+         * @param subprotocol the subprotocol, or {@code null} to remove.
+         * @return this builder.
+         */
         B setSubprotocol(@Nullable String subprotocol);
 
+        /**
+         * Sets the security configuration.
+         *
+         * @param security the security configuration, or {@code null} to remove.
+         * @return this builder.
+         */
         B setSecurity(@Nullable Security security);
 
+        /**
+         * Sets the OAuth2 scopes.
+         *
+         * @param scopes the OAuth2 scopes, or {@code null} to remove.
+         * @return this builder.
+         */
         B setScopes(@Nullable OAuth2Scopes scopes);
 
+        /**
+         * Sets the expected response metadata.
+         *
+         * @param expectedResponse the expected response, or {@code null} to remove.
+         * @return this builder.
+         */
         B setExpectedResponse(@Nullable FormElementExpectedResponse expectedResponse);
 
+        /**
+         * Sets the additional expected responses.
+         *
+         * @param additionalResponses the additional responses, or {@code null} to remove.
+         * @return this builder.
+         */
         B setAdditionalResponses(@Nullable FormElementAdditionalResponses additionalResponses);
 
     }
@@ -76,39 +182,75 @@ public interface FormElement<F extends FormElement<F>> extends TypedJsonObject<F
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the operation type (single value).
+         */
         public static final JsonFieldDefinition<String> OP = JsonFactory.newStringFieldDefinition(
                 "op");
 
+        /**
+         * JSON field definition for the operation types (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> OP_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "op");
 
+        /**
+         * JSON field definition for the target href IRI.
+         */
         public static final JsonFieldDefinition<String> HREF = JsonFactory.newStringFieldDefinition(
                 "href");
 
+        /**
+         * JSON field definition for the content type.
+         */
         public static final JsonFieldDefinition<String> CONTENT_TYPE = JsonFactory.newStringFieldDefinition(
                 "contentType");
 
+        /**
+         * JSON field definition for the content coding.
+         */
         public static final JsonFieldDefinition<String> CONTENT_CODING = JsonFactory.newStringFieldDefinition(
                 "contentCoding");
 
+        /**
+         * JSON field definition for the subprotocol.
+         */
         public static final JsonFieldDefinition<String> SUBPROTOCOL = JsonFactory.newStringFieldDefinition(
                 "subprotocol");
 
+        /**
+         * JSON field definition for the security configuration (single value).
+         */
         public static final JsonFieldDefinition<String> SECURITY = JsonFactory.newStringFieldDefinition(
                 "security");
 
+        /**
+         * JSON field definition for the security configurations (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> SECURITY_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "security");
 
+        /**
+         * JSON field definition for the OAuth2 scopes (single value).
+         */
         public static final JsonFieldDefinition<String> SCOPES = JsonFactory.newStringFieldDefinition(
                 "scopes");
 
+        /**
+         * JSON field definition for the OAuth2 scopes (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> SCOPES_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "scopes");
 
+        /**
+         * JSON field definition for the expected response.
+         */
         public static final JsonFieldDefinition<JsonObject> RESPONSE = JsonFactory.newJsonObjectFieldDefinition(
                 "response");
 
+        /**
+         * JSON field definition for the additional expected responses.
+         */
         public static final JsonFieldDefinition<JsonArray> ADDITIONAL_RESPONSES =
                 JsonFactory.newJsonArrayFieldDefinition(
                         "additionalResponses");

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementAdditionalResponse.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementAdditionalResponse.java
@@ -31,44 +31,126 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface FormElementAdditionalResponse extends Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new FormElementAdditionalResponse from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the additional response.
+     * @return the FormElementAdditionalResponse.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static FormElementAdditionalResponse fromJson(final JsonObject jsonObject) {
         return new ImmutableFormElementAdditionalResponse(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a FormElementAdditionalResponse.
+     *
+     * @return the builder.
+     */
     static FormElementAdditionalResponse.Builder newBuilder() {
         return FormElementAdditionalResponse.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a FormElementAdditionalResponse, initialized with the values from the
+     * specified JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static FormElementAdditionalResponse.Builder newBuilder(final JsonObject jsonObject) {
         return FormElementAdditionalResponse.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a FormElementAdditionalResponse, initialized with
+     * the values of this instance.
+     *
+     * @return the builder.
+     */
     default FormElementAdditionalResponse.Builder toBuilder() {
         return FormElementAdditionalResponse.Builder.newBuilder(toJson());
     }
 
+    /**
+     * Returns whether this additional response represents a success case.
+     *
+     * @return {@code true} if this is a success response, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#additionalexpectedresponse">WoT TD AdditionalExpectedResponse (success)</a>
+     */
     boolean isSuccess();
 
+    /**
+     * Returns the optional content type of this additional response.
+     *
+     * @return the optional content type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#additionalexpectedresponse">WoT TD AdditionalExpectedResponse (contentType)</a>
+     */
     Optional<String> getContentType();
 
+    /**
+     * Returns the optional schema reference for this additional response.
+     *
+     * @return the optional schema.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#additionalexpectedresponse">WoT TD AdditionalExpectedResponse (schema)</a>
+     */
     Optional<String> getSchema();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link FormElementAdditionalResponse}.
+     */
     interface Builder {
 
+        /**
+         * Creates a new builder for building a FormElementAdditionalResponse.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableFormElementAdditionalResponseBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a FormElementAdditionalResponse, initialized with the values from
+         * the specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableFormElementAdditionalResponseBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets whether this additional response represents a success case.
+         *
+         * @param success the success flag, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setSuccess(@Nullable Boolean success);
 
+        /**
+         * Sets the content type of this additional response.
+         *
+         * @param contentType the content type, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setContentType(@Nullable String contentType);
 
+        /**
+         * Sets the schema reference for this additional response.
+         *
+         * @param schema the schema, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setSchema(@Nullable String schema);
 
+        /**
+         * Builds the FormElementAdditionalResponse.
+         *
+         * @return the FormElementAdditionalResponse.
+         */
         FormElementAdditionalResponse build();
     }
 
@@ -78,12 +160,21 @@ public interface FormElementAdditionalResponse extends Jsonifiable<JsonObject> {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the success flag.
+         */
         public static final JsonFieldDefinition<Boolean> SUCCESS = JsonFactory.newBooleanFieldDefinition(
                 "success");
 
+        /**
+         * JSON field definition for the content type.
+         */
         public static final JsonFieldDefinition<String> CONTENT_TYPE = JsonFactory.newStringFieldDefinition(
                 "contentType");
 
+        /**
+         * JSON field definition for the schema reference.
+         */
         public static final JsonFieldDefinition<String> SCHEMA = JsonFactory.newStringFieldDefinition(
                 "schema");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementAdditionalResponses.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementAdditionalResponses.java
@@ -31,6 +31,12 @@ import org.eclipse.ditto.json.JsonValue;
 public interface FormElementAdditionalResponses
         extends Iterable<FormElementAdditionalResponse>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates FormElementAdditionalResponses from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of additional response objects.
+     * @return the FormElementAdditionalResponses.
+     */
     static FormElementAdditionalResponses fromJson(final JsonArray jsonArray) {
         final List<FormElementAdditionalResponse> baseLinks = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -40,10 +46,21 @@ public interface FormElementAdditionalResponses
         return of(baseLinks);
     }
 
+    /**
+     * Creates FormElementAdditionalResponses from the specified collection of additional responses.
+     *
+     * @param links the collection of additional responses.
+     * @return the FormElementAdditionalResponses.
+     */
     static FormElementAdditionalResponses of(final Collection<FormElementAdditionalResponse> links) {
         return new ImmutableFormElementAdditionalResponses(links);
     }
 
+    /**
+     * Returns a sequential stream over the additional responses.
+     *
+     * @return a stream of additional responses.
+     */
     default Stream<FormElementAdditionalResponse> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementExpectedResponse.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementExpectedResponse.java
@@ -29,10 +29,22 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface FormElementExpectedResponse extends TypedJsonObject<FormElementExpectedResponse>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new FormElementExpectedResponse from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the expected response.
+     * @return the FormElementExpectedResponse.
+     */
     static FormElementExpectedResponse fromJson(final JsonObject jsonObject) {
         return new ImmutableFormElementExpectedResponse(jsonObject);
     }
 
+    /**
+     * Returns the optional content type of the expected response.
+     *
+     * @return the optional content type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#expectedresponse">WoT TD ExpectedResponse (contentType)</a>
+     */
     Optional<String> getContentType();
 
     /**
@@ -41,6 +53,9 @@ public interface FormElementExpectedResponse extends TypedJsonObject<FormElement
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the content type.
+         */
         public static final JsonFieldDefinition<String> CONTENT_TYPE = JsonFactory.newStringFieldDefinition(
                 "contentType");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementSubprotocol.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/FormElementSubprotocol.java
@@ -21,6 +21,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface FormElementSubprotocol extends CharSequence {
 
+    /**
+     * Creates a FormElementSubprotocol from the specified subprotocol identifier.
+     *
+     * @param charSequence the subprotocol identifier (e.g., "longpoll", "websub", "sse").
+     * @return the FormElementSubprotocol.
+     */
     static FormElementSubprotocol of(final CharSequence charSequence) {
         if (charSequence instanceof FormElementSubprotocol) {
             return (FormElementSubprotocol) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Forms.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Forms.java
@@ -28,6 +28,11 @@ import org.eclipse.ditto.json.JsonArray;
  */
 public interface Forms<E extends FormElement<E>> extends Iterable<E>, Jsonifiable<JsonArray> {
 
+    /**
+     * Returns a sequential stream over the form elements.
+     *
+     * @return a stream of form elements.
+     */
     default Stream<E> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Hreflang.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Hreflang.java
@@ -22,10 +22,22 @@ import java.util.Collection;
  */
 public interface Hreflang {
 
+    /**
+     * Creates a SingleHreflang from the specified language tag.
+     *
+     * @param charSequence the language tag (e.g., "en", "de", "en-US").
+     * @return the SingleHreflang.
+     */
     static SingleHreflang newSingleHreflang(final CharSequence charSequence) {
         return SingleHreflang.of(charSequence);
     }
 
+    /**
+     * Creates a MultipleHreflang from the specified collection of language tags.
+     *
+     * @param hreflangs the collection of language tags.
+     * @return the MultipleHreflang.
+     */
     static MultipleHreflang newMultipleHreflang(final Collection<SingleHreflang> hreflangs) {
         return MultipleHreflang.of(hreflangs);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/IRI.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/IRI.java
@@ -15,6 +15,10 @@ package org.eclipse.ditto.wot.model;
 /**
  * An IRI (Internationalized Resource Identifier Reference) "value can be absolute or relative, and may have an
  * optional fragment identifier (i.e., it may be an IRI Reference)".
+ * <p>
+ * IRIs are used throughout the WoT Thing Description to identify resources such as the Thing itself,
+ * linked resources, form targets, and semantic annotations.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bib-rfc3987">RFC3987 - Internationalized Resource Identifiers (IRIs)</a>
  * @see <a href="https://www.w3.org/TR/2012/REC-xmlschema11-2-20120405/#anyURI">W3C XSD anyURI</a>
@@ -22,6 +26,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface IRI extends CharSequence {
 
+    /**
+     * Creates an IRI from the given character sequence.
+     *
+     * @param charSequence the character sequence representing the IRI.
+     * @return the IRI instance.
+     */
     static IRI of(final CharSequence charSequence) {
         if (charSequence instanceof IRI) {
             return (IRI) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/IconLink.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/IconLink.java
@@ -28,18 +28,42 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface IconLink extends BaseLink<IconLink> {
 
+    /**
+     * Creates a new IconLink from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the icon link.
+     * @return the IconLink.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static IconLink fromJson(final JsonObject jsonObject) {
         return new ImmutableIconLink(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an IconLink.
+     *
+     * @return the builder.
+     */
     static IconLink.Builder newBuilder() {
         return IconLink.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an IconLink, initialized with the values from the specified JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static IconLink.Builder newBuilder(final JsonObject jsonObject) {
         return IconLink.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns the optional sizes attribute specifying icon dimensions (e.g., "16x16", "32x32 64x64").
+     *
+     * @return the optional sizes.
+     */
     Optional<String> getSizes();
 
     @Override
@@ -47,16 +71,36 @@ public interface IconLink extends BaseLink<IconLink> {
         return IconLink.Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building an {@link IconLink}.
+     */
     interface Builder extends BaseLink.Builder<Builder, IconLink> {
 
+        /**
+         * Creates a new builder for building an IconLink.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableIconLinkBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an IconLink, initialized with the values from the specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableIconLinkBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the sizes attribute for the icon.
+         *
+         * @param sizes the sizes (e.g., "16x16"), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setSizes(@Nullable String sizes);
     }
 
@@ -66,6 +110,9 @@ public interface IconLink extends BaseLink<IconLink> {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the icon sizes.
+         */
         public static final JsonFieldDefinition<String> SIZES = JsonFactory.newStringFieldDefinition(
                 "sizes");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/IntegerSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/IntegerSchema.java
@@ -23,23 +23,51 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * An IntegerSchema is a {@link SingleDataSchema} describing the JSON data type {@code integer}.
+ * <p>
+ * Integer values are whole numbers without a fractional part.
+ * </p>
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema</a>
  * @since 2.4.0
  */
 public interface IntegerSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new IntegerSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the integer schema.
+     * @return the IntegerSchema.
+     */
     static IntegerSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableIntegerSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an IntegerSchema.
+     *
+     * @return the builder.
+     */
     static IntegerSchema.Builder newBuilder() {
         return IntegerSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an IntegerSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static IntegerSchema.Builder newBuilder(final JsonObject jsonObject) {
         return IntegerSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building an IntegerSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default IntegerSchema.Builder toBuilder() {
         return IntegerSchema.Builder.newBuilder(toJson());
     }
@@ -49,34 +77,109 @@ public interface IntegerSchema extends SingleDataSchema {
         return Optional.of(DataSchemaType.INTEGER);
     }
 
+    /**
+     * Returns the optional inclusive minimum value the integer must have.
+     *
+     * @return the optional minimum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema (minimum)</a>
+     */
     Optional<Integer> getMinimum();
 
+    /**
+     * Returns the optional exclusive minimum value the integer must exceed.
+     *
+     * @return the optional exclusive minimum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema (exclusiveMinimum)</a>
+     */
     Optional<Integer> getExclusiveMinimum();
 
+    /**
+     * Returns the optional inclusive maximum value the integer may have.
+     *
+     * @return the optional maximum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema (maximum)</a>
+     */
     Optional<Integer> getMaximum();
 
+    /**
+     * Returns the optional exclusive maximum value the integer must be less than.
+     *
+     * @return the optional exclusive maximum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema (exclusiveMaximum)</a>
+     */
     Optional<Integer> getExclusiveMaximum();
 
+    /**
+     * Returns the optional value that the integer must be a multiple of.
+     *
+     * @return the optional multiple-of constraint.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema (multipleOf)</a>
+     */
     Optional<Integer> getMultipleOf();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link IntegerSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, IntegerSchema> {
 
+        /**
+         * Creates a new builder for building an IntegerSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableIntegerSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an IntegerSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableIntegerSchemaBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the inclusive minimum value constraint.
+         *
+         * @param minimum the minimum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMinimum(@Nullable Integer minimum);
 
+        /**
+         * Sets the exclusive minimum value constraint.
+         *
+         * @param exclusiveMinimum the exclusive minimum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setExclusiveMinimum(@Nullable Integer exclusiveMinimum);
 
+        /**
+         * Sets the inclusive maximum value constraint.
+         *
+         * @param maximum the maximum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMaximum(@Nullable Integer maximum);
 
+        /**
+         * Sets the exclusive maximum value constraint.
+         *
+         * @param exclusiveMaximum the exclusive maximum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setExclusiveMaximum(@Nullable Integer exclusiveMaximum);
 
+        /**
+         * Sets the multiple-of constraint.
+         *
+         * @param multipleOf the multiple-of value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMultipleOf(@Nullable Integer multipleOf);
 
     }
@@ -87,18 +190,33 @@ public interface IntegerSchema extends SingleDataSchema {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the inclusive minimum value constraint.
+         */
         public static final JsonFieldDefinition<Integer> MINIMUM = JsonFactory.newIntFieldDefinition(
                 "minimum");
 
+        /**
+         * JSON field definition for the exclusive minimum value constraint.
+         */
         public static final JsonFieldDefinition<Integer> EXCLUSIVE_MINIMUM = JsonFactory.newIntFieldDefinition(
                 "exclusiveMinimum");
 
+        /**
+         * JSON field definition for the inclusive maximum value constraint.
+         */
         public static final JsonFieldDefinition<Integer> MAXIMUM = JsonFactory.newIntFieldDefinition(
                 "maximum");
 
+        /**
+         * JSON field definition for the exclusive maximum value constraint.
+         */
         public static final JsonFieldDefinition<Integer> EXCLUSIVE_MAXIMUM = JsonFactory.newIntFieldDefinition(
                 "exclusiveMaximum");
 
+        /**
+         * JSON field definition for the multiple-of constraint.
+         */
         public static final JsonFieldDefinition<Integer> MULTIPLE_OF = JsonFactory.newIntFieldDefinition(
                 "multipleOf");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Interaction.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Interaction.java
@@ -25,46 +25,141 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * An Interaction describes how to interact with a Thing.
+ * <p>
  * W3C WoT defines three types of Interaction Affordances: {@link Property}s, {@link Action}s, and {@link Event}s.
+ * The InteractionAffordance is the base class that provides common metadata for all interaction types.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#interactionaffordance">WoT TD InteractionAffordance</a>
  * @param <I> the type of the Interaction.
- * @param <F> the type of the Interaction's Forms.
  * @param <E> the type of the Interaction's Form's FormElements.
+ * @param <F> the type of the Interaction's Forms.
  * @since 2.4.0
  */
 public interface Interaction<I extends Interaction<I, E, F>, E extends FormElement<E>, F extends Forms<E>>
         extends TypedJsonObject<I>, Jsonifiable<JsonObject> {
 
+    /**
+     * Returns the optional JSON-LD {@code @type} providing semantic annotations for this interaction.
+     *
+     * @return the optional semantic type annotation.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#interactionaffordance">WoT TD InteractionAffordance (@type)</a>
+     */
     Optional<AtType> getAtType();
 
+    /**
+     * Returns the optional human-readable description of this interaction, based on the default language.
+     *
+     * @return the optional description.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#interactionaffordance">WoT TD InteractionAffordance (description)</a>
+     */
     Optional<Description> getDescription();
 
+    /**
+     * Returns the optional multi-language map of human-readable descriptions for this interaction.
+     *
+     * @return the optional multi-language descriptions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Descriptions> getDescriptions();
 
+    /**
+     * Returns the optional human-readable title of this interaction, based on the default language.
+     *
+     * @return the optional title.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#interactionaffordance">WoT TD InteractionAffordance (title)</a>
+     */
     Optional<Title> getTitle();
 
+    /**
+     * Returns the optional multi-language map of human-readable titles for this interaction.
+     *
+     * @return the optional multi-language titles.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Titles> getTitles();
 
+    /**
+     * Returns the optional collection of Form elements describing how to perform operations on this interaction.
+     *
+     * @return the optional forms.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form</a>
+     */
     Optional<F> getForms();
 
+    /**
+     * Returns the optional URI template variables that can be used within the Forms of this interaction.
+     *
+     * @return the optional URI variables.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#interactionaffordance">WoT TD InteractionAffordance (uriVariables)</a>
+     */
     Optional<UriVariables> getUriVariables();
 
+    /**
+     * A mutable builder for creating {@link Interaction} instances.
+     *
+     * @param <B> the type of the Builder.
+     * @param <I> the type of the Interaction.
+     * @param <E> the type of the FormElements.
+     * @param <F> the type of the Forms.
+     */
     interface Builder<B extends Builder<B, I, E, F>, I extends Interaction<I, E, F>, E extends FormElement<E>, F extends Forms<E>>
             extends TypedJsonObjectBuilder<B, I> {
 
+        /**
+         * Sets the JSON-LD {@code @type} for semantic annotations.
+         *
+         * @param atType the semantic type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setAtType(@Nullable AtType atType);
 
+        /**
+         * Sets the human-readable title.
+         *
+         * @param title the title, or {@code null} to remove.
+         * @return this builder.
+         */
         B setTitle(@Nullable Title title);
 
+        /**
+         * Sets the multi-language titles.
+         *
+         * @param titles the titles map, or {@code null} to remove.
+         * @return this builder.
+         */
         B setTitles(@Nullable Titles titles);
 
+        /**
+         * Sets the human-readable description.
+         *
+         * @param description the description, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescription(@Nullable Description description);
 
+        /**
+         * Sets the multi-language descriptions.
+         *
+         * @param descriptions the descriptions map, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescriptions(@Nullable Descriptions descriptions);
 
+        /**
+         * Sets the collection of Form elements.
+         *
+         * @param forms the forms, or {@code null} to remove.
+         * @return this builder.
+         */
         B setForms(@Nullable F forms);
 
+        /**
+         * Sets the URI template variables.
+         *
+         * @param uriVariables the URI variables, or {@code null} to remove.
+         * @return this builder.
+         */
         B setUriVariables(@Nullable UriVariables uriVariables);
 
     }
@@ -75,27 +170,51 @@ public interface Interaction<I extends Interaction<I, E, F>, E extends FormEleme
     @Immutable
     final class InteractionJsonFields {
 
+        /**
+         * JSON field definition for the JSON-LD type (single value).
+         */
         public static final JsonFieldDefinition<String> AT_TYPE = JsonFactory.newStringFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the JSON-LD type (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> AT_TYPE_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the title.
+         */
         public static final JsonFieldDefinition<String> TITLE = JsonFactory.newStringFieldDefinition(
                 "title");
 
+        /**
+         * JSON field definition for the multilingual titles.
+         */
         public static final JsonFieldDefinition<JsonObject> TITLES = JsonFactory.newJsonObjectFieldDefinition(
                 "titles");
 
+        /**
+         * JSON field definition for the description.
+         */
         public static final JsonFieldDefinition<String> DESCRIPTION = JsonFactory.newStringFieldDefinition(
                 "description");
 
+        /**
+         * JSON field definition for the multilingual descriptions.
+         */
         public static final JsonFieldDefinition<JsonObject> DESCRIPTIONS = JsonFactory.newJsonObjectFieldDefinition(
                 "descriptions");
 
+        /**
+         * JSON field definition for the form elements.
+         */
         public static final JsonFieldDefinition<JsonArray> FORMS = JsonFactory.newJsonArrayFieldDefinition(
                 "forms");
 
+        /**
+         * JSON field definition for the URI template variables.
+         */
         public static final JsonFieldDefinition<JsonObject> URI_VARIABLES = JsonFactory.newJsonObjectFieldDefinition(
                 "uriVariables");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Link.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Link.java
@@ -15,7 +15,10 @@ package org.eclipse.ditto.wot.model;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * Link is a {@link BaseLink} _not_ being of {@code rel="icon"}.
+ * Link is a {@link BaseLink} not being of {@code rel="icon"}.
+ * <p>
+ * Links provide web linking capabilities to connect the Thing Description to related resources.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link</a>
  * @see <a href="https://www.iana.org/assignments/link-relations">Link Relation definitions from IANA</a>
@@ -23,29 +26,66 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Link extends BaseLink<Link> {
 
+    /**
+     * Creates a new Link from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the link.
+     * @return the Link.
+     */
     static Link fromJson(final JsonObject jsonObject) {
         return new ImmutableLink(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a Link.
+     *
+     * @return the builder.
+     */
     static Link.Builder newBuilder() {
         return Link.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a Link, initialized with the values from the specified JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static Link.Builder newBuilder(final JsonObject jsonObject) {
         return Link.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a Link, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default Builder toBuilder() {
         return Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link Link}.
+     */
     interface Builder extends BaseLink.Builder<Builder, Link> {
 
+        /**
+         * Creates a new builder for building a Link.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableLinkBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a Link, initialized with the values from the specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableLinkBuilder(jsonObject.toBuilder());
         }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Links.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Links.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface Links extends Iterable<BaseLink<?>>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a Links from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of link objects.
+     * @return the Links.
+     */
     static Links fromJson(final JsonArray jsonArray) {
         final List<BaseLink<?>> baseLinks = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -38,10 +44,21 @@ public interface Links extends Iterable<BaseLink<?>>, Jsonifiable<JsonArray> {
         return of(baseLinks);
     }
 
+    /**
+     * Creates a Links from the specified collection of links.
+     *
+     * @param links the collection of links.
+     * @return the Links.
+     */
     static Links of(final Collection<BaseLink<?>> links) {
         return new ImmutableLinks(links);
     }
 
+    /**
+     * Returns a sequential stream over the links.
+     *
+     * @return a stream of links.
+     */
     default Stream<BaseLink<?>> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleActionFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleActionFormElementOp.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonValue;
 public interface MultipleActionFormElementOp
         extends ActionFormElementOp<SingleActionFormElementOp>, MultipleFormElementOp<SingleActionFormElementOp> {
 
+    /**
+     * Creates a MultipleActionFormElementOp from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of operation strings.
+     * @return the MultipleActionFormElementOp.
+     */
     static MultipleActionFormElementOp fromJson(final JsonArray jsonArray) {
         final List<SingleActionFormElementOp> singleActionFormOps = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,6 +44,12 @@ public interface MultipleActionFormElementOp
         return of(singleActionFormOps);
     }
 
+    /**
+     * Creates a MultipleActionFormElementOp from the specified collection of operations.
+     *
+     * @param ops the collection of operations.
+     * @return the MultipleActionFormElementOp.
+     */
     static MultipleActionFormElementOp of(final Collection<SingleActionFormElementOp> ops) {
         return new ImmutableMultipleActionFormElementOp(ops);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtContext.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonArray;
  */
 public interface MultipleAtContext extends AtContext, Iterable<SingleAtContext>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleAtContext from the specified JSON array.
+     *
+     * @param jsonArray the JSON array representing multiple context entries.
+     * @return the MultipleAtContext.
+     */
     static MultipleAtContext fromJson(final JsonArray jsonArray) {
         final List<SingleAtContext> singleDataSchemaTypes = jsonArray.stream()
                 .flatMap(jsonValue -> {
@@ -47,10 +53,21 @@ public interface MultipleAtContext extends AtContext, Iterable<SingleAtContext>,
         return of(singleDataSchemaTypes);
     }
 
+    /**
+     * Creates a MultipleAtContext from the specified collection of single contexts.
+     *
+     * @param contexts the collection of single context entries.
+     * @return the MultipleAtContext.
+     */
     static MultipleAtContext of(final Collection<SingleAtContext> contexts) {
         return new ImmutableMultipleAtContext(contexts);
     }
 
+    /**
+     * Returns a sequential stream over the single context entries.
+     *
+     * @return a stream of single contexts.
+     */
     default Stream<SingleAtContext> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtType.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleAtType.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface MultipleAtType extends AtType, Iterable<SingleAtType>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleAtType from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of type strings.
+     * @return the MultipleAtType.
+     */
     static MultipleAtType fromJson(final JsonArray jsonArray) {
         final List<SingleAtType> singleDataSchemaTypes = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,10 +44,21 @@ public interface MultipleAtType extends AtType, Iterable<SingleAtType>, Jsonifia
         return of(singleDataSchemaTypes);
     }
 
+    /**
+     * Creates a MultipleAtType from the specified collection of single types.
+     *
+     * @param contexts the collection of single type entries.
+     * @return the MultipleAtType.
+     */
     static MultipleAtType of(final Collection<SingleAtType> contexts) {
         return new ImmutableMultipleAtType(contexts);
     }
 
+    /**
+     * Returns a sequential stream over the single type entries.
+     *
+     * @return a stream of single types.
+     */
     default Stream<SingleAtType> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleDataSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleDataSchema.java
@@ -23,12 +23,18 @@ import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonValue;
 
 /**
- * MultipleActionFormElementOp is a container for multiple {@link SingleDataSchema}s.
+ * MultipleDataSchema is a container for multiple {@link SingleDataSchema}s.
  *
  * @since 2.4.0
  */
 public interface MultipleDataSchema extends DataSchema, Iterable<SingleDataSchema>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleDataSchema from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of data schema objects.
+     * @return the MultipleDataSchema.
+     */
     static MultipleDataSchema fromJson(final JsonArray jsonArray) {
         final List<SingleDataSchema> singleDataSchemas = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -38,10 +44,21 @@ public interface MultipleDataSchema extends DataSchema, Iterable<SingleDataSchem
         return of(singleDataSchemas);
     }
 
+    /**
+     * Creates a MultipleDataSchema from the specified collection of data schemas.
+     *
+     * @param dataSchemas the collection of data schemas.
+     * @return the MultipleDataSchema.
+     */
     static MultipleDataSchema of(final Collection<SingleDataSchema> dataSchemas) {
         return new ImmutableMultipleDataSchema(dataSchemas);
     }
 
+    /**
+     * Returns a sequential stream over the data schemas.
+     *
+     * @return a stream of data schemas.
+     */
     default Stream<SingleDataSchema> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleEventFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleEventFormElementOp.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonValue;
 public interface MultipleEventFormElementOp
         extends EventFormElementOp<SingleEventFormElementOp>, MultipleFormElementOp<SingleEventFormElementOp> {
 
+    /**
+     * Creates a MultipleEventFormElementOp from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of operation strings.
+     * @return the MultipleEventFormElementOp.
+     */
     static MultipleEventFormElementOp fromJson(final JsonArray jsonArray) {
         final List<SingleEventFormElementOp> singleEventFormOps = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,6 +44,12 @@ public interface MultipleEventFormElementOp
         return of(singleEventFormOps);
     }
 
+    /**
+     * Creates a MultipleEventFormElementOp from the specified collection of operations.
+     *
+     * @param ops the collection of operations.
+     * @return the MultipleEventFormElementOp.
+     */
     static MultipleEventFormElementOp of(final Collection<SingleEventFormElementOp> ops) {
         return new ImmutableMultipleEventFormElementOp(ops);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleFormElementOp.java
@@ -27,6 +27,11 @@ import org.eclipse.ditto.json.JsonArray;
 public interface MultipleFormElementOp<O extends FormElementOp<O>> extends Iterable<O>,
         Jsonifiable<JsonArray> {
 
+    /**
+     * Returns a sequential stream over the form element operations.
+     *
+     * @return a stream of form element operations.
+     */
     default Stream<O> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleHreflang.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleHreflang.java
@@ -30,6 +30,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface MultipleHreflang extends Hreflang, Iterable<SingleHreflang>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleHreflang from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of language tags.
+     * @return the MultipleHreflang.
+     */
     static MultipleHreflang fromJson(final JsonArray jsonArray) {
         final List<SingleHreflang> singleSecurities = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -39,10 +45,21 @@ public interface MultipleHreflang extends Hreflang, Iterable<SingleHreflang>, Js
         return of(singleSecurities);
     }
 
+    /**
+     * Creates a MultipleHreflang from the specified collection of language tags.
+     *
+     * @param hreflangs the collection of language tags.
+     * @return the MultipleHreflang.
+     */
     static MultipleHreflang of(final Collection<SingleHreflang> hreflangs) {
         return new ImmutableMultipleHreflang(hreflangs);
     }
 
+    /**
+     * Returns a sequential stream over the language tags.
+     *
+     * @return a stream of language tags.
+     */
     default Stream<SingleHreflang> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleOAuth2Scopes.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleOAuth2Scopes.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface MultipleOAuth2Scopes extends OAuth2Scopes, Iterable<SingleOAuth2Scopes>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleOAuth2Scopes from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of scope strings.
+     * @return the MultipleOAuth2Scopes.
+     */
     static MultipleOAuth2Scopes fromJson(final JsonArray jsonArray) {
         final List<SingleOAuth2Scopes> singleOAuth2Scopes = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,10 +44,21 @@ public interface MultipleOAuth2Scopes extends OAuth2Scopes, Iterable<SingleOAuth
         return of(singleOAuth2Scopes);
     }
 
+    /**
+     * Creates a MultipleOAuth2Scopes from the specified collection of scopes.
+     *
+     * @param scopes the collection of scopes.
+     * @return the MultipleOAuth2Scopes.
+     */
     static MultipleOAuth2Scopes of(final Collection<SingleOAuth2Scopes> scopes) {
         return new ImmutableMultipleOAuth2Scopes(scopes);
     }
 
+    /**
+     * Returns a sequential stream over the scopes.
+     *
+     * @return a stream of scopes.
+     */
     default Stream<SingleOAuth2Scopes> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleProfile.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleProfile.java
@@ -23,12 +23,18 @@ import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonValue;
 
 /**
- * MultipleSecurity is a container for multiple {@link SingleProfile}s.
+ * MultipleProfile is a container for multiple {@link SingleProfile}s.
  *
  * @since 2.4.0
  */
 public interface MultipleProfile extends Profile, Iterable<SingleProfile>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleProfile from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of profile IRIs.
+     * @return the MultipleProfile.
+     */
     static MultipleProfile fromJson(final JsonArray jsonArray) {
         final List<SingleProfile> singleProfiles = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,10 +44,21 @@ public interface MultipleProfile extends Profile, Iterable<SingleProfile>, Jsoni
         return of(singleProfiles);
     }
 
+    /**
+     * Creates a MultipleProfile from the specified collection of profiles.
+     *
+     * @param profiles the collection of profiles.
+     * @return the MultipleProfile.
+     */
     static MultipleProfile of(final Collection<SingleProfile> profiles) {
         return new ImmutableMultipleProfile(profiles);
     }
 
+    /**
+     * Returns a sequential stream over the profiles.
+     *
+     * @return a stream of profiles.
+     */
     default Stream<SingleProfile> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultiplePropertyFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultiplePropertyFormElementOp.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonValue;
 public interface MultiplePropertyFormElementOp
         extends PropertyFormElementOp<SinglePropertyFormElementOp>, MultipleFormElementOp<SinglePropertyFormElementOp> {
 
+    /**
+     * Creates a MultiplePropertyFormElementOp from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of operation strings.
+     * @return the MultiplePropertyFormElementOp.
+     */
     static MultiplePropertyFormElementOp fromJson(final JsonArray jsonArray) {
         final List<SinglePropertyFormElementOp> singlePropertyFormOps = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,6 +44,12 @@ public interface MultiplePropertyFormElementOp
         return of(singlePropertyFormOps);
     }
 
+    /**
+     * Creates a MultiplePropertyFormElementOp from the specified collection of operations.
+     *
+     * @param ops the collection of operations.
+     * @return the MultiplePropertyFormElementOp.
+     */
     static MultiplePropertyFormElementOp of(final Collection<SinglePropertyFormElementOp> ops) {
         return new ImmutableMultiplePropertyFormElementOp(ops);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleRootFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleRootFormElementOp.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonValue;
 public interface MultipleRootFormElementOp
         extends RootFormElementOp<SingleRootFormElementOp>, MultipleFormElementOp<SingleRootFormElementOp> {
 
+    /**
+     * Creates a MultipleRootFormElementOp from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of operation strings.
+     * @return the MultipleRootFormElementOp.
+     */
     static MultipleRootFormElementOp fromJson(final JsonArray jsonArray) {
         final List<SingleRootFormElementOp> singleEventFormOps = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,6 +44,12 @@ public interface MultipleRootFormElementOp
         return of(singleEventFormOps);
     }
 
+    /**
+     * Creates a MultipleRootFormElementOp from the specified collection of operations.
+     *
+     * @param ops the collection of operations.
+     * @return the MultipleRootFormElementOp.
+     */
     static MultipleRootFormElementOp of(final Collection<SingleRootFormElementOp> ops) {
         return new ImmutableMultipleRootFormElementOp(ops);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleSecurity.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/MultipleSecurity.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface MultipleSecurity extends Security, Iterable<SingleSecurity>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a MultipleSecurity from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of security scheme names.
+     * @return the MultipleSecurity.
+     */
     static MultipleSecurity fromJson(final JsonArray jsonArray) {
         final List<SingleSecurity> singleSecurities = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -38,10 +44,21 @@ public interface MultipleSecurity extends Security, Iterable<SingleSecurity>, Js
         return of(singleSecurities);
     }
 
+    /**
+     * Creates a MultipleSecurity from the specified collection of security scheme names.
+     *
+     * @param securities the collection of security scheme names.
+     * @return the MultipleSecurity.
+     */
     static MultipleSecurity of(final Collection<SingleSecurity> securities) {
         return new ImmutableMultipleSecurity(securities);
     }
 
+    /**
+     * Returns a sequential stream over the security scheme names.
+     *
+     * @return a stream of security scheme names.
+     */
     default Stream<SingleSecurity> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/NoSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/NoSecurityScheme.java
@@ -25,14 +25,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface NoSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new NoSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the NoSecurityScheme.
+     */
     static NoSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableNoSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a NoSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static NoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return NoSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a NoSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static NoSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return NoSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -42,13 +65,30 @@ public interface NoSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.NOSEC;
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link NoSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, NoSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a NoSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableNoSecuritySchemeBuilder(checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a NoSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
             return new MutableNoSecuritySchemeBuilder(checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     jsonObject.toBuilder());

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/NullSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/NullSchema.java
@@ -17,34 +17,77 @@ import java.util.Optional;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * A NullSchema is a {@link SingleDataSchema} describing the JSON {@code null}.
+ * A NullSchema is a {@link SingleDataSchema} describing the JSON {@code null} value.
+ * <p>
+ * This schema type is used to explicitly indicate that a value must be null.
+ * </p>
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#nullschema">WoT TD NullSchema</a>
  * @since 2.4.0
  */
 public interface NullSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new NullSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the null schema.
+     * @return the NullSchema.
+     */
     static NullSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableNullSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a NullSchema.
+     *
+     * @return the builder.
+     */
     static NullSchema.Builder newBuilder() {
         return NullSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a NullSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static NullSchema.Builder newBuilder(final JsonObject jsonObject) {
         return NullSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a NullSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default NullSchema.Builder toBuilder() {
         return NullSchema.Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link NullSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, NullSchema> {
 
+        /**
+         * Creates a new builder for building a NullSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableNullSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a NullSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableNullSchemaBuilder(jsonObject.toBuilder());
         }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/NumberSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/NumberSchema.java
@@ -23,23 +23,51 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * A NumberSchema is a {@link SingleDataSchema} describing the JSON data type {@code number}.
+ * <p>
+ * Number values are floating-point numbers (including integers).
+ * </p>
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema</a>
  * @since 2.4.0
  */
 public interface NumberSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new NumberSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the number schema.
+     * @return the NumberSchema.
+     */
     static NumberSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableNumberSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a NumberSchema.
+     *
+     * @return the builder.
+     */
     static NumberSchema.Builder newBuilder() {
         return NumberSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a NumberSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static NumberSchema.Builder newBuilder(final JsonObject jsonObject) {
         return NumberSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a NumberSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default NumberSchema.Builder toBuilder() {
         return NumberSchema.Builder.newBuilder(toJson());
     }
@@ -49,34 +77,109 @@ public interface NumberSchema extends SingleDataSchema {
         return Optional.of(DataSchemaType.NUMBER);
     }
 
+    /**
+     * Returns the optional inclusive minimum value the number must have.
+     *
+     * @return the optional minimum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema (minimum)</a>
+     */
     Optional<Double> getMinimum();
 
+    /**
+     * Returns the optional exclusive minimum value the number must exceed.
+     *
+     * @return the optional exclusive minimum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema (exclusiveMinimum)</a>
+     */
     Optional<Double> getExclusiveMinimum();
 
+    /**
+     * Returns the optional inclusive maximum value the number may have.
+     *
+     * @return the optional maximum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema (maximum)</a>
+     */
     Optional<Double> getMaximum();
 
+    /**
+     * Returns the optional exclusive maximum value the number must be less than.
+     *
+     * @return the optional exclusive maximum value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema (exclusiveMaximum)</a>
+     */
     Optional<Double> getExclusiveMaximum();
 
+    /**
+     * Returns the optional value that the number must be a multiple of.
+     *
+     * @return the optional multiple-of constraint.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema (multipleOf)</a>
+     */
     Optional<Double> getMultipleOf();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link NumberSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, NumberSchema> {
 
+        /**
+         * Creates a new builder for building a NumberSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableNumberSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a NumberSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableNumberSchemaBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the inclusive minimum value constraint.
+         *
+         * @param minimum the minimum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMinimum(@Nullable Double minimum);
 
+        /**
+         * Sets the exclusive minimum value constraint.
+         *
+         * @param exclusiveMinimum the exclusive minimum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setExclusiveMinimum(@Nullable Double exclusiveMinimum);
 
+        /**
+         * Sets the inclusive maximum value constraint.
+         *
+         * @param maximum the maximum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMaximum(@Nullable Double maximum);
 
+        /**
+         * Sets the exclusive maximum value constraint.
+         *
+         * @param exclusiveMaximum the exclusive maximum value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setExclusiveMaximum(@Nullable Double exclusiveMaximum);
 
+        /**
+         * Sets the multiple-of constraint.
+         *
+         * @param multipleOf the multiple-of value, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMultipleOf(@Nullable Double multipleOf);
 
     }
@@ -87,18 +190,33 @@ public interface NumberSchema extends SingleDataSchema {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the inclusive minimum value constraint.
+         */
         public static final JsonFieldDefinition<Double> MINIMUM = JsonFactory.newDoubleFieldDefinition(
                 "minimum");
 
+        /**
+         * JSON field definition for the exclusive minimum value constraint.
+         */
         public static final JsonFieldDefinition<Double> EXCLUSIVE_MINIMUM = JsonFactory.newDoubleFieldDefinition(
                 "exclusiveMinimum");
 
+        /**
+         * JSON field definition for the inclusive maximum value constraint.
+         */
         public static final JsonFieldDefinition<Double> MAXIMUM = JsonFactory.newDoubleFieldDefinition(
                 "maximum");
 
+        /**
+         * JSON field definition for the exclusive maximum value constraint.
+         */
         public static final JsonFieldDefinition<Double> EXCLUSIVE_MAXIMUM = JsonFactory.newDoubleFieldDefinition(
                 "exclusiveMaximum");
 
+        /**
+         * JSON field definition for the multiple-of constraint.
+         */
         public static final JsonFieldDefinition<Double> MULTIPLE_OF = JsonFactory.newDoubleFieldDefinition(
                 "multipleOf");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2Flow.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2Flow.java
@@ -19,10 +19,33 @@ package org.eclipse.ditto.wot.model;
  */
 public interface OAuth2Flow extends CharSequence {
 
+    /**
+     * Authorization code flow.
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (flow)</a>
+     */
     OAuth2Flow CODE = of("code");
+
+    /**
+     * Client credentials flow.
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (flow)</a>
+     */
     OAuth2Flow CLIENT = of("client");
+
+    /**
+     * Device authorization flow.
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (flow)</a>
+     */
     OAuth2Flow DEVICE = of("device");
 
+    /**
+     * Creates an OAuth2Flow from the specified string.
+     *
+     * @param charSequence the flow name.
+     * @return the OAuth2Flow.
+     */
     static OAuth2Flow of(final CharSequence charSequence) {
         if (charSequence instanceof OAuth2Flow) {
             return (OAuth2Flow) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2Scopes.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2Scopes.java
@@ -23,10 +23,22 @@ import java.util.Collection;
  */
 public interface OAuth2Scopes {
 
+    /**
+     * Creates a SingleOAuth2Scopes from the specified scope string.
+     *
+     * @param scope the OAuth2 scope.
+     * @return the SingleOAuth2Scopes.
+     */
     static SingleOAuth2Scopes newSingleOAuth2Scopes(final CharSequence scope) {
         return SingleOAuth2Scopes.of(scope);
-
     }
+
+    /**
+     * Creates a MultipleOAuth2Scopes from the specified collection of scopes.
+     *
+     * @param scopes the collection of scopes.
+     * @return the MultipleOAuth2Scopes.
+     */
     static MultipleOAuth2Scopes newMultipleOAuth2Scopes(final Collection<SingleOAuth2Scopes> scopes) {
         return MultipleOAuth2Scopes.of(scopes);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2SecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/OAuth2SecurityScheme.java
@@ -26,6 +26,10 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * An OAuth2SecurityScheme is a {@link SecurityScheme} indicating to use {@code OAuth 2.0} for authentication.
+ * <p>
+ * This security scheme supports the OAuth 2.0 authorization framework, enabling secure delegated access
+ * using access tokens.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bib-rfc6749">RFC6749 - The OAuth 2.0 Authorization Framework</a>
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bib-rfc8252">RFC8252 - OAuth 2.0 for native Apps</a>
@@ -35,14 +39,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface OAuth2SecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new OAuth2SecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the OAuth2SecurityScheme.
+     */
     static OAuth2SecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableOAuth2SecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an OAuth2SecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static OAuth2SecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return OAuth2SecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an OAuth2SecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static OAuth2SecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return OAuth2SecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -52,39 +79,123 @@ public interface OAuth2SecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.OAUTH2;
     }
 
+    /**
+     * Returns the optional URI of the authorization server for user authorization.
+     *
+     * @return the optional authorization endpoint URI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (authorization)</a>
+     */
     Optional<IRI> getAuthorization();
 
+    /**
+     * Returns the optional URI of the token server for obtaining access tokens.
+     *
+     * @return the optional token endpoint URI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (token)</a>
+     */
     Optional<IRI> getToken();
 
+    /**
+     * Returns the optional URI of the server for refreshing access tokens.
+     *
+     * @return the optional refresh endpoint URI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (refresh)</a>
+     */
     Optional<IRI> getRefresh();
 
+    /**
+     * Returns the optional OAuth2 scopes required for authorization.
+     * <p>
+     * Scopes define the extent of access requested by the client.
+     * </p>
+     *
+     * @return the optional OAuth2 scopes.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (scopes)</a>
+     */
     Optional<OAuth2Scopes> getScopes();
 
+    /**
+     * Returns the optional OAuth2 flow type being used.
+     * <p>
+     * Common flow types include "code" (Authorization Code), "client" (Client Credentials),
+     * "device" (Device Authorization), and "implicit" (Implicit Grant - deprecated).
+     * </p>
+     *
+     * @return the optional OAuth2 flow type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme (flow)</a>
+     */
     Optional<OAuth2Flow> getFlow();
 
 
+    /**
+     * A mutable builder with a fluent API for building an {@link OAuth2SecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, OAuth2SecurityScheme> {
 
+        /**
+         * Creates a new builder for building an OAuth2SecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableOAuth2SecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an OAuth2SecurityScheme, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
             return new MutableOAuth2SecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the authorization endpoint URI.
+         *
+         * @param authorization the authorization URI, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setAuthorization(@Nullable IRI authorization);
 
+        /**
+         * Sets the token endpoint URI.
+         *
+         * @param token the token URI, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setToken(@Nullable IRI token);
 
+        /**
+         * Sets the refresh endpoint URI.
+         *
+         * @param refresh the refresh URI, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setRefresh(@Nullable IRI refresh);
 
+        /**
+         * Sets the OAuth2 scopes.
+         *
+         * @param scopes the OAuth2 scopes, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setScopes(@Nullable OAuth2Scopes scopes);
 
+        /**
+         * Sets the OAuth2 flow type.
+         *
+         * @param flow the flow type (e.g., "code", "client", "device"), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setFlow(@Nullable String flow);
 
     }
@@ -95,21 +206,39 @@ public interface OAuth2SecurityScheme extends SecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the authorization endpoint URI.
+         */
         public static final JsonFieldDefinition<String> AUTHORIZATION = JsonFactory.newStringFieldDefinition(
                 "authorization");
 
+        /**
+         * JSON field definition for the token endpoint URI.
+         */
         public static final JsonFieldDefinition<String> TOKEN = JsonFactory.newStringFieldDefinition(
                 "token");
 
+        /**
+         * JSON field definition for the refresh endpoint URI.
+         */
         public static final JsonFieldDefinition<String> REFRESH = JsonFactory.newStringFieldDefinition(
                 "refresh");
 
+        /**
+         * JSON field definition for the OAuth2 scopes (single value).
+         */
         public static final JsonFieldDefinition<String> SCOPES = JsonFactory.newStringFieldDefinition(
                 "scopes");
 
+        /**
+         * JSON field definition for the OAuth2 scopes (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> SCOPES_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "scopes");
 
+        /**
+         * JSON field definition for the OAuth2 flow type.
+         */
         public static final JsonFieldDefinition<String> FLOW = JsonFactory.newStringFieldDefinition(
                 "flow");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ObjectSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ObjectSchema.java
@@ -28,22 +28,47 @@ import org.eclipse.ditto.json.JsonObject;
 /**
  * An ObjectSchema is a {@link SingleDataSchema} describing the JSON data type {@code object}.
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#objectschema">WoT TD ObjectSchema</a>
  * @since 2.4.0
  */
 public interface ObjectSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new ObjectSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the object schema.
+     * @return the ObjectSchema.
+     */
     static ObjectSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableObjectSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building an ObjectSchema.
+     *
+     * @return the builder.
+     */
     static ObjectSchema.Builder newBuilder() {
         return ObjectSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an ObjectSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static ObjectSchema.Builder newBuilder(final JsonObject jsonObject) {
         return ObjectSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building an ObjectSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default ObjectSchema.Builder toBuilder() {
         return ObjectSchema.Builder.newBuilder(toJson());
     }
@@ -53,22 +78,61 @@ public interface ObjectSchema extends SingleDataSchema {
         return Optional.of(DataSchemaType.OBJECT);
     }
 
+    /**
+     * Returns the map of property names to their data schemas defining the object's properties.
+     *
+     * @return the map of properties (may be empty).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#objectschema">WoT TD ObjectSchema (properties)</a>
+     */
     Map<String, SingleDataSchema> getProperties();
 
+    /**
+     * Returns the list of property names that are required to be present in the object.
+     *
+     * @return the list of required property names (may be empty).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#objectschema">WoT TD ObjectSchema (required)</a>
+     */
     List<String> getRequired();
 
+    /**
+     * A mutable builder with a fluent API for building an {@link ObjectSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, ObjectSchema> {
 
+        /**
+         * Creates a new builder for building an ObjectSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableObjectSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building an ObjectSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableObjectSchemaBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the map of property schemas.
+         *
+         * @param properties the map of property names to schemas, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setProperties(@Nullable Map<String, SingleDataSchema> properties);
 
+        /**
+         * Sets the list of required property names.
+         *
+         * @param required the collection of required property names, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setRequired(@Nullable Collection<String> required);
 
     }
@@ -79,9 +143,15 @@ public interface ObjectSchema extends SingleDataSchema {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the object properties map.
+         */
         public static final JsonFieldDefinition<JsonObject> PROPERTIES = JsonFactory.newJsonObjectFieldDefinition(
                 "properties");
 
+        /**
+         * JSON field definition for the required property names array.
+         */
         public static final JsonFieldDefinition<JsonArray> REQUIRED = JsonFactory.newJsonArrayFieldDefinition(
                 "required");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/OneOfComboSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/OneOfComboSecurityScheme.java
@@ -33,14 +33,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface OneOfComboSecurityScheme extends ComboSecurityScheme {
 
+    /**
+     * Creates a new OneOfComboSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the OneOfComboSecurityScheme.
+     */
     static OneOfComboSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutableOneOfComboSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a OneOfComboSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static OneOfComboSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return OneOfComboSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a OneOfComboSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static OneOfComboSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName,
             final JsonObject jsonObject) {
         return OneOfComboSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
@@ -51,17 +74,40 @@ public interface OneOfComboSecurityScheme extends ComboSecurityScheme {
         return SecuritySchemeScheme.COMBO;
     }
 
+    /**
+     * Returns the list of security scheme names where one of them must be applied.
+     *
+     * @return the list of security scheme names.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme">WoT TD ComboSecurityScheme (oneOf)</a>
+     */
     List<String> getOneOf();
 
 
+    /**
+     * A mutable builder with a fluent API for building a {@link OneOfComboSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, OneOfComboSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a OneOfComboSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutableOneOfComboSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a OneOfComboSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName,
                 final JsonObject jsonObject) {
             return new MutableOneOfComboSecuritySchemeBuilder(
@@ -69,6 +115,12 @@ public interface OneOfComboSecurityScheme extends ComboSecurityScheme {
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the security schemes where one of them must be applied.
+         *
+         * @param securitySchemes the security schemes, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setOneOf(@Nullable Collection<SecurityScheme> securitySchemes);
 
     }
@@ -79,6 +131,9 @@ public interface OneOfComboSecurityScheme extends ComboSecurityScheme {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the array of security scheme names where one must apply.
+         */
         public static final JsonFieldDefinition<JsonArray> ONE_OF = JsonFactory.newJsonArrayFieldDefinition(
                 "oneOf");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Profile.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Profile.java
@@ -24,10 +24,22 @@ import java.util.Collection;
  */
 public interface Profile {
 
+    /**
+     * Creates a SingleProfile from the specified profile IRI.
+     *
+     * @param charSequence the profile IRI.
+     * @return the SingleProfile.
+     */
     static SingleProfile newSingleProfile(final CharSequence charSequence) {
         return SingleProfile.of(charSequence);
     }
 
+    /**
+     * Creates a MultipleProfile from the specified collection of profiles.
+     *
+     * @param singleProfiles the collection of profiles.
+     * @return the MultipleProfile.
+     */
     static MultipleProfile newMultipleProfile(final Collection<SingleProfile> singleProfiles) {
         return MultipleProfile.of(singleProfiles);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Properties.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Properties.java
@@ -29,6 +29,13 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Properties extends Map<String, Property>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new Properties container from the specified JSON object.
+     *
+     * @param jsonObject the JSON object containing property definitions.
+     * @return the Properties container.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static Properties fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -41,6 +48,13 @@ public interface Properties extends Map<String, Property>, Jsonifiable<JsonObjec
         ));
     }
 
+    /**
+     * Creates a new Properties container from the specified collection of properties.
+     *
+     * @param properties the collection of properties.
+     * @return the Properties container.
+     * @throws NullPointerException if {@code properties} is {@code null}.
+     */
     static Properties from(final Collection<Property> properties) {
         return of(properties.stream().collect(Collectors.toMap(
                 Property::getPropertyName,
@@ -53,10 +67,23 @@ public interface Properties extends Map<String, Property>, Jsonifiable<JsonObjec
         ));
     }
 
+    /**
+     * Creates a new Properties container from the specified map of property name to property.
+     *
+     * @param properties the map of properties.
+     * @return the Properties container.
+     * @throws NullPointerException if {@code properties} is {@code null}.
+     */
     static Properties of(final Map<String, Property> properties) {
         return new ImmutableProperties(properties);
     }
 
+    /**
+     * Returns the property with the specified name if it exists.
+     *
+     * @param propertyName the name of the property.
+     * @return the optional property.
+     */
     Optional<Property> getProperty(CharSequence propertyName);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Property.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Property.java
@@ -23,77 +23,230 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * A Property is an {@link Interaction} describing how state of a Thing is exposed.
+ * <p>
  * "This state can then be retrieved (read) and optionally updated (write). Things can also choose to make Properties
  * observable by pushing the new state after a change."
+ * </p>
+ * <p>
+ * Properties combine the characteristics of an {@link Interaction} with a {@link SingleDataSchema} that describes
+ * the data type of the property value.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">WoT TD PropertyAffordance</a>
  * @since 2.4.0
  */
 public interface Property extends SingleDataSchema, Interaction<Property, PropertyFormElement, PropertyForms> {
 
+    /**
+     * Creates a new Property from the specified JSON object.
+     *
+     * @param propertyName the name of the property (the key in the properties map).
+     * @param jsonObject the JSON object representing the property affordance.
+     * @return the Property.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Property fromJson(final CharSequence propertyName, final JsonObject jsonObject) {
         return new ImmutableProperty(checkNotNull(propertyName, "propertyName").toString(), jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a Property.
+     *
+     * @param propertyName the name of the property.
+     * @return the builder.
+     * @throws NullPointerException if {@code propertyName} is {@code null}.
+     */
     static Property.Builder newBuilder(final CharSequence propertyName) {
         return Property.Builder.newBuilder(propertyName);
     }
 
+    /**
+     * Creates a new builder for building a Property, initialized with the values from the specified JSON object.
+     *
+     * @param propertyName the name of the property.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if any argument is {@code null}.
+     */
     static Property.Builder newBuilder(final CharSequence propertyName, final JsonObject jsonObject) {
         return Property.Builder.newBuilder(propertyName, jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a Property, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default Property.Builder toBuilder() {
         return Property.Builder.newBuilder(getPropertyName(), toJson());
     }
 
+    /**
+     * Returns the name of this property as defined in the Thing Description's properties map.
+     *
+     * @return the property name.
+     */
     String getPropertyName();
 
+    /**
+     * Returns whether this property is observable, meaning the Thing will push notifications when the property
+     * value changes.
+     *
+     * @return {@code true} if the property is observable, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">WoT TD PropertyAffordance (observable)</a>
+     */
     boolean isObservable();
 
+    /**
+     * Returns whether this property's data schema is a {@link BooleanSchema}.
+     *
+     * @return {@code true} if the schema type is boolean.
+     */
     boolean isBooleanSchema();
 
+    /**
+     * Returns this property's data schema as a {@link BooleanSchema}.
+     *
+     * @return the BooleanSchema.
+     * @throws ClassCastException if this property's schema is not a BooleanSchema.
+     */
     BooleanSchema asBooleanSchema();
 
+    /**
+     * Returns whether this property's data schema is an {@link IntegerSchema}.
+     *
+     * @return {@code true} if the schema type is integer.
+     */
     boolean isIntegerSchema();
 
+    /**
+     * Returns this property's data schema as an {@link IntegerSchema}.
+     *
+     * @return the IntegerSchema.
+     * @throws ClassCastException if this property's schema is not an IntegerSchema.
+     */
     IntegerSchema asIntegerSchema();
 
+    /**
+     * Returns whether this property's data schema is a {@link NumberSchema}.
+     *
+     * @return {@code true} if the schema type is number.
+     */
     boolean isNumberSchema();
 
+    /**
+     * Returns this property's data schema as a {@link NumberSchema}.
+     *
+     * @return the NumberSchema.
+     * @throws ClassCastException if this property's schema is not a NumberSchema.
+     */
     NumberSchema asNumberSchema();
 
+    /**
+     * Returns whether this property's data schema is a {@link StringSchema}.
+     *
+     * @return {@code true} if the schema type is string.
+     */
     boolean isStringSchema();
 
+    /**
+     * Returns this property's data schema as a {@link StringSchema}.
+     *
+     * @return the StringSchema.
+     * @throws ClassCastException if this property's schema is not a StringSchema.
+     */
     StringSchema asStringSchema();
 
+    /**
+     * Returns whether this property's data schema is an {@link ObjectSchema}.
+     *
+     * @return {@code true} if the schema type is object.
+     */
     boolean isObjectSchema();
 
+    /**
+     * Returns this property's data schema as an {@link ObjectSchema}.
+     *
+     * @return the ObjectSchema.
+     * @throws ClassCastException if this property's schema is not an ObjectSchema.
+     */
     ObjectSchema asObjectSchema();
 
+    /**
+     * Returns whether this property's data schema is an {@link ArraySchema}.
+     *
+     * @return {@code true} if the schema type is array.
+     */
     boolean isArraySchema();
 
+    /**
+     * Returns this property's data schema as an {@link ArraySchema}.
+     *
+     * @return the ArraySchema.
+     * @throws ClassCastException if this property's schema is not an ArraySchema.
+     */
     ArraySchema asArraySchema();
 
+    /**
+     * Returns whether this property's data schema is a {@link NullSchema}.
+     *
+     * @return {@code true} if the schema type is null.
+     */
     boolean isNullSchema();
 
+    /**
+     * Returns this property's data schema as a {@link NullSchema}.
+     *
+     * @return the NullSchema.
+     * @throws ClassCastException if this property's schema is not a NullSchema.
+     */
     NullSchema asNullSchema();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link Property}.
+     */
     interface Builder extends Interaction.Builder<Builder, Property, PropertyFormElement, PropertyForms>,
             SingleDataSchema.Builder<Builder, Property> {
 
+        /**
+         * Creates a new builder for building a Property.
+         *
+         * @param propertyName the name of the property.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence propertyName) {
             return new MutablePropertyBuilder(checkNotNull(propertyName, "propertyName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a Property, initialized with the values from the specified JSON object.
+         *
+         * @param propertyName the name of the property.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence propertyName, final JsonObject jsonObject) {
             return new MutablePropertyBuilder(checkNotNull(propertyName, "propertyName").toString(), jsonObject.toBuilder());
         }
 
+        /**
+         * Sets whether this property is observable.
+         *
+         * @param observable whether the property is observable, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">WoT TD PropertyAffordance (observable)</a>
+         */
         Builder setObservable(@Nullable Boolean observable);
 
+        /**
+         * Sets the data schema for this property.
+         *
+         * @param schema the data schema, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setSchema(@Nullable SingleDataSchema schema);
 
     }
@@ -104,6 +257,9 @@ public interface Property extends SingleDataSchema, Interaction<Property, Proper
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the observable flag.
+         */
         public static final JsonFieldDefinition<Boolean> OBSERVABLE = JsonFactory.newBooleanFieldDefinition(
                 "observable");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/PropertyFormElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/PropertyFormElement.java
@@ -23,14 +23,34 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface PropertyFormElement extends FormElement<PropertyFormElement> {
 
+    /**
+     * Creates a new PropertyFormElement from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the form element.
+     * @return the PropertyFormElement.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static PropertyFormElement fromJson(final JsonObject jsonObject) {
         return new ImmutablePropertyFormElement(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a PropertyFormElement.
+     *
+     * @return the builder.
+     */
     static PropertyFormElement.Builder newBuilder() {
         return PropertyFormElement.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a PropertyFormElement, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static PropertyFormElement.Builder newBuilder(final JsonObject jsonObject) {
         return PropertyFormElement.Builder.newBuilder(jsonObject);
     }
@@ -39,19 +59,46 @@ public interface PropertyFormElement extends FormElement<PropertyFormElement> {
     default PropertyFormElement.Builder toBuilder() {
         return PropertyFormElement.Builder.newBuilder(toJson());
     }
-    
+
+    /**
+     * Returns the operation type(s) this form element supports for property affordances.
+     *
+     * @return the property operation type(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form (op)</a>
+     */
     PropertyFormElementOp<SinglePropertyFormElementOp> getOp();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link PropertyFormElement}.
+     */
     interface Builder extends FormElement.Builder<Builder, PropertyFormElement> {
 
+        /**
+         * Creates a new builder for building a PropertyFormElement.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutablePropertyFormElementBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a PropertyFormElement, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutablePropertyFormElementBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the operation type(s) for this form element.
+         *
+         * @param op the operation type(s), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setOp(@Nullable PropertyFormElementOp<SinglePropertyFormElementOp> op);
 
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/PropertyForms.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/PropertyForms.java
@@ -27,6 +27,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface PropertyForms extends Forms<PropertyFormElement> {
 
+    /**
+     * Creates PropertyForms from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of form element objects.
+     * @return the PropertyForms.
+     */
     static PropertyForms fromJson(final JsonArray jsonArray) {
         final List<PropertyFormElement> propertyFormElements = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -36,6 +42,12 @@ public interface PropertyForms extends Forms<PropertyFormElement> {
         return of(propertyFormElements);
     }
 
+    /**
+     * Creates PropertyForms from the specified collection of form elements.
+     *
+     * @param formElements the collection of form elements.
+     * @return the PropertyForms.
+     */
     static PropertyForms of(final Collection<PropertyFormElement> formElements) {
         return new ImmutablePropertyForms(formElements);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/PskSecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/PskSecurityScheme.java
@@ -31,14 +31,37 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface PskSecurityScheme extends SecurityScheme {
 
+    /**
+     * Creates a new PskSecurityScheme from the specified JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the PskSecurityScheme.
+     */
     static PskSecurityScheme fromJson(final String securitySchemeName, final JsonObject jsonObject) {
         return new ImmutablePskSecurityScheme(securitySchemeName, jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a PskSecurityScheme.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static PskSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName) {
         return PskSecurityScheme.Builder.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a PskSecurityScheme, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code securitySchemeName} is {@code null}.
+     */
     static PskSecurityScheme.Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         return PskSecurityScheme.Builder.newBuilder(securitySchemeName, jsonObject);
     }
@@ -48,33 +71,65 @@ public interface PskSecurityScheme extends SecurityScheme {
         return SecuritySchemeScheme.PSK;
     }
 
+    /**
+     * Returns the optional identity hint for the PSK.
+     *
+     * @return the optional identity.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#psksecurityscheme">WoT TD PSKSecurityScheme (identity)</a>
+     */
     Optional<String> getIdentity();
 
 
+    /**
+     * A mutable builder with a fluent API for building a {@link PskSecurityScheme}.
+     */
     interface Builder extends SecurityScheme.Builder<Builder, PskSecurityScheme> {
 
+        /**
+         * Creates a new builder for building a PskSecurityScheme.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName) {
             return new MutablePskSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a PskSecurityScheme, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param securitySchemeName the name of the security scheme.
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final CharSequence securitySchemeName, final JsonObject jsonObject) {
             return new MutablePskSecuritySchemeBuilder(
                     checkNotNull(securitySchemeName, "securitySchemeName").toString(),
                     jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the identity hint for the PSK.
+         *
+         * @param identity the identity, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setIdentity(@Nullable String identity);
 
     }
-    
+
     /**
      * An enumeration of the known {@link JsonFieldDefinition}s of a PskSecurityScheme.
      */
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the PSK identity.
+         */
         public static final JsonFieldDefinition<String> IDENTITY = JsonFactory.newStringFieldDefinition(
                 "identity");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/RootFormElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/RootFormElement.java
@@ -25,14 +25,33 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface RootFormElement extends FormElement<RootFormElement> {
 
+    /**
+     * Creates a new RootFormElement from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the form element.
+     * @return the RootFormElement.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static RootFormElement fromJson(final JsonObject jsonObject) {
         return new ImmutableRootFormElement(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a RootFormElement.
+     *
+     * @return the builder.
+     */
     static RootFormElement.Builder newBuilder() {
         return RootFormElement.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a RootFormElement, initialized with the values from the specified JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static RootFormElement.Builder newBuilder(final JsonObject jsonObject) {
         return RootFormElement.Builder.newBuilder(jsonObject);
     }
@@ -42,18 +61,45 @@ public interface RootFormElement extends FormElement<RootFormElement> {
         return RootFormElement.Builder.newBuilder(toJson());
     }
 
+    /**
+     * Returns the operation type(s) this form element supports for root-level operations.
+     *
+     * @return the root form element operation type(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form-top-level">WoT TD Top level forms (op)</a>
+     */
     RootFormElementOp<SingleRootFormElementOp> getOp();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link RootFormElement}.
+     */
     interface Builder extends FormElement.Builder<Builder, RootFormElement> {
 
+        /**
+         * Creates a new builder for building a RootFormElement.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableRootFormElementBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a RootFormElement, initialized with the values from the
+         * specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableRootFormElementBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the operation type(s) for this form element.
+         *
+         * @param op the operation type(s), or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setOp(@Nullable RootFormElementOp<SingleRootFormElementOp> op);
 
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/RootForms.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/RootForms.java
@@ -27,6 +27,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface RootForms extends Forms<RootFormElement> {
 
+    /**
+     * Creates RootForms from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of form element objects.
+     * @return the RootForms.
+     */
     static RootForms fromJson(final JsonArray jsonArray) {
         final List<RootFormElement> rootFormElements = jsonArray.stream()
                 .filter(JsonValue::isObject)
@@ -36,6 +42,12 @@ public interface RootForms extends Forms<RootFormElement> {
         return of(rootFormElements);
     }
 
+    /**
+     * Creates RootForms from the specified collection of form elements.
+     *
+     * @param formElements the collection of form elements.
+     * @return the RootForms.
+     */
     static RootForms of(final Collection<RootFormElement> formElements) {
         return new ImmutableRootForms(formElements);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SchemaDefinitions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SchemaDefinitions.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface SchemaDefinitions extends Map<String, SingleDataSchema>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a SchemaDefinitions from the specified JSON object.
+     *
+     * @param jsonObject the JSON object mapping schema names to data schemas.
+     * @return the SchemaDefinitions.
+     */
     static SchemaDefinitions fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -40,10 +46,22 @@ public interface SchemaDefinitions extends Map<String, SingleDataSchema>, Jsonif
         ));
     }
 
+    /**
+     * Creates a SchemaDefinitions from the specified map of schema names to data schemas.
+     *
+     * @param dataSchemas the map of schema names to data schemas.
+     * @return the SchemaDefinitions.
+     */
     static SchemaDefinitions of(final Map<String, SingleDataSchema> dataSchemas) {
         return new ImmutableSchemaDefinitions(dataSchemas);
     }
 
+    /**
+     * Returns the schema definition with the specified name.
+     *
+     * @param key the name of the schema definition.
+     * @return the optional schema.
+     */
     Optional<SingleDataSchema> getSchemaDefinition(CharSequence key);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Security.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Security.java
@@ -24,10 +24,22 @@ import java.util.Collection;
  */
 public interface Security {
 
+    /**
+     * Creates a SingleSecurity from the specified security scheme name.
+     *
+     * @param charSequence the name of the security scheme.
+     * @return the SingleSecurity.
+     */
     static SingleSecurity newSingleSecurity(final CharSequence charSequence) {
         return SingleSecurity.of(charSequence);
     }
 
+    /**
+     * Creates a MultipleSecurity from the specified collection of security scheme names.
+     *
+     * @param securities the collection of security scheme names.
+     * @return the MultipleSecurity.
+     */
     static MultipleSecurity newMultipleSecurity(final Collection<SingleSecurity> securities) {
         return MultipleSecurity.of(securities);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityDefinitions.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityDefinitions.java
@@ -28,6 +28,12 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface SecurityDefinitions extends Map<String, SecurityScheme>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a SecurityDefinitions from the specified JSON object.
+     *
+     * @param jsonObject the JSON object mapping scheme names to security schemes.
+     * @return the SecurityDefinitions.
+     */
     static SecurityDefinitions fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -40,6 +46,12 @@ public interface SecurityDefinitions extends Map<String, SecurityScheme>, Jsonif
         ));
     }
 
+    /**
+     * Creates a SecurityDefinitions from the specified collection of security schemes.
+     *
+     * @param securityDefinitions the collection of security schemes.
+     * @return the SecurityDefinitions.
+     */
     static SecurityDefinitions from(final Collection<SecurityScheme> securityDefinitions) {
         return of(securityDefinitions.stream().collect(Collectors.toMap(
                 SecurityScheme::getSecuritySchemeName,
@@ -52,10 +64,22 @@ public interface SecurityDefinitions extends Map<String, SecurityScheme>, Jsonif
         ));
     }
 
+    /**
+     * Creates a SecurityDefinitions from the specified map of scheme names to security schemes.
+     *
+     * @param securityDefinitions the map of scheme names to security schemes.
+     * @return the SecurityDefinitions.
+     */
     static SecurityDefinitions of(final Map<String, SecurityScheme> securityDefinitions) {
         return new ImmutableSecurityDefinitions(securityDefinitions);
     }
 
+    /**
+     * Returns the security definition with the specified name.
+     *
+     * @param securityDefinitionName the name of the security definition.
+     * @return the optional security scheme.
+     */
     Optional<SecurityScheme> getSecurityDefinition(CharSequence securityDefinitionName);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecurityScheme.java
@@ -35,19 +35,22 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * A SecuritySchema describes the configuration of a security mechanism.
- * It has the following subclasses:
+ * A SecurityScheme describes the configuration of a security mechanism.
+ * <p>
+ * Security schemes define how Consumers authenticate and authorize interactions with the Thing.
+ * It has the following subclasses representing different authentication mechanisms:
+ * </p>
  * <ul>
- *     <li>{@link NoSecurityScheme}</li>
- *     <li>{@link AutoSecurityScheme}</li>
- *     <li>{@link ComboSecurityScheme}</li>
- *     <li>{@link BasicSecurityScheme}</li>
- *     <li>{@link DigestSecurityScheme}</li>
- *     <li>{@link ApiKeySecurityScheme}</li>
- *     <li>{@link BearerSecurityScheme}</li>
- *     <li>{@link PskSecurityScheme}</li>
- *     <li>{@link OAuth2SecurityScheme}</li>
- *     <li>{@link AdditionalSecurityScheme}</li>
+ *     <li>{@link NoSecurityScheme} - no authentication required</li>
+ *     <li>{@link AutoSecurityScheme} - automatically selected security mechanism</li>
+ *     <li>{@link ComboSecurityScheme} - combination of multiple security schemes</li>
+ *     <li>{@link BasicSecurityScheme} - HTTP Basic Authentication</li>
+ *     <li>{@link DigestSecurityScheme} - HTTP Digest Authentication</li>
+ *     <li>{@link ApiKeySecurityScheme} - API key-based authentication</li>
+ *     <li>{@link BearerSecurityScheme} - Bearer token authentication</li>
+ *     <li>{@link PskSecurityScheme} - Pre-Shared Key authentication</li>
+ *     <li>{@link OAuth2SecurityScheme} - OAuth 2.0 authentication</li>
+ *     <li>{@link AdditionalSecurityScheme} - custom security schemes from context extensions</li>
  * </ul>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme</a>
@@ -55,6 +58,16 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface SecurityScheme extends TypedJsonObject<SecurityScheme>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a SecurityScheme from the specified JSON object, automatically determining the correct
+     * subtype based on the {@code scheme} field.
+     *
+     * @param securitySchemeName the name of the security scheme (the key in the securityDefinitions map).
+     * @param jsonObject the JSON object representing the security scheme.
+     * @return the appropriate SecurityScheme subtype.
+     * @throws NullPointerException if any argument is {@code null}.
+     * @throws IllegalArgumentException if the scheme type is missing or unknown.
+     */
     static SecurityScheme fromJson(final CharSequence securitySchemeName, final JsonObject jsonObject) {
         final String schemeName = checkNotNull(securitySchemeName, "securitySchemeName").toString();
         return jsonObject.getValue(SecuritySchemeJsonFields.SCHEME)
@@ -86,76 +99,231 @@ public interface SecurityScheme extends TypedJsonObject<SecurityScheme>, Jsonifi
                         "json field <" + SecuritySchemeJsonFields.SCHEME.getPointer() + "> was missing or unknown"));
     }
 
+    /**
+     * Creates a new builder for building a {@link NoSecurityScheme}.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#nosecurityscheme">WoT TD NoSecurityScheme</a>
+     */
     static NoSecurityScheme.Builder newNoSecurityBuilder(final CharSequence securitySchemeName) {
         return NoSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link AutoSecurityScheme}.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#autosecurityscheme">WoT TD AutoSecurityScheme</a>
+     */
     static AutoSecurityScheme.Builder newAutoSecurityBuilder(final CharSequence securitySchemeName) {
         return AutoSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link AllOfComboSecurityScheme} where all referenced
+     * security schemes must be satisfied.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme">WoT TD ComboSecurityScheme</a>
+     */
     static AllOfComboSecurityScheme.Builder newAllOfComboSecurityBuilder(final CharSequence securitySchemeName) {
         return AllOfComboSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a {@link OneOfComboSecurityScheme} where one of the referenced
+     * security schemes must be satisfied.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme">WoT TD ComboSecurityScheme</a>
+     */
     static OneOfComboSecurityScheme.Builder newOneOfComboSecurityBuilder(final CharSequence securitySchemeName) {
         return OneOfComboSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a {@link BasicSecurityScheme} for HTTP Basic Authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">WoT TD BasicSecurityScheme</a>
+     */
     static BasicSecurityScheme.Builder newBasicSecurityBuilder(final CharSequence securitySchemeName) {
         return BasicSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a {@link DigestSecurityScheme} for HTTP Digest Authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme</a>
+     */
     static DigestSecurityScheme.Builder newDigestSecurityBuilder(final CharSequence securitySchemeName) {
         return DigestSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link ApiKeySecurityScheme} for API key-based authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#apikeysecurityscheme">WoT TD APIKeySecurityScheme</a>
+     */
     static ApiKeySecurityScheme.Builder newApiKeySecurityBuilder(final CharSequence securitySchemeName) {
         return ApiKeySecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a {@link BearerSecurityScheme} for Bearer token authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme</a>
+     */
     static BearerSecurityScheme.Builder newBearerSecurityBuilder(final CharSequence securitySchemeName) {
         return BearerSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building a {@link PskSecurityScheme} for Pre-Shared Key authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#psksecurityscheme">WoT TD PSKSecurityScheme</a>
+     */
     static PskSecurityScheme.Builder newPskSecurityBuilder(final CharSequence securitySchemeName) {
         return PskSecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link OAuth2SecurityScheme} for OAuth 2.0 authentication.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme</a>
+     */
     static OAuth2SecurityScheme.Builder newOAuth2SecurityBuilder(final CharSequence securitySchemeName) {
         return OAuth2SecurityScheme.newBuilder(securitySchemeName);
     }
 
+    /**
+     * Creates a new builder for building an {@link AdditionalSecurityScheme} defined via context extensions.
+     *
+     * @param securitySchemeName the name of the security scheme.
+     * @param contextExtensionScopedScheme the scheme name as defined in the context extension.
+     * @return the builder.
+     */
     static AdditionalSecurityScheme.Builder newAdditionalSecurityBuilder(final CharSequence securitySchemeName,
             final CharSequence contextExtensionScopedScheme) {
         return AdditionalSecurityScheme.newBuilder(securitySchemeName, contextExtensionScopedScheme);
     }
 
+    /**
+     * Returns the name of this security scheme as defined in the Thing Description's securityDefinitions map.
+     *
+     * @return the security scheme name.
+     */
     String getSecuritySchemeName();
 
+    /**
+     * Returns the optional JSON-LD {@code @type} providing semantic annotations for this security scheme.
+     *
+     * @return the optional semantic type annotation.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme (@type)</a>
+     */
     Optional<AtType> getAtType();
 
+    /**
+     * Returns the security scheme identifier (e.g., "nosec", "basic", "oauth2").
+     *
+     * @return the security scheme type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme (scheme)</a>
+     */
     SecuritySchemeScheme getScheme();
 
+    /**
+     * Returns the optional human-readable description of this security scheme, based on the default language.
+     *
+     * @return the optional description.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme (description)</a>
+     */
     Optional<Description> getDescription();
 
+    /**
+     * Returns the optional multi-language map of human-readable descriptions for this security scheme.
+     *
+     * @return the optional multi-language descriptions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Descriptions> getDescriptions();
 
+    /**
+     * Returns the optional URI of the proxy server that must be traversed for authentication.
+     *
+     * @return the optional proxy URI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme (proxy)</a>
+     */
     Optional<IRI> getProxy();
 
 
+    /**
+     * A mutable builder for creating {@link SecurityScheme} instances.
+     *
+     * @param <B> the type of the Builder.
+     * @param <S> the type of the SecurityScheme.
+     */
     interface Builder<B extends Builder<B, S>, S extends SecurityScheme> extends TypedJsonObjectBuilder<B, S> {
 
+        /**
+         * Sets the JSON-LD {@code @type} for semantic annotations.
+         *
+         * @param atType the semantic type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setAtType(@Nullable AtType atType);
 
+        /**
+         * Sets the security scheme type identifier.
+         *
+         * @param scheme the scheme type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setScheme(@Nullable SecuritySchemeScheme scheme);
 
+        /**
+         * Sets the human-readable description.
+         *
+         * @param description the description, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescription(@Nullable Description description);
 
+        /**
+         * Sets the multi-language descriptions.
+         *
+         * @param descriptions the descriptions map, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescriptions(@Nullable Descriptions descriptions);
 
+        /**
+         * Sets the proxy URI.
+         *
+         * @param proxy the proxy URI, or {@code null} to remove.
+         * @return this builder.
+         */
         B setProxy(@Nullable IRI proxy);
 
+        /**
+         * Builds the SecurityScheme.
+         *
+         * @return the built SecurityScheme instance.
+         */
         S build();
     }
 
@@ -165,21 +333,39 @@ public interface SecurityScheme extends TypedJsonObject<SecurityScheme>, Jsonifi
     @Immutable
     final class SecuritySchemeJsonFields {
 
+        /**
+         * JSON field definition for the JSON-LD type (single value).
+         */
         public static final JsonFieldDefinition<String> AT_TYPE = JsonFactory.newStringFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the JSON-LD type (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> AT_TYPE_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the security scheme type.
+         */
         public static final JsonFieldDefinition<String> SCHEME = JsonFactory.newStringFieldDefinition(
                 "scheme");
 
+        /**
+         * JSON field definition for the description.
+         */
         public static final JsonFieldDefinition<String> DESCRIPTION = JsonFactory.newStringFieldDefinition(
                 "description");
 
+        /**
+         * JSON field definition for the multilingual descriptions.
+         */
         public static final JsonFieldDefinition<JsonObject> DESCRIPTIONS = JsonFactory.newJsonObjectFieldDefinition(
                 "descriptions");
 
+        /**
+         * JSON field definition for the proxy URI.
+         */
         public static final JsonFieldDefinition<String> PROXY = JsonFactory.newStringFieldDefinition(
                 "proxy");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecuritySchemeIn.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecuritySchemeIn.java
@@ -23,11 +23,29 @@ import java.util.Optional;
  * @since 2.4.0
  */
 public enum SecuritySchemeIn implements CharSequence {
+    /**
+     * Credentials are sent in an HTTP header.
+     */
     HEADER("header"),
+    /**
+     * Credentials are sent as a query parameter.
+     */
     QUERY("query"),
+    /**
+     * Credentials are sent in the request body.
+     */
     BODY("body"),
+    /**
+     * Credentials are sent in a cookie.
+     */
     COOKIE("cookie"),
+    /**
+     * Credentials are embedded in the URI.
+     */
     URI("uri"),
+    /**
+     * Location is auto-negotiated.
+     */
     AUTO("auto");
 
     private final String name;
@@ -36,6 +54,11 @@ public enum SecuritySchemeIn implements CharSequence {
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this location.
+     *
+     * @return the location name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecuritySchemeScheme.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SecuritySchemeScheme.java
@@ -20,24 +20,75 @@ package org.eclipse.ditto.wot.model;
  */
 public interface SecuritySchemeScheme extends CharSequence {
 
+    /**
+     * No security required (nosec).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#nosecurityscheme">WoT TD NoSecurityScheme</a>
+     */
     SecuritySchemeScheme NOSEC = of("nosec");
 
+    /**
+     * Auto-negotiated security (auto).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#autosecurityscheme">WoT TD AutoSecurityScheme</a>
+     */
     SecuritySchemeScheme AUTO = of("auto");
 
+    /**
+     * Combination of security schemes (combo).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#combosecurityscheme">WoT TD ComboSecurityScheme</a>
+     */
     SecuritySchemeScheme COMBO = of("combo");
 
+    /**
+     * Basic authentication (basic).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#basicsecurityscheme">WoT TD BasicSecurityScheme</a>
+     */
     SecuritySchemeScheme BASIC = of("basic");
 
+    /**
+     * Digest authentication (digest).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#digestsecurityscheme">WoT TD DigestSecurityScheme</a>
+     */
     SecuritySchemeScheme DIGEST = of("digest");
 
+    /**
+     * API key authentication (apikey).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#apikeysecurityscheme">WoT TD APIKeySecurityScheme</a>
+     */
     SecuritySchemeScheme APIKEY = of("apikey");
 
+    /**
+     * Bearer token authentication (bearer).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#bearersecurityscheme">WoT TD BearerSecurityScheme</a>
+     */
     SecuritySchemeScheme BEARER = of("bearer");
 
+    /**
+     * Pre-shared key authentication (psk).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#psksecurityscheme">WoT TD PSKSecurityScheme</a>
+     */
     SecuritySchemeScheme PSK = of("psk");
 
+    /**
+     * OAuth 2.0 authentication (oauth2).
+     *
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#oauth2securityscheme">WoT TD OAuth2SecurityScheme</a>
+     */
     SecuritySchemeScheme OAUTH2 = of("oauth2");
 
+    /**
+     * Creates a SecuritySchemeScheme from the specified string.
+     *
+     * @param charSequence the scheme name.
+     * @return the SecuritySchemeScheme.
+     */
     static SecuritySchemeScheme of(final CharSequence charSequence) {
         if (charSequence instanceof SecuritySchemeScheme) {
             return (SecuritySchemeScheme) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleActionFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleActionFormElementOp.java
@@ -24,8 +24,17 @@ import java.util.Optional;
  * @since 2.4.0
  */
 public enum SingleActionFormElementOp implements ActionFormElementOp<SingleActionFormElementOp>, CharSequence {
+    /**
+     * Invoke the action.
+     */
     INVOKEACTION("invokeaction"),
+    /**
+     * Query the status of an ongoing action.
+     */
     QUERYACTION("queryaction"),
+    /**
+     * Cancel an ongoing action.
+     */
     CANCELACTION("cancelaction");
 
     private final String name;
@@ -34,6 +43,11 @@ public enum SingleActionFormElementOp implements ActionFormElementOp<SingleActio
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this operation.
+     *
+     * @return the operation name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleAtContext.java
@@ -19,10 +19,23 @@ package org.eclipse.ditto.wot.model;
  */
 public interface SingleAtContext extends AtContext {
 
+    /**
+     * Creates a SingleUriAtContext from the specified context IRI.
+     *
+     * @param context the context IRI.
+     * @return the SingleUriAtContext.
+     */
     static SingleUriAtContext newSingleUriAtContext(final CharSequence context) {
         return SingleUriAtContext.of(context);
     }
 
+    /**
+     * Creates a SinglePrefixedAtContext from the specified prefix and context IRI.
+     *
+     * @param prefix the prefix for this context.
+     * @param context the context IRI.
+     * @return the SinglePrefixedAtContext.
+     */
     static SinglePrefixedAtContext newSinglePrefixedAtContext(final CharSequence prefix,
             final SingleUriAtContext context) {
         return SinglePrefixedAtContext.of(prefix, context);

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleAtType.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleAtType.java
@@ -13,12 +13,19 @@
 package org.eclipse.ditto.wot.model;
 
 /**
- * A SingleAtContext is a single String {@link AtType}.
+ * A SingleAtType is a single String {@link AtType}.
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#sec-semantic-annotations">WoT TD Semantic Annotations</a>
  * @since 2.4.0
  */
 public interface SingleAtType extends AtType, CharSequence {
 
+    /**
+     * Creates a SingleAtType from the specified type string.
+     *
+     * @param charSequence the type string.
+     * @return the SingleAtType.
+     */
     static SingleAtType of(final CharSequence charSequence) {
         if (charSequence instanceof SingleAtType) {
             return (SingleAtType) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleDataSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleDataSchema.java
@@ -31,15 +31,17 @@ import org.eclipse.ditto.json.JsonValue;
 
 /**
  * A SingleDataSchema describes a used data format which can be used for validation.
- * It has the following subclasses:
+ * <p>
+ * It has the following subclasses representing the different JSON data types:
+ * </p>
  * <ul>
- *     <li>{@link ArraySchema}</li>
- *     <li>{@link BooleanSchema}</li>
- *     <li>{@link NumberSchema}</li>
- *     <li>{@link IntegerSchema}</li>
- *     <li>{@link ObjectSchema}</li>
- *     <li>{@link StringSchema}</li>
- *     <li>{@link NullSchema}</li>
+ *     <li>{@link ArraySchema} - for JSON arrays</li>
+ *     <li>{@link BooleanSchema} - for JSON booleans</li>
+ *     <li>{@link NumberSchema} - for JSON numbers (floating point)</li>
+ *     <li>{@link IntegerSchema} - for JSON integers</li>
+ *     <li>{@link ObjectSchema} - for JSON objects</li>
+ *     <li>{@link StringSchema} - for JSON strings</li>
+ *     <li>{@link NullSchema} - for JSON null values</li>
  * </ul>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema</a>
@@ -47,6 +49,14 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface SingleDataSchema extends DataSchema, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a SingleDataSchema from the specified JSON object, automatically determining the correct
+     * subtype based on the {@code type} field.
+     *
+     * @param jsonObject the JSON object representing the data schema.
+     * @return the appropriate SingleDataSchema subtype.
+     * @throws IllegalArgumentException if the type is not supported.
+     */
     static SingleDataSchema fromJson(final JsonObject jsonObject) {
         return jsonObject.getValue(DataSchemaJsonFields.TYPE)
                 .flatMap(DataSchemaType::forName)
@@ -73,94 +83,321 @@ public interface SingleDataSchema extends DataSchema, Jsonifiable<JsonObject> {
                 .orElseGet(() -> new ImmutableDataSchemaWithoutType(jsonObject));
     }
 
+    /**
+     * Creates a new builder for building a {@link BooleanSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#booleanschema">WoT TD BooleanSchema</a>
+     */
     static BooleanSchema.Builder newBooleanSchemaBuilder() {
         return BooleanSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link IntegerSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#integerschema">WoT TD IntegerSchema</a>
+     */
     static IntegerSchema.Builder newIntegerSchemaBuilder() {
         return IntegerSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link NumberSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#numberschema">WoT TD NumberSchema</a>
+     */
     static NumberSchema.Builder newNumberSchemaBuilder() {
         return NumberSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link StringSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema</a>
+     */
     static StringSchema.Builder newStringSchemaBuilder() {
         return StringSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link ObjectSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#objectschema">WoT TD ObjectSchema</a>
+     */
     static ObjectSchema.Builder newObjectSchemaBuilder() {
         return ObjectSchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building an {@link ArraySchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#arrayschema">WoT TD ArraySchema</a>
+     */
     static ArraySchema.Builder newArraySchemaBuilder() {
         return ArraySchema.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a {@link NullSchema}.
+     *
+     * @return the builder.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#nullschema">WoT TD NullSchema</a>
+     */
     static NullSchema.Builder newNullSchemaBuilder() {
         return NullSchema.newBuilder();
     }
 
+    /**
+     * Returns the optional JSON-LD {@code @type} providing semantic annotations for this data schema.
+     *
+     * @return the optional semantic type annotation.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (@type)</a>
+     */
     Optional<AtType> getAtType();
 
+    /**
+     * Returns the optional data type (e.g., boolean, integer, number, string, object, array, null).
+     *
+     * @return the optional data schema type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (type)</a>
+     */
     Optional<DataSchemaType> getType();
 
+    /**
+     * Returns the optional human-readable description of this data schema, based on the default language.
+     *
+     * @return the optional description.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (description)</a>
+     */
     Optional<Description> getDescription();
 
+    /**
+     * Returns the optional multi-language map of human-readable descriptions for this data schema.
+     *
+     * @return the optional multi-language descriptions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Descriptions> getDescriptions();
 
+    /**
+     * Returns the optional human-readable title of this data schema, based on the default language.
+     *
+     * @return the optional title.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (title)</a>
+     */
     Optional<Title> getTitle();
 
+    /**
+     * Returns the optional multi-language map of human-readable titles for this data schema.
+     *
+     * @return the optional multi-language titles.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Titles> getTitles();
 
+    /**
+     * Returns whether this data schema is write-only, meaning the data can only be written but not read.
+     *
+     * @return {@code true} if write-only, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (writeOnly)</a>
+     */
     boolean isWriteOnly();
 
+    /**
+     * Returns whether this data schema is read-only, meaning the data can only be read but not written.
+     *
+     * @return {@code true} if read-only, {@code false} otherwise.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (readOnly)</a>
+     */
     boolean isReadOnly();
 
+    /**
+     * Returns the list of data schemas where the data must match exactly one of them.
+     *
+     * @return the list of alternative schemas, may be empty.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (oneOf)</a>
+     */
     List<SingleDataSchema> getOneOf();
 
+    /**
+     * Returns the optional unit of measurement for the data value (e.g., "celsius", "km/h").
+     *
+     * @return the optional unit.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (unit)</a>
+     */
     Optional<String> getUnit();
 
+    /**
+     * Returns the set of restricted values that the data must match.
+     *
+     * @return the set of enumeration values, may be empty.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (enum)</a>
+     */
     Set<JsonValue> getEnum();
 
+    /**
+     * Returns the optional format hint for string data (e.g., "date-time", "uri", "email").
+     *
+     * @return the optional format.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (format)</a>
+     */
     Optional<String> getFormat();
 
+    /**
+     * Returns the optional constant value that the data must equal.
+     *
+     * @return the optional constant value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (const)</a>
+     */
     Optional<JsonValue> getConst();
 
+    /**
+     * Returns the optional default value to use when the data is not provided.
+     *
+     * @return the optional default value.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#dataschema">WoT TD DataSchema (default)</a>
+     */
     Optional<JsonValue> getDefault();
 
+    /**
+     * A mutable builder for creating {@link SingleDataSchema} instances.
+     *
+     * @param <B> the type of the Builder.
+     * @param <S> the type of the SingleDataSchema.
+     */
     interface Builder<B extends Builder<B, S>, S extends SingleDataSchema> {
 
+        /**
+         * Sets the JSON-LD {@code @type} for semantic annotations.
+         *
+         * @param atType the semantic type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setAtType(@Nullable AtType atType);
 
+        /**
+         * Sets the data schema type.
+         *
+         * @param type the data type, or {@code null} to remove.
+         * @return this builder.
+         */
         B setType(@Nullable DataSchemaType type);
 
+        /**
+         * Sets the human-readable title.
+         *
+         * @param title the title, or {@code null} to remove.
+         * @return this builder.
+         */
         B setTitle(@Nullable Title title);
 
+        /**
+         * Sets the multi-language titles.
+         *
+         * @param title the titles map, or {@code null} to remove.
+         * @return this builder.
+         */
         B setTitles(@Nullable Titles title);
 
+        /**
+         * Sets the human-readable description.
+         *
+         * @param description the description, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescription(@Nullable Description description);
 
+        /**
+         * Sets the multi-language descriptions.
+         *
+         * @param descriptions the descriptions map, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDescriptions(@Nullable Descriptions descriptions);
 
+        /**
+         * Sets whether this data schema is write-only.
+         *
+         * @param writeOnly whether write-only, or {@code null} to remove.
+         * @return this builder.
+         */
         B setWriteOnly(@Nullable Boolean writeOnly);
 
+        /**
+         * Sets whether this data schema is read-only.
+         *
+         * @param readOnly whether read-only, or {@code null} to remove.
+         * @return this builder.
+         */
         B setReadOnly(@Nullable Boolean readOnly);
 
+        /**
+         * Sets the oneOf schemas for alternative type validation.
+         *
+         * @param oneOf the collection of alternative schemas, or {@code null} to remove.
+         * @return this builder.
+         */
         B setOneOf(@Nullable Collection<SingleDataSchema> oneOf);
 
+        /**
+         * Sets the unit of measurement.
+         *
+         * @param unit the unit string, or {@code null} to remove.
+         * @return this builder.
+         */
         B setUnit(@Nullable String unit);
 
+        /**
+         * Sets the enumeration of allowed values.
+         *
+         * @param enumValues the collection of allowed values, or {@code null} to remove.
+         * @return this builder.
+         */
         B setEnum(@Nullable Collection<JsonValue> enumValues);
 
+        /**
+         * Sets the format hint for string values.
+         *
+         * @param format the format string, or {@code null} to remove.
+         * @return this builder.
+         */
         B setFormat(@Nullable String format);
 
+        /**
+         * Sets the constant value.
+         *
+         * @param constValue the constant value, or {@code null} to remove.
+         * @return this builder.
+         */
         B setConst(@Nullable JsonValue constValue);
 
+        /**
+         * Sets the default value.
+         *
+         * @param defaultValue the default value, or {@code null} to remove.
+         * @return this builder.
+         */
         B setDefault(@Nullable JsonValue defaultValue);
 
+        /**
+         * Provides direct access to the underlying JSON object builder for custom modifications.
+         *
+         * @param builderConsumer a consumer that receives the JSON object builder.
+         * @return this builder.
+         */
         B enhanceObjectBuilder(Consumer<JsonObjectBuilder> builderConsumer);
 
+        /**
+         * Builds the SingleDataSchema.
+         *
+         * @return the built SingleDataSchema instance.
+         */
         S build();
     }
 
@@ -170,48 +407,93 @@ public interface SingleDataSchema extends DataSchema, Jsonifiable<JsonObject> {
     @Immutable
     final class DataSchemaJsonFields {
 
+        /**
+         * JSON field definition for the JSON-LD type (single value).
+         */
         public static final JsonFieldDefinition<String> AT_TYPE = JsonFactory.newStringFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the JSON-LD type (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> AT_TYPE_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the title.
+         */
         public static final JsonFieldDefinition<String> TITLE = JsonFactory.newStringFieldDefinition(
                 "title");
 
+        /**
+         * JSON field definition for the multilingual titles.
+         */
         public static final JsonFieldDefinition<JsonObject> TITLES = JsonFactory.newJsonObjectFieldDefinition(
                 "titles");
 
+        /**
+         * JSON field definition for the description.
+         */
         public static final JsonFieldDefinition<String> DESCRIPTION = JsonFactory.newStringFieldDefinition(
                 "description");
 
+        /**
+         * JSON field definition for the multilingual descriptions.
+         */
         public static final JsonFieldDefinition<JsonObject> DESCRIPTIONS = JsonFactory.newJsonObjectFieldDefinition(
                 "descriptions");
 
+        /**
+         * JSON field definition for the write-only flag.
+         */
         public static final JsonFieldDefinition<Boolean> WRITE_ONLY = JsonFactory.newBooleanFieldDefinition(
                 "writeOnly");
 
+        /**
+         * JSON field definition for the read-only flag.
+         */
         public static final JsonFieldDefinition<Boolean> READ_ONLY = JsonFactory.newBooleanFieldDefinition(
                 "readOnly");
 
+        /**
+         * JSON field definition for the oneOf alternative schemas.
+         */
         public static final JsonFieldDefinition<JsonArray> ONE_OF = JsonFactory.newJsonArrayFieldDefinition(
                 "oneOf");
 
+        /**
+         * JSON field definition for the unit of measurement.
+         */
         public static final JsonFieldDefinition<String> UNIT = JsonFactory.newStringFieldDefinition(
                 "unit");
 
+        /**
+         * JSON field definition for the enum values.
+         */
         public static final JsonFieldDefinition<JsonArray> ENUM = JsonFactory.newJsonArrayFieldDefinition(
                 "enum");
 
+        /**
+         * JSON field definition for the format hint.
+         */
         public static final JsonFieldDefinition<String> FORMAT = JsonFactory.newStringFieldDefinition(
                 "format");
 
+        /**
+         * JSON field definition for the constant value.
+         */
         public static final JsonFieldDefinition<JsonValue> CONST = JsonFactory.newJsonValueFieldDefinition(
                 "const");
 
+        /**
+         * JSON field definition for the default value.
+         */
         public static final JsonFieldDefinition<JsonValue> DEFAULT = JsonFactory.newJsonValueFieldDefinition(
                 "default");
 
+        /**
+         * JSON field definition for the data type.
+         */
         public static final JsonFieldDefinition<String> TYPE = JsonFactory.newStringFieldDefinition(
                 "type");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleEventFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleEventFormElementOp.java
@@ -24,7 +24,13 @@ import java.util.Optional;
  * @since 2.x.0
  */
 public enum SingleEventFormElementOp implements EventFormElementOp<SingleEventFormElementOp>, CharSequence {
+    /**
+     * Subscribe to event notifications.
+     */
     SUBSCRIBEEVENT("subscribeevent"),
+    /**
+     * Unsubscribe from event notifications.
+     */
     UNSUBSCRIBEEVENT("unsubscribeevent");
 
     private final String name;
@@ -33,6 +39,11 @@ public enum SingleEventFormElementOp implements EventFormElementOp<SingleEventFo
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this operation.
+     *
+     * @return the operation name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleHreflang.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleHreflang.java
@@ -22,8 +22,18 @@ import java.util.regex.Pattern;
  */
 public interface SingleHreflang extends Hreflang, CharSequence {
 
+    /**
+     * Regex pattern for validating BCP47 language tags.
+     */
     Pattern BCP47_PATTERN = Pattern.compile("^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$");
 
+    /**
+     * Creates a SingleHreflang from the specified language tag.
+     *
+     * @param charSequence the BCP47 language tag.
+     * @return the SingleHreflang.
+     * @throws WotValidationException if the language tag does not match BCP47 format.
+     */
     static SingleHreflang of(final CharSequence charSequence) {
         if (charSequence instanceof SingleHreflang) {
             return (SingleHreflang) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleOAuth2Scopes.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleOAuth2Scopes.java
@@ -19,6 +19,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface SingleOAuth2Scopes extends OAuth2Scopes, CharSequence {
 
+    /**
+     * Creates a SingleOAuth2Scopes from the specified scope string.
+     *
+     * @param charSequence the OAuth2 scope.
+     * @return the SingleOAuth2Scopes.
+     */
     static SingleOAuth2Scopes of(final CharSequence charSequence) {
         if (charSequence instanceof SingleOAuth2Scopes) {
             return (SingleOAuth2Scopes) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SinglePrefixedAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SinglePrefixedAtContext.java
@@ -14,16 +14,38 @@ package org.eclipse.ditto.wot.model;
 
 /**
  * A SinglePrefixedAtContext is a {@link SingleAtContext} containing a {@code prefix} and a {@link SingleUriAtContext}.
+ * <p>
+ * Prefixed contexts allow using CURIEs (Compact URIs) in Thing Descriptions, where a short prefix
+ * can be used instead of the full namespace IRI.
+ * </p>
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#sec-context">WoT TD @context</a>
  * @since 2.4.0
  */
 public interface SinglePrefixedAtContext extends SingleAtContext {
 
+    /**
+     * Creates a SinglePrefixedAtContext from the specified prefix and context IRI.
+     *
+     * @param prefix the prefix to use for this context.
+     * @param singleUriAtContext the IRI context that this prefix refers to.
+     * @return the SinglePrefixedAtContext.
+     */
     static SinglePrefixedAtContext of(final CharSequence prefix, final SingleUriAtContext singleUriAtContext) {
         return new ImmutableSinglePrefixedAtContext(prefix, singleUriAtContext);
     }
 
+    /**
+     * Returns the prefix for this context.
+     *
+     * @return the prefix.
+     */
     String getPrefix();
 
+    /**
+     * Returns the IRI context that this prefix refers to.
+     *
+     * @return the delegate context IRI.
+     */
     SingleUriAtContext getDelegateContext();
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleProfile.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleProfile.java
@@ -19,6 +19,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface SingleProfile extends Profile, IRI {
 
+    /**
+     * Creates a SingleProfile from the specified profile IRI.
+     *
+     * @param charSequence the profile IRI.
+     * @return the SingleProfile.
+     */
     static SingleProfile of(final CharSequence charSequence) {
         if (charSequence instanceof SingleProfile) {
             return (SingleProfile) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SinglePropertyFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SinglePropertyFormElementOp.java
@@ -24,9 +24,21 @@ import java.util.Optional;
  * @since 2.4.0
  */
 public enum SinglePropertyFormElementOp implements PropertyFormElementOp<SinglePropertyFormElementOp>, CharSequence {
+    /**
+     * Read the current value of a property.
+     */
     READPROPERTY("readproperty"),
+    /**
+     * Write/update the value of a property.
+     */
     WRITEPROPERTY("writeproperty"),
+    /**
+     * Observe a property for value changes.
+     */
     OBSERVEPROPERTY("observeproperty"),
+    /**
+     * Stop observing a property for value changes.
+     */
     UNOBSERVEPROPERTY("unobserveproperty");
 
     private final String name;
@@ -35,6 +47,11 @@ public enum SinglePropertyFormElementOp implements PropertyFormElementOp<SingleP
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this operation.
+     *
+     * @return the operation name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleRootFormElementOp.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleRootFormElementOp.java
@@ -24,14 +24,41 @@ import java.util.Optional;
  * @since 2.4.0
  */
 public enum SingleRootFormElementOp implements RootFormElementOp<SingleRootFormElementOp>, CharSequence {
+    /**
+     * Read all properties in a single request.
+     */
     READALLPROPERTIES("readallproperties"),
+    /**
+     * Write all properties in a single request.
+     */
     WRITEALLPROPERTIES("writeallproperties"),
+    /**
+     * Read multiple selected properties in a single request.
+     */
     READMULTIPLEPROPERTIES("readmultipleproperties"),
+    /**
+     * Write multiple selected properties in a single request.
+     */
     WRITEMULTIPLEPROPERTIES("writemultipleproperties"),
+    /**
+     * Observe all properties for changes.
+     */
     OBSERVEALLPROPERTIES("observeallproperties"),
+    /**
+     * Stop observing all properties.
+     */
     UNOBSERVEALLPROPERTIES("unobserveallproperties"),
+    /**
+     * Query the status of all actions.
+     */
     QUERYALLACTIONS("queryallactions"),
+    /**
+     * Subscribe to all events.
+     */
     SUBSCRIBEALLEVENTS("subscribeallevents"),
+    /**
+     * Unsubscribe from all events.
+     */
     UNSUBSCRIBEALLEVENTS("unsubscribeallevents");
 
     private final String name;
@@ -40,6 +67,11 @@ public enum SingleRootFormElementOp implements RootFormElementOp<SingleRootFormE
         this.name = name;
     }
 
+    /**
+     * Returns the string representation of this operation.
+     *
+     * @return the operation name.
+     */
     public String getName() {
         return name;
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleSecurity.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleSecurity.java
@@ -19,6 +19,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface SingleSecurity extends Security, CharSequence {
 
+    /**
+     * Creates a SingleSecurity from the specified security scheme name.
+     *
+     * @param charSequence the name of the security scheme.
+     * @return the SingleSecurity.
+     */
     static SingleSecurity of(final CharSequence charSequence) {
         if (charSequence instanceof SingleSecurity) {
             return (SingleSecurity) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleUriAtContext.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SingleUriAtContext.java
@@ -13,20 +13,39 @@
 package org.eclipse.ditto.wot.model;
 
 /**
- * A SingleAtContext is a single IRI {@link AtContext}.
+ * A SingleUriAtContext is a single IRI {@link AtContext}.
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#sec-context">WoT TD @context</a>
  * @since 2.4.0
  */
 public interface SingleUriAtContext extends SingleAtContext, IRI {
 
+    /**
+     * The W3C WoT Thing Description 1.0 context URI.
+     */
     SingleUriAtContext W3ORG_2019_WOT_TD_V1 = of("https://www.w3.org/2019/wot/td/v1");
 
+    /**
+     * The W3C WoT Thing Description 1.1 context URI.
+     */
     SingleUriAtContext W3ORG_2022_WOT_TD_V11 = of("https://www.w3.org/2022/wot/td/v1.1");
 
+    /**
+     * The W3C WoT namespace URI for Thing Descriptions.
+     */
     SingleUriAtContext W3ORG_NS_TD = of("http://www.w3.org/ns/td");
 
+    /**
+     * The Eclipse Ditto WoT extension context URI.
+     */
     SingleUriAtContext DITTO_WOT_EXTENSION = of("https://ditto.eclipseprojects.io/wot/ditto-extension#");
 
+    /**
+     * Creates a SingleUriAtContext from the specified context IRI.
+     *
+     * @param context the context IRI.
+     * @return the SingleUriAtContext.
+     */
     static SingleUriAtContext of(final CharSequence context) {
         if (context instanceof SingleUriAtContext) {
             return (SingleUriAtContext) context;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/SkeletonGenerationFailedException.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/SkeletonGenerationFailedException.java
@@ -51,6 +51,7 @@ public final class SkeletonGenerationFailedException extends DittoRuntimeExcepti
     /**
      * A mutable builder for a {@code SkeletonGenerationFailedException}.
      *
+     * @param definition the definition that failed to generate.
      * @return the builder.
      */
     public static Builder newBuilder(@Nullable final CharSequence definition) {

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/StringSchema.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/StringSchema.java
@@ -25,22 +25,47 @@ import org.eclipse.ditto.json.JsonObject;
 /**
  * A StringSchema is a {@link SingleDataSchema} describing the JSON data type {@code string}.
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema</a>
  * @since 2.4.0
  */
 public interface StringSchema extends SingleDataSchema {
 
+    /**
+     * Creates a new StringSchema from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the string schema.
+     * @return the StringSchema.
+     */
     static StringSchema fromJson(final JsonObject jsonObject) {
         return new ImmutableStringSchema(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a StringSchema.
+     *
+     * @return the builder.
+     */
     static StringSchema.Builder newBuilder() {
         return StringSchema.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a StringSchema, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static StringSchema.Builder newBuilder(final JsonObject jsonObject) {
         return StringSchema.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a StringSchema, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default StringSchema.Builder toBuilder() {
         return StringSchema.Builder.newBuilder(toJson());
     }
@@ -50,34 +75,109 @@ public interface StringSchema extends SingleDataSchema {
         return Optional.of(DataSchemaType.STRING);
     }
 
+    /**
+     * Returns the optional minimum length (in characters) that the string must have.
+     *
+     * @return the optional minimum length.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema (minLength)</a>
+     */
     Optional<Integer> getMinLength();
 
+    /**
+     * Returns the optional maximum length (in characters) that the string may have.
+     *
+     * @return the optional maximum length.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema (maxLength)</a>
+     */
     Optional<Integer> getMaxLength();
 
+    /**
+     * Returns the optional regular expression pattern that the string must match.
+     *
+     * @return the optional regex pattern.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema (pattern)</a>
+     */
     Optional<Pattern> getPattern();
 
+    /**
+     * Returns the optional content encoding for binary data (e.g., "base64", "base16").
+     *
+     * @return the optional content encoding.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema (contentEncoding)</a>
+     */
     Optional<String> getContentEncoding();
 
+    /**
+     * Returns the optional MIME type of the content encoded in the string.
+     *
+     * @return the optional content media type.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#stringschema">WoT TD StringSchema (contentMediaType)</a>
+     */
     Optional<String> getContentMediaType();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link StringSchema}.
+     */
     interface Builder extends SingleDataSchema.Builder<Builder, StringSchema> {
 
+        /**
+         * Creates a new builder for building a StringSchema.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableStringSchemaBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a StringSchema, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableStringSchemaBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the minimum length constraint.
+         *
+         * @param minLength the minimum length, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMinLength(@Nullable Integer minLength);
 
+        /**
+         * Sets the maximum length constraint.
+         *
+         * @param maxLength the maximum length, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMaxLength(@Nullable Integer maxLength);
 
+        /**
+         * Sets the regex pattern constraint.
+         *
+         * @param pattern the pattern, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setPattern(@Nullable Pattern pattern);
 
+        /**
+         * Sets the content encoding for binary data.
+         *
+         * @param contentEncoding the content encoding, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setContentEncoding(@Nullable String contentEncoding);
 
+        /**
+         * Sets the content media type.
+         *
+         * @param mediaType the media type, or {@code null} to remove.
+         * @return this builder.
+         */
         Builder setMediaType(@Nullable String mediaType);
 
     }
@@ -88,18 +188,33 @@ public interface StringSchema extends SingleDataSchema {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the minimum length constraint.
+         */
         public static final JsonFieldDefinition<Integer> MIN_LENGTH = JsonFactory.newIntFieldDefinition(
                 "minLength");
 
+        /**
+         * JSON field definition for the maximum length constraint.
+         */
         public static final JsonFieldDefinition<Integer> MAX_LENGTH = JsonFactory.newIntFieldDefinition(
                 "maxLength");
 
+        /**
+         * JSON field definition for the regex pattern constraint.
+         */
         public static final JsonFieldDefinition<String> PATTERN = JsonFactory.newStringFieldDefinition(
                 "pattern");
 
+        /**
+         * JSON field definition for the content encoding.
+         */
         public static final JsonFieldDefinition<String> CONTENT_ENCODING = JsonFactory.newStringFieldDefinition(
                 "contentEncoding");
 
+        /**
+         * JSON field definition for the content media type.
+         */
         public static final JsonFieldDefinition<String> CONTENT_MEDIA_TYPE = JsonFactory.newStringFieldDefinition(
                 "contentMediaType");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingDescription.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingDescription.java
@@ -17,35 +17,80 @@ import org.eclipse.ditto.json.JsonObject;
 /**
  * The WoT Thing Description (TD) is a central building block in the W3C Web of Things (WoT) and can be considered as
  * the entry point of a Thing.
+ * <p>
+ * A Thing Description describes the metadata and interfaces of a Thing, enabling interaction with the Thing
+ * through its exposed Properties, Actions, and Events.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#introduction-td">WoT TD Thing Description</a>
  * @since 2.4.0
  */
 public interface ThingDescription extends ThingSkeleton<ThingDescription> {
 
+    /**
+     * Creates a new ThingDescription from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing a Thing Description.
+     * @return the ThingDescription.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ThingDescription fromJson(final JsonObject jsonObject) {
         return new ImmutableThingDescription(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a ThingDescription.
+     *
+     * @return the builder.
+     */
     static ThingDescription.Builder newBuilder() {
         return ThingDescription.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a ThingDescription, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ThingDescription.Builder newBuilder(final JsonObject jsonObject) {
         return ThingDescription.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a ThingDescription, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default ThingDescription.Builder toBuilder() {
         return Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link ThingDescription}.
+     */
     interface Builder extends ThingSkeletonBuilder<Builder, ThingDescription> {
 
+        /**
+         * Creates a new builder for building a ThingDescription.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableThingDescriptionBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a ThingDescription, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableThingDescriptionBuilder(jsonObject.toBuilder());
         }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingModel.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingModel.java
@@ -23,44 +23,103 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * The Thing Model can be used to mainly provide the data model definitions within Things' {@link Properties},
- * {@link Actions}, and/or {@link Events} and can be potentially used as template for creating
- * {@link ThingDescription} instances
+ * The Thing Model (TM) provides a reusable template for Thing Descriptions.
+ * <p>
+ * Thing Models define the data model definitions within Things' {@link Properties},
+ * {@link Actions}, and/or {@link Events} and can be used as templates for creating
+ * concrete {@link ThingDescription} instances. Unlike Thing Descriptions, Thing Models
+ * are not required to have an {@code id} and may contain placeholders.
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#introduction-tm">WoT TD Thing Model</a>
  * @since 2.4.0
  */
 public interface ThingModel extends ThingSkeleton<ThingModel> {
 
+    /**
+     * Creates a new ThingModel from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing a Thing Model.
+     * @return the ThingModel.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ThingModel fromJson(final JsonObject jsonObject) {
         return new ImmutableThingModel(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a ThingModel.
+     *
+     * @return the builder.
+     */
     static ThingModel.Builder newBuilder() {
         return ThingModel.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a ThingModel, initialized with the values from the specified
+     * JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     * @throws NullPointerException if {@code jsonObject} is {@code null}.
+     */
     static ThingModel.Builder newBuilder(final JsonObject jsonObject) {
         return ThingModel.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns the optional list of JSON Pointers identifying affordances that are optional in implementations
+     * derived from this Thing Model.
+     *
+     * @return the optional list of optional affordance pointers.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing-model">WoT TD Thing Model (tm:optional)</a>
+     */
     Optional<TmOptional> getTmOptional();
 
+    /**
+     * Returns a mutable builder with a fluent API for building a ThingModel, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     @Override
     default ThingModel.Builder toBuilder() {
         return ThingModel.Builder.newBuilder(toJson());
     }
 
+    /**
+     * A mutable builder with a fluent API for building a {@link ThingModel}.
+     */
     interface Builder extends ThingSkeletonBuilder<Builder, ThingModel> {
 
+        /**
+         * Creates a new builder for building a ThingModel.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableThingModelBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a ThingModel, initialized with the values from the specified
+         * JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableThingModelBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the list of optional affordance pointers.
+         *
+         * @param tmOptional the optional affordances, or {@code null} to remove.
+         * @return this builder.
+         * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing-model">WoT TD Thing Model (tm:optional)</a>
+         */
         Builder setTmOptional(@Nullable TmOptional tmOptional);
     }
 
@@ -70,6 +129,9 @@ public interface ThingModel extends ThingSkeleton<ThingModel> {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the array of optional affordance pointers.
+         */
         public static final JsonFieldDefinition<JsonArray> TM_OPTIONAL = JsonFactory.newJsonArrayFieldDefinition(
                 "tm:optional");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingSkeleton.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingSkeleton.java
@@ -25,54 +25,202 @@ import org.eclipse.ditto.json.JsonObject;
 
 /**
  * Contains common state/behavior shared by {@link ThingDescription} and {@link ThingModel}.
+ * <p>
+ * This interface provides access to the core vocabulary terms defined in the WoT Thing Description specification,
+ * including metadata, interaction affordances, security configurations, and hypermedia controls.
+ * </p>
  *
  * @param <T> the type of the ThingSkeleton.
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing</a>
  * @since 2.4.0
  */
 public interface ThingSkeleton<T extends ThingSkeleton<T>> extends TypedJsonObject<T>, Jsonifiable<JsonObject> {
 
+    /**
+     * Returns the JSON-LD {@code @context} that defines the semantics and vocabulary of the Thing Description or
+     * Thing Model.
+     *
+     * @return the JSON-LD context.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#sec-context">WoT TD @context</a>
+     */
     AtContext getAtContext();
 
+    /**
+     * Returns the optional JSON-LD {@code @type} that provides semantic annotations for the Thing, allowing
+     * classification using ontology terms.
+     *
+     * @return the optional semantic type annotation.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#sec-semantic-annotations">WoT TD Semantic Annotations</a>
+     */
     Optional<AtType> getAtType();
 
+    /**
+     * Returns the optional unique identifier of the Thing, typically an IRI.
+     * <p>
+     * The identifier is mandatory for Thing Descriptions but optional for Thing Models.
+     * </p>
+     *
+     * @return the optional Thing identifier.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (id)</a>
+     */
     Optional<IRI> getId();
 
+    /**
+     * Returns the optional human-readable title of the Thing, based on the default language.
+     *
+     * @return the optional title.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#titles-descriptions-serialization-json">WoT TD Human-Readable Metadata</a>
+     */
     Optional<Title> getTitle();
 
+    /**
+     * Returns the optional multi-language map of human-readable titles for the Thing.
+     *
+     * @return the optional multi-language titles.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Titles> getTitles();
 
+    /**
+     * Returns the optional human-readable description of the Thing, based on the default language.
+     *
+     * @return the optional description.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#titles-descriptions-serialization-json">WoT TD Human-Readable Metadata</a>
+     */
     Optional<Description> getDescription();
 
+    /**
+     * Returns the optional multi-language map of human-readable descriptions for the Thing.
+     *
+     * @return the optional multi-language descriptions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#multilanguage">WoT TD MultiLanguage</a>
+     */
     Optional<Descriptions> getDescriptions();
 
+    /**
+     * Returns the optional version information of the Thing Description or Thing Model.
+     *
+     * @return the optional version information.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#versioninfo">WoT TD VersionInfo</a>
+     */
     Optional<Version> getVersion();
 
+    /**
+     * Returns the optional base IRI that is used for resolving all relative IRIs in the Thing Description.
+     *
+     * @return the optional base IRI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (base)</a>
+     */
     Optional<IRI> getBase();
 
+    /**
+     * Returns the optional collection of web links to arbitrary resources related to the Thing.
+     *
+     * @return the optional links.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#link">WoT TD Link</a>
+     */
     Optional<Links> getLinks();
 
+    /**
+     * Returns the optional collection of Property affordances that expose state of the Thing.
+     *
+     * @return the optional properties.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#propertyaffordance">WoT TD PropertyAffordance</a>
+     */
     Optional<Properties> getProperties();
 
+    /**
+     * Returns the optional collection of Action affordances that describe functions that can be invoked on the Thing.
+     *
+     * @return the optional actions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#actionaffordance">WoT TD ActionAffordance</a>
+     */
     Optional<Actions> getActions();
 
+    /**
+     * Returns the optional collection of Event affordances that describe event sources of the Thing.
+     *
+     * @return the optional events.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#eventaffordance">WoT TD EventAffordance</a>
+     */
     Optional<Events> getEvents();
 
+    /**
+     * Returns the optional collection of Form elements at the Thing level describing top-level operations.
+     *
+     * @return the optional root forms.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#form">WoT TD Form</a>
+     */
     Optional<RootForms> getForms();
 
+    /**
+     * Returns the optional URI template variables that can be used in Form href expressions.
+     *
+     * @return the optional URI variables.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (uriVariables)</a>
+     */
     Optional<UriVariables> getUriVariables();
 
+    /**
+     * Returns the optional collection of named security scheme definitions.
+     * <p>
+     * These definitions can be referenced by name in the {@code security} member.
+     * </p>
+     *
+     * @return the optional security definitions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#securityscheme">WoT TD SecurityScheme</a>
+     */
     Optional<SecurityDefinitions> getSecurityDefinitions();
 
+    /**
+     * Returns the optional collection of schema definitions that can be used in data schemas.
+     *
+     * @return the optional schema definitions.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (schemaDefinitions)</a>
+     */
     Optional<SchemaDefinitions> getSchemaDefinitions();
 
+    /**
+     * Returns the optional IRI pointing to information about the TD maintainer as URI scheme (e.g., mailto, tel, https).
+     *
+     * @return the optional support IRI.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (support)</a>
+     */
     Optional<IRI> getSupport();
 
+    /**
+     * Returns the optional timestamp indicating when the Thing Description was created.
+     *
+     * @return the optional creation timestamp.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (created)</a>
+     */
     Optional<Instant> getCreated();
 
+    /**
+     * Returns the optional timestamp indicating when the Thing Description was last modified.
+     *
+     * @return the optional modification timestamp.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (modified)</a>
+     */
     Optional<Instant> getModified();
 
+    /**
+     * Returns the optional security configuration that must be satisfied to access the Thing.
+     * <p>
+     * The value references one or more named security schemes defined in {@link #getSecurityDefinitions()}.
+     * </p>
+     *
+     * @return the optional security configuration.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (security)</a>
+     */
     Optional<Security> getSecurity();
 
+    /**
+     * Returns the optional WoT profile identifier(s) indicating the Thing's conformance to specific TD profiles.
+     *
+     * @return the optional profile identifier(s).
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#thing">WoT TD Thing (profile)</a>
+     */
     Optional<Profile> getProfile();
 
     /**
@@ -97,81 +245,159 @@ public interface ThingSkeleton<T extends ThingSkeleton<T>> extends TypedJsonObje
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the JSON-LD context (single value).
+         */
         public static final JsonFieldDefinition<String> AT_CONTEXT = JsonFactory.newStringFieldDefinition(
                 "@context");
 
+        /**
+         * JSON field definition for the JSON-LD context (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> AT_CONTEXT_MULTIPLE =
                 JsonFactory.newJsonArrayFieldDefinition("@context");
 
+        /**
+         * JSON field definition for the JSON-LD type (single value).
+         */
         public static final JsonFieldDefinition<String> AT_TYPE = JsonFactory.newStringFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the JSON-LD type (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> AT_TYPE_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "@type");
 
+        /**
+         * JSON field definition for the identifier.
+         */
         public static final JsonFieldDefinition<String> ID = JsonFactory.newStringFieldDefinition(
                 "id");
 
+        /**
+         * JSON field definition for the title.
+         */
         public static final JsonFieldDefinition<String> TITLE = JsonFactory.newStringFieldDefinition(
                 "title");
 
+        /**
+         * JSON field definition for the multilingual titles.
+         */
         public static final JsonFieldDefinition<JsonObject> TITLES = JsonFactory.newJsonObjectFieldDefinition(
                 "titles");
 
+        /**
+         * JSON field definition for the property affordances.
+         */
         public static final JsonFieldDefinition<JsonObject> PROPERTIES = JsonFactory.newJsonObjectFieldDefinition(
                 "properties");
 
+        /**
+         * JSON field definition for the action affordances.
+         */
         public static final JsonFieldDefinition<JsonObject> ACTIONS = JsonFactory.newJsonObjectFieldDefinition(
                 "actions");
 
+        /**
+         * JSON field definition for the event affordances.
+         */
         public static final JsonFieldDefinition<JsonObject> EVENTS = JsonFactory.newJsonObjectFieldDefinition(
                 "events");
 
+        /**
+         * JSON field definition for the description.
+         */
         public static final JsonFieldDefinition<String> DESCRIPTION = JsonFactory.newStringFieldDefinition(
                 "description");
 
+        /**
+         * JSON field definition for the multilingual descriptions.
+         */
         public static final JsonFieldDefinition<JsonObject> DESCRIPTIONS = JsonFactory.newJsonObjectFieldDefinition(
                 "descriptions");
 
+        /**
+         * JSON field definition for the version information.
+         */
         public static final JsonFieldDefinition<JsonObject> VERSION = JsonFactory.newJsonObjectFieldDefinition(
                 "version");
 
+        /**
+         * JSON field definition for the links.
+         */
         public static final JsonFieldDefinition<JsonArray> LINKS = JsonFactory.newJsonArrayFieldDefinition(
                 "links");
 
+        /**
+         * JSON field definition for the base IRI.
+         */
         public static final JsonFieldDefinition<String> BASE = JsonFactory.newStringFieldDefinition(
                 "base");
 
+        /**
+         * JSON field definition for the root-level forms.
+         */
         public static final JsonFieldDefinition<JsonArray> FORMS = JsonFactory.newJsonArrayFieldDefinition(
                 "forms");
 
+        /**
+         * JSON field definition for the URI template variables.
+         */
         public static final JsonFieldDefinition<JsonObject> URI_VARIABLES =
                 JsonFactory.newJsonObjectFieldDefinition("uriVariables");
 
+        /**
+         * JSON field definition for the security definitions.
+         */
         public static final JsonFieldDefinition<JsonObject> SECURITY_DEFINITIONS =
                 JsonFactory.newJsonObjectFieldDefinition("securityDefinitions");
 
+        /**
+         * JSON field definition for the schema definitions.
+         */
         public static final JsonFieldDefinition<JsonObject> SCHEMA_DEFINITIONS =
                 JsonFactory.newJsonObjectFieldDefinition("schemaDefinitions");
 
+        /**
+         * JSON field definition for the support contact URI.
+         */
         public static final JsonFieldDefinition<String> SUPPORT = JsonFactory.newStringFieldDefinition(
                 "support");
 
+        /**
+         * JSON field definition for the creation timestamp.
+         */
         public static final JsonFieldDefinition<String> CREATED = JsonFactory.newStringFieldDefinition(
                 "created");
 
+        /**
+         * JSON field definition for the modification timestamp.
+         */
         public static final JsonFieldDefinition<String> MODIFIED = JsonFactory.newStringFieldDefinition(
                 "modified");
 
+        /**
+         * JSON field definition for the security configuration (single value).
+         */
         public static final JsonFieldDefinition<String> SECURITY = JsonFactory.newStringFieldDefinition(
                 "security");
 
+        /**
+         * JSON field definition for the security configurations (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> SECURITY_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "security");
 
+        /**
+         * JSON field definition for the profile (single value).
+         */
         public static final JsonFieldDefinition<String> PROFILE = JsonFactory.newStringFieldDefinition(
                 "profile");
 
+        /**
+         * JSON field definition for the profiles (multiple values).
+         */
         public static final JsonFieldDefinition<JsonArray> PROFILE_MULTIPLE = JsonFactory.newJsonArrayFieldDefinition(
                 "profile");
 

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingSkeletonBuilder.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/ThingSkeletonBuilder.java
@@ -27,52 +27,196 @@ import javax.annotation.Nullable;
 public interface ThingSkeletonBuilder<B extends ThingSkeletonBuilder<B, T>, T extends ThingSkeleton<T>> extends
         TypedJsonObjectBuilder<B, T> {
 
+    /**
+     * Sets the JSON-LD context.
+     *
+     * @param atContext the context.
+     * @return this builder.
+     */
     B setAtContext(AtContext atContext);
 
+    /**
+     * Sets the JSON-LD semantic type(s).
+     *
+     * @param atType the type(s), or {@code null} to remove.
+     * @return this builder.
+     */
     B setAtType(@Nullable AtType atType);
 
+    /**
+     * Sets the identifier of this Thing Description or Thing Model.
+     *
+     * @param id the identifier IRI, or {@code null} to remove.
+     * @return this builder.
+     */
     B setId(@Nullable IRI id);
 
+    /**
+     * Sets the human-readable title.
+     *
+     * @param title the title, or {@code null} to remove.
+     * @return this builder.
+     */
     B setTitle(@Nullable Title title);
 
+    /**
+     * Sets the multilingual titles.
+     *
+     * @param titles the titles map, or {@code null} to remove.
+     * @return this builder.
+     */
     B setTitles(@Nullable Titles titles);
 
+    /**
+     * Sets the human-readable description.
+     *
+     * @param description the description, or {@code null} to remove.
+     * @return this builder.
+     */
     B setDescription(@Nullable Description description);
 
+    /**
+     * Sets the multilingual descriptions.
+     *
+     * @param descriptions the descriptions map, or {@code null} to remove.
+     * @return this builder.
+     */
     B setDescriptions(@Nullable Descriptions descriptions);
 
+    /**
+     * Sets the version information.
+     *
+     * @param version the version, or {@code null} to remove.
+     * @return this builder.
+     */
     B setVersion(@Nullable Version version);
 
+    /**
+     * Sets the base IRI for relative URI references.
+     *
+     * @param base the base IRI, or {@code null} to remove.
+     * @return this builder.
+     */
     B setBase(@Nullable IRI base);
 
+    /**
+     * Sets the links to related resources.
+     *
+     * @param links the links, or {@code null} to remove.
+     * @return this builder.
+     */
     B setLinks(@Nullable Links links);
 
+    /**
+     * Sets the property affordances.
+     *
+     * @param properties the properties, or {@code null} to remove.
+     * @return this builder.
+     */
     B setProperties(@Nullable Properties properties);
 
+    /**
+     * Sets the action affordances.
+     *
+     * @param actions the actions, or {@code null} to remove.
+     * @return this builder.
+     */
     B setActions(@Nullable Actions actions);
 
+    /**
+     * Sets the event affordances.
+     *
+     * @param events the events, or {@code null} to remove.
+     * @return this builder.
+     */
     B setEvents(@Nullable Events events);
 
+    /**
+     * Sets the links to related resources from a collection.
+     *
+     * @param links the collection of links.
+     * @return this builder.
+     */
     B setLinks(Collection<BaseLink<?>> links);
 
+    /**
+     * Sets the root-level form elements from a collection.
+     *
+     * @param forms the collection of form elements.
+     * @return this builder.
+     */
     B setForms(Collection<RootFormElement> forms);
 
+    /**
+     * Sets the root-level form elements.
+     *
+     * @param forms the forms, or {@code null} to remove.
+     * @return this builder.
+     */
     B setForms(@Nullable RootForms forms);
 
+    /**
+     * Sets the URI template variables.
+     *
+     * @param uriVariables the URI variables, or {@code null} to remove.
+     * @return this builder.
+     */
     B setUriVariables(@Nullable UriVariables uriVariables);
 
+    /**
+     * Sets the security scheme definitions.
+     *
+     * @param securityDefinitions the security definitions, or {@code null} to remove.
+     * @return this builder.
+     */
     B setSecurityDefinitions(@Nullable SecurityDefinitions securityDefinitions);
 
+    /**
+     * Sets the data schema definitions for reuse.
+     *
+     * @param schemaDefinitions the schema definitions, or {@code null} to remove.
+     * @return this builder.
+     */
     B setSchemaDefinitions(@Nullable SchemaDefinitions schemaDefinitions);
 
+    /**
+     * Sets the support contact URI.
+     *
+     * @param support the support URI, or {@code null} to remove.
+     * @return this builder.
+     */
     B setSupport(@Nullable IRI support);
 
+    /**
+     * Sets the creation timestamp.
+     *
+     * @param created the creation timestamp, or {@code null} to remove.
+     * @return this builder.
+     */
     B setCreated(@Nullable Instant created);
 
+    /**
+     * Sets the last modification timestamp.
+     *
+     * @param modified the modification timestamp, or {@code null} to remove.
+     * @return this builder.
+     */
     B setModified(@Nullable Instant modified);
 
+    /**
+     * Sets the security configuration to apply by default.
+     *
+     * @param security the security configuration, or {@code null} to remove.
+     * @return this builder.
+     */
     B setSecurity(@Nullable Security security);
 
+    /**
+     * Sets the WoT profile(s) this Thing conforms to.
+     *
+     * @param profile the profile(s), or {@code null} to remove.
+     * @return this builder.
+     */
     B setProfile(@Nullable Profile profile);
 
 }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Title.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Title.java
@@ -15,10 +15,17 @@ package org.eclipse.ditto.wot.model;
 /**
  * A Title "provides a human-readable title (e.g., display a text for UI representation) based on a default language."
  *
+ * @see <a href="https://www.w3.org/TR/wot-thing-description11/#titles-descriptions-serialization-json">WoT TD Human-Readable Metadata</a>
  * @since 2.4.0
  */
 public interface Title extends CharSequence {
 
+    /**
+     * Creates a Title from the specified character sequence.
+     *
+     * @param charSequence the title text.
+     * @return the Title.
+     */
     static Title of(final CharSequence charSequence) {
         if (charSequence instanceof Title) {
             return (Title) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Titles.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Titles.java
@@ -29,6 +29,12 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface Titles extends Map<Locale, Title>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a Titles from the specified JSON object.
+     *
+     * @param jsonObject the JSON object mapping language tags to titles.
+     * @return the Titles.
+     */
     static Titles fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> new Locale(field.getKey().toString()),
@@ -41,6 +47,12 @@ public interface Titles extends Map<Locale, Title>, Jsonifiable<JsonObject> {
         ));
     }
 
+    /**
+     * Creates a Titles from the specified map of locale to title.
+     *
+     * @param titles the map of locales to titles.
+     * @return the Titles.
+     */
     static Titles of(final Map<Locale, Title> titles) {
         return new ImmutableTitles(titles);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/TmOptional.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/TmOptional.java
@@ -31,6 +31,12 @@ import org.eclipse.ditto.json.JsonValue;
  */
 public interface TmOptional extends Iterable<TmOptionalElement>, Jsonifiable<JsonArray> {
 
+    /**
+     * Creates a TmOptional from the specified JSON array.
+     *
+     * @param jsonArray the JSON array of optional element pointers.
+     * @return the TmOptional.
+     */
     static TmOptional fromJson(final JsonArray jsonArray) {
         final List<TmOptionalElement> optionalElements = jsonArray.stream()
                 .filter(JsonValue::isString)
@@ -40,10 +46,21 @@ public interface TmOptional extends Iterable<TmOptionalElement>, Jsonifiable<Jso
         return of(optionalElements);
     }
 
+    /**
+     * Creates a TmOptional from the specified collection of optional elements.
+     *
+     * @param optionalElements the collection of optional elements.
+     * @return the TmOptional.
+     */
     static TmOptional of(final Collection<TmOptionalElement> optionalElements) {
         return new ImmutableTmOptional(optionalElements);
     }
 
+    /**
+     * Returns a sequential stream over the optional elements.
+     *
+     * @return a stream of optional elements.
+     */
     default Stream<TmOptionalElement> stream() {
         return StreamSupport.stream(spliterator(), false);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/TmOptionalElement.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/TmOptionalElement.java
@@ -20,6 +20,12 @@ package org.eclipse.ditto.wot.model;
  */
 public interface TmOptionalElement extends CharSequence {
 
+    /**
+     * Creates a TmOptionalElement from the specified JSON Pointer string.
+     *
+     * @param charSequence the JSON Pointer string identifying the optional affordance.
+     * @return the TmOptionalElement.
+     */
     static TmOptionalElement of(final CharSequence charSequence) {
         if (charSequence instanceof TmOptionalElement) {
             return (TmOptionalElement) charSequence;

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/TypedJsonObject.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/TypedJsonObject.java
@@ -49,6 +49,8 @@ interface TypedJsonObject<T extends JsonObject> extends JsonObject {
     T determineResult(Supplier<JsonObject> newWrappedSupplier);
 
     /**
+     * Returns the wrapped, underlying JsonObject.
+     *
      * @return the wrapped, underlying JsonObject.
      */
     JsonObject getWrappedObject();

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/UriVariables.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/UriVariables.java
@@ -27,6 +27,12 @@ import org.eclipse.ditto.json.JsonObject;
  */
 public interface UriVariables extends Map<String, SingleDataSchema>, Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a UriVariables from the specified JSON object.
+     *
+     * @param jsonObject the JSON object mapping variable names to data schemas.
+     * @return the UriVariables.
+     */
     static UriVariables fromJson(final JsonObject jsonObject) {
         return of(jsonObject.stream().collect(Collectors.toMap(
                 field -> field.getKey().toString(),
@@ -39,6 +45,12 @@ public interface UriVariables extends Map<String, SingleDataSchema>, Jsonifiable
         ));
     }
 
+    /**
+     * Creates a UriVariables from the specified map of variable names to data schemas.
+     *
+     * @param uriVariables the map of variable names to data schemas.
+     * @return the UriVariables.
+     */
     static UriVariables of(final Map<String, SingleDataSchema> uriVariables) {
         return new ImmutableUriVariables(uriVariables);
     }

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/Version.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/Version.java
@@ -22,47 +22,117 @@ import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonObject;
 
 /**
- * A Version provides version information, e.g. of {@code model} or {@code instance}.
+ * A Version provides version information about the Thing Description or Thing Model.
+ * <p>
+ * Version information can include both the model version (template version) and the instance version
+ * (version of the specific Thing).
+ * </p>
  *
  * @see <a href="https://www.w3.org/TR/wot-thing-description11/#versioninfo">WoT TD VersionInfo</a>
  * @since 2.4.0
  */
 public interface Version extends Jsonifiable<JsonObject> {
 
+    /**
+     * Creates a new Version from the specified JSON object.
+     *
+     * @param jsonObject the JSON object representing the version info.
+     * @return the Version.
+     */
     static Version fromJson(final JsonObject jsonObject) {
         return new ImmutableVersion(jsonObject);
     }
 
+    /**
+     * Creates a new builder for building a Version.
+     *
+     * @return the builder.
+     */
     static Version.Builder newBuilder() {
         return Version.Builder.newBuilder();
     }
 
+    /**
+     * Creates a new builder for building a Version, initialized with the values from the specified JSON object.
+     *
+     * @param jsonObject the JSON object providing initial values.
+     * @return the builder.
+     */
     static Version.Builder newBuilder(final JsonObject jsonObject) {
         return Version.Builder.newBuilder(jsonObject);
     }
 
+    /**
+     * Returns a mutable builder with a fluent API for building a Version, initialized with the values
+     * of this instance.
+     *
+     * @return the builder.
+     */
     default Version.Builder toBuilder() {
         return Version.Builder.newBuilder(toJson());
     }
 
+    /**
+     * Returns the optional instance version, which represents the version of the specific Thing instance.
+     *
+     * @return the optional instance version.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#versioninfo">WoT TD VersionInfo (instance)</a>
+     */
     Optional<String> getInstance();
 
+    /**
+     * Returns the optional model version, which represents the version of the Thing Model this description is based on.
+     *
+     * @return the optional model version.
+     * @see <a href="https://www.w3.org/TR/wot-thing-description11/#versioninfo">WoT TD VersionInfo (model)</a>
+     */
     Optional<String> getModel();
 
+    /**
+     * A mutable builder with a fluent API for building a {@link Version}.
+     */
     interface Builder {
 
+        /**
+         * Creates a new builder for building a Version.
+         *
+         * @return the builder.
+         */
         static Builder newBuilder() {
             return new MutableVersionBuilder(JsonObject.newBuilder());
         }
 
+        /**
+         * Creates a new builder for building a Version, initialized with the values from the specified JSON object.
+         *
+         * @param jsonObject the JSON object providing initial values.
+         * @return the builder.
+         */
         static Builder newBuilder(final JsonObject jsonObject) {
             return new MutableVersionBuilder(jsonObject.toBuilder());
         }
 
+        /**
+         * Sets the instance version.
+         *
+         * @param instance the instance version.
+         * @return this builder.
+         */
         Builder setInstance(String instance);
 
+        /**
+         * Sets the model version.
+         *
+         * @param model the model version.
+         * @return this builder.
+         */
         Builder setModel(String model);
 
+        /**
+         * Builds the Version.
+         *
+         * @return the built Version instance.
+         */
         Version build();
     }
 
@@ -72,9 +142,15 @@ public interface Version extends Jsonifiable<JsonObject> {
     @Immutable
     final class JsonFields {
 
+        /**
+         * JSON field definition for the instance version.
+         */
         public static final JsonFieldDefinition<String> INSTANCE = JsonFactory.newStringFieldDefinition(
                 "instance");
 
+        /**
+         * JSON field definition for the model version.
+         */
         public static final JsonFieldDefinition<String> MODEL = JsonFactory.newStringFieldDefinition(
                 "model");
 


### PR DESCRIPTION
Add method-level JavaDoc documentation to public interfaces in the wot/model module based on the W3C WoT Thing Description 1.1 specification.

The JavaDocs of the public WoT API were mostly missing - fixed that now.

All documentation includes anchored links to the relevant sections of the W3C WoT Thing Description 1.1 specification at:
https://www.w3.org/TR/wot-thing-description11/