### PR TITLE
#2320: add ditto:deprecationNotice to WoT Extension Ontology

### DIFF
--- a/documentation/src/main/resources/pages/ditto/basic-wot-integration.md
+++ b/documentation/src/main/resources/pages/ditto/basic-wot-integration.md
@@ -647,13 +647,27 @@ things {
 
 ## Ditto WoT Extension Ontology
 
-As WoT is built on JSON-LD, extension of Thing Models (TMs) or Thing Descriptions (TDs) via a custom ontology is possible.  
-Ditto provides such an "WoT extension ontology" in order to provide the option to categorize WoT properties.
+As WoT is built on JSON-LD, extension of Thing Models (TMs) or Thing Descriptions (TDs) via a custom ontology is possible.
+Ditto provides such a "WoT extension ontology" with additional terms for:
+* **Categorization** of WoT properties (e.g., grouping into "configuration" vs. "status")
+* **Deprecation notices** for Things, properties, actions, and events (marking them as deprecated with replacement info and removal timeline)
 
-The Ditto WoT Extension Ontology can be found here:  
+The Ditto WoT Extension Ontology can be found here:
 [https://ditto.eclipseprojects.io/wot/ditto-extension#](https://ditto.eclipseprojects.io/wot/ditto-extension#)
 
 It contains an HTML description of the contained terms of the ontology.
+
+To use the Ditto WoT extension in your Thing Models or Thing Descriptions, add it to your JSON-LD `@context`:
+```json
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+    }
+  ]
+}
+```
 
 ### Ditto WoT Extension: category
 
@@ -716,6 +730,142 @@ Based on the example above, a generated feature JSON would for example look like
     },
     "status": {
       "power-consumption": 0.0
+    }
+  }
+}
+```
+
+### Ditto WoT Extension: deprecationNotice
+
+The [deprecationNotice](https://ditto.eclipseprojects.io/wot/ditto-extension#deprecationNotice) is a term which can be
+added at the WoT TM/TD (Thing) level, or in scope of
+[Property Affordances](https://www.w3.org/TR/wot-thing-description11/#propertyaffordance),
+[Action Affordances](https://www.w3.org/TR/wot-thing-description11/#actionaffordance), and
+[Event Affordances](https://www.w3.org/TR/wot-thing-description11/#eventaffordance).
+It can be used to mark an entire Thing Model/Description or individual affordances as deprecated and provide
+information about their replacement and removal timeline.
+
+The `deprecationNotice` is a JSON object containing the following properties:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `deprecated` | boolean | yes | Whether the Thing or affordance is deprecated |
+| `supersededBy` | string | no | A JSON Pointer (RFC 6901) referencing the replacement affordance (e.g. `#/properties/newProperty`), or a URL to a replacement Thing Model |
+| `removalVersion` | string | yes | The semantic version (SemVer) in which the deprecated Thing or affordance will be removed |
+
+In order to use the deprecation notice, you need to enhance your JSON-LD context with the Ditto WoT extension. You can
+then make use of the `"deprecationNotice"` in properties, actions, or events defined in your TM/TD.
+
+Example for a deprecated property with a replacement:
+```json
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+    }
+  ],
+  ...
+  "properties": {
+    "tempSetpoint": {
+      "title": "Temperature Setpoint (DEPRECATED)",
+      "description": "Use 'targetTemperature' instead",
+      "type": "number",
+      "ditto:deprecationNotice": {
+        "deprecated": true,
+        "supersededBy": "#/properties/targetTemperature",
+        "removalVersion": "2.0.0"
+      }
+    },
+    "targetTemperature": {
+      "title": "Target Temperature",
+      "type": "number",
+      "unit": "om2:degreeCelsius"
+    }
+  }
+}
+```
+
+Example for a deprecated action without a replacement:
+```json
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+    }
+  ],
+  ...
+  "actions": {
+    "legacyReset": {
+      "title": "Legacy Reset (DEPRECATED)",
+      "description": "This action will be removed without replacement",
+      "ditto:deprecationNotice": {
+        "deprecated": true,
+        "removalVersion": "3.0.0"
+      }
+    }
+  }
+}
+```
+
+Example for a deprecated event with a replacement:
+```json
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+    }
+  ],
+  ...
+  "events": {
+    "temperatureChanged": {
+      "title": "Temperature Changed (DEPRECATED)",
+      "description": "Subscribe to 'temperatureUpdate' instead for richer data",
+      "data": {
+        "type": "number"
+      },
+      "ditto:deprecationNotice": {
+        "deprecated": true,
+        "supersededBy": "#/events/temperatureUpdate",
+        "removalVersion": "2.0.0"
+      }
+    },
+    "temperatureUpdate": {
+      "title": "Temperature Update",
+      "description": "Emitted when the measured temperature changes",
+      "data": {
+        "type": "object",
+        "properties": {
+          "value": { "type": "number" },
+          "timestamp": { "type": "string", "format": "date-time" }
+        }
+      }
+    }
+  }
+}
+```
+
+Example for a deprecated Thing Model with a replacement:
+```json
+{
+  "@context": [
+    "https://www.w3.org/2022/wot/td/v1.1",
+    {
+      "ditto": "https://ditto.eclipseprojects.io/wot/ditto-extension#"
+    }
+  ],
+  "title": "Legacy Temperature Sensor (DEPRECATED)",
+  "description": "This model is deprecated, use temperature-sensor-2.0.0.tm.jsonld instead",
+  "ditto:deprecationNotice": {
+    "deprecated": true,
+    "supersededBy": "https://example.com/models/temperature-sensor-2.0.0.tm.jsonld",
+    "removalVersion": "2.0.0"
+  },
+  "properties": {
+    "temperature": {
+      "type": "number"
     }
   }
 }

--- a/documentation/src/main/resources/wot/ditto-extension.html
+++ b/documentation/src/main/resources/wot/ditto-extension.html
@@ -81,7 +81,7 @@
   </section>
   <section id="3-axiomatization">
     <h2>3. Axiomatization</h2>
-    <section id="2-1-datatype-properties">
+    <section id="3-1-datatype-properties">
       <h3>3.1 Datatype Properties</h3>
       <section id="category">
         <h4 id="3-1-1-category">
@@ -92,12 +92,111 @@
         <table class="def">
           <tbody>
           <tr>
-            <td>Sub-class of</td>
-            <td><code><a href="https://www.w3.org/2019/wot/td#PropertyAffordance" style="">td:PropertyAffordance</a></code></td>
+            <td>Domain</td>
+            <td><code><a href="https://www.w3.org/2019/wot/td#PropertyAffordance">td:PropertyAffordance</a></code></td>
           </tr>
           <tr>
-            <td>In the range of</td>
+            <td>Range</td>
             <td><code><a href="https://schema.org/Text">schema:Text</a></code></td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="deprecated">
+        <h4 id="3-1-2-deprecated">
+          <a href="#deprecated">3.1.2 deprecated</a>
+        </h4>
+        <p>IRI: <code>https://ditto.eclipseprojects.io/wot/ditto-extension#deprecated</code></p>
+        <p>Boolean flag indicating whether the Thing or affordance is deprecated.</p>
+        <table class="def">
+          <tbody>
+          <tr>
+            <td>Domain</td>
+            <td><code><a href="#3-2-1-DeprecationNotice">ditto:DeprecationNotice</a></code></td>
+          </tr>
+          <tr>
+            <td>Range</td>
+            <td><code><a href="https://schema.org/Boolean">schema:Boolean</a></code></td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="supersededBy">
+        <h4 id="3-1-3-supersededBy">
+          <a href="#supersededBy">3.1.3 supersededBy</a>
+        </h4>
+        <p>IRI: <code>https://ditto.eclipseprojects.io/wot/ditto-extension#supersededBy</code></p>
+        <p>A JSON Pointer (RFC 6901) referencing the replacement affordance that supersedes the deprecated one, e.g. <code>'#/properties/newProperty'</code>.</p>
+        <table class="def">
+          <tbody>
+          <tr>
+            <td>Domain</td>
+            <td><code><a href="#3-2-1-DeprecationNotice">ditto:DeprecationNotice</a></code></td>
+          </tr>
+          <tr>
+            <td>Range</td>
+            <td><code><a href="https://schema.org/Text">schema:Text</a></code></td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+      <section id="removalVersion">
+        <h4 id="3-1-4-removalVersion">
+          <a href="#removalVersion">3.1.4 removalVersion</a>
+        </h4>
+        <p>IRI: <code>https://ditto.eclipseprojects.io/wot/ditto-extension#removalVersion</code></p>
+        <p>The semantic version (SemVer) in which the deprecated affordance will be removed, e.g. <code>'2.0.0'</code>.</p>
+        <table class="def">
+          <tbody>
+          <tr>
+            <td>Domain</td>
+            <td><code><a href="#3-2-1-DeprecationNotice">ditto:DeprecationNotice</a></code></td>
+          </tr>
+          <tr>
+            <td>Range</td>
+            <td><code><a href="https://schema.org/Text">schema:Text</a></code></td>
+          </tr>
+          </tbody>
+        </table>
+      </section>
+    </section>
+    <section id="3-2-classes">
+      <h3>3.2 Classes</h3>
+      <section id="3-2-1-DeprecationNotice">
+        <h4>
+          <a href="#3-2-1-DeprecationNotice">3.2.1 DeprecationNotice</a>
+        </h4>
+        <p>IRI: <code>https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice</code></p>
+        <p>A structured object indicating that a WoT Thing (ThingModel/ThingDescription), or an affordance (property, action, or event) is deprecated. Contains the following properties:</p>
+        <ul>
+          <li><code>deprecated</code> (boolean, required): Whether the Thing or affordance is deprecated</li>
+          <li><code>supersededBy</code> (string, optional): JSON Pointer to replacement affordance</li>
+          <li><code>removalVersion</code> (string, required): SemVer version when affordance will be removed</li>
+        </ul>
+      </section>
+    </section>
+    <section id="3-3-object-properties">
+      <h3>3.3 Object Properties</h3>
+      <section id="deprecationNotice">
+        <h4 id="3-3-1-deprecationNotice">
+          <a href="#deprecationNotice">3.3.1 deprecationNotice</a>
+        </h4>
+        <p>IRI: <code>https://ditto.eclipseprojects.io/wot/ditto-extension#deprecationNotice</code></p>
+        <p>Indicates that a WoT Thing, or an affordance (property, action, or event) is deprecated. The value is a <code>DeprecationNotice</code> object containing deprecation details.</p>
+        <table class="def">
+          <tbody>
+          <tr>
+            <td>Domain</td>
+            <td>
+              <code><a href="https://www.w3.org/2019/wot/td#Thing">td:Thing</a></code>,
+              <code><a href="https://www.w3.org/2019/wot/td#PropertyAffordance">td:PropertyAffordance</a></code>,
+              <code><a href="https://www.w3.org/2019/wot/td#ActionAffordance">td:ActionAffordance</a></code>,
+              <code><a href="https://www.w3.org/2019/wot/td#EventAffordance">td:EventAffordance</a></code>
+            </td>
+          </tr>
+          <tr>
+            <td>Range</td>
+            <td><code><a href="#3-2-1-DeprecationNotice">ditto:DeprecationNotice</a></code></td>
           </tr>
           </tbody>
         </table>

--- a/documentation/src/main/resources/wot/ditto-extension.jsonld
+++ b/documentation/src/main/resources/wot/ditto-extension.jsonld
@@ -23,7 +23,10 @@
         "@language": "en",
         "@value": "This ontology provides additional Eclipse Ditto™ specific context for Web of Things (https://www.w3.org/WoT/) TDs and TMs"
       },
-      "owl:versionInfo": "3.0.0"
+      "owl:versionInfo": "3.9.0",
+      "owl:imports": {
+        "@id": "https://www.w3.org/2019/wot/td#"
+      }
     },
     {
       "@id": "ditto:category",
@@ -42,6 +45,101 @@
         "@id": "ditto:"
       },
       "rdfs:label": "category"
+    },
+    {
+      "@id": "ditto:DeprecationNotice",
+      "@type": "owl:Class",
+      "rdfs:comment": {
+        "@language": "en",
+        "@value": "A structured object indicating that a WoT Thing, or an affordance (property, action, or event) is deprecated"
+      },
+      "rdfs:isDefinedBy": {
+        "@id": "ditto:"
+      },
+      "rdfs:label": "DeprecationNotice"
+    },
+    {
+      "@id": "ditto:deprecationNotice",
+      "@type": "owl:ObjectProperty",
+      "schema:domainIncludes": [
+        {
+          "@id": "td:Thing"
+        },
+        {
+          "@id": "td:PropertyAffordance"
+        },
+        {
+          "@id": "td:ActionAffordance"
+        },
+        {
+          "@id": "td:EventAffordance"
+        }
+      ],
+      "schema:rangeIncludes": {
+        "@id": "ditto:DeprecationNotice"
+      },
+      "rdfs:comment": {
+        "@language": "en",
+        "@value": "Indicates that a WoT Thing, or an affordance (property, action, or event) is deprecated. The value is a DeprecationNotice object containing deprecation details."
+      },
+      "rdfs:isDefinedBy": {
+        "@id": "ditto:"
+      },
+      "rdfs:label": "deprecationNotice"
+    },
+    {
+      "@id": "ditto:deprecated",
+      "@type": "owl:DatatypeProperty",
+      "schema:domainIncludes": {
+        "@id": "ditto:DeprecationNotice"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Boolean"
+      },
+      "rdfs:comment": {
+        "@language": "en",
+        "@value": "Boolean flag indicating whether the Thing or affordance is deprecated."
+      },
+      "rdfs:isDefinedBy": {
+        "@id": "ditto:"
+      },
+      "rdfs:label": "deprecated"
+    },
+    {
+      "@id": "ditto:supersededBy",
+      "@type": "owl:DatatypeProperty",
+      "schema:domainIncludes": {
+        "@id": "ditto:DeprecationNotice"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      },
+      "rdfs:comment": {
+        "@language": "en",
+        "@value": "A JSON Pointer (RFC 6901) referencing the replacement affordance that supersedes the deprecated one, e.g. '#/properties/newProperty'"
+      },
+      "rdfs:isDefinedBy": {
+        "@id": "ditto:"
+      },
+      "rdfs:label": "supersededBy"
+    },
+    {
+      "@id": "ditto:removalVersion",
+      "@type": "owl:DatatypeProperty",
+      "schema:domainIncludes": {
+        "@id": "ditto:DeprecationNotice"
+      },
+      "schema:rangeIncludes": {
+        "@id": "schema:Text"
+      },
+      "rdfs:comment": {
+        "@language": "en",
+        "@value": "The semantic version (SemVer) in which the deprecated affordance will be removed, e.g. '2.0.0'"
+      },
+      "rdfs:isDefinedBy": {
+        "@id": "ditto:"
+      },
+      "rdfs:label": "removalVersion"
     }
   ]
 }

--- a/documentation/src/main/resources/wot/ditto-extension.rdf
+++ b/documentation/src/main/resources/wot/ditto-extension.rdf
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
 <!--
   ~ Copyright (c) 2022 Contributors to the Eclipse Foundation
   ~
@@ -11,7 +12,6 @@
   ~ SPDX-License-Identifier: EPL-2.0
 -->
 <!-- created with https://www.easyrdf.org/converter -->
-<?xml version="1.0" encoding="utf-8" ?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:owl="http://www.w3.org/2002/07/owl#"
          xmlns:vann="http://purl.org/vocab/vann/"
@@ -22,7 +22,8 @@
   <owl:Ontology rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#">
     <vann:preferredNamespacePrefix>ditto</vann:preferredNamespacePrefix>
     <vann:preferredNamespaceUri>https://ditto.eclipseprojects.io/wot/ditto-extension#</vann:preferredNamespaceUri>
-    <owl:versionInfo>3.0.0</owl:versionInfo>
+    <owl:versionInfo>3.9.0</owl:versionInfo>
+    <owl:imports rdf:resource="https://www.w3.org/2019/wot/td#"/>
     <dc:title xml:lang="en">Eclipse Ditto™ - WoT Extension Ontology</dc:title>
     <rdfs:comment xml:lang="en">This ontology provides additional Eclipse Ditto™ specific context for Web of Things (https://www.w3.org/WoT/) TDs and TMs</rdfs:comment>
   </owl:Ontology>
@@ -31,7 +32,48 @@
     <rdfs:label>category</rdfs:label>
     <rdfs:comment xml:lang="en">Optional category for WoT Property affordances, e.g. something like 'status' or 'configuration'</rdfs:comment>
     <schema:domainIncludes rdf:resource="https://www.w3.org/2019/wot/td#PropertyAffordance"/>
-    <schema:rangeIncludes rdf:resource="http://schema.org/Text"/>
+    <schema:rangeIncludes rdf:resource="https://schema.org/Text"/>
+    <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
+  </owl:DatatypeProperty>
+
+  <owl:Class rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice">
+    <rdfs:label>DeprecationNotice</rdfs:label>
+    <rdfs:comment xml:lang="en">A structured object indicating that a WoT Thing, or an affordance (property, action, or event) is deprecated</rdfs:comment>
+    <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
+  </owl:Class>
+
+  <owl:ObjectProperty rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#deprecationNotice">
+    <rdfs:label>deprecationNotice</rdfs:label>
+    <rdfs:comment xml:lang="en">Indicates that a WoT Thing, or an affordance (property, action, or event) is deprecated. The value is a DeprecationNotice object containing deprecation details.</rdfs:comment>
+    <schema:domainIncludes rdf:resource="https://www.w3.org/2019/wot/td#Thing"/>
+    <schema:domainIncludes rdf:resource="https://www.w3.org/2019/wot/td#PropertyAffordance"/>
+    <schema:domainIncludes rdf:resource="https://www.w3.org/2019/wot/td#ActionAffordance"/>
+    <schema:domainIncludes rdf:resource="https://www.w3.org/2019/wot/td#EventAffordance"/>
+    <schema:rangeIncludes rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice"/>
+    <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
+  </owl:ObjectProperty>
+
+  <owl:DatatypeProperty rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#deprecated">
+    <rdfs:label>deprecated</rdfs:label>
+    <rdfs:comment xml:lang="en">Boolean flag indicating whether the Thing or affordance is deprecated.</rdfs:comment>
+    <schema:domainIncludes rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice"/>
+    <schema:rangeIncludes rdf:resource="https://schema.org/Boolean"/>
+    <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
+  </owl:DatatypeProperty>
+
+  <owl:DatatypeProperty rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#supersededBy">
+    <rdfs:label>supersededBy</rdfs:label>
+    <rdfs:comment xml:lang="en">A JSON Pointer (RFC 6901) referencing the replacement affordance that supersedes the deprecated one, e.g. '#/properties/newProperty'</rdfs:comment>
+    <schema:domainIncludes rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice"/>
+    <schema:rangeIncludes rdf:resource="https://schema.org/Text"/>
+    <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
+  </owl:DatatypeProperty>
+
+  <owl:DatatypeProperty rdf:about="https://ditto.eclipseprojects.io/wot/ditto-extension#removalVersion">
+    <rdfs:label>removalVersion</rdfs:label>
+    <rdfs:comment xml:lang="en">The semantic version (SemVer) in which the deprecated affordance will be removed, e.g. '2.0.0'</rdfs:comment>
+    <schema:domainIncludes rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#DeprecationNotice"/>
+    <schema:rangeIncludes rdf:resource="https://schema.org/Text"/>
     <rdfs:isDefinedBy rdf:resource="https://ditto.eclipseprojects.io/wot/ditto-extension#"/>
   </owl:DatatypeProperty>
 

--- a/documentation/src/main/resources/wot/ditto-extension.ttl
+++ b/documentation/src/main/resources/wot/ditto-extension.ttl
@@ -21,7 +21,8 @@
 ditto: rdf:type owl:Ontology ;
   vann:preferredNamespacePrefix "ditto" ;
   vann:preferredNamespaceUri "https://ditto.eclipseprojects.io/wot/ditto-extension#" ;
-  owl:versionInfo "3.0.0" ;
+  owl:versionInfo "3.9.0" ;
+  owl:imports <https://www.w3.org/2019/wot/td#> ;
   dc:title "Eclipse Ditto™ - WoT Extension Ontology"@en ;
   rdfs:comment "This ontology provides additional Eclipse Ditto™ specific context for Web of Things (https://www.w3.org/WoT/) TDs and TMs"@en .
 
@@ -29,5 +30,38 @@ ditto:category rdf:type owl:DatatypeProperty ;
   rdfs:label "category" ;
   rdfs:comment "Optional category for WoT Property affordances, e.g. something like 'status' or 'configuration'"@en ;
   schema:domainIncludes td:PropertyAffordance ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy ditto: .
+
+ditto:DeprecationNotice rdf:type owl:Class ;
+  rdfs:label "DeprecationNotice" ;
+  rdfs:comment "A structured object indicating that a WoT Thing, or an affordance (property, action, or event) is deprecated"@en ;
+  rdfs:isDefinedBy ditto: .
+
+ditto:deprecationNotice rdf:type owl:ObjectProperty ;
+  rdfs:label "deprecationNotice" ;
+  rdfs:comment "Indicates that a WoT Thing, or an affordance (property, action, or event) is deprecated. The value is a DeprecationNotice object containing deprecation details."@en ;
+  schema:domainIncludes td:Thing, td:PropertyAffordance, td:ActionAffordance, td:EventAffordance ;
+  schema:rangeIncludes ditto:DeprecationNotice ;
+  rdfs:isDefinedBy ditto: .
+
+ditto:deprecated rdf:type owl:DatatypeProperty ;
+  rdfs:label "deprecated" ;
+  rdfs:comment "Boolean flag indicating whether the Thing or affordance is deprecated."@en ;
+  schema:domainIncludes ditto:DeprecationNotice ;
+  schema:rangeIncludes schema:Boolean ;
+  rdfs:isDefinedBy ditto: .
+
+ditto:supersededBy rdf:type owl:DatatypeProperty ;
+  rdfs:label "supersededBy" ;
+  rdfs:comment "A JSON Pointer (RFC 6901) referencing the replacement affordance that supersedes the deprecated one, e.g. '#/properties/newProperty'"@en ;
+  schema:domainIncludes ditto:DeprecationNotice ;
+  schema:rangeIncludes schema:Text ;
+  rdfs:isDefinedBy ditto: .
+
+ditto:removalVersion rdf:type owl:DatatypeProperty ;
+  rdfs:label "removalVersion" ;
+  rdfs:comment "The semantic version (SemVer) in which the deprecated affordance will be removed, e.g. '2.0.0'"@en ;
+  schema:domainIncludes ditto:DeprecationNotice ;
   schema:rangeIncludes schema:Text ;
   rdfs:isDefinedBy ditto: .

--- a/wot/model/src/main/java/org/eclipse/ditto/wot/model/DittoWotExtension.java
+++ b/wot/model/src/main/java/org/eclipse/ditto/wot/model/DittoWotExtension.java
@@ -33,6 +33,23 @@ public final class DittoWotExtension {
      */
     public static final String DITTO_WOT_EXTENSION_CATEGORY = "category";
 
+    /**
+     * Indicates that a WoT Thing (ThingModel/ThingDescription), or an affordance (property, action, or event)
+     * is deprecated.
+     * The value is a JSON object containing:
+     * <ul>
+     *   <li>{@code deprecated} - boolean (required): whether the Thing or affordance is deprecated</li>
+     *   <li>{@code supersededBy} - string (optional): JSON Pointer to replacement affordance, or URL to
+     *       replacement ThingModel</li>
+     *   <li>{@code removalVersion} - string (required): SemVer version when the Thing or affordance will be
+     *       removed</li>
+     * </ul>
+     *
+     * @see <a href="https://ditto.eclipseprojects.io/wot/ditto-extension#deprecationNotice">Deprecation Notice</a>
+     * @since 3.9.0
+     */
+    public static final String DITTO_WOT_EXTENSION_DEPRECATION_NOTICE = "deprecationNotice";
+
 
     private DittoWotExtension() {
         throw new AssertionError();

--- a/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/JsonSchemaTools.java
+++ b/wot/validation/src/main/java/org/eclipse/ditto/wot/validation/JsonSchemaTools.java
@@ -109,6 +109,7 @@ final class JsonSchemaTools {
         metaSchemaBuilder.keyword(new NonValidationKeyword("@type"));
         metaSchemaBuilder.keyword(new NonValidationKeyword("unit"));
         metaSchemaBuilder.keyword(new NonValidationKeyword("ditto:category"));
+        metaSchemaBuilder.keyword(new NonValidationKeyword("ditto:deprecationNotice"));
         return JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7, builder ->
                         builder.metaSchema(metaSchemaBuilder.build())
                 )


### PR DESCRIPTION
Adds a new term to the Ditto WoT Extension Ontology that allows marking WoT Things, properties, actions, and events as deprecated.

The deprecationNotice is a structured object containing:
- deprecated: boolean indicating deprecation status
- supersededBy: optional JSON Pointer or URL to replacement
- removalVersion: SemVer version when the item will be removed

Resolves: #2320