### PR TITLE
Fix aggregate metrics using wrong scrapeInterval and showing 0ms duration

### DIFF
--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/AggregateThingsMetricsActor.java
@@ -123,11 +123,13 @@ public final class AggregateThingsMetricsActor extends AbstractActor {
                         .matchAny(error -> Source.single(asDittoRuntimeException(error, command)))
                         .build()
                 ).watchTermination((notUsed, done) -> {
-                    final long now = System.nanoTime();
-                    stopTimer(searchTimer);
-                    final long duration =
-                            Duration.ofNanos(now - searchTimer.getStartInstant().toNanos()).toMillis();
-                    log.withCorrelationId(command).info("Db aggregation for metric <{}> - took: <{}ms>", command.getMetricName(), duration);
+                    done.whenComplete((d, throwable) -> {
+                        final long now = System.nanoTime();
+                        stopTimer(searchTimer);
+                        final long duration =
+                                Duration.ofNanos(now - searchTimer.getStartInstant().toNanos()).toMillis();
+                        log.withCorrelationId(command).info("Db aggregation for metric <{}> - took: <{}ms>", command.getMetricName(), duration);
+                    });
                     return NotUsed.getInstance();
                 });
     }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/starter/actors/OperatorAggregateMetricsProviderActor.java
@@ -84,7 +84,7 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
         this.customSearchMetricConfigMap.forEach(
                 (metricName, customSearchMetricConfig) -> initializeCustomMetricTimer(metricName,
                         customSearchMetricConfig,
-                        getMaxConfiguredScrapeInterval(searchConfig.getOperatorMetricsConfig())));
+                        searchConfig.getOperatorMetricsConfig().getScrapeInterval()));
         initializeCustomMetricsCleanupTimer(searchConfig.getOperatorMetricsConfig());
     }
 
@@ -232,11 +232,13 @@ public final class OperatorAggregateMetricsProviderActor extends AbstractActorWi
     }
 
     private void initializeCustomMetricTimer(final String metricName, final CustomAggregationMetricConfig config,
-            final Duration scrapeInterval) {
+            final Duration defaultScrapeInterval) {
         if (!config.isEnabled()) {
             log.info("Custom search metric Gauge for metric <{}> is DISABLED. Skipping init.", metricName);
             return;
         }
+        final Duration scrapeInterval = config.getScrapeInterval()
+                .orElse(defaultScrapeInterval);
         // start each custom metric provider with a random initialDelay
         final Duration initialDelay = Duration.ofSeconds(
                 ThreadLocalRandom.current().nextInt(MIN_INITIAL_DELAY_SECONDS, MAX_INITIAL_DELAY_SECONDS)


### PR DESCRIPTION
Fix two bugs in operator aggregate metrics:

1. OperatorAggregateMetricsProviderActor used the maximum configured scrapeInterval for all metric timers instead of each metric's own interval. Now each metric's individual scrapeInterval is respected, falling back to the global default - consistent with how OperatorMetricsProviderActor already handles it correctly.

2. AggregateThingsMetricsActor measured aggregation duration at stream materialization time (in watchTermination's materialization lambda) instead of at stream completion time. This caused the logged duration to always be ~0ms. Now the timing is done inside done.whenComplete() which fires when the stream actually finishes.