### PR TITLE
policy activation fixed in case other expired subjects exist

### DIFF
--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ActivateTokenIntegrationStrategy.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/strategies/commands/ActivateTokenIntegrationStrategy.java
@@ -43,6 +43,7 @@ import org.eclipse.ditto.policies.model.SubjectAnnouncement;
 import org.eclipse.ditto.policies.model.SubjectExpiry;
 import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.policies.model.signals.commands.actions.ActivateTokenIntegration;
 import org.eclipse.ditto.policies.model.signals.commands.actions.ActivateTokenIntegrationResponse;
 import org.eclipse.ditto.policies.model.signals.events.PolicyActionEvent;
@@ -102,7 +103,7 @@ final class ActivateTokenIntegrationStrategy
             final Policy newPolicy = policyBuilder.build();
 
             final Optional<Result<PolicyActionEvent<?>>> alreadyExpiredSubject =
-                    checkForAlreadyExpiredSubject(newPolicy, commandHeaders, command);
+                    checkForAlreadyExpiredSubject(Subjects.newInstance(adjustedSubjects), commandHeaders, command);
             if (alreadyExpiredSubject.isPresent()) {
                 return alreadyExpiredSubject.get();
             }


### PR DESCRIPTION
- Bug symptom:
  `activatePolicyIntegration` requests fail in case of other existing subjects, which are already expired. This makes impossible to activate a subject, even the request is valid and the token `exp` is far in the future.
- Reason:
  The entire policy is checked in `ActivateTokenIntegrationStrategy` for expired subjects while other expired subjects can live hours in their grace periods before being deleted.
- Fix:
  Now only the requested subject is checked for being expired.
