### PR TITLE
Optimize ThingEventEnricher -> TreeBasedPolicyEnforcer hot path

### DIFF
--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/SubjectClassification.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/SubjectClassification.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.enforcers;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+
+/**
+ * Immutable result of classifying authorization subjects into three categories based on their permissions
+ * on a specific resource:
+ * <ul>
+ *   <li>{@code unrestricted} - subjects with full access, no revocations below</li>
+ *   <li>{@code partialOnly} - subjects with some grants but not unrestricted (partial minus unrestricted)</li>
+ *   <li>{@code effectedGranted} - subjects with grants exactly at the resource level</li>
+ * </ul>
+ *
+ * @since 3.9.0
+ */
+public final class SubjectClassification {
+
+    private static final SubjectClassification EMPTY = new SubjectClassification(
+            Collections.emptySet(), Collections.emptySet(), Collections.emptySet());
+
+    private final Set<AuthorizationSubject> unrestricted;
+    private final Set<AuthorizationSubject> partialOnly;
+    private final Set<AuthorizationSubject> effectedGranted;
+
+    private SubjectClassification(final Set<AuthorizationSubject> unrestricted,
+            final Set<AuthorizationSubject> partialOnly,
+            final Set<AuthorizationSubject> effectedGranted) {
+        this.unrestricted = Collections.unmodifiableSet(unrestricted);
+        this.partialOnly = Collections.unmodifiableSet(partialOnly);
+        this.effectedGranted = Collections.unmodifiableSet(effectedGranted);
+    }
+
+    /**
+     * Creates a new {@code SubjectClassification} from the given sets.
+     *
+     * @param unrestricted subjects with full access, no revocations below.
+     * @param partialOnly subjects with some grants but not unrestricted.
+     * @param effectedGranted subjects with grants exactly at the resource level.
+     * @return the new SubjectClassification.
+     */
+    public static SubjectClassification of(final Set<AuthorizationSubject> unrestricted,
+            final Set<AuthorizationSubject> partialOnly,
+            final Set<AuthorizationSubject> effectedGranted) {
+        return new SubjectClassification(unrestricted, partialOnly, effectedGranted);
+    }
+
+    /**
+     * Returns an empty {@code SubjectClassification} with no subjects in any category.
+     *
+     * @return the empty SubjectClassification.
+     */
+    public static SubjectClassification empty() {
+        return EMPTY;
+    }
+
+    /**
+     * Returns the subjects with unrestricted (full) access.
+     *
+     * @return an unmodifiable set of unrestricted subjects.
+     */
+    public Set<AuthorizationSubject> getUnrestricted() {
+        return unrestricted;
+    }
+
+    /**
+     * Returns the subjects with partial access only (not unrestricted).
+     *
+     * @return an unmodifiable set of partial-only subjects.
+     */
+    public Set<AuthorizationSubject> getPartialOnly() {
+        return partialOnly;
+    }
+
+    /**
+     * Returns the subjects with grants exactly at the resource level.
+     *
+     * @return an unmodifiable set of effected granted subjects.
+     */
+    public Set<AuthorizationSubject> getEffectedGranted() {
+        return effectedGranted;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final SubjectClassification that = (SubjectClassification) o;
+        return Objects.equals(unrestricted, that.unrestricted) &&
+                Objects.equals(partialOnly, that.partialOnly) &&
+                Objects.equals(effectedGranted, that.effectedGranted);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(unrestricted, partialOnly, effectedGranted);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [" +
+                "unrestricted=" + unrestricted +
+                ", partialOnly=" + partialOnly +
+                ", effectedGranted=" + effectedGranted +
+                "]";
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/ClassifySubjectsVisitor.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/ClassifySubjectsVisitor.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.enforcers.tree;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.enforcers.SubjectClassification;
+
+/**
+ * A single visitor that walks the policy tree once and classifies all subjects into three categories:
+ * partial, unrestricted, and effected granted. This replaces the need for three separate tree walks
+ * using {@code CollectPartialGrantedSubjectsVisitor}, {@code CollectUnrestrictedSubjectsVisitor},
+ * and {@code CollectEffectedSubjectsVisitor}.
+ *
+ * <p>Per subject, maintains 3 {@link WeightedPermissions} instances tracking different aggregation strategies:</p>
+ * <table>
+ *   <tr><th>WeightedPermissions</th><th>ABOVE/SAME grants</th><th>ABOVE/SAME revokes</th>
+ *       <th>BELOW grants</th><th>BELOW revokes</th></tr>
+ *   <tr><td>partialWeights</td><td>yes</td><td>yes</td><td>yes</td><td>no</td></tr>
+ *   <tr><td>unrestrictedWeights</td><td>yes</td><td>yes</td><td>no</td><td>yes</td></tr>
+ *   <tr><td>effectedWeights</td><td>yes</td><td>yes</td><td>no</td><td>no</td></tr>
+ * </table>
+ *
+ * @since 3.9.0
+ */
+@NotThreadSafe
+final class ClassifySubjectsVisitor implements Visitor<SubjectClassification> {
+
+    private final Permissions expectedPermissions;
+    private final Function<JsonPointer, PointerLocation> pointerLocationEvaluator;
+    private final Collection<ResourceNodeEvaluator> evaluators;
+    @Nullable private ResourceNodeEvaluator currentEvaluator;
+
+    /**
+     * Constructs a new {@code ClassifySubjectsVisitor} object.
+     *
+     * @param resourcePointer the resource pointer to classify subjects for.
+     * @param expectedPermissions the permissions to check.
+     */
+    ClassifySubjectsVisitor(final JsonPointer resourcePointer, final Permissions expectedPermissions) {
+        this.expectedPermissions = expectedPermissions;
+        this.pointerLocationEvaluator = new PointerLocationEvaluator(resourcePointer);
+        this.evaluators = new HashSet<>();
+        this.currentEvaluator = null;
+    }
+
+    @Override
+    public void visitTreeNode(final PolicyTreeNode node) {
+        if (PolicyTreeNode.Type.SUBJECT == node.getType()) {
+            visitSubjectNode(node);
+        } else {
+            visitResourceNode((ResourceNode) node);
+        }
+    }
+
+    private void visitSubjectNode(final PolicyTreeNode subjectNode) {
+        final String currentSubjectId = subjectNode.getName();
+        currentEvaluator = new ResourceNodeEvaluator(currentSubjectId);
+        evaluators.add(currentEvaluator);
+    }
+
+    private void visitResourceNode(final ResourceNode resourceNode) {
+        if (null != currentEvaluator) {
+            currentEvaluator.aggregateWeightedPermissions(resourceNode);
+        }
+    }
+
+    @Override
+    public SubjectClassification get() {
+        final Set<AuthorizationSubject> partialSubjects = new HashSet<>();
+        final Set<AuthorizationSubject> unrestrictedSubjects = new HashSet<>();
+        final EffectedSubjectsBuilder effectedSubjectsBuilder = new EffectedSubjectsBuilder();
+
+        for (final ResourceNodeEvaluator evaluator : evaluators) {
+            evaluator.evaluate(partialSubjects, unrestrictedSubjects, effectedSubjectsBuilder);
+        }
+
+        final Set<AuthorizationSubject> partialOnly = new HashSet<>(partialSubjects);
+        partialOnly.removeAll(unrestrictedSubjects);
+
+        return SubjectClassification.of(
+                unrestrictedSubjects,
+                partialOnly,
+                effectedSubjectsBuilder.build().getGranted()
+        );
+    }
+
+    /**
+     * Aggregates and evaluates permissions for a single subject using three weight sets.
+     */
+    @NotThreadSafe
+    private final class ResourceNodeEvaluator {
+
+        private final AuthorizationSubject authorizationSubject;
+        private final WeightedPermissions partialWeights;
+        private final WeightedPermissions unrestrictedWeights;
+        private final WeightedPermissions effectedWeights;
+
+        private ResourceNodeEvaluator(final CharSequence subjectId) {
+            this.authorizationSubject = AuthorizationModelFactory.newAuthSubject(subjectId);
+            this.partialWeights = new WeightedPermissions();
+            this.unrestrictedWeights = new WeightedPermissions();
+            this.effectedWeights = new WeightedPermissions();
+        }
+
+        private void aggregateWeightedPermissions(final ResourceNode resourceNode) {
+            final PointerLocation pointerLocation =
+                    pointerLocationEvaluator.apply(resourceNode.getAbsolutePointer());
+            final EffectedPermissions effectedPermissions = resourceNode.getPermissions();
+            final Permissions grantedPermissions = effectedPermissions.getGrantedPermissions();
+            final Permissions revokedPermissions = effectedPermissions.getRevokedPermissions();
+            final int level = resourceNode.getLevel();
+
+            if (PointerLocation.ABOVE == pointerLocation || PointerLocation.SAME == pointerLocation) {
+                // All three weight sets get ABOVE/SAME grants and revokes
+                partialWeights.addGranted(grantedPermissions, level);
+                partialWeights.addRevoked(revokedPermissions, level);
+
+                unrestrictedWeights.addGranted(grantedPermissions, level);
+                unrestrictedWeights.addRevoked(revokedPermissions, level);
+
+                effectedWeights.addGranted(grantedPermissions, level);
+                effectedWeights.addRevoked(revokedPermissions, level);
+            } else if (PointerLocation.BELOW == pointerLocation) {
+                // Partial: BELOW grants only (no BELOW revokes)
+                partialWeights.addGranted(grantedPermissions, level);
+
+                // Unrestricted: BELOW revokes only (no BELOW grants)
+                unrestrictedWeights.addRevoked(revokedPermissions, level);
+
+                // Effected: nothing for BELOW
+            }
+        }
+
+        private void evaluate(final Set<AuthorizationSubject> partialSubjects,
+                final Set<AuthorizationSubject> unrestrictedSubjects,
+                final EffectedSubjectsBuilder effectedSubjectsBuilder) {
+
+            // Evaluate partial (same logic as CollectPartialGrantedSubjectsVisitor)
+            evaluatePartial(partialSubjects);
+
+            // Evaluate unrestricted (same logic as CollectUnrestrictedSubjectsVisitor)
+            evaluateUnrestricted(unrestrictedSubjects);
+
+            // Evaluate effected (same logic as CollectEffectedSubjectsVisitor)
+            evaluateEffected(effectedSubjectsBuilder);
+        }
+
+        private void evaluatePartial(final Set<AuthorizationSubject> partialSubjects) {
+            final Map<String, WeightedPermission> revoked =
+                    partialWeights.getRevokedWithHighestWeight(expectedPermissions);
+            final Map<String, WeightedPermission> granted =
+                    partialWeights.getGrantedWithHighestWeight(expectedPermissions);
+            if (areExpectedPermissionsEffectivelyRevoked(revoked, granted)) {
+                partialSubjects.remove(authorizationSubject);
+            } else if (areExpectedPermissionsEffectivelyGranted(granted, revoked)) {
+                partialSubjects.add(authorizationSubject);
+            }
+        }
+
+        private void evaluateUnrestricted(final Set<AuthorizationSubject> unrestrictedSubjects) {
+            final Map<String, WeightedPermission> revoked =
+                    unrestrictedWeights.getRevokedWithHighestWeight(expectedPermissions);
+            final Map<String, WeightedPermission> granted =
+                    unrestrictedWeights.getGrantedWithHighestWeight(expectedPermissions);
+            if (areExpectedPermissionsEffectivelyRevoked(revoked, granted)) {
+                unrestrictedSubjects.remove(authorizationSubject);
+            } else if (areExpectedPermissionsEffectivelyGranted(granted, revoked)) {
+                unrestrictedSubjects.add(authorizationSubject);
+            }
+        }
+
+        private void evaluateEffected(final EffectedSubjectsBuilder effectedSubjectsBuilder) {
+            final Map<String, WeightedPermission> revoked =
+                    effectedWeights.getRevokedWithHighestWeight(expectedPermissions);
+            final Map<String, WeightedPermission> granted =
+                    effectedWeights.getGrantedWithHighestWeight(expectedPermissions);
+            if (areExpectedPermissionsEffectivelyRevoked(revoked, granted)) {
+                effectedSubjectsBuilder.withRevoked(authorizationSubject);
+            } else if (areExpectedPermissionsEffectivelyGranted(granted, revoked)) {
+                effectedSubjectsBuilder.withGranted(authorizationSubject);
+            }
+        }
+
+        @SuppressWarnings("MethodWithMultipleReturnPoints")
+        private boolean areExpectedPermissionsEffectivelyRevoked(final Map<String, WeightedPermission> revoked,
+                final Map<String, WeightedPermission> granted) {
+
+            if (revoked.size() != expectedPermissions.size()) {
+                return false;
+            }
+
+            for (final String expectedPermission : expectedPermissions) {
+                final WeightedPermission revokedPermission = revoked.get(expectedPermission);
+                final WeightedPermission grantedPermission = granted.get(expectedPermission);
+                if (null != grantedPermission) {
+                    final int grantedPermissionWeight = grantedPermission.getWeight();
+                    final int revokedPermissionWeight = revokedPermission.getWeight();
+                    if (grantedPermissionWeight > revokedPermissionWeight) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        @SuppressWarnings("MethodWithMultipleReturnPoints")
+        private boolean areExpectedPermissionsEffectivelyGranted(final Map<String, WeightedPermission> granted,
+                final Map<String, WeightedPermission> revoked) {
+
+            if (granted.size() != expectedPermissions.size()) {
+                return false;
+            }
+
+            for (final String expectedPermission : expectedPermissions) {
+                final WeightedPermission grantedPermission = granted.get(expectedPermission);
+                final WeightedPermission revokedPermission = revoked.get(expectedPermission);
+                if (null != revokedPermission) {
+                    final int revokedPermissionWeight = revokedPermission.getWeight();
+                    final int grantedPermissionWeight = grantedPermission.getWeight();
+                    if (revokedPermissionWeight >= grantedPermissionWeight) {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+
+}

--- a/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
+++ b/policies/model/src/main/java/org/eclipse/ditto/policies/model/enforcers/tree/TreeBasedPolicyEnforcer.java
@@ -49,6 +49,7 @@ import org.eclipse.ditto.policies.model.SubjectId;
 import org.eclipse.ditto.policies.model.Subjects;
 import org.eclipse.ditto.policies.model.enforcers.EffectedSubjects;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.policies.model.enforcers.SubjectClassification;
 
 /**
  * Holds Algorithms to create a policy tree and to perform different policy checks on this tree.
@@ -56,6 +57,7 @@ import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 public final class TreeBasedPolicyEnforcer implements Enforcer {
 
     private static final String ROOT_RESOURCE = "/";
+    private static final JsonPointer ROOT_RESOURCE_POINTER = JsonFactory.newPointer(ROOT_RESOURCE);
 
     /**
      * Maps subject ID to {@link org.eclipse.ditto.policies.model.enforcers.tree.SubjectNode} whose children are {@link org.eclipse.ditto.policies.model.enforcers.tree.ResourceNode} for which the subject is granted
@@ -228,6 +230,14 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     }
 
     @Override
+    public SubjectClassification classifySubjects(final ResourceKey resourceKey, final Permissions permissions) {
+        checkResourceKey(resourceKey);
+        checkPermissions(permissions);
+        final JsonPointer resourcePointer = createAbsoluteResourcePointer(resourceKey);
+        return visitTree(new ClassifySubjectsVisitor(resourcePointer, permissions));
+    }
+
+    @Override
     public JsonObject buildJsonView(
             final ResourceKey resourceKey,
             final Iterable<JsonField> jsonFields,
@@ -240,7 +250,7 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         final Collection<String> authorizationSubjectIds = getAuthorizationSubjectIds(authorizationContext);
 
         final EffectedResources effectedResources = getGrantedAndRevokedSubResource(
-                JsonFactory.newPointer(ROOT_RESOURCE), resourceKey.getResourceType(), authorizationSubjectIds,
+                ROOT_RESOURCE_POINTER, resourceKey.getResourceType(), authorizationSubjectIds,
                 permissions);
 
         if (jsonFields instanceof JsonObject && ((JsonObject) jsonFields).isNull()) {
@@ -272,7 +282,7 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
         final Collection<String> authorizationSubjectIds = getAuthorizationSubjectIds(authorizationContext);
 
         final EffectedResources effectedResources = getGrantedAndRevokedSubResource(
-                JsonFactory.newPointer(ROOT_RESOURCE), resourceKey.getResourceType(), authorizationSubjectIds,
+                ROOT_RESOURCE_POINTER, resourceKey.getResourceType(), authorizationSubjectIds,
                 permissions);
 
         if (jsonFields instanceof JsonObject && ((JsonObject) jsonFields).isNull()) {
@@ -289,6 +299,46 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
                 .map(pv -> new PointerAndValue(resourcePath.append(pv.pointer), pv.value))
                 .collect(Collectors.toList());
         return extractAccessiblePaths(prefixedPointers, grantedResources, revokedResources, resourcePath);
+    }
+
+    @Override
+    public Map<AuthorizationSubject, Set<JsonPointer>> getAccessiblePathsForSubjects(
+            final ResourceKey resourceKey, final Iterable<JsonField> jsonFields,
+            final Set<AuthorizationSubject> authorizationSubjects, final Permissions permissions) {
+
+        checkResourceKey(resourceKey);
+        checkNotNull(jsonFields, "JSON fields");
+        checkPermissions(permissions);
+
+        if (jsonFields instanceof JsonObject && ((JsonObject) jsonFields).isNull()) {
+            return Collections.emptyMap();
+        }
+
+        // 1. Flatten once
+        final List<PointerAndValue> flatPointers = new ArrayList<>();
+        jsonFields.forEach(jf -> collectFlatPointers(jf.getKey().asPointer(), jf, flatPointers));
+        final JsonPointer resourcePath = resourceKey.getResourcePath();
+        final List<PointerAndValue> prefixedPointers = flatPointers.stream()
+                .map(pv -> new PointerAndValue(resourcePath.append(pv.pointer), pv.value))
+                .collect(Collectors.toList());
+
+        // 2. Per-subject: tree walk + filter (reusing prefixedPointers)
+        final Map<AuthorizationSubject, Set<JsonPointer>> result = new HashMap<>();
+        for (final AuthorizationSubject subject : authorizationSubjects) {
+            final Collection<String> subjectIds = Collections.singleton(subject.getId());
+            final EffectedResources effectedResources = getGrantedAndRevokedSubResource(
+                    ROOT_RESOURCE_POINTER, resourceKey.getResourceType(), subjectIds, permissions);
+
+            final Set<JsonPointer> grantedResources = extractJsonPointers(effectedResources.getGrantedResources());
+            final Set<JsonPointer> revokedResources = extractJsonPointers(effectedResources.getRevokedResources());
+
+            final Set<JsonPointer> paths = extractAccessiblePaths(
+                    prefixedPointers, grantedResources, revokedResources, resourcePath);
+            if (!paths.isEmpty()) {
+                result.put(subject, paths);
+            }
+        }
+        return result;
     }
 
     private static Set<JsonPointer> extractJsonPointers(final Collection<PointerAndPermission> resources) {
@@ -385,9 +435,8 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
     private static boolean isAccessible(final JsonPointer pointer,
             final Collection<JsonPointer> grantedResources,
             final Collection<JsonPointer> revokedResources) {
-        final JsonPointer rootResourcePointer = JsonFactory.newPointer(ROOT_RESOURCE);
-        boolean accessible = grantedResources.contains(rootResourcePointer) &&
-                !revokedResources.contains(rootResourcePointer);
+        boolean accessible = grantedResources.contains(ROOT_RESOURCE_POINTER) &&
+                !revokedResources.contains(ROOT_RESOURCE_POINTER);
 
         final int levelCount = pointer.getLevelCount();
         if (levelCount > 0) {
@@ -597,7 +646,7 @@ public final class TreeBasedPolicyEnforcer implements Enforcer {
             final ResourceNode resourceNode) {
 
         final JsonPointer resourceToAdd = ROOT_RESOURCE.equals(resource.toString())
-                ? JsonFactory.newPointer(ROOT_RESOURCE)
+                ? ROOT_RESOURCE_POINTER
                 : getPrefixPointerOrThrow(resource, level);
         final EffectedPermissions effectedPermissions = resourceNode.getPermissions();
         if (effectedPermissions.getGrantedPermissions().contains(permission)) {

--- a/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/ClassifySubjectsVisitorTest.java
+++ b/policies/model/src/test/java/org/eclipse/ditto/policies/model/enforcers/tree/ClassifySubjectsVisitorTest.java
@@ -1,0 +1,363 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.model.enforcers.tree;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.enforcers.EffectedSubjects;
+import org.eclipse.ditto.policies.model.enforcers.SubjectClassification;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link ClassifySubjectsVisitor}.
+ * <p>
+ * Verifies that the combined single-pass visitor produces the same results as
+ * the three individual visitors ({@code CollectPartialGrantedSubjectsVisitor},
+ * {@code CollectUnrestrictedSubjectsVisitor}, {@code CollectEffectedSubjectsVisitor}).
+ * </p>
+ */
+public final class ClassifySubjectsVisitorTest {
+
+    private static final Permissions READ = Permissions.newInstance("READ");
+    private static final Permissions READ_WRITE = Permissions.newInstance("READ", "WRITE");
+
+    @Test
+    public void emptyPolicyReturnsEmptyClassification() {
+        final PolicyId policyId = PolicyId.of("ns", "empty");
+        final TreeBasedPolicyEnforcer enforcer =
+                TreeBasedPolicyEnforcer.createInstance(Policy.newBuilder(policyId).build());
+
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+
+        assertThat(classification.getUnrestricted()).isEmpty();
+        assertThat(classification.getPartialOnly()).isEmpty();
+        assertThat(classification.getEffectedGranted()).isEmpty();
+    }
+
+    @Test
+    public void singleSubjectFullGrantMatchesIndividualVisitors() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:full");
+        final PolicyId policyId = PolicyId.of("ns", "single-full");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("grant-all")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        assertThat(classification.getUnrestricted()).containsExactly(subject);
+        assertThat(classification.getPartialOnly()).isEmpty();
+        assertThat(classification.getEffectedGranted()).containsExactly(subject);
+    }
+
+    @Test
+    public void subjectWithRevokedChildIsNotUnrestricted() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:revoked-child");
+        final PolicyId policyId = PolicyId.of("ns", "revoked-child");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("grant")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("revoke")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes/secret"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        // Has grants at root + below, so partial. But has revoke below -> not unrestricted.
+        assertThat(classification.getUnrestricted()).doesNotContain(subject);
+        assertThat(classification.getPartialOnly()).contains(subject);
+        assertThat(classification.getEffectedGranted()).contains(subject);
+    }
+
+    @Test
+    public void multipleSubjectsWithMixedPermissions() {
+        final AuthorizationSubject fullAccess = AuthorizationSubject.newInstance("test:full");
+        final AuthorizationSubject partialAccess = AuthorizationSubject.newInstance("test:partial");
+        final AuthorizationSubject noAccess = AuthorizationSubject.newInstance("test:none");
+
+        final PolicyId policyId = PolicyId.of("ns", "multi");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("full-grant")
+                .setSubject(fullAccess.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("partial-grant")
+                .setSubject(partialAccess.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/attributes/location"), READ)
+                .forLabel("no-access")
+                .setSubject(noAccess.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), Permissions.newInstance("WRITE"))
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        assertThat(classification.getUnrestricted()).containsExactly(fullAccess);
+        assertThat(classification.getPartialOnly()).containsExactly(partialAccess);
+        assertThat(classification.getEffectedGranted()).contains(fullAccess);
+        assertThat(classification.getEffectedGranted()).doesNotContain(partialAccess);
+        assertThat(classification.getEffectedGranted()).doesNotContain(noAccess);
+    }
+
+    @Test
+    public void subjectWithOnlyBelowGrantIsPartialOnly() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:below-only");
+        final PolicyId policyId = PolicyId.of("ns", "below-only");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("below-grant")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(
+                        PoliciesResourceType.thingResource("/features/sensor/properties/value"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        assertThat(classification.getUnrestricted()).isEmpty();
+        assertThat(classification.getPartialOnly()).containsExactly(subject);
+        assertThat(classification.getEffectedGranted()).isEmpty();
+    }
+
+    @Test
+    public void revokedAtRootMeansNotPartialAndNotUnrestricted() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:revoked-root");
+        final PolicyId policyId = PolicyId.of("ns", "revoked-root");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("revoke")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setRevokedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        assertThat(classification.getUnrestricted()).isEmpty();
+        assertThat(classification.getPartialOnly()).isEmpty();
+        assertThat(classification.getEffectedGranted()).isEmpty();
+    }
+
+    @Test
+    public void nestedResourceQueryMatchesIndividualVisitors() {
+        final AuthorizationSubject subjectA = AuthorizationSubject.newInstance("test:a");
+        final AuthorizationSubject subjectB = AuthorizationSubject.newInstance("test:b");
+
+        final PolicyId policyId = PolicyId.of("ns", "nested");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("a-full")
+                .setSubject(subjectA.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("b-features")
+                .setSubject(subjectB.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/features"), READ)
+                .setRevokedPermissions(
+                        PoliciesResourceType.thingResource("/features/private"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+
+        // Query at /features level
+        final ResourceKey featuresKey = PoliciesResourceType.thingResource("/features");
+        final SubjectClassification classification = enforcer.classifySubjects(featuresKey, READ);
+        assertMatchesIndividualVisitors(enforcer, featuresKey, READ, classification);
+    }
+
+    @Test
+    public void multiplePermissionsReadWriteMatchesIndividualVisitors() {
+        final AuthorizationSubject rwSubject = AuthorizationSubject.newInstance("test:rw");
+        final AuthorizationSubject rOnlySubject = AuthorizationSubject.newInstance("test:r-only");
+
+        final PolicyId policyId = PolicyId.of("ns", "multi-perm");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("rw-full")
+                .setSubject(rwSubject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ_WRITE)
+                .forLabel("r-only")
+                .setSubject(rOnlySubject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        // Check READ_WRITE: rOnlySubject should NOT appear as it only has READ
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ_WRITE);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ_WRITE, classification);
+
+        assertThat(classification.getUnrestricted()).containsExactly(rwSubject);
+        assertThat(classification.getEffectedGranted()).containsExactly(rwSubject);
+    }
+
+    @Test
+    public void complexScenarioWithGrantRevokeReGrant() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:complex");
+
+        final PolicyId policyId = PolicyId.of("ns", "complex");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("root-grant")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("attributes-revoke")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setRevokedPermissions(PoliciesResourceType.thingResource("/attributes"), READ)
+                .forLabel("location-re-grant")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(
+                        PoliciesResourceType.thingResource("/attributes/location"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        // Has revoke below root -> not unrestricted, but partial (has grants at/below root)
+        assertThat(classification.getUnrestricted()).doesNotContain(subject);
+        assertThat(classification.getPartialOnly()).contains(subject);
+    }
+
+    @Test
+    public void differentResourceTypesAreIsolated() {
+        final AuthorizationSubject subject = AuthorizationSubject.newInstance("test:policy-only");
+
+        final PolicyId policyId = PolicyId.of("ns", "type-isolation");
+        final Policy policy = Policy.newBuilder(policyId)
+                .forLabel("policy-grant")
+                .setSubject(subject.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.policyResource("/"), READ)
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+
+        // Query thing resource -> should be empty
+        final ResourceKey thingKey = PoliciesResourceType.thingResource("/");
+        final SubjectClassification thingClassification = enforcer.classifySubjects(thingKey, READ);
+        assertMatchesIndividualVisitors(enforcer, thingKey, READ, thingClassification);
+
+        assertThat(thingClassification.getUnrestricted()).isEmpty();
+        assertThat(thingClassification.getPartialOnly()).isEmpty();
+        assertThat(thingClassification.getEffectedGranted()).isEmpty();
+
+        // Query policy resource -> should have the subject
+        final ResourceKey policyKey = PoliciesResourceType.policyResource("/");
+        final SubjectClassification policyClassification = enforcer.classifySubjects(policyKey, READ);
+        assertMatchesIndividualVisitors(enforcer, policyKey, READ, policyClassification);
+
+        assertThat(policyClassification.getUnrestricted()).containsExactly(subject);
+    }
+
+    @Test
+    public void manySubjectsWithOverlappingPermissions() {
+        final AuthorizationSubject s1 = AuthorizationSubject.newInstance("test:s1");
+        final AuthorizationSubject s2 = AuthorizationSubject.newInstance("test:s2");
+        final AuthorizationSubject s3 = AuthorizationSubject.newInstance("test:s3");
+        final AuthorizationSubject s4 = AuthorizationSubject.newInstance("test:s4");
+
+        final PolicyId policyId = PolicyId.of("ns", "many");
+        final Policy policy = Policy.newBuilder(policyId)
+                // s1: full unrestricted
+                .forLabel("s1")
+                .setSubject(s1.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                // s2: partial only (grant below)
+                .forLabel("s2")
+                .setSubject(s2.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(
+                        PoliciesResourceType.thingResource("/features/public"), READ)
+                // s3: grant at root but revoked below -> partial
+                .forLabel("s3-grant")
+                .setSubject(s3.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"), READ)
+                .forLabel("s3-revoke")
+                .setSubject(s3.getId(), SubjectType.GENERATED)
+                .setRevokedPermissions(
+                        PoliciesResourceType.thingResource("/features/private"), READ)
+                // s4: only WRITE, no READ
+                .forLabel("s4")
+                .setSubject(s4.getId(), SubjectType.GENERATED)
+                .setGrantedPermissions(PoliciesResourceType.thingResource("/"),
+                        Permissions.newInstance("WRITE"))
+                .build();
+
+        final TreeBasedPolicyEnforcer enforcer = TreeBasedPolicyEnforcer.createInstance(policy);
+        final ResourceKey resourceKey = PoliciesResourceType.thingResource("/");
+
+        final SubjectClassification classification = enforcer.classifySubjects(resourceKey, READ);
+        assertMatchesIndividualVisitors(enforcer, resourceKey, READ, classification);
+
+        assertThat(classification.getUnrestricted()).containsExactly(s1);
+        assertThat(classification.getPartialOnly()).containsExactlyInAnyOrder(s2, s3);
+        assertThat(classification.getEffectedGranted()).containsExactlyInAnyOrder(s1, s3);
+    }
+
+    /**
+     * Asserts that the classification result matches what the three individual visitor methods return.
+     */
+    private static void assertMatchesIndividualVisitors(
+            final TreeBasedPolicyEnforcer enforcer,
+            final ResourceKey resourceKey,
+            final Permissions permissions,
+            final SubjectClassification classification) {
+
+        final Set<AuthorizationSubject> partial =
+                enforcer.getSubjectsWithPartialPermission(resourceKey, permissions);
+        final Set<AuthorizationSubject> unrestricted =
+                enforcer.getSubjectsWithUnrestrictedPermission(resourceKey, permissions);
+        final EffectedSubjects effected = enforcer.getSubjectsWithPermission(resourceKey, permissions);
+
+        // partialOnly = partial - unrestricted
+        final Set<AuthorizationSubject> expectedPartialOnly = new HashSet<>(partial);
+        expectedPartialOnly.removeAll(unrestricted);
+
+        assertThat(classification.getUnrestricted())
+                .as("unrestricted subjects")
+                .containsExactlyInAnyOrderElementsOf(unrestricted);
+        assertThat(classification.getPartialOnly())
+                .as("partialOnly subjects")
+                .containsExactlyInAnyOrderElementsOf(expectedPartialOnly);
+        assertThat(classification.getEffectedGranted())
+                .as("effectedGranted subjects")
+                .containsExactlyInAnyOrderElementsOf(effected.getGranted());
+    }
+
+}


### PR DESCRIPTION
Reduce redundant policy tree walks and thing.toJson() serializations in the per-ThingEvent enrichment path, which JFR profiling identified as the No. 1 CPU hotspot on production things nodes.

- Add ClassifySubjectsVisitor that replaces 3 separate tree walks (partial/unrestricted/effected) with a single pass, returning a SubjectClassification result. Expose as classifySubjects() on the Enforcer interface with an optimized override in TreeBasedPolicyEnforcer.

- Add batch getAccessiblePathsForSubjects() that flattens Thing JSON into leaf pointers once per batch instead of once per subject. Default method on Enforcer with an optimized override in TreeBasedPolicyEnforcer.

- Cache thing.toJson() once at the top of enrichWithPredefinedExtraFields() and thread the JsonObject through ReadGrantCollector, PartialAccessPathCalculator, and the extra fields header builder, eliminating redundant serializations per event.

- Extract ROOT_RESOURCE_POINTER constant in TreeBasedPolicyEnforcer to avoid repeated JsonFactory.newPointer("/") allocations.