### PR TITLE
Fix ThingPersistenceActorTest flaky timeout on CI with 1-2 cores

### DIFF
--- a/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/persistence/actors/ThingPersistenceActorTest.java
@@ -2146,7 +2146,10 @@ public final class ThingPersistenceActorTest extends PersistenceActorTestBase {
                 RetrieveThing retrieveThing = RetrieveThing.of(thingId, dittoHeaders);
                 underTest.tell(retrieveThing, getRef());
                 policiesShardRegionTestProbe.expectNoMessage();
-                expectMsgClass(ThingUnavailableException.class);
+                // Use explicit timeout: on CI with 1-2 cores, the child actor creation may not have
+                // completed yet when the command arrives, causing the supervisor to forward the command
+                // to the dying child via ask with localAskTimeoutDuringRecovery (5s in test config).
+                expectMsgClass(java.time.Duration.ofSeconds(10), ThingUnavailableException.class);
                 expectNoMessage();
 
             }

--- a/things/service/src/test/resources/thing-test.conf
+++ b/things/service/src/test/resources/thing-test.conf
@@ -14,6 +14,10 @@ thing {
       max = 10s
       random-factor = 0.2
     }
+    local-ask {
+      # Reduced from default 45s to avoid long waits in tests when ask is sent to a dead/dying child actor
+      timeout-during-recovery = 5s
+    }
   }
   merge {
     remove-empty-objects-after-patch-condition-filtering = false


### PR DESCRIPTION
Reduce timeout-during-recovery to 5s in test config and use explicit 10s expectMsgClass timeout to handle the race between child actor creation failure and command processing.