### PR TITLE
Optimize MongoReadJournal pipelines and bump dependency versions

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -45,7 +45,7 @@
 
         <pekko-bom.version>1.4.0</pekko-bom.version>
         <pekko-http-bom.version>1.3.0</pekko-http-bom.version>
-        <pekko-persistence-mongodb.version>1.3.1</pekko-persistence-mongodb.version>
+        <pekko-persistence-mongodb.version>1.4.0</pekko-persistence-mongodb.version>
         <pekko-persistence-inmemory.version>1.3.0</pekko-persistence-inmemory.version>
         <pekko-management.version>1.1.1</pekko-management.version>
         <pekko-connector-kafka.version>1.1.0</pekko-connector-kafka.version>
@@ -55,7 +55,7 @@
         <metrics4-scala.version>4.3.7</metrics4-scala.version>
 
         <!-- Keep these version consistent with pekko-persistence-mongodb.version's build.sbt -->
-        <mongo-java-driver.version>5.6.0</mongo-java-driver.version>
+        <mongo-java-driver.version>5.6.4</mongo-java-driver.version>
 
         <!-- AWS SDK version needed for MongoDB AWS IAM authentication -->
         <awssdk.version>2.33.0</awssdk.version>
@@ -66,7 +66,7 @@
         <pjfanning-pekko-rabbitmq.version>7.0.0</pjfanning-pekko-rabbitmq.version>
         <amqp-client.version>5.25.0</amqp-client.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
-        <netty-bom.version>4.2.4.Final</netty-bom.version>
+        <netty-bom.version>4.2.10.Final</netty-bom.version>
         <cloudevents.version>2.5.0</cloudevents.version>
 
         <slf4j.version>2.0.17</slf4j.version>

--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -18,7 +18,7 @@ ditto {
 
       # additional index which speeds up background (e.g. cleanup) aggregation queries
       # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
-      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = true
       should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/config/MongoReadJournalConfig.java
@@ -93,7 +93,7 @@ public interface MongoReadJournalConfig {
          * Whether additional index for "pid" + "sn" + "_id" should be created in order to speed up MongoReadJournal aggregation
          * queries on the snapshot collection.
          */
-        SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID("should-create-additional-snapshot-aggregation-index-pid-sn-id", false),
+        SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID("should-create-additional-snapshot-aggregation-index-pid-sn-id", true),
 
         /**
          * Hint name for aggregation done in {@code filterPidsThatDoesntContainTagInNewestEntry}.

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -166,6 +166,44 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
 
     private static final Duration MAX_BACK_OFF_DURATION = Duration.ofSeconds(128L);
 
+    private static final BsonDocument FILTER_PRIORITY_TAGS_EXPR = BsonDocument.parse(
+            "{" +
+                    "  $filter: {" +
+                    "    input: \"$" + J_TAGS + "\"," +
+                    "    as: \"tags\"," +
+                    "    cond: {" +
+                    "      $eq: [" +
+                    "        { $substrCP: [\"$$tags\", 0, " + PRIORITY_TAG_PREFIX.length() + "] }," +
+                    "        \"" + PRIORITY_TAG_PREFIX + "\"" +
+                    "      ]" +
+                    "    }" +
+                    "  }" +
+                    "}");
+
+    private static final BsonDocument DOCDB_MAP_PRIORITY_TAGS_EXPR = BsonDocument.parse(
+            "{" +
+                    "  $map: {" +
+                    "    input: \"$" + J_TAGS + "\"," +
+                    "    as: \"tag\"," +
+                    "    in: {" +
+                    "      $reduce: {" +
+                    "        input: {" +
+                    "          $range: [0, {" +
+                    "            $subtract: [1000, {" +
+                    "              $strLenCP: {" +
+                    "                $substrCP: [\"$$tag\", " + PRIORITY_TAG_PREFIX.length() +
+                    ", { $strLenCP: \"$$tag\" }]" +
+                    "              }" +
+                    "            }]" +
+                    "          }]" +
+                    "        }," +
+                    "        initialValue: \"$$tag\"," +
+                    "        in: { $concat: [\" \", \"$$value\"] }" +
+                    "      }" +
+                    "    }" +
+                    "  }" +
+                    "}");
+
     private static final Index TAG_PID_INDEX =
             IndexFactory.newInstance("ditto_tag_pid", List.of(J_TAGS, J_PROCESSOR_ID), false, true);
 
@@ -398,16 +436,20 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
 
     private Source<String, NotUsed> filterPidsThatDoesntContainTagInNewestEntry(final MongoCollection<Document> journal,
             final List<String> pids, final String tag) {
-        final AggregatePublisher<Document> aggregate = journal.aggregate(List.of(
-                Aggregates.match(Filters.in(J_PROCESSOR_ID, pids)),
-                Aggregates.sort(Sorts.descending(J_TO)),
-                Aggregates.group(
-                        "$" + J_PROCESSOR_ID,
-                        toFirstJournalEntryFields(Set.of(J_PROCESSOR_ID, J_TAGS))
-                ),
-                Aggregates.match(Filters.eq(J_TAGS, tag)),
-                Aggregates.sort(Sorts.ascending(J_PROCESSOR_ID))
+        final List<Bson> filterPipeline = new ArrayList<>(6);
+        filterPipeline.add(Aggregates.match(Filters.in(J_PROCESSOR_ID, pids)));
+        // project stage -- reduce document size before $sort to save memory
+        filterPipeline.add(Aggregates.project(Projections.include(
+                J_PROCESSOR_ID, J_TO,
+                J_EVENT + "." + J_PROCESSOR_ID, J_EVENT + "." + J_TAGS)));
+        filterPipeline.add(Aggregates.sort(Sorts.descending(J_TO)));
+        filterPipeline.add(Aggregates.group(
+                "$" + J_PROCESSOR_ID,
+                toFirstJournalEntryFields(Set.of(J_PROCESSOR_ID, J_TAGS))
         ));
+        filterPipeline.add(Aggregates.match(Filters.eq(J_TAGS, tag)));
+        filterPipeline.add(Aggregates.sort(Sorts.ascending(J_PROCESSOR_ID)));
+        final AggregatePublisher<Document> aggregate = journal.aggregate(filterPipeline);
         final AggregatePublisher<Document> hintedAggregate =
                 readJournalConfig.getIndexNameHintForFilterPidsThatDoesntContainTagInNewestEntry()
                         .filter(hint -> !hint.equals("null"))
@@ -811,73 +853,25 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             final String tag,
             final int maxRestarts) {
 
-        final List<Bson> pipeline = new ArrayList<>(4);
+        final List<Bson> pipeline = new ArrayList<>(5);
         // optional match stages: consecutive match stages are optimized together ($match + $match coalescence)
         if (!tag.isEmpty()) {
             pipeline.add(Aggregates.match(Filters.eq(J_TAGS, tag)));
         }
 
+        // project stage -- reduce document size before $group to save memory
+        pipeline.add(Aggregates.project(Projections.include(J_PROCESSOR_ID, J_TAGS)));
+
         // group stage. We can assume that the $last element ist also new latest event because of the insert order.
         pipeline.add(Aggregates.group("$" + J_PROCESSOR_ID, Accumulators.last(J_TAGS, "$" + J_TAGS)));
 
         // Filter irrelevant tags for priority ordering.
-        pipeline.add(Aggregates.project(Projections.computed(J_TAGS, BsonDocument.parse(
-                "{\n" +
-                        "    $filter: {\n" +
-                        "        input: \"$" + J_TAGS + "\",\n" +
-                        "        as: \"tags\",\n" +
-                        "        cond: {\n" +
-                        "            $eq: [\n" +
-                        "                {\n" +
-                        "                    $substrCP: [\"$$tags\", 0, " + PRIORITY_TAG_PREFIX.length() + "]\n" +
-                        "                },\n" +
-                        "                \"" + PRIORITY_TAG_PREFIX + "\"\n" +
-                        "            ]\n" +
-                        "        }\n" +
-                        "    }\n" +
-                        "}"
-        ))));
+        pipeline.add(Aggregates.project(Projections.computed(J_TAGS, FILTER_PRIORITY_TAGS_EXPR)));
 
         if (mongoClient.getDittoSettings().isDocumentDbCompatibilityMode()) {
             // extract priority as "int" from relevant tags so that they can be compared numerically:
-            pipeline.add(Aggregates.project(Projections.computed(J_TAGS, BsonDocument.parse(
-                    "{\n" +
-                            "   $map: {\n" +
-                            "      input: \"$" + J_TAGS + "\",\n" +
-                            "      as: \"tag\",\n" +
-                            "      in: {\n" +
-                            "         $reduce: {\n" +
-                            "            input: {\n" +
-                            "               $range: [\n" +
-                            "                  0,\n" +
-                            "                  {\n" +
-                            "                     $subtract: [\n" +
-                            "                        1000,\n" +
-                            // assumption: max prio is 1000 - all higher prios are not correctly ordered
-                            "                        {\n" +
-                            "                           $strLenCP: {\n" +
-                            "                              $substrCP: [\n" +
-                            "                                 \"$$tag\", " + PRIORITY_TAG_PREFIX.length() +
-                            ", { $strLenCP: \"$$tag\" }\n" +
-                            "                              ]\n" +
-                            "                           }\n" +
-                            "                        }\n" +
-                            "                     ]\n" +
-                            "                  }\n" +
-                            "               ],\n" +
-                            "            },\n" +
-                            "            initialValue: \"$$tag\",\n" +
-                            "            in: {\n" +
-                            "               $concat: [\n" +
-                            "                  \" \",\n" +
-                            "                  \"$$value\"\n" +
-                            "               ]\n" +
-                            "            }\n" +
-                            "         }\n" +
-                            "      }\n" +
-                            "   }\n" +
-                            "}\n"
-            ))));
+            // assumption: max prio is 1000 - all higher prios are not correctly ordered
+            pipeline.add(Aggregates.project(Projections.computed(J_TAGS, DOCDB_MAP_PRIORITY_TAGS_EXPR)));
         }
 
         // sort stage 2 -- order after group stage is not defined
@@ -918,7 +912,7 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             final int maxRestarts,
             final String... fieldNames) {
 
-        final List<Bson> pipeline = new ArrayList<>(6);
+        final List<Bson> pipeline = new ArrayList<>(7);
         // optional match stages: consecutive match stages are optimized together ($match + $match coalescence)
         if (!tag.isEmpty()) {
             pipeline.add(Aggregates.match(Filters.eq(J_TAGS, tag)));
@@ -927,13 +921,22 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             pipeline.add(Aggregates.match(Filters.gt(J_PROCESSOR_ID, startPid)));
         }
 
+        final Set<String> fieldNamesWithOptionalTags = Arrays.stream(fieldNames).collect(Collectors.toSet());
+
+        // project stage -- reduce document size before $sort to save memory
+        final List<String> journalProjectFields = new ArrayList<>();
+        journalProjectFields.add(J_PROCESSOR_ID);
+        journalProjectFields.add(J_TO);
+        for (final String fieldName : fieldNamesWithOptionalTags) {
+            journalProjectFields.add(J_EVENT + "." + fieldName);
+        }
+        pipeline.add(Aggregates.project(Projections.include(journalProjectFields)));
+
         // sort stage
         pipeline.add(Aggregates.sort(Sorts.orderBy(Sorts.ascending(J_PROCESSOR_ID), Sorts.descending(J_TO))));
 
         // limit stage. It should come before group stage or MongoDB would scan the entire journal collection.
         pipeline.add(Aggregates.limit(batchSize));
-
-        final Set<String> fieldNamesWithOptionalTags = Arrays.stream(fieldNames).collect(Collectors.toSet());
         // group stage
         pipeline.add(Aggregates.group("$" + J_PROCESSOR_ID, toFirstJournalEntryFields(fieldNamesWithOptionalTags)));
 
@@ -991,10 +994,20 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             final boolean includeDeleted,
             final String... snapshotFields) {
 
-        final List<Bson> pipeline = new ArrayList<>(5);
+        final List<Bson> pipeline = new ArrayList<>(6);
         // match stage
         final Bson matchFilter = snapshotFilter.toMongoFilter();
         pipeline.add(Aggregates.match(matchFilter));
+
+        // project stage -- reduce document size before $sort to save memory
+        final List<String> snapshotProjectFields = new ArrayList<>();
+        snapshotProjectFields.add(S_PROCESSOR_ID);
+        snapshotProjectFields.add(S_SN);
+        snapshotProjectFields.add(S_SERIALIZED_SNAPSHOT + "." + LIFECYCLE);
+        for (final String snapshotField : snapshotFields) {
+            snapshotProjectFields.add(S_SERIALIZED_SNAPSHOT + "." + snapshotField);
+        }
+        pipeline.add(Aggregates.project(Projections.include(snapshotProjectFields)));
 
         // sort stage
         pipeline.add(Aggregates.sort(Sorts.orderBy(Sorts.ascending(S_PROCESSOR_ID), Sorts.descending(S_SN))));
@@ -1016,17 +1029,16 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
                 Accumulators.max(maxPid, "$" + S_ID),
                 Accumulators.push(items, "$$ROOT")));
 
-        // redact stage - "$$PRUNE"s documents with "__lifecycle" = DELETED if includeDeleted=false
-        // if includeDeleted=true keeps them using "$$DESCEND"
-        // redacts operates recursively, so it evaluates all documents in items array which
-        // allows us to preserve maxPid even when all elements in the array are PRUNE-ed
-        pipeline.add(new Document().append("$redact", new Document()
-                .append("$cond", new Document()
-                        .append("if",
-                                new Document().append("$ne", Arrays.asList("$" + LIFECYCLE, "DELETED")))
-                        .append("then", "$$DESCEND")
-                        .append("else", includeDeleted ? "$$DESCEND" : "$$PRUNE")
-                )));
+        // filter stage - remove DELETED snapshots from items array (when not including deleted)
+        if (!includeDeleted) {
+            pipeline.add(new Document("$addFields", new Document(items,
+                    new Document("$filter", new Document()
+                            .append("input", "$" + items)
+                            .append("as", "item")
+                            .append("cond", new Document("$ne",
+                                    Arrays.asList("$$item." + LIFECYCLE, "DELETED")))
+                    ))));
+        }
 
         final AggregatePublisher<Document> aggregate = snapshotStore.aggregate(pipeline);
         final Optional<String> indexHint = calculateIndexHint(matchFilter);

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -32,7 +32,7 @@ ditto {
 
       # additional index which speeds up background (e.g. cleanup) aggregation queries
       # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
-      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = true
       should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -39,7 +39,7 @@ ditto {
 
       # additional index which speeds up background (e.g. cleanup) aggregation queries
       # seems to be required for MongoDB version >=6, otherwise a lot of read Disk IOPS are needed
-      should-create-additional-snapshot-aggregation-index-pid-sn-id = false
+      should-create-additional-snapshot-aggregation-index-pid-sn-id = true
       should-create-additional-snapshot-aggregation-index-pid-sn-id = ${?MONGODB_READ_JOURNAL_SHOULD_CREATE_ADDITIONAL_SNAPSHOT_AGGREGATION_INDEX_PID_SN_ID}
 
       hint-name-filterPidsThatDoesntContainTagInNewestEntry = null

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/IndexInitializationIT.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/IndexInitializationIT.java
@@ -23,7 +23,9 @@ public final class IndexInitializationIT extends AbstractThingSearchPersistenceI
     @Test
     public void indicesAreCorrectlyInitialized() {
         MongoIndexAssertions.assertIndices(getClient().getDefaultDatabase(),
-                PersistenceConstants.THINGS_COLLECTION_NAME, getMaterializer(), Indices.all(false));
+                PersistenceConstants.THINGS_COLLECTION_NAME, getMaterializer(),
+                Indices.all(false).stream().filter(f -> !f.getName().equals("v_wildcard_id")).toList()
+        );
     }
 
 }


### PR DESCRIPTION
- Extract inline BsonDocument.parse() calls into static final constants (FILTER_PRIORITY_TAGS_EXPR, DOCDB_MAP_PRIORITY_TAGS_EXPR) to avoid re-parsing on every ping interval
- Add $project stages before $sort/$group to reduce document size in memory
- Replace recursive $redact with targeted $addFields/$filter on the items array in listNewestActiveSnapshotsByBatch; skip stage entirely when includeDeleted=true
- Enable snapshot aggregation index (pid+sn+id) by default for MongoDB 6+
- Update pekko-persistence-mongodb 1.3.1 -> 1.4.0
- Update mongo-java-driver 5.6.0 -> 5.6.4
- Update netty 4.2.4.Final -> 4.2.10.Final
- Fix IndexInitializationIT to match activated index configuration