### PR TITLE
#1638 add support for namespace root policies

### DIFF
--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.15  # chart version is effectively set by release-job
+version: 3.8.16  # chart version is effectively set by release-job
 appVersion: 3.8.12
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/README.md
+++ b/deployment/helm/ditto/README.md
@@ -63,6 +63,38 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 Please consult the [values.yaml](https://github.com/eclipse-ditto/ditto/blob/master/deployment/helm/ditto/values.yaml) 
 for all available configuration options of the Ditto Helm chart.  
 
+### Namespace root policies
+
+Namespace root policies allow operators to define namespace-wide access grants that are transparently
+merged into every policy in that namespace at enforcer-build time. The canonical default configuration
+and full documentation is in
+[`ditto-namespace-policies.conf`](../../../internal/utils/config/src/main/resources/ditto-namespace-policies.conf).
+
+For Helm deployments, configure via the service-scoped values (same style as `entityCreation`):
+- `policies.config.namespacePolicies`
+- `things.config.namespacePolicies`
+
+To keep enforcement consistent across services, configure the same mapping in both sections.
+
+Example:
+```yaml
+policies:
+  config:
+    namespacePolicies:
+      org.example.devices:
+        - org.example:tenant-root
+      org.example.sensors:
+        - org.example:tenant-root
+
+things:
+  config:
+    namespacePolicies:
+      org.example.devices:
+        - org.example:tenant-root
+      org.example.sensors:
+        - org.example:tenant-root
+```
+
 ### Scaling options
 
 Please note the defaults the chart comes with:

--- a/deployment/helm/ditto/service-config/policies-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/policies-extension.conf.tpl
@@ -37,6 +37,15 @@ ditto {
     ]
   }
   policies {
+    namespace-policies {
+    {{- range $namespace, $policyIds := .Values.policies.config.namespacePolicies }}
+      "{{$namespace}}" = [
+      {{- range $index, $policyId := $policyIds }}
+        "{{$policyId}}"
+      {{- end }}
+      ]
+    {{- end }}
+    }
     policy {
       namespace-activity-check = [
       {{- range $index, $nsActivityCheck := .Values.policies.config.persistence.namespaceActivityCheckOverrides }}

--- a/deployment/helm/ditto/service-config/things-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/things-extension.conf.tpl
@@ -54,6 +54,17 @@ ditto {
     {{- end }}
     ]
   }
+  policies {
+    namespace-policies {
+    {{- range $namespace, $policyIds := .Values.things.config.namespacePolicies }}
+      "{{$namespace}}" = [
+      {{- range $index, $policyId := $policyIds }}
+        "{{$policyId}}"
+      {{- end }}
+      ]
+    {{- end }}
+    }
+  }
   things {
     thing {
       namespace-activity-check = [

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -924,6 +924,13 @@ policies:
       revokes: []
       # - namespaces: []
       #   authSubjects: []
+    # namespacePolicies configures namespace root policies used during policy enforcer resolution.
+    #  Map namespace -> list of policy IDs to be implicitly imported for that namespace.
+    namespacePolicies: {}
+    #  org.example.devices:
+    #    - org.example:tenant-root
+    #  org.example.sensors:
+    #    - org.example:tenant-root
     # policiesEnforcer contains configuration for Ditto "Policy Enforcers", e.g. regarding caching
     policiesEnforcer:
       # askWithRetry contains configuration regarding "ask with retry" for policy enforcement in policies service
@@ -1292,6 +1299,13 @@ things:
       # - namespaces: []
       #   authSubjects: []
       #   thingDefinitions: []
+    # namespacePolicies configures namespace root policies used during policy enforcer resolution.
+    #  Map namespace -> list of policy IDs to be implicitly imported for that namespace.
+    namespacePolicies: {}
+    #  org.example.devices:
+    #    - org.example:tenant-root
+    #  org.example.sensors:
+    #    - org.example:tenant-root
     # policiesEnforcer contains configuration for Ditto "Policy Enforcers", e.g. regarding caching
     policiesEnforcer:
       # askWithRetry contains configuration regarding "ask with retry" for policy enforcement in things service

--- a/internal/utils/config/src/main/resources/ditto-namespace-policies.conf
+++ b/internal/utils/config/src/main/resources/ditto-namespace-policies.conf
@@ -1,0 +1,21 @@
+# namespace root policies
+# Maps namespaces to lists of policy IDs whose implicit entries are transparently merged
+# into every policy in that namespace when building policy enforcers.
+#
+# Rules:
+#  - only entries with importable = "implicit" are merged; "explicit" and "never" are skipped.
+#  - local policy entries always win on label conflicts (namespace root cannot override local entries)
+#  - if a configured root policy is missing or deleted, its entries are skipped and an ERROR is logged
+#  - this config is read by all services that perform policy enforcement (policies, things)
+#
+# Example:
+#   "org.example.devices"  = ["org.example:tenant-root"]
+#   "org.example.sensors"  = ["org.example:tenant-root", "org.example:audit-policy"]
+#
+# For Helm deployments, configure this via the policies.config.namespacePolicies and
+# things.config.namespacePolicies values, which are rendered into the respective
+# service extension config files.
+ditto.policies.namespace-policies {
+//  "org.example.devices"  = ["org.example:tenant-root"]
+//  "org.example.sensors"  = ["org.example:tenant-root", "org.example:audit-policy"]
+}

--- a/internal/utils/config/src/main/resources/ditto-service-base.conf
+++ b/internal/utils/config/src/main/resources/ditto-service-base.conf
@@ -15,6 +15,7 @@ include "ditto-cluster-downing.conf"
 include "ditto-mongo.conf"
 include "ditto-enforcement.conf"
 include "ditto-entity-creation.conf"
+include "ditto-namespace-policies.conf"
 include "ditto-things-aggregator.conf"
 
 # extension point

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
@@ -15,6 +15,8 @@ package org.eclipse.ditto.policies.enforcement;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.dispatch.MessageDispatcher;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
@@ -30,9 +32,14 @@ abstract class AbstractPolicyEnforcerProvider implements PolicyEnforcerProvider 
 
     protected static AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader(
             final ActorSystem actorSystem) {
+        return policyEnforcerCacheLoader(actorSystem,
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
+    }
 
+    protected static AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader(
+            final ActorSystem actorSystem, final NamespacePoliciesConfig namespacePoliciesConfig) {
         final PolicyCacheLoader policyCacheLoader = PolicyCacheLoader.getSingletonInstance(actorSystem);
-        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem);
+        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem, namespacePoliciesConfig);
     }
 
     protected static MessageDispatcher enforcementCacheDispatcher(final ActorSystem actorSystem) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
@@ -35,6 +35,8 @@ import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
@@ -56,17 +58,21 @@ final class CachingPolicyEnforcerProvider extends AbstractPolicyEnforcerProvider
     private final ActorRef cachingPolicyEnforcerProviderActor;
 
     CachingPolicyEnforcerProvider(final ActorSystem actorSystem) {
-        this(actorSystem, policyEnforcerCacheLoader(actorSystem), enforcementCacheDispatcher(actorSystem),
+        this(actorSystem,
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()),
+                enforcementCacheDispatcher(actorSystem),
                 DefaultCacheConfig.of(actorSystem.settings().config(),
                         PolicyEnforcerProvider.ENFORCER_CACHE_CONFIG_KEY));
     }
 
     private CachingPolicyEnforcerProvider(final ActorSystem actorSystem,
-            final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
             final MessageDispatcher cacheDispatcher,
             final CacheConfig cacheConfig) {
 
-        this(actorSystem, new PolicyEnforcerCache(policyEnforcerCacheLoader, cacheDispatcher, cacheConfig),
+        this(actorSystem,
+                new PolicyEnforcerCache(policyEnforcerCacheLoader(actorSystem, namespacePoliciesConfig),
+                        cacheDispatcher, cacheConfig, namespacePoliciesConfig),
                 BlockedNamespaces.of(actorSystem),
                 DistributedPubSub.get(actorSystem).mediator(),
                 cacheDispatcher

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -12,7 +12,9 @@
  */
 package org.eclipse.ditto.policies.enforcement;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -20,16 +22,24 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Policy together with its enforcer.
  */
 @Immutable
 public final class PolicyEnforcer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PolicyEnforcer.class);
 
     @Nullable private final Policy policy;
     private final Enforcer enforcer;
@@ -52,6 +62,80 @@ public final class PolicyEnforcer {
                     final var enforcer = PolicyEnforcers.defaultEvaluator(resolvedPolicy);
                     return new PolicyEnforcer(resolvedPolicy, enforcer);
                 });
+    }
+
+    /**
+     * Creates a policy enforcer from a policy, resolving both its explicit imports and any namespace root policies
+     * configured for the policy's namespace. Namespace root policies are resolved with their own imports and their
+     * implicit entries are merged last with local entries taking precedence on label conflicts.
+     * <p>
+     * This is the preferred factory method to use in the cache loader. Namespace root policy resolution bypasses
+     * the normal READ permission pre-enforcer check, since namespace policies are operator-configured and injected
+     * transparently — the user never explicitly declares them in the policy's {@code imports} field.
+     * </p>
+     *
+     * @param policy the policy to build an enforcer for.
+     * @param policyResolver resolves imported policies by ID.
+     * @param namespacePoliciesConfig the static namespace policies configuration.
+     * @return a completion stage with the fully resolved PolicyEnforcer.
+     * @since 3.9.0
+     */
+    public static CompletionStage<PolicyEnforcer> withResolvedImportsAndNamespacePolicies(
+            final Policy policy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+
+        return policy.withResolvedImports(policyResolver)
+                .thenCompose(resolvedPolicy -> mergeNamespacePolicies(resolvedPolicy, policyResolver,
+                        namespacePoliciesConfig))
+                .thenApply(finalPolicy -> {
+                    final var enforcer = PolicyEnforcers.defaultEvaluator(finalPolicy);
+                    return new PolicyEnforcer(finalPolicy, enforcer);
+                });
+    }
+
+    /**
+     * Merges importable entries from configured namespace root policies into {@code resolvedPolicy}.
+     * Local/imported entries always win: if a label already exists in {@code resolvedPolicy}, the corresponding
+     * namespace root entry is skipped. Missing or deleted namespace root policies are logged as errors and silently
+     * skipped — the policy continues to function without them.
+     */
+    private static CompletionStage<Policy> mergeNamespacePolicies(
+            final Policy resolvedPolicy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+
+        final String namespace = resolvedPolicy.getNamespace().orElse("");
+        final List<PolicyId> rootPolicies = namespacePoliciesConfig.getRootPoliciesForNamespace(namespace);
+
+        if (rootPolicies.isEmpty()) {
+            return CompletableFuture.completedFuture(resolvedPolicy);
+        }
+
+        CompletionStage<Policy> resultStage = CompletableFuture.completedFuture(resolvedPolicy);
+        for (final PolicyId rootPolicyId : rootPolicies) {
+            resultStage = resultStage.thenCompose(currentPolicy ->
+                    policyResolver.apply(rootPolicyId).thenCompose(rootPolicyOpt -> {
+                        if (rootPolicyOpt.isEmpty()) {
+                            LOG.error("Namespace root policy <{}> for namespace <{}> does not exist or was deleted" +
+                                    " - skipping its entries.", rootPolicyId, namespace);
+                            return CompletableFuture.completedFuture(currentPolicy);
+                        }
+                        return rootPolicyOpt.get().withResolvedImports(policyResolver)
+                                .thenApply(rootPolicy -> mergeImplicitEntries(rootPolicy, currentPolicy));
+                    }));
+        }
+        return resultStage;
+    }
+
+    private static Policy mergeImplicitEntries(final Policy rootPolicy, final Policy currentPolicy) {
+        Policy result = currentPolicy;
+        for (final PolicyEntry entry : rootPolicy) {
+            if (ImportableType.IMPLICIT.equals(entry.getImportableType()) && !result.contains(entry.getLabel())) {
+                result = result.setEntry(entry);
+            }
+        }
+        return result;
     }
 
     /**

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -27,6 +27,7 @@ import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.internal.utils.cache.CacheFactory;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
@@ -39,11 +40,14 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
 
     private final Cache<PolicyId, Entry<PolicyEnforcer>> delegate;
     private final Map<PolicyId, Set<PolicyId>> policyIdToImportingMap;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     PolicyEnforcerCache(final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader,
             final ExecutionContextExecutor cacheDispatcher,
-            final CacheConfig cacheConfig) {
+            final CacheConfig cacheConfig,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
         policyIdToImportingMap = new ConcurrentHashMap<>();
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
                         .whenCompleteAsync(((policyEnforcerEntry, throwable) -> policyEnforcerEntry.get()
@@ -92,10 +96,10 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
 
     @Override
     public boolean invalidate(final PolicyId policyId) {
-        // Invalidate the changed policy
+        // Invalidate the changed policy itself
         final boolean directlyCached = delegate.invalidate(policyId);
 
-        // Invalidate all policies that import the changed policy
+        // Invalidate all policies that explicitly import the changed policy
         final boolean indirectlyCachedViaImport = Optional.ofNullable(policyIdToImportingMap.remove(policyId))
                 .stream()
                 .flatMap(Collection::stream)
@@ -103,16 +107,20 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
                 .reduce((previous, next) -> previous || next)
                 .orElse(false);
 
-        return directlyCached || indirectlyCachedViaImport;
+        // Invalidate all cached policies in namespaces that use the changed policy as a namespace root
+        final boolean indirectlyCachedViaNamespaceRoot = invalidateNamespaceDependents(policyId,
+                delegate::invalidate);
+
+        return directlyCached || indirectlyCachedViaImport || indirectlyCachedViaNamespaceRoot;
     }
 
     @Override
     public boolean invalidateConditionally(final PolicyId policyId,
             final Predicate<Entry<PolicyEnforcer>> valueCondition) {
-        // Invalidate the changed policy
+        // Invalidate the changed policy itself
         final boolean directlyCached = delegate.invalidateConditionally(policyId, valueCondition);
 
-        // Invalidate all policies that import the changed policy
+        // Invalidate all policies that explicitly import the changed policy
         final boolean indirectlyCachedViaImport = Optional.ofNullable(policyIdToImportingMap.remove(policyId))
                 .stream()
                 .flatMap(Collection::stream)
@@ -120,7 +128,29 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
                 .reduce((previous, next) -> previous || next)
                 .orElse(false);
 
-        return directlyCached || indirectlyCachedViaImport;
+        // Invalidate all cached policies in namespaces that use the changed policy as a namespace root
+        final boolean indirectlyCachedViaNamespaceRoot = invalidateNamespaceDependents(policyId,
+                p -> delegate.invalidateConditionally(p, valueCondition));
+
+        return directlyCached || indirectlyCachedViaImport || indirectlyCachedViaNamespaceRoot;
+    }
+
+    private boolean invalidateNamespaceDependents(final PolicyId policyId,
+            final Function<PolicyId, Boolean> invalidateFunction) {
+        if (!namespacePoliciesConfig.getAllNamespaceRootPolicyIds().contains(policyId)) {
+            return false;
+        }
+
+        final Set<String> affectedNamespaces = namespacePoliciesConfig.getNamespacesForRootPolicy(policyId);
+        if (affectedNamespaces.isEmpty()) {
+            return false;
+        }
+
+        return delegate.asMap().keySet().stream()
+                .filter(cachedPolicyId -> affectedNamespaces.contains(cachedPolicyId.getNamespace()))
+                .map(invalidateFunction)
+                .reduce((a, b) -> a || b)
+                .orElse(false);
     }
 
     @Override

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
@@ -22,6 +22,7 @@ import javax.annotation.concurrent.Immutable;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 
@@ -37,17 +38,21 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
 
     private final PolicyCacheLoader delegate;
     private final Executor enforcementCacheExecutor;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     /**
      * Constructor.
      *
      * @param policyCacheLoader used to load the policies which should be transformed to a {@link PolicyEnforcer}.
      * @param actorSystem the actor system to use.
+     * @param namespacePoliciesConfig the namespace root policies configuration.
      */
-    public PolicyEnforcerCacheLoader(final PolicyCacheLoader policyCacheLoader, final ActorSystem actorSystem) {
+    public PolicyEnforcerCacheLoader(final PolicyCacheLoader policyCacheLoader, final ActorSystem actorSystem,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
 
         delegate = policyCacheLoader;
         enforcementCacheExecutor = actorSystem.dispatchers().lookup(ENFORCEMENT_CACHE_DISPATCHER);
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
     }
 
     @Override
@@ -67,7 +72,8 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
         if (entry.exists()) {
             final var revision = entry.getRevision();
             final var policy = entry.getValueOrThrow();
-            return PolicyEnforcer.withResolvedImports(policy, policyResolver)
+            return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(policy, policyResolver,
+                            namespacePoliciesConfig)
                     .thenApply(enforcer -> Entry.of(revision, enforcer));
         } else {
             return CompletableFuture.completedFuture(Entry.nonexistent());

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfig.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfig.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+
+/**
+ * Default implementation of {@link NamespacePoliciesConfig}.
+ * <p>
+ * Reads from the HOCON config path {@value #CONFIG_PATH}, which must be a config object mapping
+ * namespace strings to lists of policy ID strings:
+ * <pre>{@code
+ * ditto.policies.namespace-policies {
+ *   "org.example.devices"  = ["org.example:tenant-root"]
+ *   "org.example.sensors"  = ["org.example:tenant-root", "org.example:audit-policy"]
+ * }
+ * }</pre>
+ */
+@Immutable
+public final class DefaultNamespacePoliciesConfig implements NamespacePoliciesConfig {
+
+    static final String CONFIG_PATH = "ditto.policies.namespace-policies";
+
+    private final Map<String, List<PolicyId>> forwardMap;
+    private final Map<PolicyId, Set<String>> reverseMap;
+
+    private DefaultNamespacePoliciesConfig(final Map<String, List<PolicyId>> forwardMap,
+            final Map<PolicyId, Set<String>> reverseMap) {
+        this.forwardMap = toUnmodifiableForwardMap(forwardMap);
+        this.reverseMap = toUnmodifiableReverseMap(reverseMap);
+    }
+
+    /**
+     * Creates a {@code DefaultNamespacePoliciesConfig} from the given root config object.
+     * Returns an empty instance if {@value #CONFIG_PATH} is not present in the config.
+     *
+     * @param config the root config (from {@code actorSystem.settings().config()}).
+     * @return the parsed instance.
+     */
+    public static DefaultNamespacePoliciesConfig of(final Config config) {
+        if (!config.hasPath(CONFIG_PATH)) {
+            return new DefaultNamespacePoliciesConfig(Collections.emptyMap(), Collections.emptyMap());
+        }
+
+        final Config nsPoliciesConfig = config.getConfig(CONFIG_PATH);
+        final Map<String, List<PolicyId>> forwardMap = new HashMap<>();
+        final Map<PolicyId, Set<String>> reverseMap = new HashMap<>();
+
+        for (final Map.Entry<String, ConfigValue> entry : nsPoliciesConfig.root().entrySet()) {
+            final String namespace = entry.getKey();
+            final ConfigValue value = entry.getValue();
+
+            if (value.valueType() != ConfigValueType.LIST) {
+                continue;
+            }
+
+            final List<PolicyId> policyIds = new ArrayList<>();
+            for (final ConfigValue listEntry : (ConfigList) value) {
+                if (listEntry.valueType() == ConfigValueType.STRING) {
+                    final PolicyId policyId = PolicyId.of(listEntry.unwrapped().toString());
+                    policyIds.add(policyId);
+                    reverseMap.computeIfAbsent(policyId, k -> new HashSet<>()).add(namespace);
+                }
+            }
+            if (!policyIds.isEmpty()) {
+                forwardMap.put(namespace, Collections.unmodifiableList(policyIds));
+            }
+        }
+
+        return new DefaultNamespacePoliciesConfig(forwardMap, reverseMap);
+    }
+
+    @Override
+    public Map<String, List<PolicyId>> getNamespacePolicies() {
+        return forwardMap;
+    }
+
+    @Override
+    public List<PolicyId> getRootPoliciesForNamespace(final String namespace) {
+        return forwardMap.getOrDefault(namespace, List.of());
+    }
+
+    @Override
+    public Set<PolicyId> getAllNamespaceRootPolicyIds() {
+        return reverseMap.keySet();
+    }
+
+    @Override
+    public Set<String> getNamespacesForRootPolicy(final PolicyId rootPolicyId) {
+        return reverseMap.getOrDefault(rootPolicyId, Collections.emptySet());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return forwardMap.isEmpty();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final DefaultNamespacePoliciesConfig that = (DefaultNamespacePoliciesConfig) o;
+        return Objects.equals(forwardMap, that.forwardMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(forwardMap);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [namespacePolicies=" + forwardMap + "]";
+    }
+
+    private static Map<String, List<PolicyId>> toUnmodifiableForwardMap(final Map<String, List<PolicyId>> source) {
+        final Map<String, List<PolicyId>> result = new HashMap<>();
+        source.forEach((namespace, policyIds) -> result.put(namespace, Collections.unmodifiableList(
+                new ArrayList<>(policyIds))));
+        return Collections.unmodifiableMap(result);
+    }
+
+    private static Map<PolicyId, Set<String>> toUnmodifiableReverseMap(final Map<PolicyId, Set<String>> source) {
+        final Map<PolicyId, Set<String>> result = new HashMap<>();
+        source.forEach((policyId, namespaces) -> result.put(policyId, Collections.unmodifiableSet(
+                new HashSet<>(namespaces))));
+        return Collections.unmodifiableMap(result);
+    }
+
+}

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/NamespacePoliciesConfig.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/NamespacePoliciesConfig.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+
+/**
+ * Configuration mapping namespaces to a set of "namespace root" policy IDs whose implicit entries are
+ * automatically merged into every policy belonging to that namespace during enforcer resolution.
+ * <p>
+ * This allows operators to define tenant/namespace-wide access policies without requiring individual
+ * policies to declare explicit imports. The injection happens transparently at enforcer-build time, so
+ * the stored policy's {@code imports} field is never modified.
+ * </p>
+ *
+ * @since 3.9.0
+ */
+@Immutable
+public interface NamespacePoliciesConfig {
+
+    /**
+     * Returns the full mapping of namespace to list of namespace root policy IDs.
+     *
+     * @return immutable map of namespace string to list of PolicyIds.
+     */
+    Map<String, List<PolicyId>> getNamespacePolicies();
+
+    /**
+     * Returns the list of namespace root policy IDs configured for the given {@code namespace}.
+     * Returns an empty list if no namespace root policies are configured for the namespace.
+     *
+     * @param namespace the namespace to look up.
+     * @return list of PolicyIds acting as namespace roots for the given namespace, never null.
+     */
+    List<PolicyId> getRootPoliciesForNamespace(String namespace);
+
+    /**
+     * Returns all policy IDs that are configured as namespace root policies across all namespaces.
+     * Used to build the cache invalidation reverse map.
+     *
+     * @return set of all namespace root PolicyIds.
+     */
+    Set<PolicyId> getAllNamespaceRootPolicyIds();
+
+    /**
+     * Returns the set of namespaces that the given {@code rootPolicyId} covers.
+     * Used during cache invalidation: when a namespace root policy changes, all cached policies
+     * in its covered namespaces must be invalidated.
+     *
+     * @param rootPolicyId the policy ID of a namespace root policy.
+     * @return set of namespaces covered by the given root policy, empty if none.
+     */
+    Set<String> getNamespacesForRootPolicy(PolicyId rootPolicyId);
+
+    /**
+     * Returns whether no namespace policies are configured at all.
+     *
+     * @return {@code true} if the config is empty.
+     */
+    boolean isEmpty();
+
+}

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
@@ -22,10 +22,18 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
@@ -65,7 +73,8 @@ public final class PolicyEnforcerCacheTest {
         final var underTest = new PolicyEnforcerCache(
                 cacheLoader,
                 executor,
-                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache")
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
         );
 
         new TestKit(actorSystem) {{
@@ -82,7 +91,8 @@ public final class PolicyEnforcerCacheTest {
         final var underTest = new PolicyEnforcerCache(
                 cacheLoader,
                 executor,
-                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache")
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
         );
 
         final var otherPolicyId = PolicyId.generateRandom();
@@ -123,6 +133,59 @@ public final class PolicyEnforcerCacheTest {
             verifyLoadedFromCache(otherPolicy, underTest, cacheLoader);
         }};
 
+    }
+
+    @Test
+    public void policyTagInvalidatesCachedPoliciesInNamespacesOfChangedRootPolicy() throws Exception {
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root-local");
+
+        final var underTest = new PolicyEnforcerCache(
+                cacheLoader,
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                namespacePoliciesConfigFor(rootPolicyId)
+        );
+
+        final Policy devicesPolicy = Policy.newBuilder(PolicyId.of("org.example.devices", "policy-a")).build();
+        final Policy sensorsPolicy = Policy.newBuilder(PolicyId.of("org.example.sensors", "policy-b")).build();
+        final Policy unrelatedPolicy = Policy.newBuilder(PolicyId.of("org.example.other", "policy-c")).build();
+
+        new TestKit(actorSystem) {{
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            verifyLoadedFromCache(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            final boolean invalidated = underTest.invalidate(rootPolicyId);
+            assertThat(invalidated).isTrue();
+
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+        }};
+    }
+
+    private NamespacePoliciesConfig namespacePoliciesConfigFor(final PolicyId rootPolicyId) {
+        final NamespacePoliciesConfig config = mock(NamespacePoliciesConfig.class);
+        final Map<String, List<PolicyId>> namespacePolicies = new HashMap<>();
+        namespacePolicies.put("org.example.devices", Collections.singletonList(rootPolicyId));
+        namespacePolicies.put("org.example.sensors", Collections.singletonList(rootPolicyId));
+
+        final Set<String> coveredNamespaces = new HashSet<>();
+        coveredNamespaces.add("org.example.devices");
+        coveredNamespaces.add("org.example.sensors");
+
+        when(config.getNamespacePolicies()).thenReturn(namespacePolicies);
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.singleton(rootPolicyId));
+        when(config.getNamespacesForRootPolicy(rootPolicyId)).thenReturn(coveredNamespaces);
+        return config;
     }
 
     private void verifyLoadedFromCacheLoader(final Policy policy,

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerNamespacePoliciesTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerNamespacePoliciesTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.Resource;
+import org.eclipse.ditto.policies.model.Resources;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
+import org.junit.Test;
+
+/**
+ * Unit tests for the namespace-root-policy merge logic in
+ * {@link PolicyEnforcer#withResolvedImportsAndNamespacePolicies}.
+ */
+public final class PolicyEnforcerNamespacePoliciesTest {
+
+    private static final String NAMESPACE = "org.example.devices";
+    private static final PolicyId CHILD_POLICY_ID = PolicyId.of(NAMESPACE, "child-policy");
+    private static final PolicyId ROOT_POLICY_ID = PolicyId.of("org.example", "tenant-root");
+
+    private static final Label LOCAL_LABEL = Label.of("LOCAL_OWNER");
+    private static final Label ROOT_IMPLICIT_LABEL = Label.of("ROOT_READER");
+    private static final Label ROOT_NEVER_LABEL = Label.of("ROOT_NEVER");
+    private static final Label ROOT_EXPLICIT_LABEL = Label.of("ROOT_EXPLICIT");
+
+    @Test
+    public void implicitRootEntryIsMergedIntoChildEnforcer() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_IMPLICIT_LABEL, ImportableType.IMPLICIT);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_IMPLICIT_LABEL)).isTrue();
+    }
+
+    @Test
+    public void neverImportableRootEntryIsNotMerged() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_NEVER_LABEL, ImportableType.NEVER);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_NEVER_LABEL)).isFalse();
+    }
+
+    @Test
+    public void explicitImportableRootEntryIsNotMerged() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_EXPLICIT_LABEL, ImportableType.EXPLICIT);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_EXPLICIT_LABEL)).isFalse();
+    }
+
+    @Test
+    public void localLabelWinsOverNamespaceRootLabelOnConflict() throws Exception {
+        // Both child and root have the same label — local must win (root entry must NOT override it)
+        final var localSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("local-issuer"), "user");
+        final var rootSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("root-issuer"), "user");
+
+        final Policy rootPolicy = policyWithEntryAndSubject(ROOT_POLICY_ID, LOCAL_LABEL,
+                ImportableType.IMPLICIT, rootSubjectId);
+        final Policy childPolicy = policyWithEntryAndSubject(CHILD_POLICY_ID, LOCAL_LABEL,
+                ImportableType.IMPLICIT, localSubjectId);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        final var entry = merged.getEntryFor(LOCAL_LABEL).orElseThrow();
+        // local subject must be present; root subject must not have replaced it
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(localSubjectId))).isTrue();
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(rootSubjectId))).isFalse();
+    }
+
+    @Test
+    public void missingRootPolicyIsHandledGracefully() throws Exception {
+        // Root policy resolver returns empty — should not throw, child policy enforcer built normally
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig config = namespaceConfig(ROOT_POLICY_ID);
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> CompletableFuture.completedFuture(Optional.empty());
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(enforcer.getPolicy().orElseThrow().contains(LOCAL_LABEL)).isTrue();
+    }
+
+    @Test
+    public void emptyNamespacePoliciesConfigLeavesChildUnchanged() throws Exception {
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig emptyConfig = mock(NamespacePoliciesConfig.class);
+        when(emptyConfig.isEmpty()).thenReturn(true);
+        when(emptyConfig.getRootPoliciesForNamespace(NAMESPACE)).thenReturn(List.of());
+
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> CompletableFuture.completedFuture(Optional.empty());
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, emptyConfig)
+                .toCompletableFuture()
+                .join();
+
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        // only the local label should be present
+        assertThat(merged.stream().count()).isEqualTo(1);
+    }
+
+    // ---- helpers ----
+
+    private static Policy policyWithEntryAndSubject(final PolicyId policyId, final Label label,
+            final ImportableType importableType, final SubjectId subjectId) {
+        final var subjects = Subjects.newInstance(
+                Subject.newInstance(subjectId, SubjectType.newInstance("test")));
+        final var resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none())));
+        final var entry = PoliciesModelFactory.newPolicyEntry(label, subjects, resources, importableType);
+        return Policy.newBuilder(policyId).set(entry).build();
+    }
+
+    private static Policy policyWithEntry(final PolicyId policyId, final Label label,
+            final ImportableType importableType) {
+        final var subjects = Subjects.newInstance(
+                Subject.newInstance(
+                        SubjectId.newInstance(SubjectIssuer.newInstance(label.toString()), "user"),
+                        SubjectType.newInstance("test")));
+        final var resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance("READ"),
+                                Permissions.none())));
+        final var entry = PoliciesModelFactory.newPolicyEntry(label, subjects, resources, importableType);
+        return Policy.newBuilder(policyId).set(entry).build();
+    }
+
+    private static PolicyEnforcer buildEnforcer(final Policy childPolicy,
+            final PolicyId rootPolicyId, final Policy rootPolicy) {
+        final NamespacePoliciesConfig config = namespaceConfig(rootPolicyId);
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> rootPolicyId.equals(id)
+                        ? CompletableFuture.completedFuture(Optional.of(rootPolicy))
+                        : CompletableFuture.completedFuture(Optional.empty());
+
+        return PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+    }
+
+    private static NamespacePoliciesConfig namespaceConfig(final PolicyId rootPolicyId) {
+        final NamespacePoliciesConfig config = mock(NamespacePoliciesConfig.class);
+        when(config.isEmpty()).thenReturn(false);
+        when(config.getRootPoliciesForNamespace(NAMESPACE)).thenReturn(Collections.singletonList(rootPolicyId));
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Set.of(rootPolicyId));
+        when(config.getNamespacesForRootPolicy(rootPolicyId)).thenReturn(Set.of(NAMESPACE));
+        return config;
+    }
+
+}

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfigTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfigTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit test for {@link DefaultNamespacePoliciesConfig}.
+ */
+public final class DefaultNamespacePoliciesConfigTest {
+
+    @Test
+    public void parsesForwardAndReverseMapsFromHocon() {
+        final var config = ConfigFactory.parseString(
+                "ditto.policies.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.sensors\" = [\"org.example:tenant-root\", \"org.example:audit-policy\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.isEmpty()).isFalse();
+
+        // forward map
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.sensors"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"), PolicyId.of("org.example:audit-policy"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.unknown")).isEmpty();
+
+        // reverse map
+        assertThat(underTest.getAllNamespaceRootPolicyIds())
+                .containsExactlyInAnyOrder(PolicyId.of("org.example:tenant-root"),
+                        PolicyId.of("org.example:audit-policy"));
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:tenant-root")))
+                .containsExactlyInAnyOrder("org.example.devices", "org.example.sensors");
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:audit-policy")))
+                .containsExactlyInAnyOrder("org.example.sensors");
+    }
+
+    @Test
+    public void returnsEmptyInstanceWhenConfigPathAbsent() {
+        final var underTest = DefaultNamespacePoliciesConfig.of(ConfigFactory.empty());
+
+        assertThat(underTest.isEmpty()).isTrue();
+        assertThat(underTest.getNamespacePolicies()).isEmpty();
+        assertThat(underTest.getAllNamespaceRootPolicyIds()).isEmpty();
+        assertThat(underTest.getRootPoliciesForNamespace("any.namespace")).isEmpty();
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:some-policy"))).isEmpty();
+    }
+
+    @Test
+    public void skipsNonListConfigValues() {
+        final var config = ConfigFactory.parseString(
+                "ditto.policies.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.badentry\" = \"not-a-list\"\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices")).hasSize(1);
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.badentry")).isEmpty();
+    }
+
+    @Test
+    public void skipsEmptyListEntries() {
+        final var config = ConfigFactory.parseString(
+                "ditto.policies.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.empty\" = []\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices")).hasSize(1);
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.empty")).isEmpty();
+        // empty lists must not appear in the forward map
+        assertThat(underTest.getNamespacePolicies()).doesNotContainKey("org.example.empty");
+    }
+
+    @Test
+    public void returnedMapsAreImmutable() {
+        final var config = ConfigFactory.parseString(
+                "ditto.policies.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThatThrownBy(() -> underTest.getNamespacePolicies().put("org.example.new", List.of()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> underTest.getAllNamespaceRootPolicyIds().add(PolicyId.of("org.example:new")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() ->
+                underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:tenant-root")).add("ns"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+}

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
@@ -25,6 +25,7 @@ import org.eclipse.ditto.policies.enforcement.AbstractPolicyLoadingEnforcerActor
 import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
@@ -76,7 +77,9 @@ public final class PolicyEnforcerActor extends
             final Function<PolicyId, CompletionStage<Optional<Policy>>> importedPolicyResolver =
                     importedPolicyId -> policyCacheLoader.asyncLoad(importedPolicyId, getContext().dispatcher())
                             .thenApply(Entry::get);
-            return PolicyEnforcer.withResolvedImports(createPolicy.getPolicy(), importedPolicyResolver)
+            return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(createPolicy.getPolicy(),
+                            importedPolicyResolver,
+                            DefaultNamespacePoliciesConfig.of(getContext().system().settings().config()))
                     .thenApply(Optional::of);
         }
         return super.loadPolicyEnforcer(signal);


### PR DESCRIPTION
Resolves: #1638

## Summary
This PR adds support for namespace root policies in Ditto policy enforcement.

A namespace can be mapped to one or more root policy IDs. During enforcer creation, Ditto transparently merges entries from those root policies into policies of that namespace.

## What changed
- Added namespace-root merge support in policy enforcer resolution.
- Added config abstraction:
  - `NamespacePoliciesConfig`
  - `DefaultNamespacePoliciesConfig`
- Wired namespace policy resolution into:
  - cache loader path
  - create-policy enforcement path (`PolicyEnforcerActor`)
- Extended cache invalidation:
  - when a namespace root policy changes, cached policies in covered namespaces are invalidated.
- Added canonical base config file:
  - `internal/utils/config/.../ditto-namespace-policies.conf`
  - included via `ditto-service-base.conf`
- Updated Helm templates and values to service-scoped config (entity-creation style):
  - `policies.config.namespacePolicies`
  - `things.config.namespacePolicies`
- Updated chart docs accordingly.

## Behavior / rules
- Only entries with `importable = "implicit"` are merged.
- Entries with `importable = "explicit"` or `importable = "never"` are not merged.
- Local policy entries win on label conflicts.
- If a configured root policy is missing/deleted, entries are skipped and an `ERROR` is logged.
- Stored policy JSON is not modified; merge happens at enforcer-build time.

## Example config
```yaml
policies:
  config:
    namespacePolicies:
      org.example.devices:
        - org.example:tenant-root

things:
  config:
    namespacePolicies:
      org.example.devices:
        - org.example:tenant-root
