### PR TITLE
Support namespace root policy

### DIFF
--- a/connectivity/service/src/main/resources/connectivity.conf
+++ b/connectivity/service/src/main/resources/connectivity.conf
@@ -174,6 +174,7 @@ ditto {
       {exceptionName: "sun.security.provider.certpath.SunCertPathBuilderException", messagePattern: ".*"}
     ]
 
+    user-indicated-errors-extended = []
     user-indicated-errors-extended = ${?USER_INDICATED_ERRORS[]}
 
     user-indicated-errors = ${ditto.connectivity.user-indicated-errors-base} ${ditto.connectivity.user-indicated-errors-extended}

--- a/deployment/helm/ditto/Chart.yaml
+++ b/deployment/helm/ditto/Chart.yaml
@@ -16,7 +16,7 @@ description: |
   A digital twin is a virtual, cloud based, representation of his real world counterpart
   (real world “Things”, e.g. devices like sensors, smart heating, connected cars, smart grids, EV charging stations etc).
 type: application
-version: 3.8.16  # chart version is effectively set by release-job
+version: 3.8.17  # chart version is effectively set by release-job
 appVersion: 3.8.12
 keywords:
   - iot-chart

--- a/deployment/helm/ditto/README.md
+++ b/deployment/helm/ditto/README.md
@@ -63,6 +63,26 @@ Alternatively, a YAML file that specifies the values for the parameters can be p
 Please consult the [values.yaml](https://github.com/eclipse-ditto/ditto/blob/master/deployment/helm/ditto/values.yaml) 
 for all available configuration options of the Ditto Helm chart.  
 
+### Namespace root policies
+
+Namespace root policies allow operators to define namespace-wide access grants that are transparently
+merged into every policy in that namespace at enforcer-build time. The canonical default configuration
+and full documentation is in
+[`ditto-namespace-policies.conf`](../../../internal/utils/config/src/main/resources/ditto-namespace-policies.conf).
+
+For Helm deployments, configure via the shared value:
+- `global.namespacePolicies`
+
+Example:
+```yaml
+global:
+  namespacePolicies:
+    org.example.devices:
+      - org.example:tenant-root
+    org.example.sensors:
+      - org.example:tenant-root
+```
+
 ### Scaling options
 
 Please note the defaults the chart comes with:

--- a/deployment/helm/ditto/service-config/policies-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/policies-extension.conf.tpl
@@ -36,6 +36,15 @@ ditto {
     {{- end }}
     ]
   }
+  namespace-policies {
+  {{- range $namespace, $policyIds := .Values.global.namespacePolicies }}
+    "{{$namespace}}" = [
+    {{- range $index, $policyId := $policyIds }}
+      "{{$policyId}}"
+    {{- end }}
+    ]
+  {{- end }}
+  }
   policies {
     policy {
       namespace-activity-check = [

--- a/deployment/helm/ditto/service-config/search-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/search-extension.conf.tpl
@@ -1,5 +1,14 @@
 # Ditto "Things Search" configuration extension file to be placed at /opt/ditto/search-extension.conf
 ditto {
+  namespace-policies {
+  {{- range $namespace, $policyIds := .Values.global.namespacePolicies }}
+    "{{$namespace}}" = [
+    {{- range $index, $policyId := $policyIds }}
+      "{{$policyId}}"
+    {{- end }}
+    ]
+  {{- end }}
+  }
   {{- if .Values.thingsSearch.config.indexedFieldsLimiting.enabled }}
   extensions {
     caching-signal-enrichment-facade-provider = "org.eclipse.ditto.thingsearch.service.persistence.write.streaming.SearchIndexingSignalEnrichmentFacadeProvider"

--- a/deployment/helm/ditto/service-config/things-extension.conf.tpl
+++ b/deployment/helm/ditto/service-config/things-extension.conf.tpl
@@ -54,6 +54,15 @@ ditto {
     {{- end }}
     ]
   }
+  namespace-policies {
+  {{- range $namespace, $policyIds := .Values.global.namespacePolicies }}
+    "{{$namespace}}" = [
+    {{- range $index, $policyId := $policyIds }}
+      "{{$policyId}}"
+    {{- end }}
+    ]
+  {{- end }}
+  }
   things {
     thing {
       namespace-activity-check = [

--- a/deployment/helm/ditto/values.yaml
+++ b/deployment/helm/ditto/values.yaml
@@ -70,6 +70,13 @@ global:
     #  higher factors can improve CPU usage (as a StringBuilder does not need to be resized as often),
     #  but will use more memory.
     escapingBufferFactor: 1.0
+  # namespacePolicies configures namespace root policies shared by all services participating in enforcement.
+  # Map namespace -> list of policy IDs to be implicitly imported for that namespace.
+  namespacePolicies: {}
+  # org.example.devices:
+  #   - org.example:tenant-root
+  # org.example.sensors:
+  #   - org.example:tenant-root
   # limits contains information about limit configuration, e.g. towards max. entity and payload sizes
   limits:
     # clusterMaxFramesize the maximum serialized message size in the cluster, including header data, default: 256 KiB

--- a/documentation/src/main/resources/pages/ditto/basic-policy.md
+++ b/documentation/src/main/resources/pages/ditto/basic-policy.md
@@ -479,6 +479,73 @@ When managing and using policy imports the following limitations apply:
  * The maximum number of policy imports allowed per policy is 10.
  * To avoid conflicts with imported entries, it is not allowed to use the prefix `imported` for the name of a policy entry label. Trying to do so will result in an error.
 
+## Namespace root policies
+
+Since Ditto *3.9.0*, operators can designate one or more **namespace root policies** that are transparently merged
+into every policy in a matching namespace, without modifying the stored policies.
+
+This is an operator-level feature (see [operator configuration](installation-operating.html#namespace-root-policies)).
+End users do not create or manage namespace root policies themselves; they are applied automatically by the
+policy enforcement layer when a policy enforcer is built.
+
+### How it works
+
+1. The operator configures a mapping of namespace patterns to policy IDs in `ditto.namespace-policies`.
+2. When an enforcer is built for a policy in namespace `org.example.devices`, Ditto looks up all root policy IDs
+   whose patterns match that namespace (e.g. `"org.example.*"` or `"org.example.devices"`).
+3. Only entries with `"importable": "implicit"` from the root policy are merged. Entries marked `"explicit"` or
+   `"never"` are skipped.
+4. **Local entries always win on label conflicts**: if the local policy already has an entry with the same label as
+   a root policy entry, the local entry is used unchanged. The root policy cannot override local entries.
+5. The merge happens entirely at enforcer-build time — the stored policy document is never modified.
+
+### Differences from policy imports
+
+| | Policy imports | Namespace root policies |
+|---|---|---|
+| Configured by | Policy author (in the policy document) | Operator (in service config) |
+| Subject permission required | Yes — importer needs READ on imported policy | No — transparent to API users |
+| Stored in the policy document | Yes (`imports` block) | No |
+| Max per policy | 10 | Unlimited (operator configures globally) |
+| Applies automatically | No — each policy must declare its imports | Yes — automatically applied to all policies in matching namespaces |
+
+### Example
+
+Given a root policy `org.eclipse.ditto:tenant-root` with an entry:
+```json
+{
+  "entries": {
+    "TENANT_READER": {
+      "subjects": {
+        "pre:tenant-reader": { "type": "tenant read access" }
+      },
+      "resources": {
+        "thing:/":   { "grant": ["READ"], "revoke": [] },
+        "policy:/":  { "grant": ["READ"], "revoke": [] },
+        "message:/": { "grant": ["READ"], "revoke": [] }
+      },
+      "importable": "implicit"
+    }
+  }
+}
+```
+
+And the operator configuration:
+```hocon
+ditto.namespace-policies {
+  "org.eclipse.ditto.*" = ["org.eclipse.ditto:tenant-root"]
+}
+```
+
+Then every policy in `org.eclipse.ditto.sensors`, `org.eclipse.ditto.devices`, etc. will automatically have
+`pre:tenant-reader` granted READ access, as if `TENANT_READER` had been declared in each of those policies.
+A local policy in `org.eclipse.ditto.sensors` that already has a `TENANT_READER` entry will keep its own entry.
+
+{% include note.html content="The namespace root policy itself is never merged into itself. A root policy
+at <code>org.eclipse.ditto:tenant-root</code> configured for pattern <code>org.eclipse.ditto.*</code> does not match
+namespace <code>org.eclipse.ditto</code> (the pattern requires at least one sub-segment after the dot)."
+%}
+
 ## Tools for editing a Policy
 
 The Policy can be edited with a text editor of your choice.

--- a/documentation/src/main/resources/pages/ditto/installation-operating.md
+++ b/documentation/src/main/resources/pages/ditto/installation-operating.md
@@ -674,6 +674,82 @@ If a namespace pattern (in `allowed-namespaces` or `blocked-namespaces`) is synt
 at startup with a `DittoConfigError`. This prevents operators from inadvertently deploying a configuration where
 access control rules are silently skipped.
 
+## Namespace root policies
+
+Since Ditto *3.9.0*, operators can configure **namespace root policies** — pre-existing policies whose
+`importable: implicit` entries are automatically merged into every policy in a matching namespace at enforcer-build
+time. This enables cross-cutting access grants (e.g. a tenant-wide read subject) without modifying any stored
+policy.
+
+For the end-user concept, see [basic-policy.html#namespace-root-policies](basic-policy.html#namespace-root-policies).
+
+### Configuration
+
+The mapping is defined under `ditto.namespace-policies` in the `policies.conf`, `things.conf`, and `search.conf`
+service configuration files (or overridden via a `-dev.conf` / extension config for a given deployment):
+
+```hocon
+ditto.namespace-policies {
+  # Exact namespace match — applies only to org.eclipse.ditto.devices
+  "org.eclipse.ditto.devices" = ["org.eclipse.ditto.devices:devices-root"]
+
+  # Prefix wildcard — applies to any sub-namespace of org.eclipse.ditto
+  # Does NOT match org.eclipse.ditto itself (requires at least one sub-segment)
+  "org.eclipse.ditto.*" = ["org.eclipse.ditto:tenant-root"]
+
+  # Catch-all — applies to every namespace
+  # "*" = ["root:global-policy"]
+}
+```
+
+Multiple patterns can match a single namespace. When they do, patterns are applied in deterministic precedence
+order: exact match first, then prefix wildcards from most specific to least specific, then `"*"`.
+
+Multiple root policy IDs can be listed per pattern. They are applied left-to-right.
+
+### Pattern syntax
+
+| Pattern | Matches |
+|---|---|
+| `"org.example.devices"` | Only the exact namespace `org.example.devices` |
+| `"org.example.*"` | Any namespace starting with `org.example.` (requires at least one sub-segment) |
+| `"*"` | Every namespace |
+
+Unsupported patterns (e.g. `"org.*.devices"` or `"foo*"`) are rejected at startup with a `DittoConfigError`.
+
+### Behaviour details
+
+**Label conflict — local wins:** If a local policy already has an entry with the same label as a root policy
+entry, the local entry is preserved unchanged. The root policy entry is silently skipped for that label.
+
+**Self-referential guard:** A root policy is never merged into itself. If `org.eclipse.ditto:tenant-root` is
+configured for `"org.eclipse.ditto.*"`, it is not merged when building the enforcer for `tenant-root` itself.
+
+**Missing root policy:** If a configured root policy does not exist or cannot be loaded, its entries are skipped
+and an ERROR is logged. The child policy's enforcer is still built successfully from its own entries.
+
+**Cache invalidation:** When a root policy is modified, Ditto automatically invalidates all cached enforcers for
+policies in matching namespaces. This is an O(n) scan over the enforcer cache and happens transparently.
+For very large deployments with frequently-changing root policies, consider keeping the root policies stable
+and pushing changes via individual child policies instead.
+
+**Search consistency:** Root policy changes are reflected in the things-search index. The search service tracks
+root policy revisions as part of the resolved-policy cache key, so a root policy update triggers re-indexing
+of all affected things.
+
+### Helm configuration
+
+For Helm deployments, configure namespace root policies in `values.yaml` via the shared `global` section:
+
+```yaml
+global:
+  namespacePolicies:
+    "org.eclipse.ditto.*":
+      - "org.eclipse.ditto:tenant-root"
+```
+
+This shared mapping is rendered into the respective service extension config files under `ditto.namespace-policies`.
+
 ## Configuring pre-defined extra fields
 
 Starting with Ditto 3.7.0, it is possible to configure [enrichment of `extraFields`](basic-enrichment.html) statically 

--- a/internal/utils/config/src/main/resources/ditto-namespace-policies.conf
+++ b/internal/utils/config/src/main/resources/ditto-namespace-policies.conf
@@ -1,0 +1,26 @@
+# namespace root policies
+# Maps namespace patterns to lists of policy IDs whose implicit entries are transparently merged
+# into every matching policy's enforcer at build time.
+#
+# Pattern syntax (key side):
+#  - exact string      e.g. "org.example.devices"  matches only that namespace
+#  - prefix wildcard   e.g. "org.example.*"        matches any namespace starting with "org.example."
+#  - catch-all         "*"                         matches every namespace
+#
+# Rules:
+#  - only entries with importable = "implicit" are merged; "explicit" and "never" are skipped.
+#  - local policy entries always win on label conflicts (namespace root cannot override local entries)
+#  - matching patterns are applied in this precedence: exact > more specific prefix wildcard > less specific prefix wildcard > "*"
+#  - unsupported wildcard syntax is rejected at config load time
+#  - if a configured root policy is missing or deleted, its entries are skipped and an ERROR is logged
+#  - changing a root policy triggers cache invalidation for all cached policies in matching namespaces
+#  - this config is read by all services that perform policy enforcement (policies, things, thingsearch)
+#
+# For Helm deployments, configure this via the global.namespacePolicies value,
+# which is rendered into the respective service extension config files.
+ditto.namespace-policies {
+//  "org.example.devices"  = ["org.example:tenant-root"]           # exact namespace
+//  "org.example.devices.*" = ["org.example:devices-root"]         # more specific prefix wildcard
+//  "org.example.*"         = ["org.example:tenant-root"]          # broader prefix wildcard
+//  "*"                     = ["root:catch-all-policy"]            # every namespace
+}

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/AbstractPolicyEnforcerProvider.java
@@ -12,9 +12,14 @@
  */
 package org.eclipse.ditto.policies.enforcement;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.dispatch.MessageDispatcher;
+import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
@@ -30,9 +35,22 @@ abstract class AbstractPolicyEnforcerProvider implements PolicyEnforcerProvider 
 
     protected static AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader(
             final ActorSystem actorSystem) {
+        return policyEnforcerCacheLoader(actorSystem,
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
+    }
 
+    protected static AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader(
+            final ActorSystem actorSystem, final NamespacePoliciesConfig namespacePoliciesConfig) {
         final PolicyCacheLoader policyCacheLoader = PolicyCacheLoader.getSingletonInstance(actorSystem);
-        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem);
+        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem, namespacePoliciesConfig);
+    }
+
+    protected static AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader(
+            final ActorSystem actorSystem,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
+            final CompletableFuture<Cache<PolicyId, Entry<PolicyEnforcer>>> cacheFuture) {
+        final PolicyCacheLoader policyCacheLoader = PolicyCacheLoader.getSingletonInstance(actorSystem);
+        return new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem, namespacePoliciesConfig, cacheFuture);
     }
 
     protected static MessageDispatcher enforcementCacheDispatcher(final ActorSystem actorSystem) {

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/CachingPolicyEnforcerProvider.java
@@ -35,6 +35,8 @@ import org.eclipse.ditto.base.model.headers.DittoHeaders;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.internal.utils.cluster.DistPubSubAccess;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoDiagnosticLoggingAdapter;
@@ -56,21 +58,45 @@ final class CachingPolicyEnforcerProvider extends AbstractPolicyEnforcerProvider
     private final ActorRef cachingPolicyEnforcerProviderActor;
 
     CachingPolicyEnforcerProvider(final ActorSystem actorSystem) {
-        this(actorSystem, policyEnforcerCacheLoader(actorSystem), enforcementCacheDispatcher(actorSystem),
+        this(actorSystem,
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()),
+                enforcementCacheDispatcher(actorSystem),
                 DefaultCacheConfig.of(actorSystem.settings().config(),
                         PolicyEnforcerProvider.ENFORCER_CACHE_CONFIG_KEY));
     }
 
     private CachingPolicyEnforcerProvider(final ActorSystem actorSystem,
-            final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
             final MessageDispatcher cacheDispatcher,
             final CacheConfig cacheConfig) {
 
-        this(actorSystem, new PolicyEnforcerCache(policyEnforcerCacheLoader, cacheDispatcher, cacheConfig),
+        this(actorSystem,
+                buildCache(actorSystem, namespacePoliciesConfig, cacheDispatcher, cacheConfig),
                 BlockedNamespaces.of(actorSystem),
                 DistributedPubSub.get(actorSystem).mediator(),
                 cacheDispatcher
         );
+    }
+
+    /**
+     * Builds the {@link PolicyEnforcerCache} with a self-referencing cache loader so that namespace
+     * root policies are loaded through the cache itself. This ensures their import declarations are
+     * registered in {@code policyIdToImportingMap}, enabling correct transitive cache invalidation
+     * when a policy imported by a namespace root policy changes.
+     */
+    private static PolicyEnforcerCache buildCache(final ActorSystem actorSystem,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
+            final MessageDispatcher cacheDispatcher,
+            final CacheConfig cacheConfig) {
+
+        final CompletableFuture<org.eclipse.ditto.internal.utils.cache.Cache<PolicyId,
+                org.eclipse.ditto.internal.utils.cache.entry.Entry<PolicyEnforcer>>> cacheFuture =
+                new CompletableFuture<>();
+        final PolicyEnforcerCache cache = new PolicyEnforcerCache(
+                policyEnforcerCacheLoader(actorSystem, namespacePoliciesConfig, cacheFuture),
+                cacheDispatcher, cacheConfig, namespacePoliciesConfig);
+        cacheFuture.complete(cache);
+        return cache;
     }
 
     CachingPolicyEnforcerProvider(final ActorSystem actorSystem,

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcer.java
@@ -12,7 +12,11 @@
  */
 package org.eclipse.ditto.policies.enforcement;
 
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
@@ -20,16 +24,25 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.policies.model.enforcers.PolicyEnforcers;
+
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+
+import org.slf4j.Logger;
 
 /**
  * Policy together with its enforcer.
  */
 @Immutable
 public final class PolicyEnforcer {
+
+    private static final Logger LOG = DittoLoggerFactory.getThreadSafeLogger(PolicyEnforcer.class);
 
     @Nullable private final Policy policy;
     private final Enforcer enforcer;
@@ -52,6 +65,103 @@ public final class PolicyEnforcer {
                     final var enforcer = PolicyEnforcers.defaultEvaluator(resolvedPolicy);
                     return new PolicyEnforcer(resolvedPolicy, enforcer);
                 });
+    }
+
+    /**
+     * Creates a policy enforcer from a policy, resolving both its explicit imports and any namespace root policies
+     * configured for the policy's namespace. Namespace root policies are resolved with their own imports and their
+     * implicit entries are merged last with local entries taking precedence on label conflicts.
+     * Matching namespace roots are applied in config precedence order: exact match first, then more
+     * specific prefix wildcards, then broader prefix wildcards, and finally {@code *}.
+     * <p>
+     * This is the preferred factory method to use in the cache loader. Namespace root policy resolution bypasses
+     * the normal READ permission pre-enforcer check, since namespace policies are operator-configured and injected
+     * transparently — the user never explicitly declares them in the policy's {@code imports} field.
+     * </p>
+     *
+     * @param policy the policy to build an enforcer for.
+     * @param policyResolver resolves imported policies by ID.
+     * @param namespacePoliciesConfig the static namespace policies configuration.
+     * @return a completion stage with the fully resolved PolicyEnforcer.
+     * @since 3.9.0
+     */
+    public static CompletionStage<PolicyEnforcer> withResolvedImportsAndNamespacePolicies(
+            final Policy policy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+
+        return policy.withResolvedImports(policyResolver)
+                .thenCompose(resolvedPolicy -> mergeNamespacePolicies(resolvedPolicy, policyResolver,
+                        namespacePoliciesConfig))
+                .thenApply(finalPolicy -> {
+                    final var enforcer = PolicyEnforcers.defaultEvaluator(finalPolicy);
+                    return new PolicyEnforcer(finalPolicy, enforcer);
+                });
+    }
+
+    /**
+     * Merges importable entries from configured namespace root policies into {@code resolvedPolicy}.
+     * Local/imported entries always win: if a label already exists in {@code resolvedPolicy}, the corresponding
+     * namespace root entry is skipped. Missing or deleted namespace root policies are logged as errors and silently
+     * skipped — the policy continues to function without them.
+     * <p>
+     * Root policies are resolved in parallel for performance, then merged in precedence order
+     * (exact match first, then more specific prefix wildcards, then broader, then catch-all).
+     * </p>
+     */
+    private static CompletionStage<Policy> mergeNamespacePolicies(
+            final Policy resolvedPolicy,
+            final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+
+        final Optional<PolicyId> entityId = resolvedPolicy.getEntityId();
+        final String namespace = resolvedPolicy.getNamespace().orElse("");
+        final List<PolicyId> rootPolicies = namespacePoliciesConfig.getRootPoliciesForNamespace(namespace).stream()
+                .filter(rootPolicyId -> !entityId.map(rootPolicyId::equals).orElse(false))
+                .toList();
+
+        if (rootPolicies.isEmpty()) {
+            return CompletableFuture.completedFuture(resolvedPolicy);
+        }
+
+        final Map<PolicyId, CompletableFuture<Optional<Policy>>> resolutionFutures = new LinkedHashMap<>();
+        for (final PolicyId rootPolicyId : rootPolicies) {
+            resolutionFutures.put(rootPolicyId,
+                    policyResolver.apply(rootPolicyId)
+                            .thenCompose(rootPolicyOpt -> {
+                                if (rootPolicyOpt.isEmpty()) {
+                                    LOG.error("Namespace root policy <{}> for namespace <{}> does not exist" +
+                                            " or was deleted - skipping its entries.", rootPolicyId, namespace);
+                                    return CompletableFuture.completedFuture(Optional.<Policy>empty());
+                                }
+                                return rootPolicyOpt.get().withResolvedImports(policyResolver)
+                                        .thenApply(Optional::of);
+                            })
+                            .toCompletableFuture());
+        }
+
+        final CompletableFuture<?>[] allFutures = resolutionFutures.values().toArray(CompletableFuture[]::new);
+        return CompletableFuture.allOf(allFutures)
+                .thenApply(ignored -> {
+                    Policy result = resolvedPolicy;
+                    for (final PolicyId rootPolicyId : rootPolicies) {
+                        final Optional<Policy> rootPolicyOpt = resolutionFutures.get(rootPolicyId).join();
+                        if (rootPolicyOpt.isPresent()) {
+                            result = mergeImplicitEntries(rootPolicyOpt.get(), result);
+                        }
+                    }
+                    return result;
+                });
+    }
+
+    private static Policy mergeImplicitEntries(final Policy rootPolicy, final Policy currentPolicy) {
+        Policy result = currentPolicy;
+        for (final PolicyEntry entry : rootPolicy) {
+            if (ImportableType.IMPLICIT.equals(entry.getImportableType()) && !result.contains(entry.getLabel())) {
+                result = result.setEntry(entry);
+            }
+        }
+        return result;
     }
 
     /**

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCache.java
@@ -27,6 +27,7 @@ import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.internal.utils.cache.CacheFactory;
 import org.eclipse.ditto.internal.utils.cache.config.CacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyImport;
@@ -39,11 +40,14 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
 
     private final Cache<PolicyId, Entry<PolicyEnforcer>> delegate;
     private final Map<PolicyId, Set<PolicyId>> policyIdToImportingMap;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     PolicyEnforcerCache(final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> policyEnforcerCacheLoader,
             final ExecutionContextExecutor cacheDispatcher,
-            final CacheConfig cacheConfig) {
+            final CacheConfig cacheConfig,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
         policyIdToImportingMap = new ConcurrentHashMap<>();
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
         this.delegate = CacheFactory.createCache(
                 (policyId, executor) -> policyEnforcerCacheLoader.asyncLoad(policyId, executor)
                         .whenCompleteAsync(((policyEnforcerEntry, throwable) -> policyEnforcerEntry.get()
@@ -92,35 +96,81 @@ final class PolicyEnforcerCache implements Cache<PolicyId, Entry<PolicyEnforcer>
 
     @Override
     public boolean invalidate(final PolicyId policyId) {
-        // Invalidate the changed policy
+        // Invalidate the changed policy itself
         final boolean directlyCached = delegate.invalidate(policyId);
 
-        // Invalidate all policies that import the changed policy
-        final boolean indirectlyCachedViaImport = Optional.ofNullable(policyIdToImportingMap.remove(policyId))
-                .stream()
-                .flatMap(Collection::stream)
-                .map(delegate::invalidate)
+        // Invalidate all policies that explicitly import the changed policy, and for each such
+        // importer that is itself a namespace root, also invalidate its namespace dependents.
+        // This covers the transitive case: imported-policy changes → root-policy (importer) is
+        // invalidated → child policies in matching namespaces are also invalidated.
+        final Set<PolicyId> importingPolicies =
+                Optional.ofNullable(policyIdToImportingMap.remove(policyId)).orElseGet(Set::of);
+        final boolean indirectlyCachedViaImport = importingPolicies.stream()
+                .map(importingPolicyId -> {
+                    final boolean importerInvalidated = delegate.invalidate(importingPolicyId);
+                    final boolean namespaceDependentsInvalidated =
+                            invalidateNamespaceDependents(importingPolicyId, delegate::invalidate);
+                    return importerInvalidated || namespaceDependentsInvalidated;
+                })
                 .reduce((previous, next) -> previous || next)
                 .orElse(false);
 
-        return directlyCached || indirectlyCachedViaImport;
+        // Invalidate all cached policies in namespaces that use the changed policy as a namespace root
+        final boolean indirectlyCachedViaNamespaceRoot = invalidateNamespaceDependents(policyId,
+                delegate::invalidate);
+
+        return directlyCached || indirectlyCachedViaImport || indirectlyCachedViaNamespaceRoot;
     }
 
     @Override
     public boolean invalidateConditionally(final PolicyId policyId,
             final Predicate<Entry<PolicyEnforcer>> valueCondition) {
-        // Invalidate the changed policy
+        // Invalidate the changed policy itself
         final boolean directlyCached = delegate.invalidateConditionally(policyId, valueCondition);
 
-        // Invalidate all policies that import the changed policy
-        final boolean indirectlyCachedViaImport = Optional.ofNullable(policyIdToImportingMap.remove(policyId))
-                .stream()
-                .flatMap(Collection::stream)
-                .map(p -> delegate.invalidateConditionally(p, valueCondition))
+        // Invalidate all policies that explicitly import the changed policy, and for each such
+        // importer that is itself a namespace root, also invalidate its namespace dependents.
+        final Set<PolicyId> importingPolicies =
+                Optional.ofNullable(policyIdToImportingMap.remove(policyId)).orElseGet(Set::of);
+        final boolean indirectlyCachedViaImport = importingPolicies.stream()
+                .map(importingPolicyId -> {
+                    final boolean importerInvalidated =
+                            delegate.invalidateConditionally(importingPolicyId, valueCondition);
+                    final boolean namespaceDependentsInvalidated = invalidateNamespaceDependents(
+                            importingPolicyId, p -> delegate.invalidateConditionally(p, valueCondition));
+                    return importerInvalidated || namespaceDependentsInvalidated;
+                })
                 .reduce((previous, next) -> previous || next)
                 .orElse(false);
 
-        return directlyCached || indirectlyCachedViaImport;
+        // Invalidate all cached policies in namespaces that use the changed policy as a namespace root
+        final boolean indirectlyCachedViaNamespaceRoot = invalidateNamespaceDependents(policyId,
+                p -> delegate.invalidateConditionally(p, valueCondition));
+
+        return directlyCached || indirectlyCachedViaImport || indirectlyCachedViaNamespaceRoot;
+    }
+
+    private boolean invalidateNamespaceDependents(final PolicyId policyId,
+            final Function<PolicyId, Boolean> invalidateFunction) {
+        if (!namespacePoliciesConfig.getAllNamespaceRootPolicyIds().contains(policyId)) {
+            return false;
+        }
+
+        final Set<String> affectedNamespaces = namespacePoliciesConfig.getNamespacesForRootPolicy(policyId);
+        if (affectedNamespaces.isEmpty()) {
+            return false;
+        }
+
+        // O(n) scan over the full cache — acceptable for typical deployments where namespace root policies
+        // change infrequently. For very large caches with frequently-changing root policies, consider
+        // tracking namespace membership at cache-load time (reverse map: namespace → cached PolicyIds).
+        return delegate.asMap().keySet().stream()
+                .filter(cachedPolicyId -> affectedNamespaces.stream()
+                        .anyMatch(pattern -> NamespacePoliciesConfig.namespaceMatchesPattern(
+                                cachedPolicyId.getNamespace(), pattern)))
+                .map(invalidateFunction)
+                .reduce((a, b) -> a || b)
+                .orElse(false);
     }
 
     @Override

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheLoader.java
@@ -18,10 +18,12 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
-import javax.annotation.concurrent.Immutable;
+import javax.annotation.Nullable;
 
 import org.apache.pekko.actor.ActorSystem;
+import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 
@@ -30,31 +32,67 @@ import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 /**
  * Loads a policy-enforcer by asking the policies shard-region-proxy.
  */
-@Immutable
 public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> {
 
     public static final String ENFORCEMENT_CACHE_DISPATCHER = "enforcement-cache-dispatcher";
 
     private final PolicyCacheLoader delegate;
     private final Executor enforcementCacheExecutor;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
+    @Nullable
+    private final CompletableFuture<Cache<PolicyId, Entry<PolicyEnforcer>>> cacheFuture;
 
     /**
      * Constructor.
      *
      * @param policyCacheLoader used to load the policies which should be transformed to a {@link PolicyEnforcer}.
      * @param actorSystem the actor system to use.
+     * @param namespacePoliciesConfig the namespace root policies configuration.
      */
-    public PolicyEnforcerCacheLoader(final PolicyCacheLoader policyCacheLoader, final ActorSystem actorSystem) {
+    public PolicyEnforcerCacheLoader(final PolicyCacheLoader policyCacheLoader, final ActorSystem actorSystem,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
+
+        this(policyCacheLoader, actorSystem, namespacePoliciesConfig, null);
+    }
+
+    /**
+     * Constructor with self-referencing cache for root-policy import tracking.
+     * When {@code cacheFuture} is provided, root policies are loaded through the cache
+     * rather than directly via the policy shard region. This ensures that their import
+     * declarations are tracked in the import map of {@link PolicyEnforcerCache}, so
+     * that changes to a policy imported by a namespace root policy correctly cascade to
+     * all child policies in the covered namespaces.
+     *
+     * @param policyCacheLoader used to load the policies.
+     * @param actorSystem the actor system to use.
+     * @param namespacePoliciesConfig the namespace root policies configuration.
+     * @param cacheFuture completed with the wrapping {@link PolicyEnforcerCache} after construction.
+     */
+    PolicyEnforcerCacheLoader(final PolicyCacheLoader policyCacheLoader, final ActorSystem actorSystem,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
+            @Nullable final CompletableFuture<Cache<PolicyId, Entry<PolicyEnforcer>>> cacheFuture) {
 
         delegate = policyCacheLoader;
         enforcementCacheExecutor = actorSystem.dispatchers().lookup(ENFORCEMENT_CACHE_DISPATCHER);
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
+        this.cacheFuture = cacheFuture;
     }
 
     @Override
     public CompletableFuture<Entry<PolicyEnforcer>> asyncLoad(final PolicyId policyId, final Executor executor) {
 
         final Function<PolicyId, CompletionStage<Optional<Policy>>> policyResolver =
-                policyIdToResolve -> delegate.asyncLoad(policyIdToResolve, executor).thenApply(Entry::get);
+                policyIdToResolve -> {
+                    if (cacheFuture != null &&
+                            namespacePoliciesConfig.getAllNamespaceRootPolicyIds().contains(policyIdToResolve)) {
+                        return cacheFuture.thenComposeAsync(
+                                cache -> cache.get(policyIdToResolve)
+                                        .thenApply(entry -> entry.flatMap(Entry::get)
+                                                .flatMap(PolicyEnforcer::getPolicy)),
+                                executor);
+                    }
+                    return delegate.asyncLoad(policyIdToResolve, executor).thenApply(Entry::get);
+                };
 
         return delegate.asyncLoad(policyId, executor)
                 .thenComposeAsync(policyEntry ->
@@ -67,7 +105,8 @@ public final class PolicyEnforcerCacheLoader implements AsyncCacheLoader<PolicyI
         if (entry.exists()) {
             final var revision = entry.getRevision();
             final var policy = entry.getValueOrThrow();
-            return PolicyEnforcer.withResolvedImports(policy, policyResolver)
+            return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(policy, policyResolver,
+                            namespacePoliciesConfig)
                     .thenApply(enforcer -> Entry.of(revision, enforcer));
         } else {
             return CompletableFuture.completedFuture(Entry.nonexistent());

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfig.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfig.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.entity.id.RegexPatterns;
+import org.eclipse.ditto.internal.utils.config.DittoConfigError;
+import org.eclipse.ditto.policies.model.PolicyId;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigList;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+
+/**
+ * Default implementation of {@link NamespacePoliciesConfig}.
+ * <p>
+ * Reads from the HOCON config path {@value #CONFIG_PATH}, which must be a config object mapping
+ * namespace patterns to lists of policy ID strings. Keys may be exact namespaces, prefix wildcards,
+ * or {@code *} to match every namespace:
+ * <pre>{@code
+ * ditto.namespace-policies {
+ *   "org.example.devices"  = ["org.example:tenant-root"]          # exact namespace
+ *   "org.example.sensors"  = ["org.example:tenant-root", "org.example:audit-policy"]
+ *   "org.example.*"        = ["org.example:tenant-root"]          # all namespaces under org.example
+ *   "*"                    = ["root:catch-all-policy"]            # every namespace
+ * }
+ * }</pre>
+ * <p>
+ * Matching patterns are resolved in deterministic precedence order:
+ * exact match first, then prefix wildcards ordered from most specific to least specific,
+ * and finally {@code *}.
+ * </p>
+ * <p>
+ * See {@link NamespacePoliciesConfig#namespaceMatchesPattern} for the supported pattern syntax.
+ * </p>
+ *
+ *  @since 3.9.0
+ */
+@Immutable
+public final class DefaultNamespacePoliciesConfig implements NamespacePoliciesConfig {
+
+    static final String CONFIG_PATH = "ditto.namespace-policies";
+
+    private final Map<String, List<PolicyId>> forwardMap;
+    private final Map<PolicyId, Set<String>> reverseMap;
+    private final List<String> sortedPatterns;
+
+    private DefaultNamespacePoliciesConfig(final Map<String, List<PolicyId>> forwardMap,
+            final Map<PolicyId, Set<String>> reverseMap) {
+        this.forwardMap = toUnmodifiableForwardMap(forwardMap);
+        this.reverseMap = toUnmodifiableReverseMap(reverseMap);
+        this.sortedPatterns = this.forwardMap.keySet().stream()
+                .sorted(Comparator.comparingInt(DefaultNamespacePoliciesConfig::patternPrecedence).reversed())
+                .toList();
+    }
+
+    /**
+     * Creates a {@code DefaultNamespacePoliciesConfig} from the given root config object.
+     * Returns an empty instance if {@value #CONFIG_PATH} is not present in the config.
+     *
+     * @param config the root config (from {@code actorSystem.settings().config()}).
+     * @return the parsed instance.
+     * @throws DittoConfigError if any configured namespace pattern is invalid.
+     */
+    public static DefaultNamespacePoliciesConfig of(final Config config) {
+        if (!config.hasPath(CONFIG_PATH)) {
+            return new DefaultNamespacePoliciesConfig(Collections.emptyMap(), Collections.emptyMap());
+        }
+
+        final Config nsPoliciesConfig = config.getConfig(CONFIG_PATH);
+        final Map<String, List<PolicyId>> forwardMap = new HashMap<>();
+        final Map<PolicyId, Set<String>> reverseMap = new HashMap<>();
+
+        for (final Map.Entry<String, ConfigValue> entry : nsPoliciesConfig.root().entrySet()) {
+            final String namespace = entry.getKey();
+            final ConfigValue value = entry.getValue();
+
+            if (value.valueType() != ConfigValueType.LIST) {
+                throw new DittoConfigError("Namespace policy entry <" + namespace + "> at config path <" +
+                        CONFIG_PATH + "> must be a list of policy IDs.");
+            }
+            patternPrecedence(namespace);
+
+            final List<PolicyId> policyIds = new ArrayList<>();
+            for (final ConfigValue listEntry : (ConfigList) value) {
+                if (listEntry.valueType() == ConfigValueType.STRING) {
+                    final PolicyId policyId = PolicyId.of(listEntry.unwrapped().toString());
+                    policyIds.add(policyId);
+                    reverseMap.computeIfAbsent(policyId, k -> new HashSet<>()).add(namespace);
+                }
+            }
+            if (!policyIds.isEmpty()) {
+                forwardMap.put(namespace, Collections.unmodifiableList(policyIds));
+            }
+        }
+
+        return new DefaultNamespacePoliciesConfig(forwardMap, reverseMap);
+    }
+
+    @Override
+    public Map<String, List<PolicyId>> getNamespacePolicies() {
+        return forwardMap;
+    }
+
+    @Override
+    public List<PolicyId> getRootPoliciesForNamespace(final String namespace) {
+        return sortedPatterns.stream()
+                .filter(p -> NamespacePoliciesConfig.namespaceMatchesPattern(namespace, p))
+                .flatMap(p -> forwardMap.get(p).stream())
+                .distinct()
+                .toList();
+    }
+
+    @Override
+    public Set<PolicyId> getAllNamespaceRootPolicyIds() {
+        return reverseMap.keySet();
+    }
+
+    @Override
+    public Set<String> getNamespacesForRootPolicy(final PolicyId rootPolicyId) {
+        return reverseMap.getOrDefault(rootPolicyId, Collections.emptySet());
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return forwardMap.isEmpty();
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        final DefaultNamespacePoliciesConfig that = (DefaultNamespacePoliciesConfig) o;
+        return Objects.equals(forwardMap, that.forwardMap);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(forwardMap);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [namespacePolicies=" + forwardMap + "]";
+    }
+
+
+    private static int patternPrecedence(final String pattern) {
+        if ("*".equals(pattern)) {
+            return 0;
+        }
+        if (pattern.endsWith(".*") &&
+                RegexPatterns.NAMESPACE_PATTERN.matcher(pattern.substring(0, pattern.length() - 2)).matches()) {
+            return pattern.length();
+        }
+        if (RegexPatterns.NAMESPACE_PATTERN.matcher(pattern).matches()) {
+            return Integer.MAX_VALUE;
+        }
+        throw new DittoConfigError("Unsupported namespace policy pattern <" + pattern + "> at config path <" +
+                CONFIG_PATH + ">. Supported syntax is exact namespace, prefix wildcard '<namespace>.*', or '*'.");
+    }
+
+    private static Map<String, List<PolicyId>> toUnmodifiableForwardMap(final Map<String, List<PolicyId>> source) {
+        final Map<String, List<PolicyId>> result = new HashMap<>();
+        source.forEach((namespace, policyIds) -> result.put(namespace, Collections.unmodifiableList(
+                new ArrayList<>(policyIds))));
+        return Collections.unmodifiableMap(result);
+    }
+
+    private static Map<PolicyId, Set<String>> toUnmodifiableReverseMap(final Map<PolicyId, Set<String>> source) {
+        final Map<PolicyId, Set<String>> result = new HashMap<>();
+        source.forEach((policyId, namespaces) -> result.put(policyId, Collections.unmodifiableSet(
+                new HashSet<>(namespaces))));
+        return Collections.unmodifiableMap(result);
+    }
+
+}

--- a/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/NamespacePoliciesConfig.java
+++ b/policies/enforcement/src/main/java/org/eclipse/ditto/policies/enforcement/config/NamespacePoliciesConfig.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+
+/**
+ * Configuration mapping namespace patterns to a set of "namespace root" policy IDs whose implicit
+ * entries are automatically merged into every policy belonging to a matching namespace during enforcer
+ * resolution.
+ * <p>
+ * This allows operators to define tenant/namespace-wide access policies without requiring individual
+ * policies to declare explicit imports. The injection happens transparently at enforcer-build time, so
+ * the stored policy's {@code imports} field is never modified.
+ * </p>
+ * <p>Namespace patterns support the following syntax:</p>
+ * <ul>
+ *   <li>{@code *} - matches every namespace</li>
+ *   <li>{@code org.example.*} - matches any namespace whose name starts with {@code org.example.}</li>
+ *   <li>exact string - matches only that exact namespace</li>
+ * </ul>
+ * <p>
+ * Matching namespace roots are applied in deterministic precedence order: exact match first, then
+ * prefix wildcards ordered from most specific to least specific, and finally the catch-all pattern
+ * {@code *}.
+ * </p>
+ *
+ * @since 3.9.0
+ */
+@Immutable
+public interface NamespacePoliciesConfig {
+
+    /**
+     * Returns the full mapping of namespace patterns to list of namespace root policy IDs.
+     * Map keys may be exact namespaces or wildcard patterns (e.g. {@code org.example.*}).
+     *
+     * @return immutable map of namespace pattern to list of PolicyIds.
+     */
+    Map<String, List<PolicyId>> getNamespacePolicies();
+
+    /**
+     * Returns the combined list of namespace root policy IDs whose patterns match the given
+     * {@code namespace}. Returns an empty list if no pattern matches.
+     * Matching patterns are resolved in deterministic precedence order: exact match first, then
+     * prefix wildcards ordered from most specific to least specific, and finally {@code *}.
+     *
+     * @param namespace the concrete namespace to look up (not a pattern).
+     * @return list of PolicyIds acting as namespace roots for the given namespace, never null.
+     */
+    List<PolicyId> getRootPoliciesForNamespace(String namespace);
+
+    /**
+     * Returns all policy IDs that are configured as namespace root policies across all patterns.
+     * Used to short-circuit cache invalidation checks.
+     *
+     * @return set of all namespace root PolicyIds.
+     */
+    Set<PolicyId> getAllNamespaceRootPolicyIds();
+
+    /**
+     * Returns the set of namespace patterns that the given {@code rootPolicyId} covers.
+     * Patterns may be exact namespaces or wildcards (e.g. {@code org.example.*} or {@code *}).
+     * Used during cache invalidation: when a namespace root policy changes, all cached policies
+     * whose namespace matches any returned pattern must be invalidated.
+     *
+     * @param rootPolicyId the policy ID of a namespace root policy.
+     * @return set of namespace patterns covered by the given root policy, empty if none.
+     */
+    Set<String> getNamespacesForRootPolicy(PolicyId rootPolicyId);
+
+    /**
+     * Returns whether no namespace policies are configured at all.
+     *
+     * @return {@code true} if the config is empty.
+     */
+    boolean isEmpty();
+
+    /**
+     * Returns whether the given concrete {@code namespace} matches the given {@code pattern}.
+     * <ul>
+     *   <li>{@code *} matches any namespace.</li>
+     *   <li>{@code org.example.*} matches any namespace starting with {@code org.example.}</li>
+     *   <li>Any other value is treated as an exact match.</li>
+     * </ul>
+     *
+     * @param namespace the concrete namespace string to test.
+     * @param pattern the pattern from the config (exact, prefix wildcard, or {@code *}).
+     * @return {@code true} if {@code namespace} matches {@code pattern}.
+     * @since 3.9.0
+     */
+    static boolean namespaceMatchesPattern(final String namespace, final String pattern) {
+        if ("*".equals(pattern)) {
+            return true;
+        }
+        if (pattern.endsWith(".*")) {
+            return namespace.startsWith(pattern.substring(0, pattern.length() - 1));
+        }
+        return namespace.equals(pattern);
+    }
+
+}

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerCacheTest.java
@@ -22,21 +22,44 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.ditto.internal.utils.cache.config.DefaultCacheConfig;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.Permissions;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.PolicyImport;
+import org.eclipse.ditto.policies.model.Resource;
+import org.eclipse.ditto.policies.model.Resources;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
+import com.typesafe.config.ConfigFactory;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.testkit.javadsl.TestKit;
+import org.eclipse.ditto.json.JsonPointer;
 import scala.concurrent.ExecutionContextExecutor;
 
 public final class PolicyEnforcerCacheTest {
@@ -65,7 +88,8 @@ public final class PolicyEnforcerCacheTest {
         final var underTest = new PolicyEnforcerCache(
                 cacheLoader,
                 executor,
-                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache")
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
         );
 
         new TestKit(actorSystem) {{
@@ -82,7 +106,8 @@ public final class PolicyEnforcerCacheTest {
         final var underTest = new PolicyEnforcerCache(
                 cacheLoader,
                 executor,
-                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache")
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config())
         );
 
         final var otherPolicyId = PolicyId.generateRandom();
@@ -123,6 +148,196 @@ public final class PolicyEnforcerCacheTest {
             verifyLoadedFromCache(otherPolicy, underTest, cacheLoader);
         }};
 
+    }
+
+    @Test
+    public void policyTagInvalidatesCachedPoliciesInNamespacesOfChangedRootPolicy() throws Exception {
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root-local");
+
+        final var underTest = new PolicyEnforcerCache(
+                cacheLoader,
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                namespacePoliciesConfigFor(rootPolicyId)
+        );
+
+        final Policy devicesPolicy = Policy.newBuilder(PolicyId.of("org.example.devices", "policy-a")).build();
+        final Policy sensorsPolicy = Policy.newBuilder(PolicyId.of("org.example.sensors", "policy-b")).build();
+        final Policy unrelatedPolicy = Policy.newBuilder(PolicyId.of("org.example.other", "policy-c")).build();
+
+        new TestKit(actorSystem) {{
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            verifyLoadedFromCache(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            final boolean invalidated = underTest.invalidate(rootPolicyId);
+            assertThat(invalidated).isTrue();
+
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+        }};
+    }
+
+    @Test
+    public void wildcardNamespacePatternInvalidatesCachedPoliciesInMatchingNamespaces() throws Exception {
+        final AsyncCacheLoader<PolicyId, Entry<PolicyEnforcer>> cacheLoader = mock(AsyncCacheLoader.class);
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root-wildcard");
+
+        // configure root policy via wildcard pattern "org.example.*"
+        final var underTest = new PolicyEnforcerCache(
+                cacheLoader,
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                namespacePoliciesConfigForWildcard(rootPolicyId, "org.example.*")
+        );
+
+        final Policy devicesPolicy = Policy.newBuilder(PolicyId.of("org.example.devices", "policy-a")).build();
+        final Policy sensorsPolicy = Policy.newBuilder(PolicyId.of("org.example.sensors", "policy-b")).build();
+        // "org.examples" must NOT match "org.example.*" (no dot separator)
+        final Policy unrelatedPolicy = Policy.newBuilder(PolicyId.of("org.examples", "policy-c")).build();
+
+        new TestKit(actorSystem) {{
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            verifyLoadedFromCache(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(sensorsPolicy, underTest, cacheLoader);
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+            reset(cacheLoader);
+
+            final boolean invalidated = underTest.invalidate(rootPolicyId);
+            assertThat(invalidated).isTrue();
+
+            // matching namespace policies must be reloaded
+            verifyLoadedFromCacheLoader(devicesPolicy, underTest, cacheLoader);
+            verifyLoadedFromCacheLoader(sensorsPolicy, underTest, cacheLoader);
+            // non-matching policy must still be served from cache
+            verifyLoadedFromCache(unrelatedPolicy, underTest, cacheLoader);
+        }};
+    }
+
+    @Test
+    public void importedPolicyChangeInvalidatesRootAndMatchingChildPolicies() {
+        final ExecutionContextExecutor executor = actorSystem.dispatcher();
+        final PolicyId childPolicyId = PolicyId.of("org.example.devices", "child-policy");
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root");
+        final PolicyId importedPolicyId = PolicyId.of("org.example", "imported-policy");
+        final Label initialImportedLabel = Label.of("IMPORTED_READER");
+        final Label updatedImportedLabel = Label.of("IMPORTED_ADMIN");
+
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "}"
+        ));
+
+        final Map<PolicyId, Policy> policies = new ConcurrentHashMap<>();
+        policies.put(importedPolicyId, policyWithLabel(importedPolicyId, 1L, initialImportedLabel));
+        policies.put(rootPolicyId, Policy.newBuilder(rootPolicyId)
+                .setRevision(1L)
+                .setPolicyImport(PolicyImport.newInstance(importedPolicyId, null))
+                .build());
+        policies.put(childPolicyId, Policy.newBuilder(childPolicyId)
+                .setRevision(1L)
+                .build());
+
+        final PolicyCacheLoader policyCacheLoader = mock(PolicyCacheLoader.class);
+        when(policyCacheLoader.asyncLoad(any(), any())).thenAnswer(invocation -> {
+            final PolicyId policyId = invocation.getArgument(0);
+            final Policy policy = policies.get(policyId);
+            return CompletableFuture.completedFuture(policy == null
+                    ? Entry.nonexistent()
+                    : Entry.of(policy.getRevision().orElseThrow().toLong(), policy));
+        });
+
+        final CompletableFuture<org.eclipse.ditto.internal.utils.cache.Cache<PolicyId, Entry<PolicyEnforcer>>> cacheFuture =
+                new CompletableFuture<>();
+        final PolicyEnforcerCache underTest = new PolicyEnforcerCache(
+                new PolicyEnforcerCacheLoader(policyCacheLoader, actorSystem, config, cacheFuture),
+                executor,
+                DefaultCacheConfig.of(actorSystem.settings().config(), "ditto.policies-enforcer-cache"),
+                config
+        );
+        cacheFuture.complete(underTest);
+
+        final PolicyEnforcer initialChild = underTest.getBlocking(childPolicyId)
+                .flatMap(Entry::get)
+                .orElseThrow();
+        assertThat(initialChild.getPolicy().orElseThrow()
+                .contains(PoliciesModelFactory.newImportedLabel(importedPolicyId, initialImportedLabel))).isTrue();
+        assertThat(initialChild.getPolicy().orElseThrow()
+                .contains(PoliciesModelFactory.newImportedLabel(importedPolicyId, updatedImportedLabel))).isFalse();
+
+        policies.put(importedPolicyId, policyWithLabel(importedPolicyId, 2L, updatedImportedLabel));
+
+        final boolean invalidated = underTest.invalidate(importedPolicyId);
+        assertThat(invalidated).isTrue();
+
+        final PolicyEnforcer reloadedChild = underTest.getBlocking(childPolicyId)
+                .flatMap(Entry::get)
+                .orElseThrow();
+        assertThat(reloadedChild.getPolicy().orElseThrow()
+                .contains(PoliciesModelFactory.newImportedLabel(importedPolicyId, initialImportedLabel))).isFalse();
+        assertThat(reloadedChild.getPolicy().orElseThrow()
+                .contains(PoliciesModelFactory.newImportedLabel(importedPolicyId, updatedImportedLabel))).isTrue();
+    }
+
+    private NamespacePoliciesConfig namespacePoliciesConfigForWildcard(final PolicyId rootPolicyId,
+            final String pattern) {
+        final NamespacePoliciesConfig config = mock(NamespacePoliciesConfig.class);
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.singleton(rootPolicyId));
+        when(config.getNamespacesForRootPolicy(rootPolicyId)).thenReturn(Collections.singleton(pattern));
+        return config;
+    }
+
+    private NamespacePoliciesConfig namespacePoliciesConfigFor(final PolicyId rootPolicyId) {
+        final NamespacePoliciesConfig config = mock(NamespacePoliciesConfig.class);
+        final Map<String, List<PolicyId>> namespacePolicies = new HashMap<>();
+        namespacePolicies.put("org.example.devices", Collections.singletonList(rootPolicyId));
+        namespacePolicies.put("org.example.sensors", Collections.singletonList(rootPolicyId));
+
+        final Set<String> coveredNamespaces = new HashSet<>();
+        coveredNamespaces.add("org.example.devices");
+        coveredNamespaces.add("org.example.sensors");
+
+        when(config.getNamespacePolicies()).thenReturn(namespacePolicies);
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.singleton(rootPolicyId));
+        when(config.getNamespacesForRootPolicy(rootPolicyId)).thenReturn(coveredNamespaces);
+        return config;
+    }
+
+    private static Policy policyWithLabel(final PolicyId policyId, final long revision, final Label label) {
+        final Subjects subjects = Subjects.newInstance(
+                Subject.newInstance(
+                        SubjectId.newInstance(SubjectIssuer.newInstance("pre"), label.toString()),
+                        SubjectType.newInstance("pre-authenticated")
+                )
+        );
+        final Resources resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none()))
+        );
+        return Policy.newBuilder(policyId)
+                .setRevision(revision)
+                .set(PoliciesModelFactory.newPolicyEntry(
+                        label,
+                        subjects,
+                        resources,
+                        ImportableType.IMPLICIT
+                ))
+                .build();
     }
 
     private void verifyLoadedFromCacheLoader(final Policy policy,

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerNamespacePoliciesTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/PolicyEnforcerNamespacePoliciesTest.java
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.Resource;
+import org.eclipse.ditto.policies.model.Resources;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit tests for the namespace-root-policy merge logic in
+ * {@link PolicyEnforcer#withResolvedImportsAndNamespacePolicies}.
+ */
+public final class PolicyEnforcerNamespacePoliciesTest {
+
+    private static final String NAMESPACE = "org.example.devices";
+    private static final PolicyId CHILD_POLICY_ID = PolicyId.of(NAMESPACE, "child-policy");
+    private static final PolicyId ROOT_POLICY_ID = PolicyId.of("org.example", "tenant-root");
+
+    private static final Label LOCAL_LABEL = Label.of("LOCAL_OWNER");
+    private static final Label ROOT_IMPLICIT_LABEL = Label.of("ROOT_READER");
+    private static final Label ROOT_NEVER_LABEL = Label.of("ROOT_NEVER");
+    private static final Label ROOT_EXPLICIT_LABEL = Label.of("ROOT_EXPLICIT");
+
+    @Test
+    public void implicitRootEntryIsMergedIntoChildEnforcer() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_IMPLICIT_LABEL, ImportableType.IMPLICIT);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_IMPLICIT_LABEL)).isTrue();
+    }
+
+    @Test
+    public void neverImportableRootEntryIsNotMerged() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_NEVER_LABEL, ImportableType.NEVER);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_NEVER_LABEL)).isFalse();
+    }
+
+    @Test
+    public void explicitImportableRootEntryIsNotMerged() throws Exception {
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_EXPLICIT_LABEL, ImportableType.EXPLICIT);
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_EXPLICIT_LABEL)).isFalse();
+    }
+
+    @Test
+    public void localLabelWinsOverNamespaceRootLabelOnConflict() throws Exception {
+        // Both child and root have the same label — local must win (root entry must NOT override it)
+        final var localSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("local-issuer"), "user");
+        final var rootSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("root-issuer"), "user");
+
+        final Policy rootPolicy = policyWithEntryAndSubject(ROOT_POLICY_ID, LOCAL_LABEL,
+                ImportableType.IMPLICIT, rootSubjectId);
+        final Policy childPolicy = policyWithEntryAndSubject(CHILD_POLICY_ID, LOCAL_LABEL,
+                ImportableType.IMPLICIT, localSubjectId);
+
+        final var enforcer = buildEnforcer(childPolicy, ROOT_POLICY_ID, rootPolicy);
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        final var entry = merged.getEntryFor(LOCAL_LABEL).orElseThrow();
+        // local subject must be present; root subject must not have replaced it
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(localSubjectId))).isTrue();
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(rootSubjectId))).isFalse();
+    }
+
+    @Test
+    public void missingRootPolicyIsHandledGracefully() throws Exception {
+        // Root policy resolver returns empty — should not throw, child policy enforcer built normally
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig config = namespaceConfig(ROOT_POLICY_ID);
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> CompletableFuture.completedFuture(Optional.empty());
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+
+        assertThat(enforcer.getPolicy().orElseThrow().contains(LOCAL_LABEL)).isTrue();
+    }
+
+    @Test
+    public void emptyNamespacePoliciesConfigLeavesChildUnchanged() throws Exception {
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig emptyConfig = mock(NamespacePoliciesConfig.class);
+        when(emptyConfig.isEmpty()).thenReturn(true);
+        when(emptyConfig.getRootPoliciesForNamespace(NAMESPACE)).thenReturn(List.of());
+
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> CompletableFuture.completedFuture(Optional.empty());
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, emptyConfig)
+                .toCompletableFuture()
+                .join();
+
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        // only the local label should be present
+        assertThat(merged.stream().count()).isEqualTo(1);
+    }
+
+    @Test
+    public void moreSpecificNamespaceWildcardWinsOnLabelConflict() {
+        final PolicyId generalRootPolicyId = PolicyId.of("org.example", "tenant-root-general");
+        final PolicyId specificRootPolicyId = PolicyId.of("org.example", "tenant-root-devices");
+        final PolicyId childPolicyId = PolicyId.of("org.example.devices.alpha", "child-policy");
+
+        final var generalSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("general-issuer"), "user");
+        final var specificSubjectId = SubjectId.newInstance(SubjectIssuer.newInstance("specific-issuer"), "user");
+
+        final Policy generalRootPolicy = policyWithEntryAndSubject(generalRootPolicyId, ROOT_IMPLICIT_LABEL,
+                ImportableType.IMPLICIT, generalSubjectId);
+        final Policy specificRootPolicy = policyWithEntryAndSubject(specificRootPolicyId, ROOT_IMPLICIT_LABEL,
+                ImportableType.IMPLICIT, specificSubjectId);
+        final Policy childPolicy = policyWithEntry(childPolicyId, LOCAL_LABEL, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.*\"         = [\"org.example:tenant-root-general\"]\n" +
+                "  \"org.example.devices.*\" = [\"org.example:tenant-root-devices\"]\n" +
+                "}"));
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> CompletableFuture.completedFuture(Optional.ofNullable(
+                        generalRootPolicyId.equals(id) ? generalRootPolicy :
+                                specificRootPolicyId.equals(id) ? specificRootPolicy : null));
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+        final var entry = merged.getEntryFor(ROOT_IMPLICIT_LABEL).orElseThrow();
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(specificSubjectId))).isTrue();
+        assertThat(entry.getSubjects().stream()
+                .anyMatch(s -> s.getId().equals(generalSubjectId))).isFalse();
+    }
+
+    @Test
+    public void rootPolicyWithOwnImportsHasImportedEntriesMergedIntoChild() throws Exception {
+        final PolicyId importedPolicyId = PolicyId.of("org.example", "imported-policy");
+        final Label importedLabel = Label.of("IMPORTED_READER");
+
+        final Policy importedPolicy = policyWithEntry(importedPolicyId, importedLabel, ImportableType.IMPLICIT);
+
+        final Policy rootPolicyWithImport = Policy.newBuilder(ROOT_POLICY_ID)
+                .set(PoliciesModelFactory.newPolicyEntry(ROOT_IMPLICIT_LABEL,
+                        Subjects.newInstance(Subject.newInstance(
+                                SubjectId.newInstance(SubjectIssuer.newInstance("root-issuer"), "user"),
+                                SubjectType.newInstance("test"))),
+                        Resources.newInstance(Resource.newInstance("thing", JsonPointer.of("/"),
+                                EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none()))),
+                        ImportableType.IMPLICIT))
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(importedPolicyId))
+                .build();
+
+        final NamespacePoliciesConfig config = namespaceConfig(ROOT_POLICY_ID);
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver = id -> {
+            if (ROOT_POLICY_ID.equals(id)) return CompletableFuture.completedFuture(Optional.of(rootPolicyWithImport));
+            if (importedPolicyId.equals(id)) return CompletableFuture.completedFuture(Optional.of(importedPolicy));
+            return CompletableFuture.completedFuture(Optional.empty());
+        };
+
+        final Policy childPolicy = policyWithEntry(CHILD_POLICY_ID, LOCAL_LABEL, ImportableType.IMPLICIT);
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+        final Label importedMergedLabel = PoliciesModelFactory.newImportedLabel(importedPolicyId, importedLabel);
+        assertThat(merged.contains(LOCAL_LABEL)).isTrue();
+        assertThat(merged.contains(ROOT_IMPLICIT_LABEL)).isTrue();
+        assertThat(merged.contains(importedMergedLabel)).isTrue();
+        assertThat(merged.contains(importedLabel)).isFalse();
+    }
+
+    @Test
+    public void rootPolicyStillReceivesOtherMatchingNamespaceRoots() {
+        final PolicyId globalRootPolicyId = PolicyId.of("global", "catch-all");
+        final Label globalLabel = Label.of("GLOBAL_READER");
+
+        final Policy rootPolicy = policyWithEntry(ROOT_POLICY_ID, ROOT_IMPLICIT_LABEL, ImportableType.IMPLICIT);
+        final Policy globalRootPolicy = policyWithEntry(globalRootPolicyId, globalLabel, ImportableType.IMPLICIT);
+
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"*\" = [\"global:catch-all\"]\n" +
+                "}"));
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver = id -> CompletableFuture.completedFuture(
+                Optional.ofNullable(ROOT_POLICY_ID.equals(id) ? rootPolicy :
+                        globalRootPolicyId.equals(id) ? globalRootPolicy : null));
+
+        final var enforcer = PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(rootPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+
+        final Policy merged = enforcer.getPolicy().orElseThrow();
+        assertThat(merged.contains(ROOT_IMPLICIT_LABEL)).isTrue();
+        assertThat(merged.contains(globalLabel)).isTrue();
+    }
+
+    // ---- helpers ----
+
+    private static Policy policyWithEntryAndSubject(final PolicyId policyId, final Label label,
+            final ImportableType importableType, final SubjectId subjectId) {
+        final var subjects = Subjects.newInstance(
+                Subject.newInstance(subjectId, SubjectType.newInstance("test")));
+        final var resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none())));
+        final var entry = PoliciesModelFactory.newPolicyEntry(label, subjects, resources, importableType);
+        return Policy.newBuilder(policyId).set(entry).build();
+    }
+
+    private static Policy policyWithEntry(final PolicyId policyId, final Label label,
+            final ImportableType importableType) {
+        final var subjects = Subjects.newInstance(
+                Subject.newInstance(
+                        SubjectId.newInstance(SubjectIssuer.newInstance(label.toString()), "user"),
+                        SubjectType.newInstance("test")));
+        final var resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(
+                                Permissions.newInstance("READ"),
+                                Permissions.none())));
+        final var entry = PoliciesModelFactory.newPolicyEntry(label, subjects, resources, importableType);
+        return Policy.newBuilder(policyId).set(entry).build();
+    }
+
+    private static PolicyEnforcer buildEnforcer(final Policy childPolicy,
+            final PolicyId rootPolicyId, final Policy rootPolicy) {
+        final NamespacePoliciesConfig config = namespaceConfig(rootPolicyId);
+        final Function<PolicyId, CompletableFuture<Optional<Policy>>> resolver =
+                id -> rootPolicyId.equals(id)
+                        ? CompletableFuture.completedFuture(Optional.of(rootPolicy))
+                        : CompletableFuture.completedFuture(Optional.empty());
+
+        return PolicyEnforcer
+                .withResolvedImportsAndNamespacePolicies(childPolicy, resolver::apply, config)
+                .toCompletableFuture()
+                .join();
+    }
+
+    private static NamespacePoliciesConfig namespaceConfig(final PolicyId rootPolicyId) {
+        final NamespacePoliciesConfig config = mock(NamespacePoliciesConfig.class);
+        when(config.isEmpty()).thenReturn(false);
+        when(config.getRootPoliciesForNamespace(NAMESPACE)).thenReturn(Collections.singletonList(rootPolicyId));
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Set.of(rootPolicyId));
+        when(config.getNamespacesForRootPolicy(rootPolicyId)).thenReturn(Set.of(NAMESPACE));
+        return config;
+    }
+
+}

--- a/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfigTest.java
+++ b/policies/enforcement/src/test/java/org/eclipse/ditto/policies/enforcement/config/DefaultNamespacePoliciesConfigTest.java
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.policies.enforcement.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.junit.Test;
+
+import org.eclipse.ditto.internal.utils.config.DittoConfigError;
+
+import com.typesafe.config.ConfigFactory;
+
+/**
+ * Unit test for {@link DefaultNamespacePoliciesConfig}.
+ */
+public final class DefaultNamespacePoliciesConfigTest {
+
+    @Test
+    public void parsesForwardAndReverseMapsFromHocon() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.sensors\" = [\"org.example:tenant-root\", \"org.example:audit-policy\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.isEmpty()).isFalse();
+
+        // forward map
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.sensors"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"), PolicyId.of("org.example:audit-policy"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.unknown")).isEmpty();
+
+        // reverse map
+        assertThat(underTest.getAllNamespaceRootPolicyIds())
+                .containsExactlyInAnyOrder(PolicyId.of("org.example:tenant-root"),
+                        PolicyId.of("org.example:audit-policy"));
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:tenant-root")))
+                .containsExactlyInAnyOrder("org.example.devices", "org.example.sensors");
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:audit-policy")))
+                .containsExactlyInAnyOrder("org.example.sensors");
+    }
+
+    @Test
+    public void returnsEmptyInstanceWhenConfigPathAbsent() {
+        final var underTest = DefaultNamespacePoliciesConfig.of(ConfigFactory.empty());
+
+        assertThat(underTest.isEmpty()).isTrue();
+        assertThat(underTest.getNamespacePolicies()).isEmpty();
+        assertThat(underTest.getAllNamespaceRootPolicyIds()).isEmpty();
+        assertThat(underTest.getRootPoliciesForNamespace("any.namespace")).isEmpty();
+        assertThat(underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:some-policy"))).isEmpty();
+    }
+
+    @Test
+    public void rejectsNonListConfigValues() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.badentry\" = \"not-a-list\"\n" +
+                "}");
+
+        assertThatThrownBy(() -> DefaultNamespacePoliciesConfig.of(config))
+                .isInstanceOf(DittoConfigError.class)
+                .hasMessageContaining("Namespace policy entry <org.example.badentry>");
+    }
+
+    @Test
+    public void skipsEmptyListEntries() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.empty\" = []\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices")).hasSize(1);
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.empty")).isEmpty();
+        // empty lists must not appear in the forward map
+        assertThat(underTest.getNamespacePolicies()).doesNotContainKey("org.example.empty");
+    }
+
+    @Test
+    public void prefixWildcardMatchesNamespacesUnderPrefix() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.*\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.sensors"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.examples")).isEmpty();
+        assertThat(underTest.getRootPoliciesForNamespace("com.other.ns")).isEmpty();
+    }
+
+    @Test
+    public void catchAllWildcardMatchesEveryNamespace() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"*\" = [\"root:catch-all\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(PolicyId.of("root:catch-all"));
+        assertThat(underTest.getRootPoliciesForNamespace("com.completely.different"))
+                .containsExactly(PolicyId.of("root:catch-all"));
+    }
+
+    @Test
+    public void exactAndWildcardPoliciesAreCombinedForMatchingNamespace() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:device-root\"]\n" +
+                "  \"org.example.*\"       = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(
+                        PolicyId.of("org.example:device-root"),
+                        PolicyId.of("org.example:tenant-root"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.sensors"))
+                .containsExactly(PolicyId.of("org.example:tenant-root"));
+    }
+
+    @Test
+    public void rejectsUnsupportedWildcardInMiddleOfPattern() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.*.devices\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        assertThatThrownBy(() -> DefaultNamespacePoliciesConfig.of(config))
+                .isInstanceOf(DittoConfigError.class)
+                .hasMessageContaining("Unsupported namespace policy pattern <org.*.devices>");
+    }
+
+    @Test
+    public void rejectsUnsupportedWildcardSuffixPattern() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"foo*\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        assertThatThrownBy(() -> DefaultNamespacePoliciesConfig.of(config))
+                .isInstanceOf(DittoConfigError.class)
+                .hasMessageContaining("Unsupported namespace policy pattern <foo*>");
+    }
+
+    @Test
+    public void rejectsInvalidCatchAllLikePattern() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"**\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        assertThatThrownBy(() -> DefaultNamespacePoliciesConfig.of(config))
+                .isInstanceOf(DittoConfigError.class)
+                .hasMessageContaining("Unsupported namespace policy pattern <**>");
+    }
+
+    @Test
+    public void matchingPoliciesAreReturnedInDeterministicPrecedenceOrder() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"*\"                     = [\"root:catch-all\"]\n" +
+                "  \"org.example.*\"         = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.devices.*\" = [\"org.example:devices-root\"]\n" +
+                "  \"org.example.devices\"   = [\"org.example:device-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(
+                        PolicyId.of("org.example:device-root"),
+                        PolicyId.of("org.example:tenant-root"),
+                        PolicyId.of("root:catch-all"));
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices.alpha"))
+                .containsExactly(
+                        PolicyId.of("org.example:devices-root"),
+                        PolicyId.of("org.example:tenant-root"),
+                        PolicyId.of("root:catch-all"));
+    }
+
+    @Test
+    public void moreSpecificPrefixWildcardPrecedesBroaderPrefixWildcard() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.*\"         = [\"org.example:tenant-root\"]\n" +
+                "  \"org.example.devices.*\" = [\"org.example:devices-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices.alpha"))
+                .containsExactly(
+                        PolicyId.of("org.example:devices-root"),
+                        PolicyId.of("org.example:tenant-root"));
+    }
+
+    @Test
+    public void duplicatePolicyIdsAcrossMatchingPatternsAreDeduplicatedInPrecedenceOrder() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:device-root\", \"org.example:shared-root\"]\n" +
+                "  \"org.example.*\"       = [\"org.example:shared-root\", \"org.example:tenant-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThat(underTest.getRootPoliciesForNamespace("org.example.devices"))
+                .containsExactly(
+                        PolicyId.of("org.example:device-root"),
+                        PolicyId.of("org.example:shared-root"),
+                        PolicyId.of("org.example:tenant-root"));
+    }
+
+    @Test
+    public void prefixWildcardDoesNotMatchParentNamespaceItself() {
+        // "org.example.*" should NOT match "org.example" — it only matches sub-namespaces
+        // (requires at least one segment after the dot, e.g. "org.example.devices")
+        assertThat(NamespacePoliciesConfig.namespaceMatchesPattern("org.example", "org.example.*")).isFalse();
+    }
+
+    @Test
+    public void prefixWildcardMatchesMultiLevelSubNamespaces() {
+        // "org.example.*" matches arbitrary depth, not just a single segment
+        // operators from glob semantics should be aware this is not single-level-only
+        assertThat(NamespacePoliciesConfig.namespaceMatchesPattern("org.example.a.b.c", "org.example.*")).isTrue();
+    }
+
+    @Test
+    public void returnedMapsAreImmutable() {
+        final var config = ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                "}");
+
+        final var underTest = DefaultNamespacePoliciesConfig.of(config);
+
+        assertThatThrownBy(() -> underTest.getNamespacePolicies().put("org.example.new", List.of()))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> underTest.getAllNamespaceRootPolicyIds().add(PolicyId.of("org.example:new")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() ->
+                underTest.getNamespacesForRootPolicy(PolicyId.of("org.example:tenant-root")).add("ns"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+}

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyEnforcerActor.java
@@ -25,6 +25,7 @@ import org.eclipse.ditto.policies.enforcement.AbstractPolicyLoadingEnforcerActor
 import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
@@ -39,13 +40,17 @@ import org.eclipse.ditto.policies.service.enforcement.PolicyCommandEnforcement;
 public final class PolicyEnforcerActor extends
         AbstractPolicyLoadingEnforcerActor<PolicyId, Signal<?>, PolicyCommandResponse<?>, PolicyCommandEnforcement> {
 
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
+
     @SuppressWarnings("unused")
     private PolicyEnforcerActor(final PolicyId policyId,
             final PolicyCommandEnforcement policyCommandEnforcement,
             final PolicyEnforcerProvider policyEnforcerProvider,
-            final LocalAskTimeoutConfig localAskTimeoutConfig
+            final LocalAskTimeoutConfig localAskTimeoutConfig,
+            final NamespacePoliciesConfig namespacePoliciesConfig
     ) {
         super(policyId, policyCommandEnforcement, policyEnforcerProvider, localAskTimeoutConfig);
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
     }
 
     /**
@@ -55,12 +60,14 @@ public final class PolicyEnforcerActor extends
      * @param policyCommandEnforcement the policy command enforcement logic to apply in the enforcer.
      * @param policyEnforcerProvider the policy enforcer provider.
      * @param localAskTimeoutConfig the configuration for determining local "ask" timeouts.
+     * @param namespacePoliciesConfig the pre-parsed namespace policies configuration (should be parsed once and shared).
      * @return the {@link Props} to create this actor.
      */
     public static Props props(final PolicyId policyId, final PolicyCommandEnforcement policyCommandEnforcement,
-            final PolicyEnforcerProvider policyEnforcerProvider, final LocalAskTimeoutConfig localAskTimeoutConfig) {
+            final PolicyEnforcerProvider policyEnforcerProvider, final LocalAskTimeoutConfig localAskTimeoutConfig,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
         return Props.create(PolicyEnforcerActor.class, policyId, policyCommandEnforcement, policyEnforcerProvider,
-                        localAskTimeoutConfig
+                        localAskTimeoutConfig, namespacePoliciesConfig
                 ).withDispatcher(ENFORCEMENT_DISPATCHER);
     }
 
@@ -76,7 +83,9 @@ public final class PolicyEnforcerActor extends
             final Function<PolicyId, CompletionStage<Optional<Policy>>> importedPolicyResolver =
                     importedPolicyId -> policyCacheLoader.asyncLoad(importedPolicyId, getContext().dispatcher())
                             .thenApply(Entry::get);
-            return PolicyEnforcer.withResolvedImports(createPolicy.getPolicy(), importedPolicyResolver)
+            return PolicyEnforcer.withResolvedImportsAndNamespacePolicies(createPolicy.getPolicy(),
+                            importedPolicyResolver,
+                            namespacePoliciesConfig)
                     .thenApply(Optional::of);
         }
         return super.loadPolicyEnforcer(signal);

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActor.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.internal.utils.persistence.mongo.streaming.MongoReadJou
 import org.eclipse.ditto.internal.utils.persistentactors.AbstractPersistenceSupervisor;
 import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.policies.model.signals.commands.PolicyCommand;
@@ -52,6 +53,7 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
     private final ActorRef announcementManager;
     private final PoliciesConfig policiesConfig;
     private final PolicyEnforcerProvider policyEnforcerProvider;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     @SuppressWarnings("unused")
     private PolicySupervisorActor(final ActorRef pubSubMediator,
@@ -59,12 +61,14 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
             final DistributedPub<PolicyAnnouncement<?>> policyAnnouncementPub,
             @Nullable final BlockedNamespaces blockedNamespaces,
             final PolicyEnforcerProvider policyEnforcerProvider,
-            final MongoReadJournal mongoReadJournal) {
+            final MongoReadJournal mongoReadJournal,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
 
         super(blockedNamespaces, mongoReadJournal, policiesConfig.getPolicyConfig().getSupervisorConfig());
         this.policyEnforcerProvider = policyEnforcerProvider;
         this.pubSubMediator = pubSubMediator;
         this.policiesConfig = policiesConfig;
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
 
         final var props = getAnnouncementManagerProps(policyAnnouncementPub,
                 policiesConfig.getPolicyConfig().getPolicyAnnouncementConfig());
@@ -88,6 +92,7 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
      * @param blockedNamespaces the blocked namespaces functionality to retrieve/subscribe for blocked namespaces.
      * @param policyEnforcerProvider used to load the policy enforcer to authorize commands.
      * @param mongoReadJournal the ReadJournal used for gaining access to historical values of the policy.
+     * @param namespacePoliciesConfig the pre-parsed namespace policies configuration shared for the actor system.
      * @return the {@link Props} to create this actor.
      */
     public static Props props(final ActorRef pubSubMediator,
@@ -95,10 +100,12 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
             final DistributedPub<PolicyAnnouncement<?>> policyAnnouncementPub,
             @Nullable final BlockedNamespaces blockedNamespaces,
             final PolicyEnforcerProvider policyEnforcerProvider,
-            final MongoReadJournal mongoReadJournal) {
+            final MongoReadJournal mongoReadJournal,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
 
         return Props.create(PolicySupervisorActor.class, pubSubMediator, policiesConfig,
-                policyAnnouncementPub, blockedNamespaces, policyEnforcerProvider, mongoReadJournal);
+                policyAnnouncementPub, blockedNamespaces, policyEnforcerProvider, mongoReadJournal,
+                namespacePoliciesConfig);
     }
 
     @Override
@@ -115,7 +122,8 @@ public final class PolicySupervisorActor extends AbstractPersistenceSupervisor<P
     @Override
     protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
         return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
-                policiesConfig.getPolicyConfig().getSupervisorConfig().getLocalAskTimeoutConfig()
+                policiesConfig.getPolicyConfig().getSupervisorConfig().getLocalAskTimeoutConfig(),
+                namespacePoliciesConfig
         );
     }
 

--- a/policies/service/src/main/java/org/eclipse/ditto/policies/service/starter/PoliciesRootActor.java
+++ b/policies/service/src/main/java/org/eclipse/ditto/policies/service/starter/PoliciesRootActor.java
@@ -46,6 +46,8 @@ import org.eclipse.ditto.internal.utils.pubsubpolicies.PolicyAnnouncementPubSubF
 import org.eclipse.ditto.policies.api.PoliciesMessagingConstants;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProviderExtension;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
 import org.eclipse.ditto.policies.service.common.config.PoliciesConfig;
 import org.eclipse.ditto.policies.service.persistence.actors.PoliciesPersistenceStreamingActorCreator;
@@ -92,10 +94,12 @@ public final class PoliciesRootActor extends DittoRootActor {
 
         final PolicyEnforcerProvider policyEnforcerProvider = PolicyEnforcerProviderExtension.get(actorSystem).getPolicyEnforcerProvider();
         final var mongoReadJournal = MongoReadJournal.newInstance(actorSystem);
+        final NamespacePoliciesConfig namespacePoliciesConfig =
+                DefaultNamespacePoliciesConfig.of(actorSystem.settings().config());
 
         final var policySupervisorProps =
                 getPolicySupervisorActorProps(pubSubMediator, policiesConfig, policyAnnouncementPub, blockedNamespaces,
-                        policyEnforcerProvider, mongoReadJournal);
+                        policyEnforcerProvider, mongoReadJournal, namespacePoliciesConfig);
 
         final ActorRef policiesShardRegion =
                 ShardRegionCreator.start(actorSystem, PoliciesMessagingConstants.SHARD_REGION, policySupervisorProps,
@@ -150,10 +154,11 @@ public final class PoliciesRootActor extends DittoRootActor {
             final DistributedPub<PolicyAnnouncement<?>> policyAnnouncementPub,
             final BlockedNamespaces blockedNamespaces,
             final PolicyEnforcerProvider policyEnforcerProvider,
-            final MongoReadJournal mongoReadJournal) {
+            final MongoReadJournal mongoReadJournal,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
 
         return PolicySupervisorActor.props(pubSubMediator, policiesConfig, policyAnnouncementPub, blockedNamespaces,
-                policyEnforcerProvider, mongoReadJournal);
+                policyEnforcerProvider, mongoReadJournal, namespacePoliciesConfig);
     }
 
     /**

--- a/policies/service/src/main/resources/policies.conf
+++ b/policies/service/src/main/resources/policies.conf
@@ -1,3 +1,5 @@
+include "ditto-namespace-policies.conf"
+
 ditto {
   service-name = "policies"
   mapping-strategy.implementation = "org.eclipse.ditto.policies.api.PoliciesMappingStrategies"

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/enforcement/PolicyCommandEnforcementTest.java
@@ -59,6 +59,7 @@ import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.Label;
 import org.eclipse.ditto.policies.model.PoliciesModelFactory;
@@ -810,7 +811,8 @@ public final class PolicyCommandEnforcementTest {
         @Override
         protected Props getPersistenceEnforcerProps(final PolicyId entityId) {
             return PolicyEnforcerActor.props(entityId, new PolicyCommandEnforcement(), policyEnforcerProvider,
-                    DefaultLocalAskTimeoutConfig.of(ConfigFactory.empty()));
+                    DefaultLocalAskTimeoutConfig.of(ConfigFactory.empty()),
+                    emptyNamespacePoliciesConfig());
         }
 
         @Override
@@ -828,6 +830,16 @@ public final class PolicyCommandEnforcementTest {
             final PolicyId policyId = entityId != null ? entityId : PolicyId.of("UNKNOWN:ID");
             return PolicyUnavailableException.newBuilder(policyId);
         }
+    }
+
+    private static NamespacePoliciesConfig emptyNamespacePoliciesConfig() {
+        final NamespacePoliciesConfig config = Mockito.mock(NamespacePoliciesConfig.class);
+        when(config.isEmpty()).thenReturn(true);
+        when(config.getNamespacePolicies()).thenReturn(Collections.emptyMap());
+        when(config.getRootPoliciesForNamespace(Mockito.anyString())).thenReturn(Collections.emptyList());
+        when(config.getAllNamespaceRootPolicyIds()).thenReturn(Collections.emptySet());
+        when(config.getNamespacesForRootPolicy(Mockito.any())).thenReturn(Collections.emptySet());
+        return config;
     }
 
 }

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceOperationsActorIT.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/PolicyPersistenceOperationsActorIT.java
@@ -43,6 +43,7 @@ import org.eclipse.ditto.internal.utils.persistence.operations.NamespacePersiste
 import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracingInitResource;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.EffectedPermissions;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyConstants;
@@ -242,7 +243,8 @@ public final class PolicyPersistenceOperationsActorIT extends MongoEventSourceIT
                 DittoPoliciesConfig.of(DefaultScopedConfig.dittoScoped(system.settings().config()));
         final Props props =
                 PolicySupervisorActor.props(pubSubMediator, config, Mockito.mock(DistributedPub.class), null,
-                        Mockito.mock(PolicyEnforcerProvider.class), Mockito.mock(MongoReadJournal.class));
+                        Mockito.mock(PolicyEnforcerProvider.class), Mockito.mock(MongoReadJournal.class),
+                        DefaultNamespacePoliciesConfig.of(system.settings().config()));
         return system.actorOf(props, id.toString());
     }
 

--- a/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActorTest.java
+++ b/policies/service/src/test/java/org/eclipse/ditto/policies/service/persistence/actors/PolicySupervisorActorTest.java
@@ -34,6 +34,7 @@ import org.eclipse.ditto.internal.utils.pubsub.DistributedPub;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracingInitResource;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcerProvider;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.enforcers.Enforcer;
 import org.eclipse.ditto.policies.model.signals.announcements.PolicyAnnouncement;
@@ -87,7 +88,8 @@ public final class PolicySupervisorActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {{
             final PolicyId policyId = PolicyId.of("test.ns", "stopNonexistentPolicy");
             final var props = PolicySupervisorActor.props(pubSubMediator, config, pub, blockedNamespaces,
-                    policyEnforcerProvider, Mockito.mock(MongoReadJournal.class));
+                    policyEnforcerProvider, Mockito.mock(MongoReadJournal.class),
+                    DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
             final var underTest = watch(childActorOf(props, policyId.toString()));
             underTest.tell(new StopShardedActor(), getRef());
             expectTerminated(underTest);
@@ -101,7 +103,8 @@ public final class PolicySupervisorActorTest extends PersistenceActorTestBase {
         new TestKit(actorSystem) {{
             final PolicyId policyId = PolicyId.of("test.ns", "retrieveNonexistentPolicy");
             final var props = PolicySupervisorActor.props(pubSubMediator, config, pub, blockedNamespaces,
-                    policyEnforcerProvider, Mockito.mock(MongoReadJournal.class));
+                    policyEnforcerProvider, Mockito.mock(MongoReadJournal.class),
+                    DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
             final var underTest = watch(childActorOf(props, policyId.toString()));
             final var probe = TestProbe.apply(actorSystem);
             final var retrievePolicy = RetrievePolicy.of(policyId, DittoHeaders.empty());
@@ -124,7 +127,8 @@ public final class PolicySupervisorActorTest extends PersistenceActorTestBase {
                 final var policy = createPolicyWithRandomId();
                 final var policyId = policy.getEntityId().orElseThrow();
                 final var props = PolicySupervisorActor.props(pubSubMediator, config, pub, blockedNamespaces,
-                        policyEnforcerProvider, Mockito.mock(MongoReadJournal.class));
+                        policyEnforcerProvider, Mockito.mock(MongoReadJournal.class),
+                        DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
                 final var underTest = watch(childActorOf(props, policyId.toString()));
                 final var probe = TestProbe.apply(actorSystem);
 

--- a/things/service/src/main/resources/things.conf
+++ b/things/service/src/main/resources/things.conf
@@ -1,3 +1,5 @@
+include "ditto-namespace-policies.conf"
+
 ditto {
   service-name = "things"
   mapping-strategy.implementation = "org.eclipse.ditto.things.api.ThingsMappingStrategies"

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStream.java
@@ -15,11 +15,13 @@ package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorRef;
@@ -33,6 +35,7 @@ import org.eclipse.ditto.internal.models.streaming.LowerBound;
 import org.eclipse.ditto.internal.utils.pekko.controlflow.MergeSortedAsPair;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.policies.api.PolicyTag;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyRevision;
@@ -62,18 +65,21 @@ public final class BackgroundSyncStream {
     private final Duration toleranceWindow;
     private final int throttleThroughput;
     private final Duration throttlePeriod;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     private BackgroundSyncStream(
             final ActorRef policiesShardRegion,
             final Duration policiesAskTimeout,
             final Duration toleranceWindow,
             final int throttleThroughput,
-            final Duration throttlePeriod) {
+            final Duration throttlePeriod,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
         this.policiesShardRegion = policiesShardRegion;
         this.policiesAskTimeout = policiesAskTimeout;
         this.toleranceWindow = toleranceWindow;
         this.throttleThroughput = throttleThroughput;
         this.throttlePeriod = throttlePeriod;
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
     }
 
     /**
@@ -91,10 +97,11 @@ public final class BackgroundSyncStream {
             final Duration policiesAskTimeout,
             final Duration toleranceWindow,
             final int throttleThroughput,
-            final Duration throttlePeriod) {
+            final Duration throttlePeriod,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
 
         return new BackgroundSyncStream(policiesShardRegion, policiesAskTimeout, toleranceWindow, throttleThroughput,
-                throttlePeriod);
+                throttlePeriod, namespacePoliciesConfig);
     }
 
     /**
@@ -240,36 +247,67 @@ public final class BackgroundSyncStream {
                             return CompletableFuture.completedFuture(false);
                         }
 
-                        final List<PolicyId> importedPolicyIds = optionalPolicy.get().getPolicyImports()
-                                .stream()
-                                .map(PolicyImport::getImportedPolicyId)
-                                .toList();
-
                         final Set<PolicyTag> indexedReferencedPolicyTags = indexed.getAllReferencedPolicyTags();
+                        return getExpectedReferencedPolicyIds(optionalPolicy.get())
+                                .thenCompose(expectedReferencedPolicyIds -> {
+                                    final Set<PolicyId> indexedReferencedPolicyIds = indexedReferencedPolicyTags.stream()
+                                            .map(PolicyTag::getEntityId)
+                                            .filter(indexedPolicyId -> !indexedPolicyId.equals(thingPolicyId))
+                                            .collect(Collectors.toCollection(LinkedHashSet::new));
 
-                        // -1 because we need to ignore the actual thing policy which is also included in referenced policies.
-                        if (importedPolicyIds.size() != (indexedReferencedPolicyTags.size() - 1)) {
-                            // Number of referenced policies changed. Trigger update.
-                            return CompletableFuture.completedFuture(false);
-                        }
-
-                        final List<CompletableFuture<Boolean>> completionStages = importedPolicyIds.stream()
-                                .map(importedPolicyId -> {
-                                    final Optional<PolicyTag> optionalIndexedPolicyTag =
-                                            indexedReferencedPolicyTags.stream()
-                                                    .filter(tag -> tag.getEntityId().equals(importedPolicyId))
-                                                    .findAny();
-                                    if (optionalIndexedPolicyTag.isEmpty()) {
+                                    if (!expectedReferencedPolicyIds.equals(indexedReferencedPolicyIds)) {
                                         return CompletableFuture.completedFuture(false);
                                     }
-                                    final PolicyTag indexedPolicyTag = optionalIndexedPolicyTag.get();
-                                    return isPolicyTagUpToDate(indexedPolicyTag).toCompletableFuture();
-                                })
-                                .toList();
 
-                        return CompletableFuture.allOf(completionStages.toArray(new CompletableFuture[0]))
-                                .thenApply(done -> completionStages.stream().allMatch(CompletableFuture::join));
+                                    final List<CompletableFuture<Boolean>> completionStages =
+                                            indexedReferencedPolicyTags.stream()
+                                                    .filter(indexedPolicyTag ->
+                                                            !indexedPolicyTag.getEntityId().equals(thingPolicyId))
+                                                    .map(indexedPolicyTag ->
+                                                            isPolicyTagUpToDate(indexedPolicyTag).toCompletableFuture())
+                                                    .toList();
+
+                                    return CompletableFuture.allOf(
+                                                    completionStages.toArray(new CompletableFuture[0]))
+                                            .thenApply(done ->
+                                                    completionStages.stream().allMatch(CompletableFuture::join));
+                                });
                     }
+                });
+    }
+
+    private CompletionStage<Set<PolicyId>> getExpectedReferencedPolicyIds(final Policy thingPolicy) {
+        final Set<PolicyId> expectedReferencedPolicyIds = thingPolicy.getPolicyImports().stream()
+                .map(PolicyImport::getImportedPolicyId)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        final Optional<PolicyId> entityId = thingPolicy.getEntityId();
+        final String namespace = thingPolicy.getNamespace().orElse("");
+        final List<PolicyId> namespaceRootPolicyIds = namespacePoliciesConfig.getRootPoliciesForNamespace(namespace)
+                .stream()
+                .filter(rootPolicyId -> !entityId.map(rootPolicyId::equals).orElse(false))
+                .toList();
+
+        if (namespaceRootPolicyIds.isEmpty()) {
+            return CompletableFuture.completedFuture(expectedReferencedPolicyIds);
+        }
+
+        final List<CompletableFuture<Optional<Policy>>> rootPolicyStages = namespaceRootPolicyIds.stream()
+                .map(rootPolicyId -> retrievePolicy(rootPolicyId).toCompletableFuture())
+                .toList();
+
+        return CompletableFuture.allOf(rootPolicyStages.toArray(new CompletableFuture[0]))
+                .thenApply(done -> {
+                    for (int i = 0; i < namespaceRootPolicyIds.size(); i++) {
+                        final Optional<Policy> optionalRootPolicy = rootPolicyStages.get(i).join();
+                        if (optionalRootPolicy.isPresent()) {
+                            expectedReferencedPolicyIds.add(namespaceRootPolicyIds.get(i));
+                            optionalRootPolicy.get().getPolicyImports().stream()
+                                    .map(PolicyImport::getImportedPolicyId)
+                                    .forEach(expectedReferencedPolicyIds::add);
+                        }
+                    }
+                    return expectedReferencedPolicyIds;
                 });
     }
 

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/EnforcementFlow.java
@@ -49,6 +49,7 @@ import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonRuntimeException;
 import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyIdInvalidException;
@@ -129,7 +130,8 @@ final class EnforcementFlow {
         final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture =
                 new CompletableFuture<>();
         final ResolvedPolicyCacheLoader resolvedPolicyCacheLoader =
-                new ResolvedPolicyCacheLoader(policyCacheLoader, cacheFuture);
+                new ResolvedPolicyCacheLoader(policyCacheLoader, cacheFuture,
+                        DefaultNamespacePoliciesConfig.of(actorSystem.settings().config()));
         final Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> policyEnforcerCache =
                 CacheFactory.createCache(resolvedPolicyCacheLoader, policyCacheConfig,
                         "things-search_enforcementflow_enforcer_cache_policy", policyCacheDispatcher);
@@ -337,17 +339,27 @@ final class EnforcementFlow {
                                     // invalid entry; invalidate and retry after delay
                                     policyEnforcerCache.invalidate(new PolicyIdResolvingImports(policyId, true));
 
-                                    // only invalidate causing policy tag once, e.g. when a massively imported policy is changed:
+                                    // Invalidate the resolveImports=true entry for every policy referenced by this
+                                    // thing: the child policy, any namespace root policies, and any policies imported
+                                    // by those root policies.  Using unconditional invalidation here is intentional:
+                                    // a change anywhere in the chain (e.g. an imported policy whose own revision is
+                                    // unchanged in the root-policy entry) makes the resolved root-policy stale, and
+                                    // a revision-based comparison cannot detect that transitive staleness.
+                                    metadata.getAllReferencedPolicyTags().forEach(tag ->
+                                            policyEnforcerCache.invalidate(
+                                                    new PolicyIdResolvingImports(tag.getEntityId(), true)));
+
+                                    // Conditionally invalidate the raw (resolveImports=false) entry for the causing
+                                    // policy only, so that changes to a directly-imported policy also refresh the
+                                    // underlying raw-policy entry that the loader uses as input.
                                     metadata.getCausingPolicyTag()
-                                            .ifPresent(causingPolicyTag -> {
-                                                final boolean invalidated = policyEnforcerCache.invalidateConditionally(
-                                                        new PolicyIdResolvingImports(causingPolicyTag.getEntityId(), false),
-                                                        entry -> !entry.exists() ||
-                                                                entry.getRevision() < causingPolicyTag.getRevision()
-                                                );
-                                                log.debug("Causing policy tag was invalidated conditionally: <{}>",
-                                                        invalidated);
-                                            });
+                                            .ifPresent(causingPolicyTag ->
+                                                    policyEnforcerCache.invalidateConditionally(
+                                                            new PolicyIdResolvingImports(
+                                                                    causingPolicyTag.getEntityId(), false),
+                                                            entry -> !entry.exists() ||
+                                                                    entry.getRevision() < causingPolicyTag.getRevision()
+                                                    ));
 
                                     return readCachedEnforcer(metadata, policyId, iteration + 1)
                                             .initialDelay(cacheRetryDelay);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoader.java
@@ -12,7 +12,10 @@
  */
 package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
 
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -22,24 +25,34 @@ import java.util.concurrent.Executor;
 import org.apache.pekko.japi.Pair;
 import org.eclipse.ditto.internal.utils.cache.Cache;
 import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.policies.api.PolicyTag;
 import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.ImportableType;
 import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyEntry;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.PolicyRevision;
+import org.slf4j.Logger;
 
 import com.github.benmanes.caffeine.cache.AsyncCacheLoader;
 
 final class ResolvedPolicyCacheLoader
         implements AsyncCacheLoader<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> {
 
+    private static final Logger LOG = DittoLoggerFactory.getThreadSafeLogger(ResolvedPolicyCacheLoader.class);
+
     private final PolicyCacheLoader policyCacheLoader;
     private final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture;
+    private final NamespacePoliciesConfig namespacePoliciesConfig;
 
     ResolvedPolicyCacheLoader(final PolicyCacheLoader policyCacheLoader,
-            final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture) {
+            final CompletableFuture<Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>>> cacheFuture,
+            final NamespacePoliciesConfig namespacePoliciesConfig) {
         this.policyCacheLoader = policyCacheLoader;
         this.cacheFuture = cacheFuture;
+        this.namespacePoliciesConfig = namespacePoliciesConfig;
     }
 
     @Override
@@ -54,15 +67,18 @@ final class ResolvedPolicyCacheLoader
                         final long revision = policy.getRevision().map(PolicyRevision::toLong)
                                 .orElseThrow(
                                         () -> new IllegalStateException("Bad SudoRetrievePolicyResponse: no revision"));
-                        final Set<PolicyTag> referencedPolicies = new HashSet<>();
+                        final Set<PolicyTag> referencedPolicies = new LinkedHashSet<>();
 
                         if (policyIdResolvingImports.resolveImports()) {
                             return cacheFuture.thenComposeAsync(cache ->
-                                            resolvePolicyImports(cache, policy, referencedPolicies), executor
-                                    )
-                                    .thenApply(resolvedPolicy ->
-                                            Entry.of(revision, new Pair<>(resolvedPolicy, referencedPolicies))
-                                    );
+                                            resolvePolicyImports(cache, policy, referencedPolicies)
+                                                    .thenCompose(resolvedPolicy ->
+                                                            mergeNamespaceRootPolicies(cache, resolvedPolicy,
+                                                                    referencedPolicies, executor)),
+                                            executor)
+                                    .thenApplyAsync(resolvedPolicy ->
+                                            Entry.of(revision, new Pair<>(resolvedPolicy, referencedPolicies)),
+                                            executor);
                         } else {
                             return CompletableFuture.completedFuture(
                                     Entry.of(revision, new Pair<>(policy, referencedPolicies))
@@ -72,6 +88,65 @@ final class ResolvedPolicyCacheLoader
                         return CompletableFuture.completedFuture(Entry.nonexistent());
                     }
                 }, executor);
+    }
+
+    /**
+     * Merges implicit entries from configured namespace root policies into {@code resolvedPolicy}.
+     * Root policies are loaded via the cache in parallel; their revisions are added to
+     * {@code referencedPolicies} so that search index entries are invalidated when a root policy changes.
+     * Local/imported entries always take precedence: if a label already exists in {@code resolvedPolicy},
+     * the corresponding namespace root entry is skipped.
+     */
+    private CompletionStage<Policy> mergeNamespaceRootPolicies(
+            final Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> cache,
+            final Policy resolvedPolicy,
+            final Set<PolicyTag> referencedPolicies,
+            final Executor executor) {
+
+        if (namespacePoliciesConfig.isEmpty()) {
+            return CompletableFuture.completedFuture(resolvedPolicy);
+        }
+
+        final Optional<PolicyId> entityId = resolvedPolicy.getEntityId();
+        final String namespace = resolvedPolicy.getNamespace().orElse("");
+        final List<PolicyId> rootPolicies = namespacePoliciesConfig.getRootPoliciesForNamespace(namespace).stream()
+                // Skip only the self-reference, while still allowing other matching roots such as a global catch-all.
+                .filter(rootId -> !entityId.map(rootId::equals).orElse(false))
+                .toList();
+
+        if (rootPolicies.isEmpty()) {
+            return CompletableFuture.completedFuture(resolvedPolicy);
+        }
+
+        final Map<PolicyId, CompletableFuture<Optional<Pair<Policy, Set<PolicyTag>>>>> futures =
+                new LinkedHashMap<>();
+        for (final PolicyId rootId : rootPolicies) {
+            futures.put(rootId, resolveNamespaceRootPolicy(cache, rootId, namespace, executor));
+        }
+
+        return CompletableFuture.allOf(futures.values().toArray(CompletableFuture[]::new))
+                .thenApplyAsync(ignored -> {
+                    Policy result = resolvedPolicy;
+                    for (final PolicyId rootId : rootPolicies) {
+                        final Optional<Pair<Policy, Set<PolicyTag>>> rootPolicyOpt =
+                                futures.get(rootId).getNow(Optional.empty());
+                        if (rootPolicyOpt.isPresent()) {
+                            referencedPolicies.addAll(rootPolicyOpt.get().second());
+                            result = mergeImplicitEntries(rootPolicyOpt.get().first(), result);
+                        }
+                    }
+                    return result;
+                }, executor);
+    }
+
+    private static Policy mergeImplicitEntries(final Policy rootPolicy, final Policy currentPolicy) {
+        Policy result = currentPolicy;
+        for (final PolicyEntry entry : rootPolicy) {
+            if (ImportableType.IMPLICIT.equals(entry.getImportableType()) && !result.contains(entry.getLabel())) {
+                result = result.setEntry(entry);
+            }
+        }
+        return result;
     }
 
     private static CompletionStage<Policy> resolvePolicyImports(
@@ -94,6 +169,35 @@ final class ResolvedPolicyCacheLoader
                             return optionalReferencedPolicy.map(Pair::first);
                         })
         );
+    }
+
+    private CompletableFuture<Optional<Pair<Policy, Set<PolicyTag>>>> resolveNamespaceRootPolicy(
+            final Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> cache,
+            final PolicyId rootPolicyId,
+            final String namespace,
+            final Executor executor) {
+
+        return cache.get(new PolicyIdResolvingImports(rootPolicyId, true))
+                .thenApplyAsync(entry -> entry.flatMap(Entry::get), executor)
+                .thenApplyAsync(optionalResolvedRootPolicy -> {
+                    if (optionalResolvedRootPolicy.isEmpty()) {
+                        LOG.error("Namespace root policy <{}> for namespace <{}> does not exist or was deleted - " +
+                                "skipping its entries.", rootPolicyId, namespace);
+                        return Optional.empty();
+                    }
+
+                    final Pair<Policy, Set<PolicyTag>> resolvedRootPolicy = optionalResolvedRootPolicy.get();
+                    final Set<PolicyTag> rootReferencedPolicies = new LinkedHashSet<>(resolvedRootPolicy.second());
+                    addPolicyTag(resolvedRootPolicy.first(), rootReferencedPolicies);
+                    return Optional.of(new Pair<>(resolvedRootPolicy.first(), rootReferencedPolicies));
+                }, executor);
+    }
+
+    private static void addPolicyTag(final Policy policy, final Set<PolicyTag> referencedPolicies) {
+        policy.getRevision()
+                .flatMap(revision -> policy.getEntityId()
+                        .map(entityId -> PolicyTag.of(entityId, revision.toLong())))
+                .ifPresent(referencedPolicies::add);
     }
 
 }

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActor.java
@@ -27,6 +27,7 @@ import org.eclipse.ditto.internal.utils.health.AbstractBackgroundStreamingActorW
 import org.eclipse.ditto.internal.utils.health.StatusDetailMessage;
 import org.eclipse.ditto.internal.utils.metrics.DittoMetrics;
 import org.eclipse.ditto.internal.utils.metrics.instruments.counter.Counter;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonValue;
@@ -119,13 +120,15 @@ public final class BackgroundSyncActor
             final ThingsSearchPersistence thingsSearchPersistence,
             final TimestampPersistence backgroundSyncPersistence,
             final ActorRef policiesShardRegion,
+            final NamespacePoliciesConfig namespacePoliciesConfig,
             final ActorRef thingsUpdater) {
 
         final var thingsMetadataSource =
                 ThingsMetadataSource.of(pubSubMediator, config.getThrottleThroughput(), config.getIdleTimeout());
         final var backgroundSyncStream =
                 BackgroundSyncStream.of(policiesShardRegion, config.getPolicyAskTimeout(),
-                        config.getToleranceWindow(), config.getThrottleThroughput(), config.getThrottlePeriod());
+                        config.getToleranceWindow(), config.getThrottleThroughput(), config.getThrottlePeriod(),
+                        namespacePoliciesConfig);
 
         return Props.create(BackgroundSyncActor.class, config, thingsMetadataSource, thingsSearchPersistence,
                 backgroundSyncPersistence, backgroundSyncStream, thingsUpdater);

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/updater/actors/SearchUpdaterRootActor.java
@@ -30,6 +30,7 @@ import org.eclipse.ditto.internal.utils.health.RetrieveHealth;
 import org.eclipse.ditto.internal.utils.namespaces.BlockedNamespaces;
 import org.eclipse.ditto.internal.utils.pekko.streaming.TimestampPersistence;
 import org.eclipse.ditto.internal.utils.persistence.mongo.DittoMongoClient;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.thingsearch.api.ThingsSearchConstants;
 import org.eclipse.ditto.thingsearch.service.common.config.SearchConfig;
 import org.eclipse.ditto.thingsearch.service.common.util.RootSupervisorStrategyFactory;
@@ -76,6 +77,7 @@ public final class SearchUpdaterRootActor extends AbstractActor {
         final int numberOfShards = clusterConfig.getNumberOfShards();
 
         final var actorSystem = getContext().getSystem();
+        final var namespacePoliciesConfig = DefaultNamespacePoliciesConfig.of(actorSystem.settings().config());
 
         dittoMongoClient = MongoClientExtension.get(actorSystem).getUpdaterClient();
 
@@ -124,6 +126,7 @@ public final class SearchUpdaterRootActor extends AbstractActor {
                 thingsSearchPersistence,
                 backgroundSyncPersistence,
                 shardRegionFactory.getPoliciesShardRegion(numberOfShards),
+                namespacePoliciesConfig,
                 thingsUpdaterActor
         );
         backgroundSyncActorProxy =

--- a/thingsearch/service/src/main/resources/search.conf
+++ b/thingsearch/service/src/main/resources/search.conf
@@ -1,3 +1,5 @@
+include "ditto-namespace-policies.conf"
+
 ditto {
   service-name = "search"
   mapping-strategy.implementation = "org.eclipse.ditto.thingsearch.api.ThingSearchMappingStrategies"

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/BackgroundSyncStreamTest.java
@@ -31,6 +31,7 @@ import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicy;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyResponse;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyRevision;
 import org.eclipse.ditto.policies.api.commands.sudo.SudoRetrievePolicyRevisionResponse;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.Policy;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.policies.model.signals.commands.exceptions.PolicyNotAccessibleException;
@@ -39,6 +40,8 @@ import org.eclipse.ditto.thingsearch.service.persistence.write.model.Metadata;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
 
 /**
  * Tests {@link BackgroundSyncStream}.
@@ -91,7 +94,7 @@ public final class BackgroundSyncStreamTest {
         new TestKit(actorSystem) {{
             final BackgroundSyncStream underTest =
                     BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
-                            Duration.ofSeconds(10L));
+                            Duration.ofSeconds(10L), DefaultNamespacePoliciesConfig.of(ConfigFactory.empty()));
             final CompletionStage<List<String>> inconsistentThingIds =
                     underTest.filterForInconsistencies(persisted, indexed)
                             .map(metadata -> metadata.getThingId().toString())
@@ -114,6 +117,93 @@ public final class BackgroundSyncStreamTest {
                     "x:4-policy-id-mismatch",
                     "x:5-policy-revision-mismatch"
             );
+        }};
+    }
+
+    @Test
+    public void namespaceRootPoliciesAreConsideredConsistentDuringBackgroundSync() {
+        final Duration toleranceWindow = Duration.ofHours(1L);
+        final PolicyId thingPolicyId = PolicyId.of("org.example.devices", "thing-policy");
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root");
+
+        final Source<Metadata, NotUsed> persisted = Source.from(List.of(
+                Metadata.of(ThingId.of("x:8-namespace-root"), 3L, PolicyTag.of(thingPolicyId, 7L), null, Set.of(), null)
+        ));
+        final Source<Metadata, NotUsed> indexed = Source.from(List.of(
+                Metadata.of(ThingId.of("x:8-namespace-root"), 3L, PolicyTag.of(thingPolicyId, 7L), null,
+                        Set.of(PolicyTag.of(rootPolicyId, 8L)), null)
+        ));
+
+        new TestKit(actorSystem) {{
+            final BackgroundSyncStream underTest =
+                    BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
+                            Duration.ofSeconds(10L), DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                            "ditto.namespace-policies {\n" +
+                            "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                            "}")));
+            final CompletionStage<List<String>> inconsistentThingIds =
+                    underTest.filterForInconsistencies(persisted, indexed)
+                            .map(metadata -> metadata.getThingId().toString())
+                            .runWith(Sink.seq(), actorSystem);
+
+            expectMsg(SudoRetrievePolicy.of(thingPolicyId, DittoHeaders.empty()));
+            reply(SudoRetrievePolicyResponse.of(thingPolicyId, policyWithoutImports(thingPolicyId, 7L),
+                    DittoHeaders.empty()));
+
+            expectMsg(SudoRetrievePolicy.of(rootPolicyId, DittoHeaders.empty()));
+            reply(SudoRetrievePolicyResponse.of(rootPolicyId, policyWithoutImports(rootPolicyId, 8L),
+                    DittoHeaders.empty()));
+
+            expectMsg(SudoRetrievePolicyRevision.of(rootPolicyId, DittoHeaders.empty()));
+            reply(SudoRetrievePolicyRevisionResponse.of(rootPolicyId, 8L, DittoHeaders.empty()));
+
+            assertThat(inconsistentThingIds.toCompletableFuture().join()).isEmpty();
+        }};
+    }
+
+    @Test
+    public void missingNamespaceRootPolicyTagInIndexTriggersReIndexing() {
+        final Duration toleranceWindow = Duration.ofHours(1L);
+        final PolicyId thingPolicyId = PolicyId.of("org.example.devices", "thing-policy");
+        final PolicyId rootPolicyId = PolicyId.of("org.example", "tenant-root");
+
+        // Persisted and indexed have matching thing revision and policy revision,
+        // but the indexed entry is missing the namespace root policy tag in allReferencedPolicyTags.
+        final Source<Metadata, NotUsed> persisted = Source.from(List.of(
+                Metadata.of(ThingId.of("x:9-missing-root-tag"), 3L,
+                        PolicyTag.of(thingPolicyId, 7L), null, Set.of(), null)
+        ));
+        final Source<Metadata, NotUsed> indexed = Source.from(List.of(
+                Metadata.of(ThingId.of("x:9-missing-root-tag"), 3L,
+                        PolicyTag.of(thingPolicyId, 7L), null, Set.of(), null)
+        ));
+
+        new TestKit(actorSystem) {{
+            final BackgroundSyncStream underTest =
+                    BackgroundSyncStream.of(getRef(), Duration.ofSeconds(3L), toleranceWindow, 100,
+                            Duration.ofSeconds(10L), DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                            "ditto.namespace-policies {\n" +
+                            "  \"org.example.devices\" = [\"org.example:tenant-root\"]\n" +
+                            "}")));
+            final CompletionStage<List<String>> inconsistentThingIds =
+                    underTest.filterForInconsistencies(persisted, indexed)
+                            .map(metadata -> metadata.getThingId().toString())
+                            .runWith(Sink.seq(), actorSystem);
+
+            // BackgroundSyncStream retrieves the thing's policy to check consistency
+            expectMsg(SudoRetrievePolicy.of(thingPolicyId, DittoHeaders.empty()));
+            reply(SudoRetrievePolicyResponse.of(thingPolicyId, policyWithoutImports(thingPolicyId, 7L),
+                    DittoHeaders.empty()));
+
+            // BackgroundSyncStream retrieves the namespace root policy to compute expected references
+            expectMsg(SudoRetrievePolicy.of(rootPolicyId, DittoHeaders.empty()));
+            reply(SudoRetrievePolicyResponse.of(rootPolicyId, policyWithoutImports(rootPolicyId, 8L),
+                    DittoHeaders.empty()));
+
+            // The indexed entry has no root policy tag, but the expected set includes it —
+            // the set-equality check fails and the entry is flagged as inconsistent.
+            assertThat(inconsistentThingIds.toCompletableFuture().join())
+                    .containsExactly("x:9-missing-root-tag");
         }};
     }
 

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoaderTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/write/streaming/ResolvedPolicyCacheLoaderTest.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.write.streaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+
+import org.apache.pekko.japi.Pair;
+import org.eclipse.ditto.internal.utils.cache.Cache;
+import org.eclipse.ditto.internal.utils.cache.entry.Entry;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.policies.api.PolicyTag;
+import org.eclipse.ditto.policies.enforcement.PolicyCacheLoader;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
+import org.eclipse.ditto.policies.enforcement.config.NamespacePoliciesConfig;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.ImportableType;
+import org.eclipse.ditto.policies.model.Label;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.Resource;
+import org.eclipse.ditto.policies.model.Resources;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.SubjectIssuer;
+import org.eclipse.ditto.policies.model.SubjectType;
+import org.eclipse.ditto.policies.model.Subjects;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+public final class ResolvedPolicyCacheLoaderTest {
+
+    private static final Executor DIRECT_EXECUTOR = Runnable::run;
+    private static final PolicyId CHILD_POLICY_ID = PolicyId.of("org.example.devices.alpha", "child-policy");
+    private static final PolicyId ROOT_POLICY_ID = PolicyId.of("org.example", "tenant-root");
+    private static final PolicyId GLOBAL_ROOT_POLICY_ID = PolicyId.of("global", "catch-all");
+    private static final PolicyId IMPORTED_POLICY_ID = PolicyId.of("org.example", "imported-policy");
+    private static final long CHILD_POLICY_REVISION = 1L;
+    private static final long ROOT_POLICY_REVISION = 2L;
+    private static final long GLOBAL_ROOT_POLICY_REVISION = 4L;
+    private static final long IMPORTED_POLICY_REVISION = 3L;
+    private static final Label LOCAL_LABEL = Label.of("LOCAL_OWNER");
+    private static final Label ROOT_LABEL = Label.of("ROOT_READER");
+    private static final Label GLOBAL_ROOT_LABEL = Label.of("GLOBAL_READER");
+    private static final Label IMPORTED_LABEL = Label.of("IMPORTED_READER");
+
+    private PolicyCacheLoader policyCacheLoader;
+    private Cache<PolicyIdResolvingImports, Entry<Pair<Policy, Set<PolicyTag>>>> cache;
+
+    @Before
+    public void setUp() {
+        policyCacheLoader = mock(PolicyCacheLoader.class);
+        cache = mock(Cache.class);
+    }
+
+    @Test
+    public void namespaceRootPoliciesResolveTheirOwnImportsAndTrackReferencedPolicies() {
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices.*\" = [\"org.example:tenant-root\"]\n" +
+                "}"));
+
+        final Policy childPolicy =
+                policyWithEntry(CHILD_POLICY_ID, CHILD_POLICY_REVISION, LOCAL_LABEL, ImportableType.IMPLICIT);
+        final Label resolvedImportedLabel = PoliciesModelFactory.newImportedLabel(IMPORTED_POLICY_ID, IMPORTED_LABEL);
+        final Policy resolvedRootPolicy = Policy.newBuilder(ROOT_POLICY_ID)
+                .setRevision(ROOT_POLICY_REVISION)
+                .set(policyEntry(ROOT_LABEL, ImportableType.IMPLICIT))
+                .set(policyEntry(resolvedImportedLabel, ImportableType.IMPLICIT))
+                .build();
+
+        when(policyCacheLoader.asyncLoad(CHILD_POLICY_ID, DIRECT_EXECUTOR))
+                .thenReturn(CompletableFuture.completedFuture(Entry.of(CHILD_POLICY_REVISION, childPolicy)));
+        when(cache.get(new PolicyIdResolvingImports(ROOT_POLICY_ID, true)))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(Entry.of(ROOT_POLICY_REVISION, new Pair<>(resolvedRootPolicy,
+                                Set.of(PolicyTag.of(IMPORTED_POLICY_ID, IMPORTED_POLICY_REVISION)))))
+                ));
+
+        final ResolvedPolicyCacheLoader underTest =
+                new ResolvedPolicyCacheLoader(policyCacheLoader, CompletableFuture.completedFuture(cache), config);
+
+        final Entry<Pair<Policy, Set<PolicyTag>>> entry = underTest
+                .asyncLoad(new PolicyIdResolvingImports(CHILD_POLICY_ID, true), DIRECT_EXECUTOR)
+                .join();
+
+        final Policy resolvedPolicy = entry.getValueOrThrow().first();
+        final Set<PolicyTag> referencedPolicies = entry.getValueOrThrow().second();
+
+        assertThat(resolvedPolicy.contains(LOCAL_LABEL)).isTrue();
+        assertThat(resolvedPolicy.contains(ROOT_LABEL)).isTrue();
+        assertThat(resolvedPolicy.contains(
+                PoliciesModelFactory.newImportedLabel(IMPORTED_POLICY_ID, IMPORTED_LABEL))).isTrue();
+        assertThat(referencedPolicies)
+                .contains(PolicyTag.of(ROOT_POLICY_ID, ROOT_POLICY_REVISION),
+                        PolicyTag.of(IMPORTED_POLICY_ID, IMPORTED_POLICY_REVISION));
+        verify(cache).get(new PolicyIdResolvingImports(ROOT_POLICY_ID, true));
+        verify(policyCacheLoader, never()).asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR);
+    }
+
+    /**
+     * Verifies the inner resolution path: asyncLoad(rootPolicyId, true) must itself call
+     * cache.get(importedPolicyId, false) to resolve the root policy's own imports, and the
+     * resulting entry must contain the imported label and the imported policy's tag.
+     * <p>
+     * The previous test mocks cache.get(ROOT_POLICY_ID, true) directly so it never exercises
+     * this code path. This test does not mock that key — it lets asyncLoad compute it from
+     * policyCacheLoader + cache.get(IMPORTED_POLICY_ID, false).
+     */
+    @Test
+    public void asyncLoadOfRootPolicyResolvesItsOwnImportsViaCache() {
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example.devices.*\" = [\"org.example:tenant-root\"]\n" +
+                "}"));
+
+        // Root policy has a direct entry AND an import declaration for IMPORTED_POLICY_ID
+        final Policy rawRootPolicy = Policy.newBuilder(ROOT_POLICY_ID)
+                .setRevision(ROOT_POLICY_REVISION)
+                .set(policyEntry(ROOT_LABEL, ImportableType.IMPLICIT))
+                .setPolicyImport(PoliciesModelFactory.newPolicyImport(IMPORTED_POLICY_ID))
+                .build();
+
+        // Imported policy has IMPORTED_LABEL (IMPLICIT) — must be resolvable via cache
+        final Policy rawImportedPolicy = policyWithEntry(IMPORTED_POLICY_ID, IMPORTED_POLICY_REVISION,
+                IMPORTED_LABEL, ImportableType.IMPLICIT);
+
+        when(policyCacheLoader.asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR))
+                .thenReturn(CompletableFuture.completedFuture(Entry.of(ROOT_POLICY_REVISION, rawRootPolicy)));
+        // The loader resolves imported-policy via cache.get(IMPORTED_POLICY_ID, false)
+        when(cache.get(new PolicyIdResolvingImports(IMPORTED_POLICY_ID, false)))
+                .thenReturn(CompletableFuture.completedFuture(
+                        Optional.of(Entry.of(IMPORTED_POLICY_REVISION,
+                                new Pair<>(rawImportedPolicy, Set.of())))));
+
+        final ResolvedPolicyCacheLoader underTest =
+                new ResolvedPolicyCacheLoader(policyCacheLoader, CompletableFuture.completedFuture(cache), config);
+
+        final Entry<Pair<Policy, Set<PolicyTag>>> entry = underTest
+                .asyncLoad(new PolicyIdResolvingImports(ROOT_POLICY_ID, true), DIRECT_EXECUTOR)
+                .join();
+
+        assertThat(entry.exists()).isTrue();
+        final Policy resolvedRoot = entry.getValueOrThrow().first();
+        final Set<PolicyTag> tags = entry.getValueOrThrow().second();
+
+        // Direct root entry must be present
+        assertThat(resolvedRoot.contains(ROOT_LABEL)).isTrue();
+        // Imported entry must be present under its rewritten label
+        assertThat(resolvedRoot.contains(PoliciesModelFactory.newImportedLabel(IMPORTED_POLICY_ID, IMPORTED_LABEL)))
+                .isTrue();
+        // Imported policy's tag must be tracked so that changes to it trigger re-indexing
+        assertThat(tags).contains(PolicyTag.of(IMPORTED_POLICY_ID, IMPORTED_POLICY_REVISION));
+
+        verify(policyCacheLoader).asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR);
+        verify(cache).get(new PolicyIdResolvingImports(IMPORTED_POLICY_ID, false));
+    }
+
+    @Test
+    public void namespaceRootPolicyDoesNotAttemptToLoadItselfAgain() {
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example\" = [\"org.example:tenant-root\"]\n" +
+                "}"));
+        final Policy rootPolicy =
+                policyWithEntry(ROOT_POLICY_ID, ROOT_POLICY_REVISION, ROOT_LABEL, ImportableType.IMPLICIT);
+
+        when(policyCacheLoader.asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR))
+                .thenReturn(CompletableFuture.completedFuture(Entry.of(ROOT_POLICY_REVISION, rootPolicy)));
+
+        final ResolvedPolicyCacheLoader underTest =
+                new ResolvedPolicyCacheLoader(policyCacheLoader, CompletableFuture.completedFuture(cache), config);
+
+        final Entry<Pair<Policy, Set<PolicyTag>>> entry = underTest
+                .asyncLoad(new PolicyIdResolvingImports(ROOT_POLICY_ID, true), DIRECT_EXECUTOR)
+                .join();
+
+        assertThat(entry.exists()).isTrue();
+        assertThat(entry.getValueOrThrow().second()).isEmpty();
+        verify(policyCacheLoader, times(1)).asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR);
+        verifyNoInteractions(cache);
+    }
+
+    @Test
+    public void rootPolicyStillMergesOtherMatchingNamespaceRoots() {
+        final NamespacePoliciesConfig config = DefaultNamespacePoliciesConfig.of(ConfigFactory.parseString(
+                "ditto.namespace-policies {\n" +
+                "  \"org.example\" = [\"org.example:tenant-root\"]\n" +
+                "  \"*\" = [\"global:catch-all\"]\n" +
+                "}"));
+        final Policy rootPolicy =
+                policyWithEntry(ROOT_POLICY_ID, ROOT_POLICY_REVISION, ROOT_LABEL, ImportableType.IMPLICIT);
+        final Policy globalRootPolicy = policyWithEntry(GLOBAL_ROOT_POLICY_ID, GLOBAL_ROOT_POLICY_REVISION,
+                GLOBAL_ROOT_LABEL, ImportableType.IMPLICIT);
+
+        when(policyCacheLoader.asyncLoad(ROOT_POLICY_ID, DIRECT_EXECUTOR))
+                .thenReturn(CompletableFuture.completedFuture(Entry.of(ROOT_POLICY_REVISION, rootPolicy)));
+        when(cache.get(new PolicyIdResolvingImports(GLOBAL_ROOT_POLICY_ID, true)))
+                .thenReturn(CompletableFuture.completedFuture(Optional.of(Entry.of(GLOBAL_ROOT_POLICY_REVISION,
+                        new Pair<>(globalRootPolicy, Set.of())))));
+
+        final ResolvedPolicyCacheLoader underTest =
+                new ResolvedPolicyCacheLoader(policyCacheLoader, CompletableFuture.completedFuture(cache), config);
+
+        final Entry<Pair<Policy, Set<PolicyTag>>> entry = underTest
+                .asyncLoad(new PolicyIdResolvingImports(ROOT_POLICY_ID, true), DIRECT_EXECUTOR)
+                .join();
+
+        assertThat(entry.exists()).isTrue();
+        assertThat(entry.getValueOrThrow().first().contains(ROOT_LABEL)).isTrue();
+        assertThat(entry.getValueOrThrow().first().contains(GLOBAL_ROOT_LABEL)).isTrue();
+        verify(cache).get(new PolicyIdResolvingImports(GLOBAL_ROOT_POLICY_ID, true));
+        verify(cache, never()).get(new PolicyIdResolvingImports(ROOT_POLICY_ID, true));
+    }
+
+    private static Policy policyWithEntry(final PolicyId policyId,
+            final long revision,
+            final Label label,
+            final ImportableType importableType) {
+        return Policy.newBuilder(policyId)
+                .setRevision(revision)
+                .set(policyEntry(label, importableType))
+                .build();
+    }
+
+    private static org.eclipse.ditto.policies.model.PolicyEntry policyEntry(final Label label,
+            final ImportableType importableType) {
+        final Subjects subjects = Subjects.newInstance(
+                Subject.newInstance(
+                        SubjectId.newInstance(SubjectIssuer.newInstance(label.toString()), "user"),
+                        SubjectType.newInstance("test")));
+        final Resources resources = Resources.newInstance(
+                Resource.newInstance("thing", JsonPointer.of("/"),
+                        EffectedPermissions.newInstance(Permissions.newInstance("READ"), Permissions.none())));
+        return PoliciesModelFactory.newPolicyEntry(label, subjects, resources, importableType);
+    }
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/updater/actors/BackgroundSyncActorTest.java
@@ -64,6 +64,7 @@ import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.PolicyTag;
+import org.eclipse.ditto.policies.enforcement.config.DefaultNamespacePoliciesConfig;
 import org.eclipse.ditto.policies.model.PolicyId;
 import org.eclipse.ditto.rql.query.Query;
 import org.eclipse.ditto.things.model.Thing;
@@ -332,6 +333,7 @@ public final class BackgroundSyncActorTest {
                 searchPersistence,
                 timestampPersistence,
                 policiesShardRegion.getRef(),
+                DefaultNamespacePoliciesConfig.of(ConfigFactory.empty()),
                 thingsUpdater.getRef()
         ));
     }


### PR DESCRIPTION
Resolves: #1638

  ## Summary

  This PR adds support for namespace root policies in Ditto policy enforcement, including wildcard-based namespace mappings.

  A namespace can be mapped to one or more root policy IDs. During enforcer creation, Ditto transparently merges entries from those root policies into policies of that namespace.

  ## What changed

  - Added namespace-root merge support in policy enforcer resolution.
  - Added config abstraction:
    - `NamespacePoliciesConfig`
    - `DefaultNamespacePoliciesConfig`
  - Added support for namespace policy patterns:
    - exact namespace: `org.example.devices`
    - prefix wildcard: `org.example.devices.*`
    - catch-all: `*`
  - Added deterministic precedence for overlapping patterns:
    - exact namespace
    - more specific prefix wildcard
    - broader prefix wildcard
    - catch-all `*`
  - Wired namespace policy resolution into:
    - cache loader path
    - create-policy enforcement path (`PolicyEnforcerActor`)
  - Extended cache invalidation:
    - when a namespace root policy changes, cached policies in covered namespaces are invalidated
  - Added canonical base config file:
    - `internal/utils/config/.../ditto-namespace-policies.conf`
    - included via `ditto-service-base.conf`
  - Updated Helm templates and values to service-scoped config:
    - `policies.config.namespacePolicies`
    - `things.config.namespacePolicies`
  - Updated chart docs accordingly.
  - Added config validation for unsupported wildcard syntax at startup.

  ## Behavior / rules

  - Only entries with `importable = "implicit"` are merged.
  - Entries with `importable = "explicit"` or `importable = "never"` are not merged.
  - Local policy entries win on label conflicts.
  - If multiple namespace root policies match, they are applied in deterministic precedence order:
    1. exact namespace
    2. more specific wildcard prefix
    3. broader wildcard prefix
    4. `*`
  - If a configured root policy is missing or deleted, entries are skipped and an error is logged.
  - Stored policy JSON is not modified; merging happens only at enforcer-build time.
  - Unsupported namespace policy patterns are rejected at config load time.

  ## Supported config syntax

  - `org.example.devices`
  - `org.example.devices.*`
  - `*`

  Unsupported examples:

  - `org.*.devices`
  - `foo*`
  - `**`

  ## Example config

  ```yaml
  policies:
    config:
      namespacePolicies:
        org.example.devices:
          - org.example:tenant-root-exact
        org.example.devices.*:
          - org.example:tenant-root-devices
        org.example.*:
          - org.example:tenant-root-general

  things:
    config:
      namespacePolicies:
        org.example.devices:
          - org.example:tenant-root-exact
        org.example.devices.*:
          - org.example:tenant-root-devices
        org.example.*:
          - org.example:tenant-root-general