### PR TITLE
Fix MongoDB aggregation pipeline performance regression

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ConnectionIdsRetrievalActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/ConnectionIdsRetrievalActor.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.function.Supplier;
 
 import org.apache.pekko.NotUsed;
@@ -184,35 +185,31 @@ public final class ConnectionIdsRetrievalActor extends AbstractActor {
                         logger.debug("idsFromSnapshots element: <{}>", result);
                         return result;
                     }));
-            final Source<String, NotUsed> idsFromJournal = persistenceIdsFromJournalSourceSupplier.get()
-                    .via(Flow.fromFunction(result -> {
-                        logger.debug("idsFromJournalSource element: <{}>", result);
-                        return result;
-                    }))
-                    .filter(ConnectionIdsRetrievalActor::isNotDeleted)
-                    .map(document -> document.getString(MongoReadJournal.J_EVENT_PID))
-                    .via(Flow.fromFunction(result -> {
-                        logger.debug("idsFromJournal element: <{}>", result);
-                        return result;
-                    }));
 
-            final CompletionStage<List<String>> deletedPidsStage = persistenceIdsFromJournalSourceSupplier.get()
-                    .filter(ConnectionIdsRetrievalActor::isDeleted)
-                    .map(document -> document.getString(MongoReadJournal.J_EVENT_PID))
-                    .runWith(Sink.seq(), materializer);
+            // scan journal only ONCE and partition into deleted/non-deleted in memory
+            final CompletionStage<List<Document>> allJournalDocsStage =
+                    persistenceIdsFromJournalSourceSupplier.get()
+                            .runWith(Sink.seq(), materializer);
 
-            final CompletionStage<CommandResponse> retrieveAllConnectionIdsResponse = deletedPidsStage
-                    .thenApply(deletedIdsFromJournal -> {
-                        logger.debug("deletedIdsFromJournal element: <{}>", deletedIdsFromJournal);
-                        return deletedIdsFromJournal;
+            final CompletionStage<CommandResponse> retrieveAllConnectionIdsResponse = allJournalDocsStage
+                    .thenCompose(allJournalDocs -> {
+                        final Set<String> deletedIdsFromJournal = allJournalDocs.stream()
+                                .filter(ConnectionIdsRetrievalActor::isDeleted)
+                                .map(document -> document.getString(MongoReadJournal.J_EVENT_PID))
+                                .collect(Collectors.toSet());
+                        logger.debug("deletedIdsFromJournal: <{}>", deletedIdsFromJournal);
+
+                        final Source<String, NotUsed> idsFromJournal = Source.from(allJournalDocs)
+                                .filter(ConnectionIdsRetrievalActor::isNotDeleted)
+                                .map(document -> document.getString(MongoReadJournal.J_EVENT_PID));
+
+                        return idsFromSnapshots.concat(idsFromJournal)
+                                .filter(pid -> !deletedIdsFromJournal.contains(pid))
+                                .filter(pid -> pid.startsWith(ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX))
+                                .map(pid -> pid.substring(
+                                        ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX.length()))
+                                .runWith(Sink.seq(), materializer);
                     })
-                    .thenCompose(deletedIdsFromJournal -> idsFromSnapshots.concat(idsFromJournal)
-                            .filter(pid -> !deletedIdsFromJournal.contains(pid))
-                            .filter(pid -> pid.startsWith(ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX))
-                            .map(pid -> pid.substring(
-                                    ConnectionPersistenceActor.PERSISTENCE_ID_PREFIX.length()))
-                            .runWith(Sink.seq(), materializer)
-                    )
                     .thenApply(idList -> idList.stream().sorted().toList())
                     .thenApply(LinkedHashSet::new)
                     .thenApply(ids -> buildResponse(cmd, ids))

--- a/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
+++ b/internal/utils/persistence/src/main/java/org/eclipse/ditto/internal/utils/persistence/mongo/streaming/MongoReadJournal.java
@@ -436,12 +436,8 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
 
     private Source<String, NotUsed> filterPidsThatDoesntContainTagInNewestEntry(final MongoCollection<Document> journal,
             final List<String> pids, final String tag) {
-        final List<Bson> filterPipeline = new ArrayList<>(6);
+        final List<Bson> filterPipeline = new ArrayList<>(5);
         filterPipeline.add(Aggregates.match(Filters.in(J_PROCESSOR_ID, pids)));
-        // project stage -- reduce document size before $sort to save memory
-        filterPipeline.add(Aggregates.project(Projections.include(
-                J_PROCESSOR_ID, J_TO,
-                J_EVENT + "." + J_PROCESSOR_ID, J_EVENT + "." + J_TAGS)));
         filterPipeline.add(Aggregates.sort(Sorts.descending(J_TO)));
         filterPipeline.add(Aggregates.group(
                 "$" + J_PROCESSOR_ID,
@@ -912,7 +908,7 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             final int maxRestarts,
             final String... fieldNames) {
 
-        final List<Bson> pipeline = new ArrayList<>(7);
+        final List<Bson> pipeline = new ArrayList<>(6);
         // optional match stages: consecutive match stages are optimized together ($match + $match coalescence)
         if (!tag.isEmpty()) {
             pipeline.add(Aggregates.match(Filters.eq(J_TAGS, tag)));
@@ -921,22 +917,13 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
             pipeline.add(Aggregates.match(Filters.gt(J_PROCESSOR_ID, startPid)));
         }
 
-        final Set<String> fieldNamesWithOptionalTags = Arrays.stream(fieldNames).collect(Collectors.toSet());
-
-        // project stage -- reduce document size before $sort to save memory
-        final List<String> journalProjectFields = new ArrayList<>();
-        journalProjectFields.add(J_PROCESSOR_ID);
-        journalProjectFields.add(J_TO);
-        for (final String fieldName : fieldNamesWithOptionalTags) {
-            journalProjectFields.add(J_EVENT + "." + fieldName);
-        }
-        pipeline.add(Aggregates.project(Projections.include(journalProjectFields)));
-
         // sort stage
         pipeline.add(Aggregates.sort(Sorts.orderBy(Sorts.ascending(J_PROCESSOR_ID), Sorts.descending(J_TO))));
 
         // limit stage. It should come before group stage or MongoDB would scan the entire journal collection.
         pipeline.add(Aggregates.limit(batchSize));
+
+        final Set<String> fieldNamesWithOptionalTags = Arrays.stream(fieldNames).collect(Collectors.toSet());
         // group stage
         pipeline.add(Aggregates.group("$" + J_PROCESSOR_ID, toFirstJournalEntryFields(fieldNamesWithOptionalTags)));
 
@@ -998,16 +985,6 @@ public final class MongoReadJournal implements CurrentEventsByPersistenceIdQuery
         // match stage
         final Bson matchFilter = snapshotFilter.toMongoFilter();
         pipeline.add(Aggregates.match(matchFilter));
-
-        // project stage -- reduce document size before $sort to save memory
-        final List<String> snapshotProjectFields = new ArrayList<>();
-        snapshotProjectFields.add(S_PROCESSOR_ID);
-        snapshotProjectFields.add(S_SN);
-        snapshotProjectFields.add(S_SERIALIZED_SNAPSHOT + "." + LIFECYCLE);
-        for (final String snapshotField : snapshotFields) {
-            snapshotProjectFields.add(S_SERIALIZED_SNAPSHOT + "." + snapshotField);
-        }
-        pipeline.add(Aggregates.project(Projections.include(snapshotProjectFields)));
 
         // sort stage
         pipeline.add(Aggregates.sort(Sorts.orderBy(Sorts.ascending(S_PROCESSOR_ID), Sorts.descending(S_SN))));


### PR DESCRIPTION
Remove $project stages that were inserted between $match and $sort in MongoReadJournal aggregation pipelines (commit 6a47f201b9). These stages prevented MongoDB from combining $match + $sort + $limit into an efficient index-backed top-K scan, causing 296-second queries on the connections_journal collection.

Affected methods:
- listLatestJournalEntries: remove $project between $match and $sort
- filterPidsThatDoesntContainTagInNewestEntry: remove $project between $match and $sort
- listNewestActiveSnapshotsByBatch: remove $project between $match and $sort

Additionally, optimize ConnectionIdsRetrievalActor.getAllConnectionIDs() to scan the journal only once instead of twice (once for deleted PIDs, once for non-deleted), partitioning the results in memory.