### PR TITLE
Surface enforcement/validation errors for fire-and-forget commands

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
@@ -320,7 +320,7 @@ public abstract class AbstractHttpRequestActor extends AbstractActorWithShutdown
             handleCommandWithResponse(signalWithoutAckregator, getResponseAwaitingBehavior(), timeoutOverride);
             setDefaultTimeoutExceptionSupplier(signalWithoutAckregator);
         } else {
-            handleCommandAndAcceptImmediately(signalWithoutAckregator);
+            handleFireAndForgetCommand(signalWithoutAckregator);
         }
 
         return null;
@@ -332,10 +332,24 @@ public abstract class AbstractHttpRequestActor extends AbstractActorWithShutdown
                 mapAcknowledgementsForHttp(acks)));
     }
 
-    private void handleCommandAndAcceptImmediately(final Signal<?> command) {
-        logger.debug("Received <{}> that doesn't expect a response. Answering with status code 202 ...", command);
+    /**
+     * Handles a fire-and-forget command (timeout=0, no ack requests) by sending it to the proxy
+     * and waiting for the enforcement/validation result before returning the HTTP response.
+     * <p>
+     * If an enforcement or validation error occurs (e.g., policy check fails, WoT validation fails),
+     * the error is returned to the client. If no error arrives within the enforcement timeout,
+     * HTTP 202 Accepted is returned.
+     *
+     * @param command the fire-and-forget command to handle.
+     */
+    private void handleFireAndForgetCommand(final Signal<?> command) {
+        logger.debug("Received fire-and-forget <{}>. Awaiting enforcement/validation result before accepting ...",
+                command.getType());
         proxyActor.tell(command, getSelf());
-        completeWithResult(createHttpResponse(HttpStatus.ACCEPTED));
+        final Duration enforcementTimeout = gatewayConfig.getCommandConfig().getDefaultTimeout();
+        getContext().setReceiveTimeout(enforcementTimeout);
+        // Clear timeoutExceptionSupplier so that handleReceiveTimeout returns 202 instead of a timeout error
+        timeoutExceptionSupplier = null;
     }
 
     private void rememberResponseLocationUri(final CommandResponse<?> commandResponse) {
@@ -540,17 +554,21 @@ public abstract class AbstractHttpRequestActor extends AbstractActorWithShutdown
     private void handleReceiveTimeout() {
         final var actorContext = getContext();
         final var receiveTimeout = actorContext.getReceiveTimeout();
-
-        logger.withCorrelationId(receivedCommand)
-                .info("Got <{}> after <{}> before an appropriate response arrived.",
-                ReceiveTimeout.class.getSimpleName(), receiveTimeout);
+        actorContext.cancelReceiveTimeout();
 
         if (null != timeoutExceptionSupplier) {
-            final var timeoutException = timeoutExceptionSupplier.get();
-            actorContext.cancelReceiveTimeout();
-            handleDittoRuntimeException(timeoutException);
+            logger.withCorrelationId(receivedCommand)
+                    .info("Got <{}> after <{}> before an appropriate response arrived.",
+                            ReceiveTimeout.class.getSimpleName(), receiveTimeout);
+            handleDittoRuntimeException(timeoutExceptionSupplier.get());
+        } else if (!isResponseRequired()) {
+            // Fire-and-forget: no enforcement/validation error arrived within the timeout, accept optimistically
+            logger.withCorrelationId(receivedCommand)
+                    .debug("Got <{}> for fire-and-forget command after <{}>. " +
+                                    "No enforcement/validation error received, responding with HTTP 202.",
+                            ReceiveTimeout.class.getSimpleName(), receiveTimeout);
+            completeWithResult(createHttpResponse(HttpStatus.ACCEPTED));
         } else {
-            actorContext.cancelReceiveTimeout();
             // This case is a programming error that should not happen at all.
             logger.withCorrelationId(receivedCommand)
                     .error("Actor does not have a timeout exception supplier. " +

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorHeaderInteractionTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorHeaderInteractionTest.java
@@ -110,12 +110,20 @@ public final class HttpRequestActorHeaderInteractionTest extends AbstractHttpReq
         final HttpStatus successCode = HttpStatus.NO_CONTENT;
         final HttpStatus errorCode = HttpStatus.NOT_FOUND;
         if (timeout.isZero()) {
-            status = isAwaiting ? HttpStatus.BAD_REQUEST : HttpStatus.ACCEPTED;
+            if (isAwaiting) {
+                status = HttpStatus.BAD_REQUEST;
+            } else if (isSuccess) {
+                status = HttpStatus.ACCEPTED;
+            } else {
+                // Fire-and-forget: enforcement/validation errors are now surfaced instead of returning 202
+                status = errorCode;
+            }
         } else {
             if (isSuccess) {
                 status = responseRequired ? successCode : HttpStatus.ACCEPTED;
             } else {
-                status = isAwaiting ? errorCode : HttpStatus.ACCEPTED;
+                // Enforcement/validation errors are always surfaced, even for fire-and-forget commands
+                status = errorCode;
             }
         }
         return status;

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorTest.java
@@ -54,8 +54,10 @@ import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.messages.model.Message;
 import org.eclipse.ditto.messages.model.MessageDirection;
 import org.eclipse.ditto.messages.model.MessageHeaders;
+import org.eclipse.ditto.messages.model.signals.commands.SendThingMessage;
 import org.eclipse.ditto.messages.model.signals.commands.SendThingMessageResponse;
 import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.exceptions.ThingNotAccessibleException;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyAttribute;
 import org.eclipse.ditto.things.model.signals.commands.modify.ModifyAttributeResponse;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThingResponse;
@@ -225,18 +227,23 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
 
     @Test
     public void handlesThingModifyCommandLiveNoResponseRequired() throws ExecutionException, InterruptedException {
+        final var thingId = ThingId.generateRandom();
         final var attributeName = "foo";
+        final var attributePointer = JsonPointer.of(attributeName);
 
         final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
                 .responseRequired(false)
                 .channel("live")
                 .build();
 
-        testThingModifyCommand(ThingId.generateRandom(),
-                JsonPointer.of(attributeName),
+        final var expectedHeaders =
+                DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build();
+
+        testThingModifyCommand(thingId,
+                attributePointer,
                 dittoHeaders,
-                DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build(),
-                null,
+                expectedHeaders,
+                ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders),
                 StatusCodes.ACCEPTED,
                 null);
     }
@@ -389,16 +396,157 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
     public void handlesMessageCommandNoResponseRequiredAndLiveResponseAckRequest()
             throws ExecutionException, InterruptedException {
 
+        final var thingId = ThingId.generateRandom();
+        final var messageSubject = "sayPing";
+
         final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
                 .channel("live")
                 .responseRequired(false)
                 .build();
 
-        testMessageCommand(ThingId.generateRandom(),
-                "sayPing",
+        final var expectedHeaders =
+                DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build();
+
+        final var probeResponse = buildSendThingMessageResponse(thingId, messageSubject, expectedHeaders,
+                "application/json", JsonValue.of("pong"));
+
+        testMessageCommand(thingId,
+                messageSubject,
                 dittoHeaders,
-                DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build(),
+                expectedHeaders,
+                probeResponse,
+                StatusCodes.ACCEPTED,
                 null,
+                null);
+    }
+
+    @Test
+    public void noResponseRequiredCommandSurfacesEnforcementError() throws ExecutionException, InterruptedException {
+        final var thingId = ThingId.generateRandom();
+        final var attributePointer = JsonPointer.of("foo");
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .responseRequired(false)
+                .channel("live")
+                .build();
+        final var expectedHeaders = DittoHeaders.newBuilder(dittoHeaders)
+                .acknowledgementRequests(Collections.emptyList())
+                .build();
+
+        testThingModifyCommand(thingId,
+                attributePointer,
+                dittoHeaders,
+                expectedHeaders,
+                ThingNotAccessibleException.newBuilder(thingId).dittoHeaders(expectedHeaders).build(),
+                StatusCodes.NOT_FOUND,
+                null);
+    }
+
+    @Test
+    public void fireAndForgetCommandSurfacesEnforcementError() throws ExecutionException, InterruptedException {
+        final var thingId = ThingId.generateRandom();
+        final var attributePointer = JsonPointer.of("foo");
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .responseRequired(false)
+                .build();
+        final var expectedHeaders = DittoHeaders.newBuilder(dittoHeaders)
+                .acknowledgementRequests(Collections.emptyList())
+                .build();
+
+        testThingModifyCommand(thingId,
+                attributePointer,
+                dittoHeaders,
+                expectedHeaders,
+                ThingNotAccessibleException.newBuilder(thingId).dittoHeaders(expectedHeaders).build(),
+                StatusCodes.NOT_FOUND,
+                null);
+    }
+
+    @Test
+    public void fireAndForgetCommandReturnsAcceptedOnSuccess() throws ExecutionException, InterruptedException {
+        final var thingId = ThingId.generateRandom();
+        final var attributePointer = JsonPointer.of("foo");
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .responseRequired(false)
+                .build();
+        final var expectedHeaders = DittoHeaders.newBuilder(dittoHeaders)
+                .acknowledgementRequests(Collections.emptyList())
+                .build();
+
+        testThingModifyCommand(thingId,
+                attributePointer,
+                dittoHeaders,
+                expectedHeaders,
+                ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders),
+                StatusCodes.ACCEPTED,
+                null);
+    }
+
+    @Test
+    public void fireAndForgetMessageCommandSurfacesEnforcementError()
+            throws ExecutionException, InterruptedException {
+
+        final var thingId = ThingId.generateRandom();
+        final var messageSubject = "doSomething";
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .responseRequired(false)
+                .channel("live")
+                .build();
+
+        final var proxyActorProbe = ACTOR_SYSTEM_RESOURCE.newTestProbe();
+        final var messageHeaders = MessageHeaders.newBuilder(MessageDirection.TO, thingId, messageSubject)
+                .contentType("application/json")
+                .build();
+        final Message<?> message = Message.newBuilder(messageHeaders)
+                .payload(JsonValue.of("ping"))
+                .build();
+        final var sendThingMessage = SendThingMessage.of(thingId, message, dittoHeaders);
+
+        final var httpRequest = HttpRequest.PUT("/api/2/things/" + thingId + "/inbox/messages/" + messageSubject);
+        final var responseFuture = new CompletableFuture<HttpResponse>();
+
+        final var underTest = createHttpRequestActor(proxyActorProbe.ref(), httpRequest, responseFuture);
+        underTest.tell(sendThingMessage, ActorRef.noSender());
+
+        proxyActorProbe.expectMsgClass(SendThingMessage.class);
+        proxyActorProbe.reply(ThingNotAccessibleException.newBuilder(thingId)
+                .dittoHeaders(dittoHeaders)
+                .build());
+
+        final var httpResponse = responseFuture.get();
+        assertThat(httpResponse.status()).isEqualTo(StatusCodes.NOT_FOUND);
+    }
+
+    @Test
+    public void fireAndForgetMessageCommandReturnsAcceptedOnSuccess()
+            throws ExecutionException, InterruptedException {
+
+        final var thingId = ThingId.generateRandom();
+        final var messageSubject = "doSomething";
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .responseRequired(false)
+                .channel("live")
+                .build();
+
+        final var expectedHeaders =
+                DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build();
+
+        final var probeResponse = buildSendThingMessageResponse(thingId, messageSubject, expectedHeaders,
+                "application/json", JsonValue.of("pong"));
+
+        testMessageCommand(thingId,
+                messageSubject,
+                dittoHeaders,
+                expectedHeaders,
+                probeResponse,
                 StatusCodes.ACCEPTED,
                 null,
                 null);


### PR DESCRIPTION
Previously, fire-and-forget commands (timeout=0, no ack requests) immediately returned HTTP 202 Accepted without waiting for enforcement or validation results. This meant policy violations and WoT validation errors were silently swallowed.

Now the gateway waits for the enforcement/validation result before responding. If an error arrives (e.g. policy check fails), it is returned to the client. If no error arrives within the default command timeout, HTTP 202 is returned.

Resolves #2392