### PR TITLE
introduced empty rql filter

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/Thing3ValuePredicateVisitor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/Thing3ValuePredicateVisitor.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.rql.query.expression.ExistsFieldExpression;
 import org.eclipse.ditto.rql.query.expression.FieldExpression;
 import org.eclipse.ditto.rql.query.expression.FilterFieldExpression;
 import org.eclipse.ditto.rql.query.expression.visitors.FieldExpressionVisitor;
+import org.eclipse.ditto.rql.query.things.EmptyThingPredicateVisitor;
 import org.eclipse.ditto.rql.query.things.ExistsThingPredicateVisitor;
 import org.eclipse.ditto.rql.query.things.FilterThingPredicateVisitor;
 import org.eclipse.ditto.rql.query.things.ThingPredicatePredicateVisitor;
@@ -101,6 +102,13 @@ final class Thing3ValuePredicateVisitor implements CriteriaVisitor<Function<Thin
         return thing -> isUnknownField(fieldExpression)
                 ? Trilean.UNKNOWN
                 : Trilean.lift(ExistsThingPredicateVisitor.apply(fieldExpression, placeholderResolvers).test(thing));
+    }
+
+    @Override
+    public Function<Thing, Trilean> visitEmpty(final ExistsFieldExpression fieldExpression) {
+        return thing -> isUnknownField(fieldExpression)
+                ? Trilean.UNKNOWN
+                : Trilean.lift(EmptyThingPredicateVisitor.apply(fieldExpression, placeholderResolvers).test(thing));
     }
 
     @Override

--- a/documentation/src/main/resources/openapi/ditto-api-2.yml
+++ b/documentation/src/main/resources/openapi/ditto-api-2.yml
@@ -9735,6 +9735,7 @@ components:
         * ```?condition=ge(features/temperature/properties/lastModified,"2021-08-22T19:45:00Z")```
         * ```?condition=gt(_modified,"2021-08-05T12:17:00Z")```
         * ```?condition=exists(features/temperature/properties/value)```
+        * ```?condition=empty(features/temperature/properties/value)```
         * ```?condition=and(gt(features/temperature/properties/value,18.5),lt(features/temperature/properties/value,25.2))```
         * ```?condition=or(gt(features/temperature/properties/value,18.5),not(exists(features/temperature/properties/value))```
       required: false
@@ -10189,6 +10190,8 @@ components:
 
         * ```exists({property})```  (i.e. all things in which the given path exists)
 
+        * ```empty({property})```  (i.e. all things in which the given path is absent, null, an empty array, an empty object or an empty string)
+
 
         Note: When using filter operations, only things with the specified properties are returned.
         For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
@@ -10214,6 +10217,8 @@ components:
         * ```gt(_created,"2020-08-05T12:17")```
 
         * ```exists(features/featureId)```
+
+        * ```empty(attributes/tags)```
 
         * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
 
@@ -12107,6 +12112,8 @@ components:
 
         * ```exists({property})```  (i.e. all things in which the given path exists)
 
+        * ```empty({property})```  (i.e. all things in which the given path is absent, null, an empty array, an empty object or an empty string)
+
 
         Note: When using filter operations, only things with the specified properties are returned.
         For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
@@ -12132,6 +12139,8 @@ components:
         * ```gt(_created,"2020-08-05T12:17")```
 
         * ```exists(features/featureId)```
+
+        * ```empty(attributes/tags)```
 
         * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
 

--- a/documentation/src/main/resources/openapi/sources/parameters/conditionParam.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/conditionParam.yml
@@ -32,6 +32,8 @@ description: >-
 
   * ```?condition=exists(features/temperature/properties/value)```
 
+  * ```?condition=empty(features/temperature/properties/value)```
+
   * ```?condition=and(gt(features/temperature/properties/value,18.5),lt(features/temperature/properties/value,25.2))```
 
   * ```?condition=or(gt(features/temperature/properties/value,18.5),not(exists(features/temperature/properties/value))```

--- a/documentation/src/main/resources/openapi/sources/parameters/searchFilter.yml
+++ b/documentation/src/main/resources/openapi/sources/parameters/searchFilter.yml
@@ -34,6 +34,8 @@ description: |-
 
   * ```exists({property})```  (i.e. all things in which the given path exists)
 
+  * ```empty({property})```  (i.e. all things in which the given path is absent, null, an empty array, an empty object or an empty string)
+
 
   Note: When using filter operations, only things with the specified properties are returned.
   For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
@@ -59,6 +61,8 @@ description: |-
   * ```gt(_created,"2020-08-05T12:17")```
 
   * ```exists(features/featureId)```
+
+  * ```empty(attributes/tags)```
 
   * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
 

--- a/documentation/src/main/resources/openapi/sources/schemas/properties/searchFilterProperty.yml
+++ b/documentation/src/main/resources/openapi/sources/schemas/properties/searchFilterProperty.yml
@@ -32,8 +32,10 @@ description: |-
     * ```ilike({property},{value})```  (i.e. contains values similar and case insensitive to the expressions listed)
   
     * ```exists({property})```  (i.e. all things in which the given path exists)
-  
-  
+
+    * ```empty({property})```  (i.e. all things in which the given path is absent, null, an empty array, an empty object or an empty string)
+
+
     Note: When using filter operations, only things with the specified properties are returned.
     For example, the filter `ne(attributes/owner, "SID123")` will only return things that do have
     the `owner` attribute.
@@ -58,7 +60,9 @@ description: |-
     * ```gt(_created,"2020-08-05T12:17")```
   
     * ```exists(features/featureId)```
-  
+
+    * ```empty(attributes/tags)```
+
     * ```and(eq(attributes/location,"kitchen"),eq(attributes/color,"red"))```
   
     * ```or(eq(attributes/location,"kitchen"),eq(attributes/location,"living-room"))```

--- a/documentation/src/main/resources/pages/ditto/basic-rql.md
+++ b/documentation/src/main/resources/pages/ditto/basic-rql.md
@@ -29,7 +29,7 @@ Eclipse Ditto.
 
 {% include note.html content="Please note that only the \"normalized\" RQL form, e.g. 
     `eq(foo,3)`, is supported by Eclipse Ditto and that Ditto added more non-specified operators, e.g. 
-    `like` and `exists`." %}
+    `like`, `exists` and `empty`." %}
 
 
 ## RQL filter
@@ -270,6 +270,41 @@ exists(features/feature_1)
 **Example - filter lamps which are located in the "living-room"**
 ```
 and(exists(features/lamp),eq(attributes/location,"living-room"))
+```
+
+#### empty
+
+Filter property values which are absent or void of content.
+
+```
+empty(<property>)
+```
+
+{% include note.html content="The `empty` operator is not defined in the linked RQL grammar, it is a Ditto
+    specific operator." %}
+
+A field is considered "empty" when:
+* The field does not exist
+* The field is `null`
+* The field is an empty array `[]`
+* The field is an empty object `{}`
+* The field is an empty string `""`
+
+Numeric values (including `0`) and boolean values (including `false`) are **not** considered empty.
+
+**Example - filter things where tags are absent or empty**
+```
+empty(attributes/tags)
+```
+
+**Example - filter things where tags exist and have content**
+```
+not(empty(attributes/tags))
+```
+
+**Example - filter things where tags are either empty or contain "default"**
+```
+or(empty(attributes/tags),eq(attributes/tags,"default"))
 ```
 
 

--- a/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/EmptyNode.java
+++ b/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/EmptyNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.rql.model.predicates.ast;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+/**
+ * Implements an empty node. Such a node only has one parameter that is the field name to check for emptiness.
+ * A field is considered "empty" when it is absent, {@code null}, an empty array {@code []}, an empty object
+ * {@code {}} or an empty string {@code ""}.
+ *
+ * @since 3.9.0
+ */
+public class EmptyNode implements Node {
+
+    private final String property;
+
+    /**
+     * Constructor. Creates a new node with the given property.
+     *
+     * @param property property of this empty node.
+     */
+    public EmptyNode(final String property) {
+        this.property = requireNonNull(property);
+    }
+
+    /**
+     * Retrieve the property of this empty node.
+     *
+     * @return the property of the empty node.
+     */
+    public String getProperty() {
+        return property;
+    }
+
+    @Override
+    public void accept(final PredicateVisitor predicateVisitor) {
+        predicateVisitor.visit(this);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final EmptyNode that = (EmptyNode) o;
+        return Objects.equals(property, that.property);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(property);
+    }
+
+    @Override
+    public String toString() {
+        return "EmptyNode [property=" + property + "]";
+    }
+}

--- a/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/PredicateVisitor.java
+++ b/rql/model/src/main/java/org/eclipse/ditto/rql/model/predicates/ast/PredicateVisitor.java
@@ -54,6 +54,16 @@ public interface PredicateVisitor {
     void visit(ExistsNode node);
 
     /**
+     * Is called by a {@link EmptyNode} in its {@link EmptyNode#accept(PredicateVisitor)} method.
+     *
+     * @param node an instance of the {@link EmptyNode}
+     * @since 3.9.0
+     */
+    default void visit(final EmptyNode node) {
+        throw new UnsupportedOperationException("visit(EmptyNode) is not supported by " + getClass().getName());
+    }
+
+    /**
      * Is called by a {@link Node} in its {@link Node#accept(PredicateVisitor)} method.
      *
      * @param node an instance of the {@link Node}

--- a/rql/model/src/test/java/org/eclipse/ditto/rql/model/predicates/ast/EmptyNodeTest.java
+++ b/rql/model/src/test/java/org/eclipse/ditto/rql/model/predicates/ast/EmptyNodeTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.rql.model.predicates.ast;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+
+/**
+ * Tests {@link EmptyNode}.
+ */
+public class EmptyNodeTest {
+
+    @Test
+    public void hashcodeAndEquals() {
+        EqualsVerifier.forClass(EmptyNode.class).usingGetClass().verify();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void typeConstructorWithNull() {
+        new EmptyNode(null);
+    }
+
+    @Test
+    public void constructorSuccess() {
+        final EmptyNode emptyNode = new EmptyNode("propertyName");
+        assertThat(emptyNode.getProperty()).isEqualTo("propertyName");
+    }
+
+    @Test
+    public void visitorGetsVisited() {
+        final PredicateVisitor visitorMock = mock(PredicateVisitor.class);
+        final EmptyNode emptyNode = new EmptyNode("propertyName");
+        emptyNode.accept(visitorMock);
+        verify(visitorMock).visit(emptyNode);
+    }
+
+}

--- a/rql/parser/src/main/scala/org/eclipse/ditto/rql/parser/internal/RqlPredicateParser.scala
+++ b/rql/parser/src/main/scala/org/eclipse/ditto/rql/parser/internal/RqlPredicateParser.scala
@@ -26,7 +26,7 @@ import scala.util.{Failure, Success}
   * RQL Parser. Parses predicates in the RQL "standard" according to https://github.com/persvr/rql with the following
   * EBNF:
   * <pre>
-  * Query                      = SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp
+  * Query                      = SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp | EmptyOp
   * SingleComparisonOp         = SingleComparisonName, '(', ComparisonProperty, ',', ComparisonValue, ')'
   * SingleComparisonName       = "eq" | "ne" | "gt" | "ge" | "lt" | "le" | "like" | "ilike"
   * MultiComparisonOp          = MultiComparisonName, '(', ComparisonProperty, ',', ComparisonValue, { ',', ComparisonValue }, ')'
@@ -36,6 +36,7 @@ import scala.util.{Failure, Success}
   * SingleLogicalOp            = SingleLogicalName, '(', Query, ')'
   * SingleLogicalName          = "not"
   * ExistsOp                   = "exists" '(', ComparisonProperty, ')'
+  * EmptyOp                    = "empty" '(', ComparisonProperty, ')'
   *
   * ComparisonProperty         = PropertyLiteral
   * ComparisonValue            = Literal
@@ -51,10 +52,10 @@ private class RqlPredicateParser(override val input: ParserInput) extends RqlPar
   }
 
   /**
-    * Query                      = SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp
+    * Query                      = SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp | EmptyOp
     */
   private def Query: Rule1[Node] = rule {
-    SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp
+    SingleComparisonOp | MultiComparisonOp | MultiLogicalOp | SingleLogicalOp | ExistsOp | EmptyOp
   }
 
   /**
@@ -185,6 +186,13 @@ private class RqlPredicateParser(override val input: ParserInput) extends RqlPar
     */
   private def ExistsOp: Rule1[Node] = rule {
     "exists" ~ '(' ~ ComparisonProperty ~ ')' ~> (property => new ExistsNode(property))
+  }
+
+  /**
+    * EmptyOp                    = "empty" '(', ComparisonProperty, ')'
+    */
+  private def EmptyOp: Rule1[Node] = rule {
+    "empty" ~ '(' ~ ComparisonProperty ~ ')' ~> (property => new EmptyNode(property))
   }
 
 

--- a/rql/parser/src/test/java/org/eclipse/ditto/rql/parser/RqlPredicateParserTest.java
+++ b/rql/parser/src/test/java/org/eclipse/ditto/rql/parser/RqlPredicateParserTest.java
@@ -17,6 +17,7 @@ import static org.eclipse.ditto.base.model.assertions.DittoBaseAssertions.assert
 import org.eclipse.ditto.rql.model.ParsedPlaceholder;
 import org.eclipse.ditto.rql.model.ParserException;
 import org.eclipse.ditto.rql.model.predicates.PredicateParser;
+import org.eclipse.ditto.rql.model.predicates.ast.EmptyNode;
 import org.eclipse.ditto.rql.model.predicates.ast.ExistsNode;
 import org.eclipse.ditto.rql.model.predicates.ast.LogicalNode;
 import org.eclipse.ditto.rql.model.predicates.ast.MultiComparisonNode;
@@ -592,6 +593,43 @@ public class RqlPredicateParserTest {
     @Test(expected = ParserException.class)
     public void testFieldExistsInvalidWithMoreParams() throws ParserException {
         parser.parse("exists(features/scanner,\"test\")");
+    }
+
+    @Test
+    public void testFieldEmpty() throws ParserException {
+        final RootNode root = parser.parse("empty(attributes/tags)");
+
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final EmptyNode emptyNode = (EmptyNode) root.getChildren().get(0);
+        assertThat(emptyNode.getProperty().getClass()).isEqualTo(String.class);
+        assertThat(emptyNode.getProperty()).isEqualTo("attributes/tags");
+    }
+
+    @Test
+    public void testFieldEmptyNegated() throws ParserException {
+        final RootNode root = parser.parse("not(empty(attributes/tags))");
+
+        assertThat(root).isNotNull();
+        assertThat(root.getChildren().size()).isEqualTo(1);
+
+        final LogicalNode logicalNode = (LogicalNode) root.getChildren().get(0);
+        assertThat(logicalNode.getType()).isEqualTo(LogicalNode.Type.NOT);
+        assertThat(logicalNode.getChildren().size()).isEqualTo(1);
+
+        final EmptyNode emptyNode = (EmptyNode) logicalNode.getChildren().get(0);
+        assertThat(emptyNode.getProperty()).isEqualTo("attributes/tags");
+    }
+
+    @Test(expected = ParserException.class)
+    public void testFieldEmptyInvalidWithQuotes() throws ParserException {
+        parser.parse("empty(\"attributes/tags\")");
+    }
+
+    @Test(expected = ParserException.class)
+    public void testFieldEmptyInvalidWithMoreParams() throws ParserException {
+        parser.parse("empty(attributes/tags,\"test\")");
     }
 
     @Test

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/CriteriaFactory.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/CriteriaFactory.java
@@ -97,6 +97,17 @@ public interface CriteriaFactory {
     Criteria existsCriteria(ExistsFieldExpression fieldExpression);
 
     /**
+     * Creates a criteria to filter based on the emptiness of the given field.
+     * A field is considered "empty" when it is absent, {@code null}, an empty array, an empty object or an empty
+     * string.
+     *
+     * @param fieldExpression the field to check for emptiness.
+     * @return the criteria.
+     * @since 3.9.0
+     */
+    Criteria emptyCriteria(ExistsFieldExpression fieldExpression);
+
+    /**
      * Creates a predicate which checks for equality.
      *
      * @param value the value, may be {@code null}.

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/CriteriaFactoryImpl.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/CriteriaFactoryImpl.java
@@ -72,6 +72,11 @@ final class CriteriaFactoryImpl implements CriteriaFactory {
     }
 
     @Override
+    public Criteria emptyCriteria(final ExistsFieldExpression fieldExpression) {
+        return new EmptyCriteriaImpl(requireNonNull(fieldExpression));
+    }
+
+    @Override
     public Predicate eq(@Nullable final Object value) {
         return new EqPredicateImpl(value);
     }

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/EmptyCriteriaImpl.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/EmptyCriteriaImpl.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.rql.query.criteria;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Objects;
+
+import org.eclipse.ditto.rql.query.criteria.visitors.CriteriaVisitor;
+import org.eclipse.ditto.rql.query.expression.ExistsFieldExpression;
+
+/**
+ * Criteria implementation which can handle arbitrary field emptiness filters.
+ * A field is considered "empty" when it is absent, {@code null}, an empty array, an empty object or an empty string.
+ *
+ * @since 3.9.0
+ */
+final class EmptyCriteriaImpl implements Criteria {
+
+    private final ExistsFieldExpression fieldExpression;
+
+    EmptyCriteriaImpl(final ExistsFieldExpression fieldExpression) {
+        this.fieldExpression = requireNonNull(fieldExpression);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final EmptyCriteriaImpl that = (EmptyCriteriaImpl) o;
+        return Objects.equals(fieldExpression, that.fieldExpression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(fieldExpression);
+    }
+
+    @Override
+    public <T> T accept(final CriteriaVisitor<T> visitor) {
+        return visitor.visitEmpty(fieldExpression);
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + " [fieldExpression=" + fieldExpression + "]";
+    }
+
+}

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/visitors/CriteriaVisitor.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/criteria/visitors/CriteriaVisitor.java
@@ -50,6 +50,19 @@ public interface CriteriaVisitor<T> {
     T visitExists(ExistsFieldExpression fieldExpression);
 
     /**
+     * Visits the passed {@code fieldExpression} applying "empty" semantics.
+     * A field is considered "empty" when it is absent, {@code null}, an empty array, an empty object or an empty
+     * string.
+     *
+     * @param fieldExpression the expression to check emptiness for.
+     * @return the created thingy.
+     * @since 3.9.0
+     */
+    default T visitEmpty(final ExistsFieldExpression fieldExpression) {
+        throw new UnsupportedOperationException("visitEmpty is not supported by " + getClass().getName());
+    }
+
+    /**
      * Visits the passed {@code fieldExpression} and {@code predicate} applying "filtering" semantics.
      *
      * @param fieldExpression the expression to check.

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/filter/ParameterPredicateVisitor.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/filter/ParameterPredicateVisitor.java
@@ -23,6 +23,7 @@ import java.util.function.BiFunction;
 
 import javax.annotation.Nullable;
 
+import org.eclipse.ditto.rql.model.predicates.ast.EmptyNode;
 import org.eclipse.ditto.rql.model.predicates.ast.ExistsNode;
 import org.eclipse.ditto.rql.model.predicates.ast.LogicalNode;
 import org.eclipse.ditto.rql.model.predicates.ast.MultiComparisonNode;
@@ -149,6 +150,13 @@ final class ParameterPredicateVisitor implements PredicateVisitor {
         checkNotNull(node, "exists node");
         final ExistsFieldExpression field = fieldExprFactory.existsBy(node.getProperty());
         criteria.add(criteriaFactory.existsCriteria(field));
+    }
+
+    @Override
+    public void visit(final EmptyNode node) {
+        checkNotNull(node, "empty node");
+        final ExistsFieldExpression field = fieldExprFactory.existsBy(node.getProperty());
+        criteria.add(criteriaFactory.emptyCriteria(field));
     }
 
     @Override

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/EmptyThingPredicateVisitor.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/EmptyThingPredicateVisitor.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.rql.query.things;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.placeholders.Expression;
+import org.eclipse.ditto.placeholders.PlaceholderResolver;
+import org.eclipse.ditto.rql.query.expression.ExistsFieldExpression;
+import org.eclipse.ditto.rql.query.expression.visitors.ExistsFieldExpressionVisitor;
+import org.eclipse.ditto.things.model.Feature;
+import org.eclipse.ditto.things.model.Thing;
+
+/**
+ * ExistsFieldExpressionVisitor for Java {@link Predicate}s of {@link Thing}s which checks whether a field is
+ * "empty" — meaning it is absent, {@code null}, an empty array, an empty object or an empty string.
+ *
+ * @since 3.9.0
+ */
+public final class EmptyThingPredicateVisitor implements ExistsFieldExpressionVisitor<Predicate<Thing>> {
+
+    private final List<PlaceholderResolver<?>> additionalPlaceholderResolvers;
+
+    private EmptyThingPredicateVisitor() {
+        this.additionalPlaceholderResolvers = Collections.emptyList();
+    }
+
+    private EmptyThingPredicateVisitor(final Collection<PlaceholderResolver<?>> additionalPlaceholderResolvers) {
+        this.additionalPlaceholderResolvers = Collections.unmodifiableList(
+                new ArrayList<>(additionalPlaceholderResolvers));
+    }
+
+    /**
+     * Applies the passed {@code expression} by visiting with a new created {@link EmptyThingPredicateVisitor}
+     * instance not containing any {@code Placeholder}s.
+     *
+     * @param expression the "empty" expression to visit.
+     * @return the Predicate of a thing to test.
+     */
+    public static Predicate<Thing> apply(final ExistsFieldExpression expression) {
+        return expression.acceptExistsVisitor(new EmptyThingPredicateVisitor());
+    }
+
+    /**
+     * Applies the passed {@code expression} by visiting with a new created {@link EmptyThingPredicateVisitor}
+     * instance containing the provided additional {@code PlaceholderResolver}s.
+     *
+     * @param expression the "empty" expression to visit.
+     * @param additionalPlaceholderResolvers the additional {@code PlaceholderResolver} to use for resolving
+     * placeholders in RQL "empty" predicates.
+     * @return the Predicate of a thing to test.
+     */
+    public static Predicate<Thing> apply(final ExistsFieldExpression expression,
+            final Collection<PlaceholderResolver<?>> additionalPlaceholderResolvers) {
+        return expression.acceptExistsVisitor(new EmptyThingPredicateVisitor(additionalPlaceholderResolvers));
+    }
+
+    /**
+     * Applies the passed {@code expression} by visiting with a new created {@link EmptyThingPredicateVisitor}
+     * instance containing the provided additional {@code PlaceholderResolver}s.
+     *
+     * @param expression the "empty" expression to visit.
+     * @param additionalPlaceholderResolvers the additional {@code PlaceholderResolver} to use for resolving
+     * placeholders in RQL "empty" predicates.
+     * @return the Predicate of a thing to test.
+     */
+    public static Predicate<Thing> apply(final ExistsFieldExpression expression,
+            final PlaceholderResolver<?>... additionalPlaceholderResolvers) {
+        return apply(expression, Arrays.asList(additionalPlaceholderResolvers));
+    }
+
+    @Override
+    public Predicate<Thing> visitAttribute(final String key) {
+        return thing -> thing.getAttributes()
+                .map(attributes -> isValueEmpty(attributes.getValueFlatteningArrays(key)))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeature(final String featureId) {
+        return thing -> thing.getFeatures()
+                .map(features -> features.getFeature(featureId)
+                        .map(feature -> !feature.getDefinition().isPresent()
+                                && !feature.getProperties().isPresent()
+                                && !feature.getDesiredProperties().isPresent())
+                        .orElse(true))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeatureDefinition(final String featureId) {
+        return thing -> thing.getFeatures()
+                .flatMap(features -> features.getFeature(featureId))
+                .map(feature -> feature.getDefinition()
+                        .map(def -> def.getSize() == 0)
+                        .orElse(true))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeatureProperties(final CharSequence featureId) {
+        return thing -> thing.getFeatures()
+                .flatMap(features -> features.getFeature(featureId.toString()))
+                .map(feature -> feature.getProperties()
+                        .map(props -> props.isEmpty())
+                        .orElse(true))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeatureDesiredProperties(final CharSequence featureId) {
+        return thing -> thing.getFeatures()
+                .flatMap(features -> features.getFeature(featureId.toString()))
+                .map(feature -> feature.getDesiredProperties()
+                        .map(props -> props.isEmpty())
+                        .orElse(true))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeatureIdProperty(final String featureId, final String property) {
+        return thing -> thing.getFeatures()
+                .flatMap(features -> features.getFeature(featureId))
+                .flatMap(Feature::getProperties)
+                .map(properties -> isValueEmpty(properties.getValueFlatteningArrays(property)))
+                .orElse(true); 
+    }
+
+    @Override
+    public Predicate<Thing> visitFeatureIdDesiredProperty(final CharSequence featureId, final CharSequence property) {
+        return thing -> thing.getFeatures()
+                .flatMap(features -> features.getFeature(featureId.toString()))
+                .flatMap(Feature::getDesiredProperties)
+                .map(properties -> isValueEmpty(properties.getValueFlatteningArrays(property)))
+                .orElse(true);
+    }
+
+    @Override
+    public Predicate<Thing> visitSimple(final String fieldName) {
+        return thing -> {
+            final Optional<JsonValue> value = thing.toJson().getValue(fieldName);
+            if (value.isPresent()) {
+                return isJsonValueEmpty(value.get());
+            }
+            // field not found in thing JSON, check placeholder resolvers
+            return isEmptyInAdditionalPlaceholderResolvers(fieldName);
+        };
+    }
+
+    @Override
+    public Predicate<Thing> visitMetadata(final String key) {
+        return thing -> thing.getMetadata()
+                .map(metadata -> isValueEmpty(metadata.getValue(key)))
+                .orElse(true); 
+    }
+
+    /**
+     * Checks whether a field value is considered "empty".
+     * Empty means: absent (empty Optional), null, empty array, empty object, or empty string.
+     */
+    private static boolean isValueEmpty(final Optional<JsonValue> optionalValue) {
+        if (!optionalValue.isPresent()) {
+            return true; // absent
+        }
+        return isJsonValueEmpty(optionalValue.get());
+    }
+
+    private static boolean isJsonValueEmpty(final JsonValue value) {
+        if (value.isNull()) {
+            return true;
+        }
+        if (value.isString()) {
+            return value.asString().isEmpty();
+        }
+        if (value.isArray()) {
+            return value.asArray().isEmpty();
+        }
+        if (value.isObject()) {
+            return value.asObject().isEmpty();
+        }
+        return false;
+    }
+
+    /**
+     * Checks whether the given field name is "empty" according to placeholder resolvers.
+     * Returns {@code true} (empty) when:
+     * <ul>
+     *   <li>No placeholder resolver can resolve the field</li>
+     *   <li>The resolved values are empty</li>
+     *   <li>All resolved values are empty strings</li>
+     * </ul>
+     */
+    private boolean isEmptyInAdditionalPlaceholderResolvers(final String fieldName) {
+        final String[] fieldNameSplit = fieldName.split(Expression.SEPARATOR, 2);
+        if (fieldNameSplit.length > 1) {
+            final String placeholderPrefix = fieldNameSplit[0];
+            final String placeholderName = fieldNameSplit[1];
+            return additionalPlaceholderResolvers.stream()
+                    .filter(pr -> placeholderPrefix.equals(pr.getPrefix()))
+                    .filter(pr -> pr.supports(placeholderName))
+                    .map(pr -> pr.resolveValues(placeholderName))
+                    .findFirst()
+                    .map(resolvedValues -> resolvedValues.isEmpty() ||
+                            resolvedValues.stream().allMatch(String::isEmpty))
+                    .orElse(true);
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/FieldNamesPredicateVisitor.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/FieldNamesPredicateVisitor.java
@@ -18,6 +18,7 @@ import java.util.Set;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
+import org.eclipse.ditto.rql.model.predicates.ast.EmptyNode;
 import org.eclipse.ditto.rql.model.predicates.ast.ExistsNode;
 import org.eclipse.ditto.rql.model.predicates.ast.LogicalNode;
 import org.eclipse.ditto.rql.model.predicates.ast.MultiComparisonNode;
@@ -75,6 +76,11 @@ public final class FieldNamesPredicateVisitor implements PredicateVisitor {
 
     @Override
     public void visit(final ExistsNode node) {
+        fieldNames.add(node.getProperty());
+    }
+
+    @Override
+    public void visit(final EmptyNode node) {
         fieldNames.add(node.getProperty());
     }
 

--- a/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/ThingPredicateVisitor.java
+++ b/rql/query/src/main/java/org/eclipse/ditto/rql/query/things/ThingPredicateVisitor.java
@@ -83,6 +83,11 @@ public final class ThingPredicateVisitor implements CriteriaVisitor<Predicate<Th
     }
 
     @Override
+    public Predicate<Thing> visitEmpty(final ExistsFieldExpression fieldExpression) {
+        return EmptyThingPredicateVisitor.apply(fieldExpression, additionalPlaceholderResolvers);
+    }
+
+    @Override
     public Predicate<Thing> visitField(final FilterFieldExpression fieldExpression,
             final org.eclipse.ditto.rql.query.criteria.Predicate predicate) {
         return FilterThingPredicateVisitor.apply(fieldExpression,

--- a/rql/query/src/test/java/org/eclipse/ditto/rql/query/filter/ParameterPredicateVisitorTest.java
+++ b/rql/query/src/test/java/org/eclipse/ditto/rql/query/filter/ParameterPredicateVisitorTest.java
@@ -18,6 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.eclipse.ditto.rql.model.predicates.ast.EmptyNode;
+import org.eclipse.ditto.rql.model.predicates.ast.ExistsNode;
 import org.eclipse.ditto.rql.model.predicates.ast.LogicalNode;
 import org.eclipse.ditto.rql.model.predicates.ast.RootNode;
 import org.eclipse.ditto.rql.model.predicates.ast.SingleComparisonNode;
@@ -128,6 +130,24 @@ public final class ParameterPredicateVisitorTest {
         visitorUnderTest.visit(logicalNode);
 
         Assertions.assertThat(visitorUnderTest.getCriteria()).containsExactly(cf.nor(Collections.emptyList()));
+    }
+
+    @Test
+    public void existsNode() {
+        final ExistsNode existsNode = new ExistsNode(KNOWN_FIELD_NAME);
+        visitorUnderTest.visit(existsNode);
+
+        final Criteria expectedCrit = cf.existsCriteria(ef.existsBy(KNOWN_FIELD_NAME));
+        Assertions.assertThat(visitorUnderTest.getCriteria()).containsExactly(expectedCrit);
+    }
+
+    @Test
+    public void emptyNode() {
+        final EmptyNode emptyNode = new EmptyNode(KNOWN_FIELD_NAME);
+        visitorUnderTest.visit(emptyNode);
+
+        final Criteria expectedCrit = cf.emptyCriteria(ef.existsBy(KNOWN_FIELD_NAME));
+        Assertions.assertThat(visitorUnderTest.getCriteria()).containsExactly(expectedCrit);
     }
 
     @Test

--- a/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/FieldNamesPredicateVisitorTest.java
+++ b/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/FieldNamesPredicateVisitorTest.java
@@ -41,6 +41,18 @@ public final class FieldNamesPredicateVisitorTest {
                 .containsExactlyInAnyOrder("_metadata/attributes/manufacturer", "_metadata");
     }
 
+    @Test
+    public void verifyCorrectFilteringWithEmpty() {
+        softly.assertThat(extractFieldsFromRql("empty(attributes/tags)"))
+                .containsExactlyInAnyOrder("attributes/tags");
+        softly.assertThat(extractFieldsFromRql("not(empty(attributes/tags))"))
+                .containsExactlyInAnyOrder("attributes/tags");
+        softly.assertThat(extractFieldsFromRql("and(empty(attributes/foo),eq(attributes/bar,1))"))
+                .containsExactlyInAnyOrder("attributes/foo", "attributes/bar");
+        softly.assertThat(extractFieldsFromRql("or(empty(features/sensor/properties/value),exists(attributes/tags))"))
+                .containsExactlyInAnyOrder("features/sensor/properties/value", "attributes/tags");
+    }
+
     private static Set<String> extractFieldsFromRql(final String filter) {
         final FieldNamesPredicateVisitor fieldNameVisitor = FieldNamesPredicateVisitor.getNewInstance();
         fieldNameVisitor.visit(RqlPredicateParser.parse(filter));

--- a/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/ThingPredicateVisitorTest.java
+++ b/rql/query/src/test/java/org/eclipse/ditto/rql/query/things/ThingPredicateVisitorTest.java
@@ -618,6 +618,189 @@ public final class ThingPredicateVisitorTest {
                 .isTrue();
     }
 
+    // --- empty() tests ---
+
+    @Test
+    public void testEmptyAttributeAbsent() {
+        // attributes/missing does not exist on MATCHING_THING -> empty
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/missing)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(attributes/missing)' should be true (absent)")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributePresent() {
+        // attributes/aString exists and is "ccc_string" -> NOT empty
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/aString)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(attributes/aString)' should be false (has content)")
+                .isFalse();
+    }
+
+    @Test
+    public void testNotEmptyAttribute() {
+        final Predicate<Thing> thingPredicate = createPredicate("not(empty(attributes/aString))");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'not(empty(attributes/aString))' should be true")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributeWithEmptyString() {
+        final Thing thingWithEmptyString = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "empty-str"))
+                .setAttribute(JsonPointer.of("tag"), JsonValue.of(""))
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/tag)");
+        assertThat(thingPredicate.test(thingWithEmptyString))
+                .as("Filtering 'empty(attributes/tag)' should be true for empty string")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributeWithEmptyArray() {
+        final Thing thingWithEmptyArray = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "empty-arr"))
+                .setAttribute(JsonPointer.of("tags"), JsonArray.empty())
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/tags)");
+        assertThat(thingPredicate.test(thingWithEmptyArray))
+                .as("Filtering 'empty(attributes/tags)' should be true for empty array")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributeWithEmptyObject() {
+        final Thing thingWithEmptyObject = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "empty-obj"))
+                .setAttribute(JsonPointer.of("info"), JsonObject.empty())
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/info)");
+        assertThat(thingPredicate.test(thingWithEmptyObject))
+                .as("Filtering 'empty(attributes/info)' should be true for empty object")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributeWithNull() {
+        final Thing thingWithNull = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "null-val"))
+                .setAttribute(JsonPointer.of("tag"), JsonValue.nullLiteral())
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/tag)");
+        assertThat(thingPredicate.test(thingWithNull))
+                .as("Filtering 'empty(attributes/tag)' should be true for null")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyAttributeWithNumber() {
+        // Number 0 is NOT empty
+        final Thing thingWithZero = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "zero-val"))
+                .setAttribute(JsonPointer.of("count"), JsonValue.of(0))
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/count)");
+        assertThat(thingPredicate.test(thingWithZero))
+                .as("Filtering 'empty(attributes/count)' should be false (0 is not empty)")
+                .isFalse();
+    }
+
+    @Test
+    public void testEmptyAttributeWithBoolean() {
+        // Boolean false is NOT empty
+        final Thing thingWithFalse = Thing.newBuilder()
+                .setId(ThingId.of("org.eclipse.ditto", "false-val"))
+                .setAttribute(JsonPointer.of("flag"), JsonValue.of(false))
+                .build();
+
+        final Predicate<Thing> thingPredicate = createPredicate("empty(attributes/flag)");
+        assertThat(thingPredicate.test(thingWithFalse))
+                .as("Filtering 'empty(attributes/flag)' should be false (false is not empty)")
+                .isFalse();
+    }
+
+    @Test
+    public void testEmptyFeatureAbsent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(features/bar)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(features/bar)' should be true (absent)")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyFeaturePresent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(features/foo)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(features/foo)' should be false (has properties)")
+                .isFalse();
+    }
+
+    @Test
+    public void testEmptyFeaturePropertyAbsent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(features/foo/properties/missing)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(features/foo/properties/missing)' should be true (absent)")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyFeaturePropertyPresent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(features/foo/properties/aString)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(features/foo/properties/aString)' should be false (has content)")
+                .isFalse();
+    }
+
+    @Test
+    public void testEmptyMetadataPresent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(_metadata/attributes/sensorType)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(_metadata/attributes/sensorType)' should be false (has content)")
+                .isFalse();
+    }
+
+    @Test
+    public void testEmptyMetadataAbsent() {
+        final Predicate<Thing> thingPredicate = createPredicate("empty(_metadata/missing)");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'empty(_metadata/missing)' should be true (absent)")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyThingIdIsNeverEmpty() {
+        final Predicate<Thing> thingPredicate = createPredicate("not(empty(thingId))");
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering 'not(empty(thingId))' should be true")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyCombinedWithExists() {
+        // exists AND empty = present but vacuous (only possible with null/[]/{}/"")
+        final String filter = "and(exists(attributes/aString),not(empty(attributes/aString)))";
+        final Predicate<Thing> thingPredicate = createPredicate(filter);
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering '" + filter + "' should be true")
+                .isTrue();
+    }
+
+    @Test
+    public void testEmptyCombinedWithOr() {
+        final String filter = "or(empty(attributes/missing),eq(attributes/anInteger,999))";
+        final Predicate<Thing> thingPredicate = createPredicate(filter);
+        assertThat(thingPredicate.test(MATCHING_THING))
+                .as("Filtering '" + filter + "' should be true (first clause matches)")
+                .isTrue();
+    }
+
     @Test
     public void testKnownPlaceholderExists() {
         final Predicate<Thing> thingPredicate = createPredicateWithPlaceholderResolver("exists(test:lower)");

--- a/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/ImmutableSearchProperty.java
+++ b/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/ImmutableSearchProperty.java
@@ -76,6 +76,11 @@ final class ImmutableSearchProperty implements SearchProperty {
     }
 
     @Override
+    public PropertySearchFilter empty() {
+        return ImmutablePropertyFilter.of(SearchFilter.Type.EMPTY, propertyPath, Collections.emptySet());
+    }
+
+    @Override
     public PropertySearchFilter eq(final boolean value) {
         return ImmutablePropertyFilter.of(SearchFilter.Type.EQ, propertyPath, JsonFactory.newValue(value));
     }

--- a/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/SearchFilter.java
+++ b/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/SearchFilter.java
@@ -65,6 +65,14 @@ public interface SearchFilter {
         EXISTS("exists"),
 
         /**
+         * Filter type for checking if a field is absent or void of content (null, empty array, empty object,
+         * empty string).
+         *
+         * @since 3.9.0
+         */
+        EMPTY("empty"),
+
+        /**
          * Filter type for checking if two entities are equal.
          */
         EQ("eq"),

--- a/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/SearchProperty.java
+++ b/thingsearch/model/src/main/java/org/eclipse/ditto/thingsearch/model/SearchProperty.java
@@ -35,6 +35,16 @@ public interface SearchProperty {
     PropertySearchFilter exists();
 
     /**
+     * Returns a new search filter for checking if this property is empty.
+     * A field is considered "empty" when it is absent, {@code null}, an empty array, an empty object or an empty
+     * string.
+     *
+     * @return the new search filter.
+     * @since 3.9.0
+     */
+    PropertySearchFilter empty();
+
+    /**
      * Returns a new search filter for checking if the value of this property is equal to the given value.
      *
      * @param value the value to compare the value of this property with.

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/criteria/visitors/CreateBsonVisitor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/criteria/visitors/CreateBsonVisitor.java
@@ -29,6 +29,7 @@ import org.eclipse.ditto.rql.query.criteria.visitors.CriteriaVisitor;
 import org.eclipse.ditto.rql.query.expression.ExistsFieldExpression;
 import org.eclipse.ditto.rql.query.expression.FilterFieldExpression;
 import org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.AbstractFieldBsonCreator;
+import org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.GetEmptyBsonVisitor;
 import org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.GetExistsBsonVisitor;
 import org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.GetFilterBsonVisitor;
 
@@ -81,6 +82,11 @@ public class CreateBsonVisitor implements CriteriaVisitor<Bson> {
     @Override
     public Bson visitExists(final ExistsFieldExpression fieldExpression) {
         return GetExistsBsonVisitor.apply(fieldExpression, authorizationSubjectIds);
+    }
+
+    @Override
+    public Bson visitEmpty(final ExistsFieldExpression fieldExpression) {
+        return GetEmptyBsonVisitor.apply(fieldExpression, authorizationSubjectIds);
     }
 
     @Override

--- a/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetEmptyBsonVisitor.java
+++ b/thingsearch/service/src/main/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetEmptyBsonVisitor.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors;
+
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.DESIRED_PROPERTIES;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_ATTRIBUTES_PATH;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_DEFINITION;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_DESIRED_PROPERTIES;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_FEATURES_PATH;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_FEATURE_ID;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_F_ARRAY;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_METADATA_PATH;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_PROPERTIES;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.FIELD_THING;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.PROPERTIES;
+import static org.eclipse.ditto.thingsearch.service.persistence.PersistenceConstants.SLASH;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import org.bson.BsonDocument;
+import org.bson.conversions.Bson;
+import org.eclipse.ditto.json.JsonKey;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.rql.query.expression.ExistsFieldExpression;
+import org.eclipse.ditto.rql.query.expression.visitors.ExistsFieldExpressionVisitor;
+
+import com.mongodb.client.model.Filters;
+
+/**
+ * Creates a Mongo Bson object for field-based empty criteria.
+ * A field is considered "empty" when it is absent, {@code null}, an empty array {@code []}, an empty object
+ * {@code {}} or an empty string {@code ""}.
+ *
+ * @since 3.9.0
+ */
+public final class GetEmptyBsonVisitor extends AbstractFieldBsonCreator implements ExistsFieldExpressionVisitor<Bson> {
+
+    GetEmptyBsonVisitor(@Nullable final List<String> authorizationSubjectIds) {
+        super(authorizationSubjectIds);
+    }
+
+    /**
+     * Creates a Mongo Bson object for field-based empty criteria.
+     *
+     * @param expression the expression of the resource whose emptiness is under scrutiny.
+     * @param authorizationSubjectIds subject IDs for authorization filtering.
+     * @return the complete Bson for the field-based empty criteria.
+     */
+    public static Bson apply(final ExistsFieldExpression expression, final List<String> authorizationSubjectIds) {
+        return expression.acceptExistsVisitor(new GetEmptyBsonVisitor(authorizationSubjectIds));
+    }
+
+    /**
+     * Creates a Mongo Bson object for field-based empty criteria without authorization filtering.
+     *
+     * @param expression the expression of the resource whose emptiness is under scrutiny.
+     * @return the complete Bson for the field-based empty criteria.
+     */
+    public static Bson apply(final ExistsFieldExpression expression) {
+        return apply(expression, null);
+    }
+
+    @Override
+    public Bson visitAttribute(final String key) {
+        return matchEmptyKey(FIELD_ATTRIBUTES_PATH + key);
+    }
+
+    @Override
+    public Bson visitFeature(final String featureId) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            // for wildcard features, check that no feature ID exists at all (absent or null)
+            final String featureIdPath = toDottedPath(FIELD_F_ARRAY, List.of(JsonKey.of(FIELD_FEATURE_ID)));
+            return Filters.or(
+                    Filters.eq(featureIdPath, null),
+                    Filters.eq(featureIdPath, "")
+            );
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId);
+        }
+    }
+
+    @Override
+    public Bson visitFeatureDefinition(final String featureId) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            return matchWildcardFeatureEmptyKey(SLASH + FIELD_DEFINITION);
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId + SLASH + FIELD_DEFINITION);
+        }
+    }
+
+    @Override
+    public Bson visitFeatureProperties(final CharSequence featureId) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            return matchWildcardFeatureEmptyKey(SLASH + FIELD_PROPERTIES);
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId + SLASH + FIELD_PROPERTIES);
+        }
+    }
+
+    @Override
+    public Bson visitFeatureDesiredProperties(final CharSequence featureId) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            return matchWildcardFeatureEmptyKey(SLASH + FIELD_DESIRED_PROPERTIES);
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId + SLASH + FIELD_DESIRED_PROPERTIES);
+        }
+    }
+
+    @Override
+    public Bson visitFeatureIdProperty(final String featureId, final String property) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            return matchWildcardFeatureEmptyKey(PROPERTIES + property);
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId + PROPERTIES + property);
+        }
+    }
+
+    @Override
+    public Bson visitFeatureIdDesiredProperty(final CharSequence featureId, final CharSequence property) {
+        if (FEATURE_ID_WILDCARD.equals(featureId)) {
+            return matchWildcardFeatureEmptyKey(DESIRED_PROPERTIES + property);
+        } else {
+            return matchEmptyKey(FIELD_FEATURES_PATH + featureId + DESIRED_PROPERTIES + property);
+        }
+    }
+
+    @Override
+    Bson visitPointer(final String key) {
+        return matchEmptyKey(key);
+    }
+
+    @Override
+    Bson visitRootLevelField(final String fieldName) {
+        return createEmptyBson(fieldName);
+    }
+
+    @Override
+    public Bson visitMetadata(final String key) {
+        return matchEmptyKey(FIELD_METADATA_PATH + key);
+    }
+
+    private Bson matchEmptyKey(final CharSequence key) {
+        final JsonPointer pointer = JsonPointer.of(key);
+        final String dottedPath = toDottedPath(FIELD_THING, pointer);
+
+        final Bson emptyBson = createEmptyBson(dottedPath);
+        return getAuthorizationBson(pointer)
+                .map(authBson -> Filters.and(emptyBson, authBson))
+                .orElse(emptyBson);
+    }
+
+    private Bson matchWildcardFeatureEmptyKey(final CharSequence featureRelativeKey) {
+        final JsonPointer pointer = JsonPointer.of(featureRelativeKey);
+        final String dottedPath = toDottedPath(pointer);
+
+        final Bson emptyBson = createEmptyBson(dottedPath);
+        return getFeatureWildcardAuthorizationBson(pointer)
+                .map(authBson -> Filters.elemMatch(FIELD_F_ARRAY, Filters.and(emptyBson, authBson)))
+                .orElseGet(() -> Filters.elemMatch(FIELD_F_ARRAY, emptyBson));
+    }
+
+    /**
+     * Creates the BSON filter for "empty" semantics on the given field path.
+     * The filter matches when the field is:
+     * <ul>
+     *   <li>absent or {@code null} ({@code $eq: null} — MongoDB matches both absent and null)</li>
+     *   <li>an empty array ({@code $eq: []})</li>
+     *   <li>an empty object ({@code $eq: {}})</li>
+     *   <li>an empty string ({@code $eq: ""})</li>
+     * </ul>
+     *
+     * <p>Note: {@code $eq: null} in MongoDB matches both fields with value {@code null} AND absent fields,
+     * so a separate {@code $exists: false} branch is not needed.</p>
+     *
+     * @param fieldPath the MongoDB dotted field path.
+     * @return the BSON filter.
+     */
+    private static Bson createEmptyBson(final String fieldPath) {
+        return Filters.or(
+                Filters.eq(fieldPath, null),
+                Filters.eq(fieldPath, Collections.emptyList()),
+                Filters.eq(fieldPath, new BsonDocument()),
+                Filters.eq(fieldPath, "")
+        );
+    }
+
+}

--- a/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetEmptyBsonVisitorTest.java
+++ b/thingsearch/service/src/test/java/org/eclipse/ditto/thingsearch/service/persistence/read/expression/visitors/GetEmptyBsonVisitorTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.FilterAssertions.AND;
+import static org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.FilterAssertions.ELEM_MATCH;
+import static org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.FilterAssertions.OR;
+import static org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.FilterAssertions.assertAuthFilter;
+import static org.eclipse.ditto.thingsearch.service.persistence.read.expression.visitors.FilterAssertions.toBsonDocument;
+
+import java.util.List;
+
+import org.bson.BsonArray;
+import org.bson.BsonDocument;
+import org.bson.BsonNull;
+import org.bson.BsonString;
+import org.bson.BsonValue;
+import org.bson.conversions.Bson;
+import org.eclipse.ditto.rql.query.expression.visitors.ExistsFieldExpressionVisitor;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link GetEmptyBsonVisitor}.
+ */
+public class GetEmptyBsonVisitorTest {
+
+    private ExistsFieldExpressionVisitor<Bson> underTest;
+
+    @Before
+    public void setUp() {
+        underTest = new GetEmptyBsonVisitor(List.of("subject1", "subject2"));
+    }
+
+    @Test
+    public void testAttribute() {
+        final Bson filterBson = underTest.visitAttribute("a1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        // Should be $and with [emptyBson, authFilter]
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+        final BsonValue authFilter = andArray.get(1);
+
+        // emptyFilter should be $or with 4 conditions
+        assertEmptyOrFilter(emptyFilter, "t.attributes.a1");
+        assertAuthFilter(authFilter, List.of("subject1", "subject2"), "attributes.a1", "attributes", "");
+    }
+
+    @Test
+    public void testFeature() {
+        final Bson filterBson = underTest.visitFeature("f1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t.features.f1");
+    }
+
+    @Test
+    public void testFeatureProperties() {
+        final Bson filterBson = underTest.visitFeatureProperties("f1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t.features.f1.properties");
+        assertAuthFilter(andArray.get(1), List.of("subject1", "subject2"),
+                "features.f1.properties", "features.f1", "features", "");
+    }
+
+    @Test
+    public void testFeatureDesiredProperties() {
+        final Bson filterBson = underTest.visitFeatureDesiredProperties("f1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t.features.f1.desiredProperties");
+    }
+
+    @Test
+    public void testFeatureProperty() {
+        final Bson filterBson = underTest.visitFeatureIdProperty("f1", "temperature");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t.features.f1.properties.temperature");
+        assertAuthFilter(andArray.get(1), List.of("subject1", "subject2"),
+                "features.f1.properties.temperature",
+                "features.f1.properties",
+                "features.f1",
+                "features",
+                "");
+    }
+
+    @Test
+    public void testFeatureDesiredProperty() {
+        final Bson filterBson = underTest.visitFeatureIdDesiredProperty("f1", "targetTemperature");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t.features.f1.desiredProperties.targetTemperature");
+    }
+
+    @Test
+    public void testWildcardFeatureProperty() {
+        final Bson filterBson = underTest.visitFeatureIdProperty("*", "temperature");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray elemMatchAnd = document.get("f").asDocument().get(ELEM_MATCH).asDocument().get(AND).asArray();
+        final BsonDocument emptyFilter = elemMatchAnd.get(0).asDocument();
+        final BsonValue authFilter = elemMatchAnd.get(1);
+
+        assertEmptyOrFilter(emptyFilter, "properties.temperature");
+        assertAuthFilter(authFilter, List.of("subject1", "subject2"),
+                "properties.temperature",
+                "properties",
+                "id",
+                "features",
+                "");
+    }
+
+    @Test
+    public void testSimplePropertyWithLeadingSlash() {
+        final Bson filterBson = underTest.visitSimple("/_modified");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t._modified");
+    }
+
+    @Test
+    public void testSimplePropertyNoLeadingSlash() {
+        final Bson filterBson = underTest.visitSimple("_id");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        // Root-level field: no auth filter, just the empty $or
+        assertEmptyOrFilter(document, "_id");
+    }
+
+    @Test
+    public void testMetadata() {
+        final Bson filterBson = underTest.visitMetadata("m1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        final BsonArray andArray = document.getArray(AND);
+        final BsonDocument emptyFilter = andArray.get(0).asDocument();
+
+        assertEmptyOrFilter(emptyFilter, "t._metadata.m1");
+        assertAuthFilter(andArray.get(1), List.of("subject1", "subject2"),
+                "_metadata.m1", "_metadata", "");
+    }
+
+    @Test
+    public void testWithoutAuthorizationSubjects() {
+        final ExistsFieldExpressionVisitor<Bson> noAuthVisitor = new GetEmptyBsonVisitor(null);
+        final Bson filterBson = noAuthVisitor.visitAttribute("a1");
+        final BsonDocument document = toBsonDocument(filterBson);
+
+        // Without auth, should be just the $or (no $and wrapping)
+        assertEmptyOrFilter(document, "t.attributes.a1");
+    }
+
+    /**
+     * Asserts that the given BSON document is a 4-way {@code $or} filter for "empty" semantics:
+     * null (covers absent), empty array, empty object, empty string.
+     */
+    private static void assertEmptyOrFilter(final BsonDocument document, final String fieldPath) {
+        final BsonArray orArray = document.getArray(OR);
+        assertThat(orArray).hasSize(4);
+
+        // Condition 1: $eq: null (also matches absent fields in MongoDB)
+        assertThat(orArray.get(0).asDocument())
+                .isEqualTo(new BsonDocument(fieldPath, BsonNull.VALUE));
+
+        // Condition 2: $eq: [] (empty array)
+        assertThat(orArray.get(1).asDocument())
+                .isEqualTo(new BsonDocument(fieldPath, new BsonArray()));
+
+        // Condition 3: $eq: {} (empty object)
+        assertThat(orArray.get(2).asDocument())
+                .isEqualTo(new BsonDocument(fieldPath, new BsonDocument()));
+
+        // Condition 4: $eq: "" (empty string)
+        assertThat(orArray.get(3).asDocument())
+                .isEqualTo(new BsonDocument(fieldPath, new BsonString("")));
+    }
+
+}


### PR DESCRIPTION
Resolves: #2377  
## Summary                                                                                                                                                                 
                                                                                                                                                                           
  Introduces a new RQL filter function `empty(<field>)` that returns true when a field is absent                                                                             
  or void of content (null, empty array, empty object, empty string), regardless of its JSON type.
                                                                                                                                                                             
  This enables use cases like finding all things where e.g. `attributes/tags` either doesn't exist                                                                           
  or is an empty array — which was previously not expressible in a single RQL filter.                                                                                        
