### PR TITLE
fix Kafka consumer crash loop on messages with blank header values

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStream.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -93,7 +94,8 @@ final class AtLeastOnceConsumerStream implements KafkaConsumerStream {
 
         final var source = sourceSupplier.get()
                 .filter(committableMessage -> isNotDryRun(committableMessage.record(), dryRun))
-                .map(kafkaMessageTransformer::transform);
+                .map(kafkaMessageTransformer::transform)
+                .filter(Objects::nonNull);
 
         final Source<CommittableTransformationResult, Consumer.Control> throttledSource;
         if (throttlingConfig.isEnabled()) {

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStream.java
@@ -13,6 +13,7 @@
 package org.eclipse.ditto.connectivity.service.messaging.kafka;
 
 import java.nio.ByteBuffer;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
@@ -87,6 +88,7 @@ final class AtMostOnceConsumerStream implements KafkaConsumerStream {
         final var source = sourceSupplier.get()
                 .filter(consumerRecord -> isNotDryRun(consumerRecord, dryRun))
                 .map(kafkaMessageTransformer::transform)
+                .filter(Objects::nonNull)
                 .filter(result -> !result.isExpired());
 
         final Source<TransformationResult, Consumer.Control> throttledSource;

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformer.java
@@ -41,6 +41,7 @@ import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.pekko.logging.ThreadSafeDittoLogger;
 import org.eclipse.ditto.internal.utils.tracing.DittoTracing;
 import org.eclipse.ditto.internal.utils.tracing.span.SpanOperationName;
+import org.eclipse.ditto.internal.utils.tracing.span.StartedSpan;
 
 /**
  * Transforms incoming messages from Apache Kafka to {@link org.eclipse.ditto.connectivity.api.ExternalMessage}.
@@ -107,14 +108,15 @@ final class KafkaMessageTransformer {
         final String correlationId = messageHeaders
                 .getOrDefault(DittoHeaderDefinition.CORRELATION_ID.getKey(), UUID.randomUUID().toString());
 
-        final var startedSpan = DittoTracing.newPreparedSpan(messageHeaders,
-                        SpanOperationName.of("kafka_consume: " + consumerRecord.topic())
-                ).correlationId(correlationId)
-                .connectionId(connectionId)
-                .start();
-        messageHeaders = startedSpan.propagateContext(messageHeaders);
-
+        @Nullable StartedSpan startedSpan = null;
         try {
+            startedSpan = DittoTracing.newPreparedSpan(messageHeaders,
+                            SpanOperationName.of("kafka_consume: " + consumerRecord.topic())
+                    ).correlationId(correlationId)
+                    .connectionId(connectionId)
+                    .start();
+            messageHeaders = startedSpan.propagateContext(messageHeaders);
+
             final String key = consumerRecord.key();
             final ByteBuffer value = consumerRecord.value();
             final ThreadSafeDittoLogger correlationIdScopedLogger = LOGGER.withCorrelationId(messageHeaders);
@@ -144,16 +146,22 @@ final class KafkaMessageTransformer {
                         "Got DittoRuntimeException '{}' when command was parsed: {}", e.getErrorCode(),
                         e.getMessage());
             }
-            startedSpan.tagAsFailed(e);
+            if (startedSpan != null) {
+                startedSpan.tagAsFailed(e);
+            }
             return TransformationResult.failed(e.setDittoHeaders(DittoHeaders.of(messageHeaders)));
         } catch (final Exception e) {
             inboundMonitor.exception(messageHeaders, e);
             LOGGER.withCorrelationId(messageHeaders)
                     .error(String.format("Unexpected {%s}: {%s}", e.getClass().getName(), e.getMessage()), e);
-            startedSpan.tagAsFailed(e);
+            if (startedSpan != null) {
+                startedSpan.tagAsFailed(e);
+            }
             return null; // Drop message
         } finally {
-            startedSpan.finish();
+            if (startedSpan != null) {
+                startedSpan.finish();
+            }
         }
 
     }

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtLeastOnceConsumerStreamTest.java
@@ -129,10 +129,10 @@ public final class AtLeastOnceConsumerStreamTest {
             }
 
             /*
-             * Further messages are queued but not forwarded to the mapping sink. I can't fully explain why it is 2.
-             * This depends on the test setup of the SourceQueue.
+             * Further messages are queued but not forwarded to the mapping sink. I can't fully explain why it is 3.
+             * This depends on the test setup of the SourceQueue and the number of stream stages.
              */
-            final int bufferSize = 2;
+            final int bufferSize = 3;
             for (int i = 0; i < bufferSize; i++) {
                 assertThat(sourceQueue.get().offer(committableMessage)).isEqualTo(QueueOfferResult.enqueued());
                 // This is done to verify that no matter that inboundSinkProbe is requesting new Elements. The mapAsync stage is blocking further elements to be processed.

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/AtMostOnceConsumerStreamTest.java
@@ -120,10 +120,10 @@ public final class AtMostOnceConsumerStreamTest {
             }
 
             /*
-             * Further messages are queued but not forwarded to the mapping sink. I can't fully explain why it is 3.
-             * This depends on the test setup of the SourceQueue.
+             * Further messages are queued but not forwarded to the mapping sink. I can't fully explain why it is 4.
+             * This depends on the test setup of the SourceQueue and the number of stream stages.
              */
-            final int bufferSize = 3;
+            final int bufferSize = 4;
             for (int i = 0; i < bufferSize; i++) {
                 assertThat(sourceQueue.get().offer(consumerRecord)).isEqualTo(QueueOfferResult.enqueued());
                 // This is done to verify that no matter that inboundSinkProbe is requesting new Elements. The mapAsync stage is blocking further elements to be processed.

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/kafka/KafkaMessageTransformerTest.java
@@ -176,6 +176,28 @@ public final class KafkaMessageTransformerTest {
     }
 
     @Test
+    public void messageWithBlankCorrelationIdHeaderDoesNotCrash() {
+        final String deviceId = "ditto:test-device";
+        final RecordHeaders headers =
+                new RecordHeaders(List.of(
+                        new RecordHeader("device_id", deviceId.getBytes(StandardCharsets.UTF_8)),
+                        new RecordHeader("correlation-id", new byte[0])
+                ));
+        final ConsumerRecord<String, ByteBuffer> consumerRecord = mock(ConsumerRecord.class);
+        when(consumerRecord.headers()).thenReturn(headers);
+        when(consumerRecord.key()).thenReturn("someKey");
+        when(consumerRecord.value()).thenReturn(ByteBufferUtils.fromUtf8String("someValue"));
+        when(consumerRecord.topic()).thenReturn("someTopic");
+        when(consumerRecord.timestamp()).thenReturn(TIMESTAMP);
+
+        // should not throw - previously this caused IllegalArgumentException: The value must not be blank
+        final TransformationResult transformResult = underTest.transform(consumerRecord);
+
+        // enforcement will fail since this test uses enforcement, but the message should not crash
+        assertThat(transformResult).isNotNull();
+    }
+
+    @Test
     public void unexpectedExceptionCausesMessageToBeDropped() {
         final String deviceId = "ditto:test-device";
         final RecordHeaders headers =

--- a/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/SpanTagging.java
+++ b/internal/utils/tracing/src/main/java/org/eclipse/ditto/internal/utils/tracing/span/SpanTagging.java
@@ -32,7 +32,7 @@ public interface SpanTagging<T extends TaggableMetricsInstrument<T>> extends Tag
      */
     default T correlationId(@Nullable final CharSequence correlationId) {
         final T result;
-        if (null == correlationId) {
+        if (null == correlationId || correlationId.toString().isBlank()) {
             result = self();
         } else {
             result = tag(SpanTagKey.CORRELATION_ID.getTagForValue(correlationId.toString()));
@@ -48,7 +48,7 @@ public interface SpanTagging<T extends TaggableMetricsInstrument<T>> extends Tag
      */
     default T connectionId(@Nullable final CharSequence connectionId) {
         final T result;
-        if (null == connectionId) {
+        if (null == connectionId || connectionId.toString().isBlank()) {
             result = self();
         } else {
             result = tag(SpanTagKey.CONNECTION_ID.getTagForValue(connectionId));
@@ -64,7 +64,7 @@ public interface SpanTagging<T extends TaggableMetricsInstrument<T>> extends Tag
      */
     default T entityId(@Nullable final CharSequence entityId) {
         final T result;
-        if (null == entityId) {
+        if (null == entityId || entityId.toString().isBlank()) {
             result = self();
         } else {
             result = tag(SpanTagKey.ENTITY_ID.getTagForValue(entityId));

--- a/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/PreparedKamonSpanTest.java
+++ b/internal/utils/tracing/src/test/java/org/eclipse/ditto/internal/utils/tracing/span/PreparedKamonSpanTest.java
@@ -101,6 +101,15 @@ public final class PreparedKamonSpanTest {
     }
 
     @Test
+    public void blankSpanTagsAreIgnored() {
+        underTest.correlationId("");
+        underTest.connectionId("  ");
+        underTest.entityId("");
+
+        assertThat(underTest.getTagSet()).isEmpty();
+    }
+
+    @Test
     public void tagsWithNullMapThrowsNullPointerException() {
         assertThatNullPointerException()
                 .isThrownBy(() -> underTest.tags(null))


### PR DESCRIPTION
Blank tracing header values (e.g. empty correlation-id) caused IllegalArgumentException in Tag.of() during span creation, which was outside the try-catch in KafkaMessageTransformer. With QoS 1, the uncommitted offset led to re-consuming the same poison message indefinitely.

Three defensive fixes:
- SpanTagging: skip blank values like null in correlationId/connectionId/entityId
- KafkaMessageTransformer: move span creation inside try-catch block
- Consumer streams: filter null results from transform() to prevent NPE