### PR TITLE
fix partial access filtering for subscribers with multiple auth subjects

### DIFF
--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/routes/sse/ThingsSseRouteBuilderTest.java
@@ -400,6 +400,40 @@ public final class ThingsSseRouteBuilderTest extends EndpointTestBase {
     }
 
     @Test
+    public void filterJsonByPartialAccessPathsReturnsFullPayloadWhenSubscriberHasBothPartialAndFullSubjects() throws Exception {
+        final Thing thing = Thing.newBuilder()
+                .setId(ThingId.of("test:thing"))
+                .setAttributes(Attributes.newBuilder().set("foo", "bar").build())
+                .setFeatures(Features.newBuilder()
+                        .set(Feature.newBuilder()
+                                .properties(FeatureProperties.newBuilder()
+                                        .set("baz", 42)
+                                        .build())
+                                .withId("fluxCompensator")
+                                .build())
+                        .build())
+                .build();
+        final AuthorizationSubject fullReader = AuthorizationSubject.newInstance("test:full-reader");
+        final AuthorizationSubject partialReader = AuthorizationSubject.newInstance("test:partial-reader");
+
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.PARTIAL_ACCESS_PATHS.getKey(),
+                        "{\"subjects\":[\"test:partial-reader\"],\"paths\":{\"attributes\":[0],\"attributes/foo\":[0]}}")
+                .readGrantedSubjects(List.of(fullReader, partialReader))
+                .build();
+
+        final ThingModifiedEvent<?> event = ThingModified.of(thing, 1L, null, headers, null);
+
+        // Subscriber has BOTH partial and full-access subjects — unrestricted must take precedence
+        final AuthorizationContext subscriberAuthContext = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, partialReader, fullReader);
+
+        final JsonObject filtered = filterJsonByPartialAccessPaths(thing, event, subscriberAuthContext);
+
+        assertThat(filtered).isEqualTo(thing.toJson());
+    }
+
+    @Test
     public void filterJsonByPartialAccessPathsReturnsEmptyForNoAccessReader() throws Exception {
         final Thing thing = Thing.newBuilder().setId(ThingId.of("test:thing")).build();
         final AuthorizationSubject partialReader = AuthorizationSubject.newInstance("test:partial-reader");

--- a/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/PartialAccessPathResolver.java
+++ b/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/PartialAccessPathResolver.java
@@ -160,27 +160,28 @@ public final class PartialAccessPathResolver {
         readGrantedSubjects.forEach(subject -> readGrantedSubjectIds.add(subject.getId()));
 
         final Set<String> subscriberSubjectIds = new LinkedHashSet<>();
-        final Set<String> allSubscriberSubjectIds = new LinkedHashSet<>();
-        subscriberAuthContext.getAuthorizationSubjects().forEach(subject -> {
+        boolean hasUnrestrictedAccess = false;
+        for (final AuthorizationSubject subject : subscriberAuthContext.getAuthorizationSubjects()) {
             final String subjectId = subject.getId();
-            allSubscriberSubjectIds.add(subjectId);
-            if (partialAccessPaths.containsKey(subjectId) && readGrantedSubjectIds.contains(subjectId)) {
-                subscriberSubjectIds.add(subjectId);
+            if (readGrantedSubjectIds.contains(subjectId)) {
+                if (partialAccessPaths.containsKey(subjectId)) {
+                    subscriberSubjectIds.add(subjectId);
+                } else {
+                    // Subject has read grant but is NOT in partial access paths → unrestricted
+                    hasUnrestrictedAccess = true;
+                }
             }
-        });
+        }
+
+        // If ANY subscriber subject has unrestricted access, return full payload immediately.
+        // This must be checked before partial access filtering to avoid incorrectly restricting
+        // subscribers that have both partial-access and unrestricted subjects.
+        if (hasUnrestrictedAccess) {
+            return AccessiblePathsResult.unrestricted();
+        }
 
         if (subscriberSubjectIds.isEmpty()) {
-            final boolean hasUnrestrictedAccess = allSubscriberSubjectIds.stream()
-                    .anyMatch(subjectId ->
-                            readGrantedSubjectIds.contains(subjectId) &&
-                                    !partialAccessPaths.containsKey(subjectId)
-                    );
-
-            if (hasUnrestrictedAccess) {
-                return AccessiblePathsResult.unrestricted();
-            } else {
-                return AccessiblePathsResult.noAccess();
-            }
+            return AccessiblePathsResult.noAccess();
         }
 
         final Set<JsonPointer> accessiblePaths = new HashSet<>();

--- a/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/PartialAccessPathResolverTest.java
+++ b/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/PartialAccessPathResolverTest.java
@@ -132,6 +132,38 @@ public final class PartialAccessPathResolverTest {
         assertThat(result.getAccessiblePaths()).isEmpty();
     }
 
+    @Test
+    public void unrestrictedWhenSubscriberHasBothPartialAndUnrestrictedSubjectsPartialFirst() {
+        // Subscriber has two subjects: partial listed first, full listed second.
+        // The unrestricted subject must take precedence regardless of ordering.
+        final AuthorizationContext context = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, SUBJECT_PARTIAL, SUBJECT_FULL);
+
+        final var result = PartialAccessPathResolver.resolveAccessiblePathsFromHeader(
+                PARTIAL_ACCESS_HEADER,
+                context,
+                readGranted(SUBJECT_PARTIAL, SUBJECT_FULL));
+
+        assertThat(result.hasUnrestrictedAccess()).isTrue();
+        assertThat(result.shouldFilter()).isFalse();
+    }
+
+    @Test
+    public void unrestrictedWhenSubscriberHasBothPartialAndUnrestrictedSubjectsFullFirst() {
+        // Subscriber has two subjects: full listed first, partial listed second.
+        // The unrestricted subject must take precedence regardless of ordering.
+        final AuthorizationContext context = AuthorizationContext.newInstance(
+                DittoAuthorizationContextType.UNSPECIFIED, SUBJECT_FULL, SUBJECT_PARTIAL);
+
+        final var result = PartialAccessPathResolver.resolveAccessiblePathsFromHeader(
+                PARTIAL_ACCESS_HEADER,
+                context,
+                readGranted(SUBJECT_PARTIAL, SUBJECT_FULL));
+
+        assertThat(result.hasUnrestrictedAccess()).isTrue();
+        assertThat(result.shouldFilter()).isFalse();
+    }
+
     private static AuthorizationContext authContext(final AuthorizationSubject subject) {
         return AuthorizationContext.newInstance(DittoAuthorizationContextType.UNSPECIFIED, subject);
     }


### PR DESCRIPTION
When a subscriber has multiple authorization subjects — some with partial READ access and some with unrestricted access — the partial access path resolver incorrectly skipped the unrestricted access check. This caused the subscriber to be treated as having only partial access, stripping fields like thingId, _revision, _modified, and _created from SSE events.

The fix checks for unrestricted access before falling through to partial access filtering: if ANY subscriber subject has unrestricted access, the full payload is returned immediately.