### PR TITLE
Dynamically scope WoT Thing Description by user permissions

### DIFF
--- a/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
+++ b/base/model/src/main/java/org/eclipse/ditto/base/model/signals/FeatureToggle.java
@@ -74,6 +74,16 @@ public final class FeatureToggle {
             "ditto.devops.feature.policy-enforcement-use-throughput-optimized-evaluator-enabled";
 
     /**
+     * System property name of the property defining whether WoT Thing Description responses are filtered based on
+     * the requesting user's policy permissions. When enabled, TDs only contain properties, actions, and events the
+     * user is authorized to access. When disabled, TDs are returned unfiltered (legacy behavior).
+     *
+     * @since 3.9.0
+     */
+    public static final String WOT_TD_PERMISSION_FILTERING_ENABLED =
+            "ditto.devops.feature.wot-td-permission-filtering-enabled";
+
+    /**
      * Resolves the system property {@value MERGE_THINGS_ENABLED}.
      */
     private static final boolean IS_MERGE_THINGS_ENABLED = resolveProperty(MERGE_THINGS_ENABLED);
@@ -108,6 +118,12 @@ public final class FeatureToggle {
      */
     private static final boolean IS_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED =
             resolveProperty(POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED);
+
+    /**
+     * Resolves the system property {@value WOT_TD_PERMISSION_FILTERING_ENABLED}.
+     */
+    private static final boolean IS_WOT_TD_PERMISSION_FILTERING_ENABLED =
+            resolveProperty(WOT_TD_PERMISSION_FILTERING_ENABLED);
 
     private static boolean resolveProperty(final String propertyName) {
         final String propertyValue = System.getProperty(propertyName, Boolean.TRUE.toString());
@@ -240,5 +256,16 @@ public final class FeatureToggle {
      */
     public static boolean isPolicyEnforcementUseThroughputOptimizedEvaluatorEnabled() {
         return IS_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED;
+    }
+
+    /**
+     * Returns whether WoT Thing Description permission filtering is enabled based on the system property
+     * {@value WOT_TD_PERMISSION_FILTERING_ENABLED}.
+     *
+     * @return whether WoT TD permission filtering is enabled.
+     * @since 3.9.0
+     */
+    public static boolean isWotTdPermissionFilteringEnabled() {
+        return IS_WOT_TD_PERMISSION_FILTERING_ENABLED;
     }
 }

--- a/documentation/src/main/resources/pages/ditto/basic-wot-integration.md
+++ b/documentation/src/main/resources/pages/ditto/basic-wot-integration.md
@@ -301,15 +301,30 @@ prefix to create into the TDs, depending on your public Ditto endpoint.
 
 #### Security: TD access / authorization
 
-For accessing Thing Descriptions created for Things and Features no special permission in the Thing's 
-[Policy](basic-policy.html) is required.
+Starting with Ditto **3.9.0**, the generated Thing Description is **dynamically scoped** to the requesting user's
+permissions defined in the Thing's [Policy](basic-policy.html).
 
-As the Thing Model must be a publicly available resource and the Thing ID is also known for a user requesting the TD of 
-a Thing, there is no additional information to disclose.
+This means:
+* the user must have at least partial `READ` permission on the Thing (or Feature) to request its TD
+* only WoT **properties** the user is allowed to `READ` (on the corresponding [Thing](basic-policy.html#thing) or
+  [Feature](basic-policy.html#feature) resource) are included in the TD
+* properties the user can `READ` but **not** `WRITE` are marked as `readOnly` in the TD, and their `writeproperty`
+  form elements are removed
+* only WoT **actions** the user is allowed to invoke (`WRITE` on the corresponding
+  [Message](basic-policy.html#message) `inbox` resource) are included
+* only WoT **events** the user is allowed to subscribe to (`READ` on the corresponding
+  [Message](basic-policy.html#message) `outbox` resource) are included
+* sub-model `item` links to Features the user has no `READ` access to are removed from Thing-level TDs
+* root-level `readallproperties`/`writeallproperties` forms are removed when no readable/writable properties remain
 
-Accessing the `properties`, invoking `actions` and subscribing for `events` is of course authorized by the Thing's 
-Policy via its [Thing](basic-policy.html#thing), [Feature](basic-policy.html#feature) and 
-[Message](basic-policy.html#message) resources.
+This feature can be disabled to restore the previous behavior (unfiltered TDs for any authenticated user) by setting:
+
+```bash
+DITTO_DEVOPS_FEATURE_WOT_TD_PERMISSION_FILTERING_ENABLED=false
+```
+
+{% include note.html content="Prior to Ditto 3.9.0, any authenticated user could access the full TD of any Thing
+    without authorization checks. The TD was treated as public information." %}
 
 #### TD generation for Things
 

--- a/internal/utils/config/src/main/resources/ditto-devops.conf
+++ b/internal/utils/config/src/main/resources/ditto-devops.conf
@@ -42,5 +42,12 @@ ditto.devops {
     //  If configured to `false`, the memory optimized one is used which provides slower policy evaluation but uses less memory
     policy-enforcement-use-throughput-optimized-evaluator-enabled = true
     policy-enforcement-use-throughput-optimized-evaluator-enabled = ${?DITTO_DEVOPS_FEATURE_POLICY_ENFORCEMENT_USE_THROUGHPUT_OPTIMIZED_EVALUATOR_ENABLED}
+
+    // enables/disables the WoT Thing Description permission filtering
+    //  When enabled, WoT Thing Description responses are filtered based on the requesting user's policy permissions.
+    //  TDs only contain properties, actions, and events the user is authorized to access.
+    //  When disabled, TDs are returned unfiltered to any authenticated user (legacy behavior).
+    wot-td-permission-filtering-enabled = true
+    wot-td-permission-filtering-enabled = ${?DITTO_DEVOPS_FEATURE_WOT_TD_PERMISSION_FILTERING_ENABLED}
   }
 }

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/ThingCommandEnforcement.java
@@ -82,6 +82,7 @@ import org.eclipse.ditto.things.model.signals.commands.modify.MergeThing;
 import org.eclipse.ditto.things.model.signals.commands.modify.ThingModifyCommand;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveFeature;
 import org.eclipse.ditto.things.model.signals.commands.query.RetrieveThing;
+import org.eclipse.ditto.things.model.signals.commands.query.RetrieveWotThingDescriptionResponse;
 import org.eclipse.ditto.things.model.signals.commands.query.ThingQueryCommand;
 import org.eclipse.ditto.things.model.signals.commands.query.ThingQueryCommandResponse;
 import org.eclipse.ditto.things.model.devops.commands.WotValidationConfigCommand;
@@ -165,11 +166,17 @@ final class ThingCommandEnforcement
 
         final ThingCommand<?> authorizedCommand;
         if (isWotTdRequestingThingQueryCommand(command)) {
-            // authorization is not necessary for WoT TD requesting thing query command, this is treated as public
-            // information:
             FeatureToggle.checkWotIntegrationFeatureEnabled(command.getType(), command.getDittoHeaders());
-            // for retrieving the WoT TD, assume that full TD gets returned unfiltered:
-            authorizedCommand = prepareThingCommandBeforeSendingToPersistence(command);
+            if (FeatureToggle.isWotTdPermissionFilteringEnabled()) {
+                // user needs at least partial READ permission; TD will be filtered in filterResponse()
+                final var commandWithReadSubjects =
+                        authorizeByPolicyOrThrow(policyEnforcer.getEnforcer(), command, partialAccessEventsEnabled);
+                authorizedCommand = prepareThingCommandBeforeSendingToPersistence(
+                        ensureTwinChannel((ThingQueryCommand<?>) commandWithReadSubjects));
+            } else {
+                // legacy behavior: TD is public information, no authorization check
+                authorizedCommand = prepareThingCommandBeforeSendingToPersistence(command);
+            }
         } else {
             try {
                 final var commandWithReadSubjects =
@@ -227,7 +234,16 @@ final class ThingCommandEnforcement
     public CompletionStage<ThingCommandResponse<?>> filterResponse(final ThingCommandResponse<?> commandResponse,
             final PolicyEnforcer policyEnforcer) {
 
-        if (commandResponse instanceof ThingQueryCommandResponse<?> thingQueryCommandResponse) {
+        if (commandResponse instanceof RetrieveWotThingDescriptionResponse tdResponse
+                && FeatureToggle.isWotTdPermissionFilteringEnabled()) {
+            try {
+                return WotThingDescriptionEnforcement.filterThingDescription(tdResponse,
+                        policyEnforcer.getEnforcer())
+                        .thenApply(ThingCommandResponse.class::cast);
+            } catch (final RuntimeException e) {
+                throw reportError("Error after filtering WoT TD", e, commandResponse.getDittoHeaders());
+            }
+        } else if (commandResponse instanceof ThingQueryCommandResponse<?> thingQueryCommandResponse) {
             try {
                 final ThingQueryCommandResponse<?> filteredResponse =
                         buildJsonViewForThingQueryCommandResponse(thingQueryCommandResponse,

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/WotThingDescriptionEnforcement.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/enforcement/WotThingDescriptionEnforcement.java
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.enforcement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.json.JsonArray;
+import org.eclipse.ditto.json.JsonCollectors;
+import org.eclipse.ditto.json.JsonField;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonObjectBuilder;
+import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.api.Permission;
+import org.eclipse.ditto.policies.model.PoliciesResourceType;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.ResourceKey;
+import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.things.model.signals.commands.query.RetrieveWotThingDescriptionResponse;
+import org.eclipse.ditto.wot.model.FormElement;
+import org.eclipse.ditto.wot.model.SingleDataSchema;
+import org.eclipse.ditto.wot.model.ThingSkeleton;
+
+/**
+ * Utility for filtering a WoT Thing Description based on the requesting user's policy permissions.
+ * <p>
+ * Properties the user cannot READ are removed. Properties the user cannot WRITE are marked {@code readOnly}.
+ * Actions the user cannot invoke (WRITE on message resource) are removed.
+ * Events the user cannot subscribe to (READ on message resource) are removed.
+ * Sub-model links to inaccessible features are removed.
+ *
+ * @since 3.9.0
+ */
+@Immutable
+final class WotThingDescriptionEnforcement {
+
+    private static final Permissions READ_PERMISSION = Permissions.newInstance(Permission.READ);
+    private static final Permissions WRITE_PERMISSION = Permissions.newInstance(Permission.WRITE);
+
+    private static final Pattern FEATURE_ID_FROM_TD_ID_PATTERN =
+            Pattern.compile(".*/features/([^/]+)$");
+    private static final Pattern FEATURE_ID_FROM_LINK_HREF_PATTERN =
+            Pattern.compile("^features/([^/]+)$");
+
+    private static final String OP_FIELD = FormElement.JsonFields.OP.getPointer().getRoot()
+            .map(Object::toString).orElse("op");
+    private static final String HREF_FIELD = FormElement.JsonFields.HREF.getPointer().getRoot()
+            .map(Object::toString).orElse("href");
+    private static final String READ_ONLY_FIELD = SingleDataSchema.DataSchemaJsonFields.READ_ONLY.getPointer()
+            .getRoot().map(Object::toString).orElse("readOnly");
+
+    private WotThingDescriptionEnforcement() {
+        throw new AssertionError();
+    }
+
+    /**
+     * Filters the TD in the given response based on the user's permissions determined by the enforcer.
+     *
+     * @param response the WoT TD response to filter.
+     * @param enforcer the policy enforcer to check permissions with.
+     * @return a completion stage with the filtered response.
+     */
+    static CompletionStage<RetrieveWotThingDescriptionResponse> filterThingDescription(
+            final RetrieveWotThingDescriptionResponse response,
+            final Enforcer enforcer) {
+
+        final JsonObject tdJson = response.getEntity(response.getImplementedSchemaVersion()).asObject();
+        final AuthorizationContext authContext = response.getDittoHeaders().getAuthorizationContext();
+        final String featureId = extractFeatureIdFromTd(tdJson);
+
+        final JsonObject filteredTd = filterTdJson(tdJson, enforcer, authContext, featureId);
+        return CompletableFuture.completedFuture(response.setEntity(filteredTd));
+    }
+
+    /**
+     * Filters the TD JSON object based on permissions.
+     *
+     * @param tdJson the full TD JSON.
+     * @param enforcer the policy enforcer.
+     * @param authContext the user's authorization context.
+     * @param featureId the feature ID if this is a feature-level TD, or {@code null} for thing-level.
+     * @return the filtered TD JSON.
+     */
+    static JsonObject filterTdJson(final JsonObject tdJson,
+            final Enforcer enforcer,
+            final AuthorizationContext authContext,
+            @Nullable final String featureId) {
+
+        final JsonObjectBuilder builder = tdJson.toBuilder();
+
+        final boolean hasWritableProperties = filterProperties(tdJson, builder, enforcer, authContext, featureId);
+        final boolean hasReadableProperties = builder.build()
+                .getValue(ThingSkeleton.JsonFields.PROPERTIES)
+                .filter(obj -> !obj.isEmpty())
+                .isPresent();
+
+        filterActions(tdJson, builder, enforcer, authContext, featureId);
+        filterEvents(tdJson, builder, enforcer, authContext, featureId);
+        filterSubmodelLinks(tdJson, builder, enforcer, authContext);
+        filterRootForms(tdJson, builder, hasReadableProperties, hasWritableProperties);
+
+        return builder.build();
+    }
+
+    /**
+     * Filters properties in the TD based on READ/WRITE permissions.
+     *
+     * @return {@code true} if at least one property remains writable after filtering.
+     */
+    private static boolean filterProperties(final JsonObject tdJson,
+            final JsonObjectBuilder tdBuilder,
+            final Enforcer enforcer,
+            final AuthorizationContext authContext,
+            @Nullable final String featureId) {
+
+        return tdJson.getValue(ThingSkeleton.JsonFields.PROPERTIES)
+                .filter(props -> !props.isEmpty())
+                .map(propertiesJson -> {
+                    final JsonObjectBuilder propsBuilder = JsonObject.newBuilder();
+                    boolean anyWritable = false;
+
+                    for (final JsonField field : propertiesJson) {
+                        final String propertyName = field.getKeyName();
+                        final JsonObject propertyJson = field.getValue().asObject();
+
+                        final String resourcePath = extractResourcePathFromProperty(propertyJson, propertyName,
+                                featureId);
+                        final ResourceKey thingResourceKey =
+                                PoliciesResourceType.thingResource(JsonPointer.of(resourcePath));
+
+                        final boolean canRead = enforcer.hasUnrestrictedPermissions(thingResourceKey, authContext,
+                                READ_PERMISSION);
+                        if (!canRead) {
+                            continue; // skip this property entirely
+                        }
+
+                        final boolean canWrite = enforcer.hasUnrestrictedPermissions(thingResourceKey, authContext,
+                                WRITE_PERMISSION);
+                        if (canWrite) {
+                            anyWritable = true;
+                            propsBuilder.set(propertyName, propertyJson);
+                        } else {
+                            // mark as readOnly and remove WRITEPROPERTY forms
+                            propsBuilder.set(propertyName, makePropertyReadOnly(propertyJson));
+                        }
+                    }
+
+                    final JsonObject filteredProps = propsBuilder.build();
+                    if (filteredProps.isEmpty()) {
+                        tdBuilder.remove(ThingSkeleton.JsonFields.PROPERTIES);
+                    } else {
+                        tdBuilder.set(ThingSkeleton.JsonFields.PROPERTIES, filteredProps);
+                    }
+                    return anyWritable;
+                })
+                .orElse(false);
+    }
+
+    /**
+     * Filters actions in the TD based on WRITE permission on message resources.
+     */
+    private static void filterActions(final JsonObject tdJson,
+            final JsonObjectBuilder tdBuilder,
+            final Enforcer enforcer,
+            final AuthorizationContext authContext,
+            @Nullable final String featureId) {
+
+        tdJson.getValue(ThingSkeleton.JsonFields.ACTIONS)
+                .filter(actions -> !actions.isEmpty())
+                .ifPresent(actionsJson -> {
+                    final JsonObjectBuilder actionsBuilder = JsonObject.newBuilder();
+
+                    for (final JsonField field : actionsJson) {
+                        final String actionName = field.getKeyName();
+                        final String messagePath = buildMessagePath("inbox/messages/" + actionName, featureId);
+                        final ResourceKey messageResourceKey =
+                                PoliciesResourceType.messageResource(JsonPointer.of(messagePath));
+
+                        if (enforcer.hasUnrestrictedPermissions(messageResourceKey, authContext, WRITE_PERMISSION)) {
+                            actionsBuilder.set(actionName, field.getValue());
+                        }
+                    }
+
+                    final JsonObject filteredActions = actionsBuilder.build();
+                    if (filteredActions.isEmpty()) {
+                        tdBuilder.remove(ThingSkeleton.JsonFields.ACTIONS);
+                    } else {
+                        tdBuilder.set(ThingSkeleton.JsonFields.ACTIONS, filteredActions);
+                    }
+                });
+    }
+
+    /**
+     * Filters events in the TD based on READ permission on message resources.
+     */
+    private static void filterEvents(final JsonObject tdJson,
+            final JsonObjectBuilder tdBuilder,
+            final Enforcer enforcer,
+            final AuthorizationContext authContext,
+            @Nullable final String featureId) {
+
+        tdJson.getValue(ThingSkeleton.JsonFields.EVENTS)
+                .filter(events -> !events.isEmpty())
+                .ifPresent(eventsJson -> {
+                    final JsonObjectBuilder eventsBuilder = JsonObject.newBuilder();
+
+                    for (final JsonField field : eventsJson) {
+                        final String eventName = field.getKeyName();
+                        final String messagePath = buildMessagePath("outbox/messages/" + eventName, featureId);
+                        final ResourceKey messageResourceKey =
+                                PoliciesResourceType.messageResource(JsonPointer.of(messagePath));
+
+                        if (enforcer.hasUnrestrictedPermissions(messageResourceKey, authContext, READ_PERMISSION)) {
+                            eventsBuilder.set(eventName, field.getValue());
+                        }
+                    }
+
+                    final JsonObject filteredEvents = eventsBuilder.build();
+                    if (filteredEvents.isEmpty()) {
+                        tdBuilder.remove(ThingSkeleton.JsonFields.EVENTS);
+                    } else {
+                        tdBuilder.set(ThingSkeleton.JsonFields.EVENTS, filteredEvents);
+                    }
+                });
+    }
+
+    /**
+     * Filters sub-model links (rel="item") in thing-level TDs based on feature access.
+     */
+    private static void filterSubmodelLinks(final JsonObject tdJson,
+            final JsonObjectBuilder tdBuilder,
+            final Enforcer enforcer,
+            final AuthorizationContext authContext) {
+
+        tdJson.getValue(ThingSkeleton.JsonFields.LINKS)
+                .filter(links -> !links.isEmpty())
+                .ifPresent(linksArray -> {
+                    final List<JsonValue> filteredLinks = new ArrayList<>();
+
+                    for (final JsonValue linkValue : linksArray) {
+                        if (!linkValue.isObject()) {
+                            filteredLinks.add(linkValue);
+                            continue;
+                        }
+                        final JsonObject link = linkValue.asObject();
+                        final Optional<String> rel = link.getValue("rel")
+                                .filter(JsonValue::isString)
+                                .map(JsonValue::asString);
+                        final Optional<String> href = link.getValue(HREF_FIELD)
+                                .filter(JsonValue::isString)
+                                .map(JsonValue::asString);
+
+                        if (rel.filter("item"::equals).isPresent() && href.isPresent()) {
+                            final Matcher matcher = FEATURE_ID_FROM_LINK_HREF_PATTERN.matcher(href.get());
+                            if (matcher.matches()) {
+                                final String linkedFeatureId = matcher.group(1);
+                                final ResourceKey featureResourceKey = PoliciesResourceType.thingResource(
+                                        JsonPointer.of("/features/" + linkedFeatureId));
+                                if (!enforcer.hasPartialPermissions(featureResourceKey, authContext,
+                                        READ_PERMISSION)) {
+                                    continue; // skip this link
+                                }
+                            }
+                        }
+                        filteredLinks.add(linkValue);
+                    }
+
+                    final JsonArray filteredLinksArray = filteredLinks.stream()
+                            .collect(JsonCollectors.valuesToArray());
+                    tdBuilder.set(ThingSkeleton.JsonFields.LINKS, filteredLinksArray);
+                });
+    }
+
+    /**
+     * Filters root-level forms based on whether readable/writable properties remain.
+     */
+    private static void filterRootForms(final JsonObject tdJson,
+            final JsonObjectBuilder tdBuilder,
+            final boolean hasReadableProperties,
+            final boolean hasWritableProperties) {
+
+        tdJson.getValue(ThingSkeleton.JsonFields.FORMS)
+                .filter(forms -> !forms.isEmpty())
+                .ifPresent(formsArray -> {
+                    final List<JsonValue> filteredForms = new ArrayList<>();
+
+                    for (final JsonValue formValue : formsArray) {
+                        if (!formValue.isObject()) {
+                            filteredForms.add(formValue);
+                            continue;
+                        }
+                        final JsonObject form = formValue.asObject();
+                        final Optional<String> op = extractOp(form);
+
+                        if (op.isPresent()) {
+                            final String opName = op.get();
+                            if (isReadOp(opName) && !hasReadableProperties) {
+                                continue; // remove read forms when no readable properties
+                            }
+                            if (isWriteOp(opName) && !hasWritableProperties) {
+                                continue; // remove write forms when no writable properties
+                            }
+                        }
+                        filteredForms.add(formValue);
+                    }
+
+                    if (filteredForms.isEmpty()) {
+                        tdBuilder.remove(ThingSkeleton.JsonFields.FORMS);
+                    } else {
+                        tdBuilder.set(ThingSkeleton.JsonFields.FORMS,
+                                filteredForms.stream().collect(JsonCollectors.valuesToArray()));
+                    }
+                });
+    }
+
+    /**
+     * Extracts the feature ID from the TD's {@code "id"} field.
+     *
+     * @return the feature ID, or {@code null} if this is a thing-level TD.
+     */
+    @Nullable
+    static String extractFeatureIdFromTd(final JsonObject tdJson) {
+        return tdJson.getValue(ThingSkeleton.JsonFields.ID)
+                .map(FEATURE_ID_FROM_TD_ID_PATTERN::matcher)
+                .filter(Matcher::matches)
+                .map(m -> m.group(1))
+                .orElse(null);
+    }
+
+    /**
+     * Extracts the thing resource path for a property from its first form's {@code href},
+     * falling back to a constructed path from the property name.
+     */
+    private static String extractResourcePathFromProperty(final JsonObject propertyJson,
+            final String propertyName,
+            @Nullable final String featureId) {
+
+        // try to extract from the first form's href
+        final Optional<String> hrefFromForm = propertyJson.getValue("forms")
+                .filter(JsonValue::isArray)
+                .map(JsonValue::asArray)
+                .filter(arr -> !arr.isEmpty())
+                .flatMap(arr -> arr.get(0))
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .flatMap(form -> form.getValue(HREF_FIELD))
+                .filter(JsonValue::isString)
+                .map(JsonValue::asString)
+                .map(WotThingDescriptionEnforcement::stripUriVariables);
+
+        if (hrefFromForm.isPresent()) {
+            if (featureId != null) {
+                return "/features/" + featureId + "/" + hrefFromForm.get();
+            } else {
+                return "/" + hrefFromForm.get();
+            }
+        }
+
+        // fallback: construct from property name
+        if (featureId != null) {
+            return "/features/" + featureId + "/properties/" + propertyName;
+        } else {
+            return "/attributes/" + propertyName;
+        }
+    }
+
+    /**
+     * Strips URI template variable suffixes like {@code {?channel,timeout}} from an href.
+     */
+    private static String stripUriVariables(final String href) {
+        final int braceIndex = href.indexOf('{');
+        return braceIndex >= 0 ? href.substring(0, braceIndex) : href;
+    }
+
+    /**
+     * Makes a property read-only: sets {@code "readOnly": true} and removes WRITEPROPERTY form elements.
+     */
+    private static JsonObject makePropertyReadOnly(final JsonObject propertyJson) {
+        final JsonObjectBuilder builder = propertyJson.toBuilder()
+                .set(READ_ONLY_FIELD, true);
+
+        // remove WRITEPROPERTY form elements
+        propertyJson.getValue("forms")
+                .filter(JsonValue::isArray)
+                .map(JsonValue::asArray)
+                .ifPresent(forms -> {
+                    final List<JsonValue> filteredForms = new ArrayList<>();
+                    for (final JsonValue formValue : forms) {
+                        if (formValue.isObject()) {
+                            final Optional<String> op = extractOp(formValue.asObject());
+                            if (op.filter("writeproperty"::equals).isPresent()) {
+                                continue; // skip write forms
+                            }
+                        }
+                        filteredForms.add(formValue);
+                    }
+                    builder.set("forms", filteredForms.stream().collect(JsonCollectors.valuesToArray()));
+                });
+
+        return builder.build();
+    }
+
+    /**
+     * Extracts the {@code "op"} value from a form element. Handles both single string and array values.
+     */
+    private static Optional<String> extractOp(final JsonObject form) {
+        return form.getValue(OP_FIELD)
+                .map(opValue -> {
+                    if (opValue.isString()) {
+                        return opValue.asString();
+                    } else if (opValue.isArray()) {
+                        // for array op, return the first entry
+                        return opValue.asArray().stream()
+                                .filter(JsonValue::isString)
+                                .map(JsonValue::asString)
+                                .findFirst()
+                                .orElse(null);
+                    }
+                    return null;
+                });
+    }
+
+    private static boolean isReadOp(final String op) {
+        return "readallproperties".equals(op) || "readmultipleproperties".equals(op)
+                || "observeallproperties".equals(op);
+    }
+
+    private static boolean isWriteOp(final String op) {
+        return "writeallproperties".equals(op) || "writemultipleproperties".equals(op);
+    }
+
+    /**
+     * Builds the message resource path, prepending the feature path for feature-level TDs.
+     */
+    private static String buildMessagePath(final String relativePath, @Nullable final String featureId) {
+        if (featureId != null) {
+            return "/features/" + featureId + "/" + relativePath;
+        } else {
+            return "/" + relativePath;
+        }
+    }
+}

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/WotThingDescriptionEnforcementTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/enforcement/WotThingDescriptionEnforcementTest.java
@@ -1,0 +1,533 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.things.service.enforcement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.eclipse.ditto.base.model.auth.AuthorizationContext;
+import org.eclipse.ditto.base.model.auth.AuthorizationModelFactory;
+import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
+import org.eclipse.ditto.base.model.auth.DittoAuthorizationContextType;
+import org.eclipse.ditto.base.model.headers.DittoHeaders;
+import org.eclipse.ditto.json.JsonObject;
+import org.eclipse.ditto.json.JsonValue;
+import org.eclipse.ditto.policies.api.Permission;
+import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
+import org.eclipse.ditto.policies.model.EffectedPermissions;
+import org.eclipse.ditto.policies.model.PoliciesModelFactory;
+import org.eclipse.ditto.policies.model.Permissions;
+import org.eclipse.ditto.policies.model.Policy;
+import org.eclipse.ditto.policies.model.PolicyId;
+import org.eclipse.ditto.policies.model.Subject;
+import org.eclipse.ditto.policies.model.SubjectId;
+import org.eclipse.ditto.policies.model.enforcers.Enforcer;
+import org.eclipse.ditto.things.model.ThingId;
+import org.eclipse.ditto.things.model.signals.commands.query.RetrieveWotThingDescriptionResponse;
+import org.junit.Test;
+
+/**
+ * Tests for {@link WotThingDescriptionEnforcement}.
+ *
+ * @since 3.9.0
+ */
+public final class WotThingDescriptionEnforcementTest {
+
+    private static final String SUBJECT_ID = "test:subject";
+    private static final AuthorizationContext AUTH_CONTEXT = AuthorizationModelFactory.newAuthContext(
+            DittoAuthorizationContextType.UNSPECIFIED,
+            AuthorizationSubject.newInstance(SUBJECT_ID));
+    private static final PolicyId POLICY_ID = PolicyId.of("test:policy");
+
+    // A thing-level TD with 2 properties, 1 action, 1 event, and sub-model links
+    private static final JsonObject THING_LEVEL_TD = JsonObject.of("""
+            {
+              "id": "urn:test.ns:my-thing",
+              "title": "My Thing",
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "properties": {
+                "temperature": {
+                  "type": "number",
+                  "forms": [
+                    {"op": "readproperty", "href": "attributes/temperature"},
+                    {"op": "writeproperty", "href": "attributes/temperature"}
+                  ]
+                },
+                "location": {
+                  "type": "string",
+                  "forms": [
+                    {"op": "readproperty", "href": "attributes/location"},
+                    {"op": "writeproperty", "href": "attributes/location"}
+                  ]
+                }
+              },
+              "actions": {
+                "reset": {
+                  "forms": [{"op": "invokeaction", "href": "inbox/messages/reset"}]
+                }
+              },
+              "events": {
+                "overheated": {
+                  "forms": [{"op": "subscribeevent", "href": "outbox/messages/overheated"}]
+                }
+              },
+              "links": [
+                {"rel": "type", "href": "https://example.com/model.tm.jsonld", "type": "application/tm+json"},
+                {"rel": "item", "href": "features/lamp", "type": "application/td+json"},
+                {"rel": "item", "href": "features/sensor", "type": "application/td+json"}
+              ],
+              "forms": [
+                {"op": "readallproperties", "href": "attributes"},
+                {"op": "writeallproperties", "href": "attributes"}
+              ]
+            }
+            """);
+
+    // A feature-level TD
+    private static final JsonObject FEATURE_LEVEL_TD = JsonObject.of("""
+            {
+              "id": "urn:test.ns:my-thing/features/lamp",
+              "title": "Lamp Feature",
+              "@context": "https://www.w3.org/2022/wot/td/v1.1",
+              "properties": {
+                "on": {
+                  "type": "boolean",
+                  "forms": [
+                    {"op": "readproperty", "href": "properties/on"},
+                    {"op": "writeproperty", "href": "properties/on"}
+                  ]
+                },
+                "brightness": {
+                  "type": "integer",
+                  "forms": [
+                    {"op": "readproperty", "href": "properties/brightness"},
+                    {"op": "writeproperty", "href": "properties/brightness"}
+                  ]
+                }
+              },
+              "actions": {
+                "toggle": {
+                  "forms": [{"op": "invokeaction", "href": "inbox/messages/toggle"}]
+                }
+              },
+              "events": {
+                "stateChanged": {
+                  "forms": [{"op": "subscribeevent", "href": "outbox/messages/stateChanged"}]
+                }
+              }
+            }
+            """);
+
+    @Test
+    public void extractFeatureIdFromThingLevelTd() {
+        assertThat(WotThingDescriptionEnforcement.extractFeatureIdFromTd(THING_LEVEL_TD)).isNull();
+    }
+
+    @Test
+    public void extractFeatureIdFromFeatureLevelTd() {
+        assertThat(WotThingDescriptionEnforcement.extractFeatureIdFromTd(FEATURE_LEVEL_TD)).isEqualTo("lamp");
+    }
+
+    @Test
+    public void fullAccessRetainsEntireTd() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/", Permission.READ, Permission.WRITE),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        assertThat(filtered.getValue("properties")).isPresent();
+        final JsonObject props = filtered.getValue("properties").map(JsonValue::asObject).orElseThrow();
+        assertThat(props.contains("temperature")).isTrue();
+        assertThat(props.contains("location")).isTrue();
+        assertThat(filtered.getValue("actions")).isPresent();
+        assertThat(filtered.getValue("events")).isPresent();
+        assertThat(filtered.getValue("forms")).isPresent();
+    }
+
+    @Test
+    public void partialReadRemovesUnreadableProperties() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes/temperature", Permission.READ),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        final JsonObject props = filtered.getValue("properties").map(JsonValue::asObject).orElseThrow();
+        assertThat(props.contains("temperature")).isTrue();
+        assertThat(props.contains("location")).isFalse();
+    }
+
+    @Test
+    public void readOnlyWhenNoWritePermission() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes/temperature", Permission.READ),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        final JsonObject tempProp = filtered.getValue("properties")
+                .map(JsonValue::asObject).orElseThrow()
+                .getValue("temperature").map(JsonValue::asObject).orElseThrow();
+
+        assertThat(tempProp.getValue("readOnly")).contains(JsonValue.of(true));
+
+        // writeproperty forms should be removed
+        tempProp.getValue("forms").map(JsonValue::asArray).orElseThrow().forEach(form -> {
+            final String op = form.asObject().getValue("op").map(JsonValue::asString).orElse("");
+            assertThat(op).isNotEqualTo("writeproperty");
+        });
+    }
+
+    @Test
+    public void readAndWritePermissionKeepsPropertyFullyAccessible() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes/temperature", Permission.READ, Permission.WRITE),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        final JsonObject tempProp = filtered.getValue("properties")
+                .map(JsonValue::asObject).orElseThrow()
+                .getValue("temperature").map(JsonValue::asObject).orElseThrow();
+
+        // readOnly should NOT be set
+        assertThat(tempProp.getValue("readOnly").map(JsonValue::asBoolean).orElse(false)).isFalse();
+    }
+
+    @Test
+    public void noMessageWriteRemovesActions() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/", Permission.READ, Permission.WRITE),
+                grant("message", "/outbox/messages/overheated", Permission.READ)
+                // no WRITE on inbox/messages → actions removed
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        assertThat(filtered.contains("actions")).isFalse();
+    }
+
+    @Test
+    public void noMessageReadRemovesEvents() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/", Permission.READ, Permission.WRITE),
+                grant("message", "/inbox/messages/reset", Permission.WRITE)
+                // no READ on outbox/messages → events removed
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        assertThat(filtered.contains("events")).isFalse();
+    }
+
+    @Test
+    public void submodelLinksFilteredByFeatureAccess() {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/", Permission.READ, Permission.WRITE),
+                // only grant access to feature "lamp", not "sensor"
+                revoke("thing", "/features/sensor", Permission.READ),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        final var links = filtered.getValue("links").map(JsonValue::asArray).orElseThrow();
+        // "type" link should remain, "lamp" item link should remain, "sensor" should be removed
+        final long itemLinkCount = links.stream()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .filter(link -> link.getValue("rel").map(JsonValue::asString).orElse("").equals("item"))
+                .count();
+        assertThat(itemLinkCount).isEqualTo(1);
+
+        // verify the remaining item link points to lamp
+        final boolean hasLampLink = links.stream()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .filter(link -> link.getValue("rel").map(JsonValue::asString).orElse("").equals("item"))
+                .anyMatch(link -> link.getValue("href").map(JsonValue::asString).orElse("").equals("features/lamp"));
+        assertThat(hasLampLink).isTrue();
+    }
+
+    @Test
+    public void featureLevelTdUsesCorrectResourcePaths() {
+        // grant READ+WRITE on feature lamp property "on" but only READ on "brightness"
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/features/lamp/properties/on", Permission.READ, Permission.WRITE),
+                grant("thing", "/features/lamp/properties/brightness", Permission.READ),
+                grant("message", "/features/lamp/inbox/messages/toggle", Permission.WRITE),
+                grant("message", "/features/lamp/outbox/messages/stateChanged", Permission.READ)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                FEATURE_LEVEL_TD, enforcer, AUTH_CONTEXT, "lamp");
+
+        // both properties should be present
+        final JsonObject props = filtered.getValue("properties").map(JsonValue::asObject).orElseThrow();
+        assertThat(props.contains("on")).isTrue();
+        assertThat(props.contains("brightness")).isTrue();
+
+        // "on" should not be readOnly
+        assertThat(props.getValue("on").map(JsonValue::asObject).orElseThrow()
+                .getValue("readOnly").map(JsonValue::asBoolean).orElse(false)).isFalse();
+
+        // "brightness" should be readOnly
+        assertThat(props.getValue("brightness").map(JsonValue::asObject).orElseThrow()
+                .getValue("readOnly")).contains(JsonValue.of(true));
+
+        // action and event should remain
+        assertThat(filtered.contains("actions")).isTrue();
+        assertThat(filtered.contains("events")).isTrue();
+    }
+
+    @Test
+    public void rootFormsRemovedWhenNoReadableProperties() {
+        // no READ access to any attribute
+        final Enforcer enforcer = createEnforcer(
+                grant("message", "/", Permission.READ, Permission.WRITE)
+                // no thing permissions
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        // no properties should remain
+        assertThat(filtered.contains("properties")).isFalse();
+        // root forms should be removed
+        assertThat(filtered.contains("forms")).isFalse();
+    }
+
+    @Test
+    public void writeRootFormRemovedWhenNoWritableProperties() {
+        // READ on all attributes but no WRITE
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes", Permission.READ),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        // properties should remain but be readOnly
+        assertThat(filtered.getValue("properties")).isPresent();
+
+        // root forms: readallproperties should remain, writeallproperties should be removed
+        final var forms = filtered.getValue("forms").map(JsonValue::asArray);
+        assertThat(forms).isPresent();
+        final boolean hasReadAll = forms.get().stream()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .anyMatch(f -> f.getValue("op").map(JsonValue::asString).orElse("").equals("readallproperties"));
+        final boolean hasWriteAll = forms.get().stream()
+                .filter(JsonValue::isObject)
+                .map(JsonValue::asObject)
+                .anyMatch(f -> f.getValue("op").map(JsonValue::asString).orElse("").equals("writeallproperties"));
+        assertThat(hasReadAll).isTrue();
+        assertThat(hasWriteAll).isFalse();
+    }
+
+    @Test
+    public void emptyTdReturnedWhenNoPermissions() {
+        // empty policy → no permissions at all
+        final Enforcer enforcer = createEnforcer();
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                THING_LEVEL_TD, enforcer, AUTH_CONTEXT, null);
+
+        // metadata should remain
+        assertThat(filtered.getValue("id")).isPresent();
+        assertThat(filtered.getValue("title")).isPresent();
+        assertThat(filtered.getValue("@context")).isPresent();
+
+        // affordances should be removed
+        assertThat(filtered.contains("properties")).isFalse();
+        assertThat(filtered.contains("actions")).isFalse();
+        assertThat(filtered.contains("events")).isFalse();
+        assertThat(filtered.contains("forms")).isFalse();
+    }
+
+    @Test
+    public void categoryBasedPropertyHrefHandledCorrectly() {
+        // TD with a property that has a category prefix in the href
+        final JsonObject tdWithCategory = JsonObject.of("""
+                {
+                  "id": "urn:test.ns:my-thing",
+                  "properties": {
+                    "temperature": {
+                      "type": "number",
+                      "forms": [
+                        {"op": "readproperty", "href": "attributes/environment/temperature"}
+                      ]
+                    }
+                  }
+                }
+                """);
+
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes/environment/temperature", Permission.READ)
+        );
+
+        final JsonObject filtered = WotThingDescriptionEnforcement.filterTdJson(
+                tdWithCategory, enforcer, AUTH_CONTEXT, null);
+
+        assertThat(filtered.getValue("properties").map(JsonValue::asObject).orElseThrow()
+                .contains("temperature")).isTrue();
+    }
+
+    // --- response-level filtering tests ---
+
+    @Test
+    public void filterThingDescriptionResponseRemovesUnauthorizedProperties() throws Exception {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/attributes/temperature", Permission.READ),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+        final RetrieveWotThingDescriptionResponse response = buildTdResponse(THING_LEVEL_TD);
+
+        final RetrieveWotThingDescriptionResponse filtered =
+                WotThingDescriptionEnforcement.filterThingDescription(response, enforcer)
+                        .toCompletableFuture().get();
+
+        final JsonObject filteredTd = filtered.getEntity(filtered.getImplementedSchemaVersion()).asObject();
+
+        // temperature should remain (user has READ), location should be removed
+        final JsonObject props = filteredTd.getValue("properties").map(JsonValue::asObject).orElseThrow();
+        assertThat(props.contains("temperature")).isTrue();
+        assertThat(props.contains("location")).isFalse();
+
+        // temperature should be readOnly (user has no WRITE)
+        assertThat(props.getValue("temperature").map(JsonValue::asObject).orElseThrow()
+                .getValue("readOnly")).contains(JsonValue.of(true));
+    }
+
+    @Test
+    public void filterThingDescriptionResponsePreservesThingId() throws Exception {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/", Permission.READ, Permission.WRITE),
+                grant("message", "/", Permission.READ, Permission.WRITE)
+        );
+        final RetrieveWotThingDescriptionResponse response = buildTdResponse(THING_LEVEL_TD);
+
+        final RetrieveWotThingDescriptionResponse filtered =
+                WotThingDescriptionEnforcement.filterThingDescription(response, enforcer)
+                        .toCompletableFuture().get();
+
+        assertThat((Object) filtered.getEntityId()).isEqualTo(response.getEntityId());
+        assertThat((Object) filtered.getDittoHeaders()).isEqualTo(response.getDittoHeaders());
+    }
+
+    @Test
+    public void filterThingDescriptionResponseStripsAllAffordancesWithNoPermissions() throws Exception {
+        final Enforcer enforcer = createEnforcer();
+        final RetrieveWotThingDescriptionResponse response = buildTdResponse(THING_LEVEL_TD);
+
+        final RetrieveWotThingDescriptionResponse filtered =
+                WotThingDescriptionEnforcement.filterThingDescription(response, enforcer)
+                        .toCompletableFuture().get();
+
+        final JsonObject filteredTd = filtered.getEntity(filtered.getImplementedSchemaVersion()).asObject();
+        assertThat(filteredTd.contains("properties")).isFalse();
+        assertThat(filteredTd.contains("actions")).isFalse();
+        assertThat(filteredTd.contains("events")).isFalse();
+        // metadata must survive
+        assertThat(filteredTd.getValue("id")).isPresent();
+    }
+
+    @Test
+    public void filterFeatureLevelThingDescriptionResponse() throws Exception {
+        final Enforcer enforcer = createEnforcer(
+                grant("thing", "/features/lamp/properties/on", Permission.READ, Permission.WRITE),
+                grant("message", "/features/lamp/inbox/messages/toggle", Permission.WRITE),
+                grant("message", "/features/lamp/outbox/messages/stateChanged", Permission.READ)
+                // no access to "brightness"
+        );
+        final RetrieveWotThingDescriptionResponse response = buildTdResponse(FEATURE_LEVEL_TD);
+
+        final RetrieveWotThingDescriptionResponse filtered =
+                WotThingDescriptionEnforcement.filterThingDescription(response, enforcer)
+                        .toCompletableFuture().get();
+
+        final JsonObject filteredTd = filtered.getEntity(filtered.getImplementedSchemaVersion()).asObject();
+
+        // "on" should be present, "brightness" removed (no READ)
+        final JsonObject props = filteredTd.getValue("properties").map(JsonValue::asObject).orElseThrow();
+        assertThat(props.contains("on")).isTrue();
+        assertThat(props.contains("brightness")).isFalse();
+
+        // action and event should remain
+        assertThat(filteredTd.contains("actions")).isTrue();
+        assertThat(filteredTd.contains("events")).isTrue();
+    }
+
+    private static RetrieveWotThingDescriptionResponse buildTdResponse(final JsonObject td) {
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .authorizationContext(AUTH_CONTEXT)
+                .build();
+        return RetrieveWotThingDescriptionResponse.of(
+                ThingId.of("test.ns", "my-thing"), td, headers);
+    }
+
+    // --- helper methods ---
+
+    private static Enforcer createEnforcer(final ResourceGrant... grants) {
+        var policyBuilder = PoliciesModelFactory.newPolicyBuilder(POLICY_ID)
+                .setRevision(1L);
+
+        int entryIndex = 0;
+        for (final ResourceGrant grant : grants) {
+            final String entryLabel = "entry-" + entryIndex++;
+            policyBuilder.set(PoliciesModelFactory.newPolicyEntry(entryLabel,
+                    Collections.singletonList(Subject.newInstance(SubjectId.newInstance(SUBJECT_ID))),
+                    Collections.singletonList(PoliciesModelFactory.newResource(
+                            grant.resourceType, grant.path,
+                            EffectedPermissions.newInstance(
+                                    grant.grantedPermissions,
+                                    grant.revokedPermissions)))));
+        }
+
+        final Policy policy = policyBuilder.build();
+        return PolicyEnforcer.of(policy).getEnforcer();
+    }
+
+    private static ResourceGrant grant(final String resourceType, final String path, final String... permissions) {
+        return new ResourceGrant(resourceType, path,
+                permissions.length > 0 ? Permissions.newInstance(permissions[0],
+                java.util.Arrays.copyOfRange(permissions, 1, permissions.length)) : Permissions.none(),
+                Permissions.none());
+    }
+
+    private static ResourceGrant revoke(final String resourceType, final String path, final String... permissions) {
+        return new ResourceGrant(resourceType, path,
+                Permissions.none(),
+                permissions.length > 0 ? Permissions.newInstance(permissions[0],
+                java.util.Arrays.copyOfRange(permissions, 1, permissions.length)) : Permissions.none());
+    }
+
+    private record ResourceGrant(String resourceType, String path,
+                                 Permissions grantedPermissions, Permissions revokedPermissions) {}
+}


### PR DESCRIPTION
Filter the generated WoT Thing Description in the enforcement layer based on the requesting user's policy permissions.  
Resolves: #2144

- Properties the user cannot READ are removed from the TD
- Properties the user cannot WRITE are marked readOnly
- Actions the user cannot invoke (WRITE on message resource) are removed
- Events the user cannot subscribe to (READ on message resource) are removed
- Sub-model links to inaccessible features are removed
- Root-level forms are cleaned up when affordances are filtered

Added behind feature toggle `WOT_TD_PERMISSION_FILTERING_ENABLED` (default: true). Setting the env var
`DITTO_DEVOPS_FEATURE_WOT_TD_PERMISSION_FILTERING_ENABLED=false` restores the previous behavior of unfiltered TDs.