### PR TITLE
fix: collapse partial-access-paths header to ancestor pointers

### DIFF
--- a/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilter.java
+++ b/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilter.java
@@ -222,6 +222,14 @@ public final class AdaptablePartialAccessFilter {
             return true;
         }
 
+        final int eventLevelCount = eventPath.getLevelCount();
+        for (int i = 1; i < eventLevelCount; i++) {
+            final JsonPointer prefix = eventPath.getPrefixPointer(i).orElse(null);
+            if (prefix != null && accessiblePaths.contains(prefix)) {
+                return true;
+            }
+        }
+
         return false;
     }
 

--- a/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/JsonPartialAccessFilter.java
+++ b/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/JsonPartialAccessFilter.java
@@ -184,6 +184,16 @@ public final class JsonPartialAccessFilter {
     /**
      * Recursively filters a JSON object based on accessible paths.
      * Uses a PathTrie for efficient prefix matching.
+     * <p>
+     * A field is included when any of the following holds:
+     * <ul>
+     *   <li>The field path is an exact match in the accessible set.</li>
+     *   <li>The field has an accessible descendant (partial match — recurse).</li>
+     *   <li>A proper ancestor of the field path is an exact match — in which case the entire
+     *       subtree rooted at this field is included as-is (no further filtering needed). This
+     *       mirrors Ditto policy semantics: a READ grant on an ancestor grants read on every
+     *       descendant.</li>
+     * </ul>
      *
      * @param jsonObject the JSON object to filter
      * @param currentPath the current path in the JSON structure
@@ -201,10 +211,16 @@ public final class JsonPartialAccessFilter {
                     ? JsonPointer.of("/" + field.getKey())
                     : currentPath.append(JsonPointer.of("/" + field.getKey()));
 
-            final boolean isAccessible = pathTrie.isExactMatch(fieldPath) ||
-                    pathTrie.hasAccessibleDescendant(fieldPath);
+            final boolean hasAncestorMatch = pathTrie.hasAncestorMatch(fieldPath);
+            final boolean isExactMatch = pathTrie.isExactMatch(fieldPath);
 
-            if (isAccessible) {
+            if (hasAncestorMatch || isExactMatch) {
+                // Ancestor or exact match: the entire subtree (or scalar) is accessible.
+                // Include the field as-is; no need to descend further because every descendant
+                // is implicitly granted by the ancestor/exact grant.
+                builder.set(field);
+            } else if (pathTrie.hasAccessibleDescendant(fieldPath)) {
+                // Partial match: some descendants are accessible, recurse to filter them.
                 if (field.getValue().isObject()) {
                     final JsonObject filteredNested = filterJsonRecursive(
                             field.getValue().asObject(), fieldPath, pathTrie);

--- a/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/PathTrie.java
+++ b/internal/utils/protocol/src/main/java/org/eclipse/ditto/internal/utils/protocol/PathTrie.java
@@ -112,8 +112,35 @@ final class PathTrie {
                 return false;
             }
         }
-        
+
         return current.hasDescendants || !current.exactPaths.isEmpty();
+    }
+
+    /**
+     * Checks if any proper ancestor of the given path is an exact match in the trie.
+     * <p>
+     * An ancestor match means the caller has access to the ancestor resource and therefore implicitly
+     * to all descendants (this mirrors Ditto policy semantics: a READ grant on {@code /attributes}
+     * grants read on every field under {@code /attributes}). This is used to let the producer emit
+     * a compact ancestor pointer instead of thousands of leaves when the same grant covers a whole
+     * subtree.
+     *
+     * @param path the path to check
+     * @return true if any proper ancestor of {@code path} is in the accessible set
+     * @since 3.9.0
+     */
+    boolean hasAncestorMatch(final JsonPointer path) {
+        final int levelCount = path.getLevelCount();
+        if (levelCount == 0) {
+            return false;
+        }
+        for (int i = 1; i < levelCount; i++) {
+            final JsonPointer prefix = path.getPrefixPointer(i).orElse(null);
+            if (prefix != null && exactPaths.contains(prefix)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilterTest.java
+++ b/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/AdaptablePartialAccessFilterTest.java
@@ -254,6 +254,37 @@ public final class AdaptablePartialAccessFilterTest {
     }
 
     @Test
+    public void ancestorGrantAllowsScalarDescendantForNonObjectPayload() {
+        final String partialAccessHeader = JsonFactory.newObjectBuilder()
+                .set("subjects", JsonFactory.newArrayBuilder()
+                        .add(SUBJECT_PARTIAL.getId())
+                        .build())
+                .set("paths", JsonFactory.newObjectBuilder()
+                        .set(JsonFactory.newKey("features/featureA"),
+                                JsonFactory.newArrayBuilder().add(0).build())
+                        .build())
+                .build()
+                .toString();
+
+        final DittoHeaders headers = DittoHeaders.newBuilder()
+                .putHeader(DittoHeaderDefinition.PARTIAL_ACCESS_PATHS.getKey(), partialAccessHeader)
+                .readGrantedSubjects(Set.of(SUBJECT_PARTIAL))
+                .build();
+
+        final Adaptable adaptable = createThingEventAdaptable(
+                JsonPointer.of("features/featureA/properties/x"),
+                JsonValue.of(42),
+                headers);
+
+        final AuthorizationContext context = authContext(SUBJECT_PARTIAL);
+        final Adaptable result = AdaptablePartialAccessFilter.filterAdaptableForPartialAccess(
+                adaptable, context);
+
+        assertThat(result.getPayload().getValue()).isPresent();
+        assertThat(result.getPayload().getValue().orElse(JsonFactory.nullLiteral())).isEqualTo(JsonValue.of(42));
+    }
+
+    @Test
     public void strictMatchingDeniesParentPathWhenChildIsRevoked() {
         // GIVEN: A user has access to /attributes/complex/some but /attributes/complex/secret is revoked
         // This means /attributes/complex should NOT be in accessible paths (parent with revoked child)

--- a/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/JsonPartialAccessFilterTest.java
+++ b/internal/utils/protocol/src/test/java/org/eclipse/ditto/internal/utils/protocol/JsonPartialAccessFilterTest.java
@@ -66,7 +66,7 @@ public final class JsonPartialAccessFilterTest {
     }
 
     @Test
-    public void filterJsonByPathsWithExactPaths() {
+    public void filterJsonByPathsAncestorGrantIncludesAllDescendants() {
         final JsonObject thingJson = JsonFactory.newObjectBuilder()
                 .set("attributes", JsonFactory.newObjectBuilder()
                         .set("foo", "bar")
@@ -76,6 +76,24 @@ public final class JsonPartialAccessFilterTest {
 
         final Set<JsonPointer> accessiblePaths = new LinkedHashSet<>();
         accessiblePaths.add(JsonPointer.of("/attributes"));
+
+        final JsonObject filtered = JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
+
+        assertThat(filtered.getValue("attributes")).isPresent();
+        assertThat(filtered.getValue("attributes").get().asObject().getValue("foo")).isPresent();
+        assertThat(filtered.getValue("attributes").get().asObject().getValue("bar")).isPresent();
+    }
+
+    @Test
+    public void filterJsonByPathsLeafOnlyGrantExcludesSiblings() {
+        final JsonObject thingJson = JsonFactory.newObjectBuilder()
+                .set("attributes", JsonFactory.newObjectBuilder()
+                        .set("foo", "bar")
+                        .set("bar", "baz")
+                        .build())
+                .build();
+
+        final Set<JsonPointer> accessiblePaths = new LinkedHashSet<>();
         accessiblePaths.add(JsonPointer.of("/attributes/foo"));
 
         final JsonObject filtered = JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
@@ -83,6 +101,67 @@ public final class JsonPartialAccessFilterTest {
         assertThat(filtered.getValue("attributes")).isPresent();
         assertThat(filtered.getValue("attributes").get().asObject().getValue("foo")).isPresent();
         assertThat(filtered.getValue("attributes").get().asObject().getValue("bar")).isEmpty();
+    }
+
+    @Test
+    public void filterJsonByPathsAncestorGrantIncludesArrayValueAsIs() {
+        final JsonObject thingJson = JsonFactory.newObjectBuilder()
+                .set("features", JsonFactory.newObjectBuilder()
+                        .set("featureA", JsonFactory.newObjectBuilder()
+                                .set("items", JsonFactory.newArrayBuilder()
+                                        .add("a").add("b").add("c")
+                                        .build())
+                                .build())
+                        .build())
+                .build();
+
+        final Set<JsonPointer> accessiblePaths = new LinkedHashSet<>();
+        accessiblePaths.add(JsonPointer.of("/features/featureA"));
+
+        final JsonObject filtered = JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
+
+        assertThat(filtered.getValue(JsonPointer.of("/features/featureA/items")))
+                .hasValueSatisfying(value -> {
+                    assertThat(value.isArray()).isTrue();
+                    assertThat(value.asArray()).hasSize(3);
+                });
+    }
+
+    @Test
+    public void filterJsonByPathsAncestorGrantIncludesScalarDescendantAsIs() {
+        final JsonObject thingJson = JsonFactory.newObjectBuilder()
+                .set("attributes", JsonFactory.newObjectBuilder()
+                        .set("count", 42)
+                        .set("active", true)
+                        .build())
+                .build();
+
+        final Set<JsonPointer> accessiblePaths = new LinkedHashSet<>();
+        accessiblePaths.add(JsonPointer.of("/attributes"));
+
+        final JsonObject filtered = JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
+
+        assertThat(filtered.getValue(JsonPointer.of("/attributes/count")))
+                .hasValue(JsonFactory.newValue(42));
+        assertThat(filtered.getValue(JsonPointer.of("/attributes/active")))
+                .hasValue(JsonFactory.newValue(true));
+    }
+
+    @Test
+    public void filterJsonByPathsAncestorGrantIncludesNullValueAsIs() {
+        final JsonObject thingJson = JsonFactory.newObjectBuilder()
+                .set("attributes", JsonFactory.newObjectBuilder()
+                        .set("optional", JsonFactory.nullLiteral())
+                        .build())
+                .build();
+
+        final Set<JsonPointer> accessiblePaths = new LinkedHashSet<>();
+        accessiblePaths.add(JsonPointer.of("/attributes"));
+
+        final JsonObject filtered = JsonPartialAccessFilter.filterJsonByPaths(thingJson, accessiblePaths);
+
+        assertThat(filtered.getValue(JsonPointer.of("/attributes/optional")))
+                .hasValueSatisfying(value -> assertThat(value.isNull()).isTrue());
     }
 
     @Test

--- a/things/service/src/main/java/org/eclipse/ditto/things/service/utils/PartialAccessPathCalculator.java
+++ b/things/service/src/main/java/org/eclipse/ditto/things/service/utils/PartialAccessPathCalculator.java
@@ -25,11 +25,13 @@ import org.eclipse.ditto.base.model.auth.AuthorizationSubject;
 import org.eclipse.ditto.base.model.json.FieldType;
 import org.eclipse.ditto.json.JsonArray;
 import org.eclipse.ditto.json.JsonArrayBuilder;
+import org.eclipse.ditto.json.JsonField;
 import org.eclipse.ditto.json.JsonFieldDefinition;
 import org.eclipse.ditto.json.JsonFactory;
 import org.eclipse.ditto.json.JsonObject;
 import org.eclipse.ditto.json.JsonObjectBuilder;
 import org.eclipse.ditto.json.JsonPointer;
+import org.eclipse.ditto.json.JsonValue;
 import org.eclipse.ditto.policies.api.Permission;
 import org.eclipse.ditto.policies.enforcement.PolicyEnforcer;
 import org.eclipse.ditto.policies.model.Permissions;
@@ -137,11 +139,25 @@ public final class PartialAccessPathCalculator {
 
     /**
      * Calculates accessible paths for a set of subjects with restricted access using a batch call.
+     * <p>
+     * The {@link Enforcer#getAccessiblePathsForSubjects} call returns a per-subject set of
+     * <em>leaf</em> JsonPointers obtained by flattening the Thing JSON. For Things with
+     * high-cardinality features (hundreds of child entries, each potentially with several
+     * properties), that leaf set can reach several thousand entries per subject. Serialized
+     * into the {@code ditto-partial-access-paths} header, the resulting JSON easily exceeds
+     * the Pekko Artery remoting frame size, causing {@code BufferOverflowException} in
+     * {@code PublishSignal} serialization and silently dropping every {@code ThingEvent} for
+     * the affected Thing cluster-wide.
+     * <p>
+     * This method therefore post-processes the enforcer output by collapsing any subtree of
+     * the Thing JSON whose leaves are <em>all</em> accessible to the subject into a single
+     * ancestor pointer. This mirrors Ditto's native policy semantics (a READ grant on an
+     * ancestor implies read on every descendant) and the consumer-side filter
      *
      * @param subjectsWithRestrictedAccess subjects to calculate paths for
      * @param thingJson the Thing JSON representation
      * @param enforcer the Enforcer to use
-     * @return map of subject ID to their accessible paths
+     * @return map of subject ID to their accessible paths (ancestor-collapsed)
      */
     private static Map<String, List<JsonPointer>> calculateAccessiblePathsForSubjects(
             final Set<AuthorizationSubject> subjectsWithRestrictedAccess,
@@ -155,9 +171,90 @@ public final class PartialAccessPathCalculator {
 
         final Map<String, List<JsonPointer>> result = new LinkedHashMap<>();
         for (final Map.Entry<AuthorizationSubject, Set<JsonPointer>> entry : batchResult.entrySet()) {
-            result.put(entry.getKey().getId(), new ArrayList<>(entry.getValue()));
+            final Set<JsonPointer> collapsed = collapseLeavesToAncestors(entry.getValue(), thingJson);
+            result.put(entry.getKey().getId(), new ArrayList<>(collapsed));
         }
         return result;
+    }
+
+    /**
+     * Collapses a flat set of leaf pointers into the minimal set of pointers that still covers
+     * the same accessible fields when the consumer filter is applied.
+     * <p>
+     * The algorithm walks the Thing JSON top-down: at each non-empty object node, if every
+     * descendant leaf of that node is in {@code leaves}, the entire subtree is replaced by a
+     * single entry for the node's path; otherwise recursion continues into the children. Leaves
+     * outside {@code leaves} are naturally omitted.
+     * <p>
+     * Empty-object nodes (e.g. {@code "properties": {}}) are treated as leaves themselves to
+     * match how the enforcer emits them.
+     *
+     * @param leaves the leaf-level accessible pointers returned by the enforcer
+     * @param thingJson the Thing JSON representation to walk
+     * @return the ancestor-collapsed accessible pointer set
+     * @since 3.9.0
+     */
+    static Set<JsonPointer> collapseLeavesToAncestors(final Set<JsonPointer> leaves,
+            final JsonObject thingJson) {
+
+        if (leaves.isEmpty()) {
+            return Set.of();
+        }
+        final Set<JsonPointer> result = new LinkedHashSet<>();
+        final boolean allAccessible = collapseRecursive(thingJson, ROOT_RESOURCE_POINTER, leaves, result);
+        if (allAccessible && result.isEmpty()) {
+            // Every leaf in the Thing is accessible to this subject — emit the root pointer so the
+            // consumer filter short-circuits to "unrestricted". The subject should normally have
+            // been excluded upstream (via SubjectClassification), but a policy that grants the
+            // union of all leaves without granting the root would otherwise be flattened here.
+            result.add(ROOT_RESOURCE_POINTER);
+        }
+        return result;
+    }
+
+    /**
+     * Walks the Thing JSON and emits into {@code result} the minimal pointer set that still
+     * covers every leaf of {@code leaves} when the consumer filter is applied. A fully-accessible
+     * subtree collapses to a single ancestor pointer.
+     *
+     * @return {@code true} iff every leaf descendant of {@code node} at {@code currentPath} is
+     * present in {@code leaves} — signalling to the caller that it may collapse further up.
+     */
+    private static boolean collapseRecursive(final JsonValue node, final JsonPointer currentPath,
+            final Set<JsonPointer> leaves, final Set<JsonPointer> result) {
+
+        if (!node.isObject() || node.isNull()) {
+            if (leaves.contains(currentPath)) {
+                result.add(currentPath);
+                return true;
+            }
+            return false;
+        }
+        final JsonObject obj = node.asObject();
+        if (obj.isEmpty()) {
+            if (leaves.contains(currentPath)) {
+                result.add(currentPath);
+                return true;
+            }
+            return false;
+        }
+
+        final Set<JsonPointer> childEmissions = new LinkedHashSet<>();
+        boolean allChildrenAccessible = true;
+        for (final JsonField field : obj) {
+            final JsonPointer childPath = currentPath.addLeaf(field.getKey());
+            final boolean childAll = collapseRecursive(field.getValue(), childPath, leaves, childEmissions);
+            if (!childAll) {
+                allChildrenAccessible = false;
+            }
+        }
+        if (allChildrenAccessible && !currentPath.isEmpty()) {
+            // Collapse: replace all descendant emissions with a single ancestor pointer.
+            result.add(currentPath);
+            return true;
+        }
+        result.addAll(childEmissions);
+        return allChildrenAccessible;
     }
 
     /**

--- a/things/service/src/test/java/org/eclipse/ditto/things/service/utils/PartialAccessPathCalculatorTest.java
+++ b/things/service/src/test/java/org/eclipse/ditto/things/service/utils/PartialAccessPathCalculatorTest.java
@@ -106,6 +106,118 @@ public final class PartialAccessPathCalculatorTest {
     }
 
     @Test
+    public void collapsesLeavesToAncestorWhenSubtreeFullyAccessible() {
+        final FeatureProperties childA = FeatureProperties.newBuilder()
+                .set("item1", JsonFactory.newObjectBuilder()
+                        .set("x", 1).set("y", 2).set("z", 3).build())
+                .set("item2", JsonFactory.newObjectBuilder()
+                        .set("x", 4).set("y", 5).set("z", 6).build())
+                .set("item3", JsonFactory.newObjectBuilder()
+                        .set("x", 7).set("y", 8).set("z", 9).build())
+                .build();
+        // Sibling feature so the collapse stops at /features/featureA instead of walking up to /features.
+        final FeatureProperties childB = FeatureProperties.newBuilder()
+                .set("other", "value")
+                .build();
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(KNOWN_THING_ID)
+                .setFeature(ThingsModelFactory.newFeature("featureA", null, childA))
+                .setFeature(ThingsModelFactory.newFeature("featureB", null, childB))
+                .build();
+
+        final String partialSubject = "test:partial-featureA";
+        final Policy policy = Policy.newBuilder(KNOWN_POLICY_ID)
+                .setSubjectFor("partial-featureA", Subject.newInstance(
+                        SubjectId.newInstance(partialSubject), SubjectType.GENERATED))
+                .setGrantedPermissionsFor("partial-featureA",
+                        ResourceKey.newInstance("thing", "/features/featureA"), "READ")
+                .build();
+        final PolicyEnforcer enforcer = PolicyEnforcer.of(policy);
+
+        final Map<String, List<JsonPointer>> result =
+                PartialAccessPathCalculator.calculatePartialAccessPaths(thing, enforcer);
+
+        assertThat(result).containsKey(partialSubject);
+        assertThat(result.get(partialSubject))
+                .containsExactly(JsonPointer.of("/features/featureA"));
+    }
+
+    @Test
+    public void collapseLeavesToAncestorsReturnsEmptyForEmptyInput() {
+        final Thing thing = createThingWithAttributesAndFeatures();
+
+        final var result = PartialAccessPathCalculator.collapseLeavesToAncestors(
+                java.util.Set.of(), thing.toJson());
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void collapseMixedSubtreeEmitsAncestorForFullBranchAndLeavesForPartialBranch() {
+        final FeatureProperties fullProps = FeatureProperties.newBuilder()
+                .set("a", 1)
+                .set("b", 2)
+                .build();
+        final FeatureProperties partialProps = FeatureProperties.newBuilder()
+                .set("granted", "yes")
+                .set("denied", "no")
+                .build();
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(KNOWN_THING_ID)
+                .setFeature(ThingsModelFactory.newFeature("full", null, fullProps))
+                .setFeature(ThingsModelFactory.newFeature("partial", null, partialProps))
+                .build();
+
+        final String subject = "test:mixed-subject";
+        final Policy policy = Policy.newBuilder(KNOWN_POLICY_ID)
+                .setSubjectFor("mixed", Subject.newInstance(
+                        SubjectId.newInstance(subject), SubjectType.GENERATED))
+                .setGrantedPermissionsFor("mixed",
+                        ResourceKey.newInstance("thing", "/features/full"), "READ")
+                .setGrantedPermissionsFor("mixed",
+                        ResourceKey.newInstance("thing", "/features/partial/properties/granted"), "READ")
+                .build();
+        final PolicyEnforcer enforcer = PolicyEnforcer.of(policy);
+
+        final Map<String, List<JsonPointer>> result =
+                PartialAccessPathCalculator.calculatePartialAccessPaths(thing, enforcer);
+
+        assertThat(result).containsKey(subject);
+        assertThat(result.get(subject))
+                .containsExactlyInAnyOrder(
+                        JsonPointer.of("/features/full"),
+                        JsonPointer.of("/features/partial/properties/granted"));
+    }
+
+    @Test
+    public void doesNotCollapseWhenSubtreeOnlyPartiallyAccessible() {
+        final FeatureProperties items = FeatureProperties.newBuilder()
+                .set("item1", JsonFactory.newObjectBuilder().set("x", 1).set("y", 2).build())
+                .set("item2", JsonFactory.newObjectBuilder().set("x", 3).set("y", 4).build())
+                .build();
+        final Thing thing = ThingsModelFactory.newThingBuilder()
+                .setId(KNOWN_THING_ID)
+                .setFeature(ThingsModelFactory.newFeature("featureA", null, items))
+                .build();
+
+        final String partialSubject = "test:partial-limited";
+        final Policy policy = Policy.newBuilder(KNOWN_POLICY_ID)
+                .setSubjectFor("partial-limited", Subject.newInstance(
+                        SubjectId.newInstance(partialSubject), SubjectType.GENERATED))
+                .setGrantedPermissionsFor("partial-limited",
+                        ResourceKey.newInstance("thing", "/features/featureA/properties/item1"), "READ")
+                .build();
+        final PolicyEnforcer enforcer = PolicyEnforcer.of(policy);
+
+        final Map<String, List<JsonPointer>> result =
+                PartialAccessPathCalculator.calculatePartialAccessPaths(thing, enforcer);
+
+        assertThat(result).containsKey(partialSubject);
+        assertThat(result.get(partialSubject))
+                .containsExactly(JsonPointer.of("/features/featureA/properties/item1"));
+    }
+
+    @Test
     public void toIndexedJsonObjectReturnsEmptyStructureForEmptyMap() {
         final JsonObject result = PartialAccessPathCalculator.toIndexedJsonObject(Map.of());
 


### PR DESCRIPTION
  ## Problem                                                

 Testing Ditto 3.9.0-M2, we observed ~10 000 `BufferOverflowException` per hour                                                                                                       
  on the things-service logged by `org.apache.pekko.remote.artery.Encoder`:
    
```                                                                                                                                                                         
  Failed to serialize message [org.eclipse.ditto.internal.utils.pubsub.api.PublishSignal]                                                                                    
  Caused by: java.nio.BufferOverflowException                                                                                                                                
    at java.base/java.nio.ByteBuffer.put(ByteBuffer.java:1220)                                                                                                               
    at ...ByteBufferOutputStream.write(...)                                                                                                                                  
    at ...AbstractJsonifiableWithDittoHeadersSerializer.toBinary(...)                                                                                                        
    at ...MessageSerializer$.serializeForArtery(...)                                                                                                                         
 ```
                                                                                                                                                                        
  Each failure silently drops the `ThingEvent` for every cluster subscriber                                                                                                  
  — SSE, WebSocket, connectivity targets, and thingsearch all stop seeing                                                                                                    
  changes for the affected Thing.                                                                                                                                            
                                                                                                                                                                             
  ## Root cause                                                                                                                                                              
                                                            
  `TreeBasedPolicyEnforcer.getAccessiblePathsForSubjects` (added in #2287)                                                                                                   
  flattens the Thing JSON to leaf pointers. For a Thing whose features
  carry a few hundred child entries with several properties each, the                                                                                                        
  per-subject leaf set reaches several thousand entries. Serialised into
  the `ditto-partial-access-paths` internal DittoHeader (indexed JSON                                                                                                        
  format), the header alone exceeds 350 KiB, well over the default Pekko                                                                                                     
  Artery 256 KiB frame.                                                                                                                                                      
                                                                                                                                                                             
  Example measurement (synthetic reproduction): a Thing with 1000 child                                                                                                      
  entries under each of two features, and a partial reader granted the                                                                                                       
  two feature resources:                                                                                                                                                     
                                                                                                                                                                             
  | | Path count | Indexed header bytes |                                                                                                                                    
  |---|---:|---:|                                                                                                                                                            
  | Before fix | 5 011 | 367 564 |                                                                                                                                           
  | After fix  |     2 |      94 |                          
                                                                                                                                                                             
  ## Fix
                                                                                                                                                                             
  Two coordinated changes:                                  

  **1. Producer — `PartialAccessPathCalculator` collapses leaves to ancestor pointers**                                                                                      
   
  After the enforcer returns the per-subject leaf set, walk the Thing JSON                                                                                                   
  top-down; if every leaf of a subtree is in the subject's accessible set,
  replace them with a single ancestor pointer. Mirrors the policy                                                                                                            
  semantics — a READ grant on an ancestor implicitly grants read on every                                                                                                    
  descendant.                                                                                                                                                                
                                                                                                                                                                             
  **2. Consumer — `JsonPartialAccessFilter` honours ancestor grants**
                                                                                                                                                                             
  New `PathTrie.hasAncestorMatch(path)` check. When a field has an                                                                                                           
  accessible ancestor the whole subtree is included, keeping filtering
  semantically identical to pre-collapse leaf enumeration.    