### PR TITLE
Fix fire-and-forget commands returning 503 instead of 202

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
@@ -345,6 +345,11 @@ public abstract class AbstractHttpRequestActor extends AbstractActorWithShutdown
     private void handleFireAndForgetCommand(final Signal<?> command) {
         logger.debug("Received fire-and-forget <{}>. Awaiting enforcement/validation result before accepting ...",
                 command.getType());
+        // Update receivedCommand with AckRequestSetter-modified headers (e.g. response-required: false)
+        // so that handleReceiveTimeout correctly identifies this as fire-and-forget via isResponseRequired()
+        if (command instanceof Command<?> cmd) {
+            receivedCommand = cmd;
+        }
         proxyActor.tell(command, getSelf());
         final Duration enforcementTimeout = gatewayConfig.getCommandConfig().getDefaultTimeout();
         getContext().setReceiveTimeout(enforcementTimeout);

--- a/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorTest.java
+++ b/gateway/service/src/test/java/org/eclipse/ditto/gateway/service/endpoints/actors/HttpRequestActorTest.java
@@ -487,6 +487,31 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
     }
 
     @Test
+    public void fireAndForgetCommandReturnsAcceptedWhenResponseRequiredNotExplicitlySet()
+            throws ExecutionException, InterruptedException {
+
+        final var thingId = ThingId.generateRandom();
+        final var attributePointer = JsonPointer.of("foo");
+
+        // Do NOT set responseRequired(false) — let AckRequestSetter handle it (real HTTP flow)
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .build();
+        final var expectedHeaders = DittoHeaders.newBuilder(dittoHeaders)
+                .responseRequired(false)
+                .acknowledgementRequests(Collections.emptyList())
+                .build();
+
+        testThingModifyCommand(thingId,
+                attributePointer,
+                dittoHeaders,
+                expectedHeaders,
+                ModifyAttributeResponse.modified(thingId, attributePointer, expectedHeaders),
+                StatusCodes.ACCEPTED,
+                null);
+    }
+
+    @Test
     public void fireAndForgetMessageCommandSurfacesEnforcementError()
             throws ExecutionException, InterruptedException {
 
@@ -538,6 +563,39 @@ public final class HttpRequestActorTest extends AbstractHttpRequestActorTest {
 
         final var expectedHeaders =
                 DittoHeaders.newBuilder(dittoHeaders).acknowledgementRequests(Collections.emptyList()).build();
+
+        final var probeResponse = buildSendThingMessageResponse(thingId, messageSubject, expectedHeaders,
+                "application/json", JsonValue.of("pong"));
+
+        testMessageCommand(thingId,
+                messageSubject,
+                dittoHeaders,
+                expectedHeaders,
+                probeResponse,
+                StatusCodes.ACCEPTED,
+                null,
+                null);
+    }
+
+    @Test
+    public void fireAndForgetMessageCommandReturnsAcceptedWhenResponseRequiredNotExplicitlySet()
+            throws ExecutionException, InterruptedException {
+
+        // Simulates the real HTTP flow where timeout=0 is set but response-required is NOT explicitly
+        // set in the headers. The AckRequestSetter will set response-required=false during processing.
+        // This verifies that the HttpRequestActor correctly uses the AckRequestSetter-modified headers.
+        final var thingId = ThingId.generateRandom();
+        final var messageSubject = "doSomething";
+
+        final var dittoHeaders = DittoHeaders.newBuilder(createAuthorizedHeaders())
+                .timeout(Duration.ZERO)
+                .channel("live")
+                .build();
+
+        final var expectedHeaders = DittoHeaders.newBuilder(dittoHeaders)
+                .responseRequired(false)
+                .acknowledgementRequests(Collections.emptyList())
+                .build();
 
         final var probeResponse = buildSendThingMessageResponse(thingId, messageSubject, expectedHeaders,
                 "application/json", JsonValue.of("pong"));


### PR DESCRIPTION
The handleFireAndForgetCommand method received the AckRequestSetter-modified signal (with response-required: false), but receivedCommand still held the original command where response-required defaults to true. When the receive timeout fired, isResponseRequired() checked receivedCommand and returned true, hitting the error branch instead of returning HTTP 202 Accepted.

Fix: update receivedCommand with the modified signal in handleFireAndForgetCommand so that isResponseRequired() correctly identifies fire-and-forget commands.

Add regression tests that mirror the real HTTP flow (timeout=0 without explicitly setting response-required: false) for both ThingModifyCommand and MessageCommand.