### PR TITLE
Fix fire-and-forget commands delayed by full request timeout

### DIFF
--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/endpoints/actors/AbstractHttpRequestActor.java
@@ -351,7 +351,7 @@ public abstract class AbstractHttpRequestActor extends AbstractActorWithShutdown
             receivedCommand = cmd;
         }
         proxyActor.tell(command, getSelf());
-        final Duration enforcementTimeout = gatewayConfig.getCommandConfig().getDefaultTimeout();
+        final Duration enforcementTimeout = gatewayConfig.getCommandConfig().getFireAndForgetEnforcementTimeout();
         getContext().setReceiveTimeout(enforcementTimeout);
         // Clear timeoutExceptionSupplier so that handleReceiveTimeout returns 202 instead of a timeout error
         timeoutExceptionSupplier = null;

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/CommandConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/CommandConfig.java
@@ -47,6 +47,17 @@ public interface CommandConfig {
     Duration getSmartChannelBuffer();
 
     /**
+     * Returns the timeout used for fire-and-forget commands to wait for enforcement/validation errors before
+     * returning HTTP 202 Accepted. This should be short since enforcement typically completes within milliseconds.
+     * For fire-and-forget commands (timeout=0), the things-service does not send a response on success, so the
+     * gateway waits this duration for potential errors and then optimistically accepts the command.
+     *
+     * @return the fire-and-forget enforcement timeout.
+     * @since 3.9.0
+     */
+    Duration getFireAndForgetEnforcementTimeout();
+
+    /**
      * Return the limit of how many connections can be retrieved.
      * If not limited the response may become few MB in size.
      *
@@ -75,6 +86,11 @@ public interface CommandConfig {
          * thing persistence.
          */
         SMART_CHANNEL_BUFFER("smart-channel-buffer", "10s"),
+
+        /**
+         * The timeout for fire-and-forget enforcement/validation checks.
+         */
+        FIRE_AND_FORGET_ENFORCEMENT_TIMEOUT("fire-and-forget-enforcement-timeout", "3s"),
 
         /**
          * The limit of how many connections can be retrieved.

--- a/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultCommandConfig.java
+++ b/gateway/service/src/main/java/org/eclipse/ditto/gateway/service/util/config/endpoints/DefaultCommandConfig.java
@@ -35,6 +35,7 @@ public final class DefaultCommandConfig implements CommandConfig {
     private final Duration defaultTimeout;
     private final Duration maxTimeout;
     private final Duration smartChannelBuffer;
+    private final Duration fireAndForgetEnforcementTimeout;
     private final int connectionsRetrieveLimit;
 
     private DefaultCommandConfig(final ScopedConfig scopedConfig) {
@@ -42,6 +43,8 @@ public final class DefaultCommandConfig implements CommandConfig {
         maxTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(CommandConfigValue.MAX_TIMEOUT);
         smartChannelBuffer =
                 scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(CommandConfigValue.SMART_CHANNEL_BUFFER);
+        fireAndForgetEnforcementTimeout = scopedConfig.getNonNegativeAndNonZeroDurationOrThrow(
+                CommandConfigValue.FIRE_AND_FORGET_ENFORCEMENT_TIMEOUT);
         connectionsRetrieveLimit = scopedConfig.getNonNegativeIntOrThrow(CommandConfigValue.CONNECTIONS_RETRIEVE_LIMIT);
     }
 
@@ -73,6 +76,11 @@ public final class DefaultCommandConfig implements CommandConfig {
     }
 
     @Override
+    public Duration getFireAndForgetEnforcementTimeout() {
+        return fireAndForgetEnforcementTimeout;
+    }
+
+    @Override
     public int connectionsRetrieveLimit() {
         return connectionsRetrieveLimit;
     }
@@ -89,12 +97,14 @@ public final class DefaultCommandConfig implements CommandConfig {
         return Objects.equals(defaultTimeout, that.defaultTimeout) &&
                 Objects.equals(maxTimeout, that.maxTimeout) &&
                 Objects.equals(smartChannelBuffer, that.smartChannelBuffer) &&
+                Objects.equals(fireAndForgetEnforcementTimeout, that.fireAndForgetEnforcementTimeout) &&
                 Objects.equals(connectionsRetrieveLimit, that.connectionsRetrieveLimit);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(defaultTimeout, maxTimeout, smartChannelBuffer, connectionsRetrieveLimit);
+        return Objects.hash(defaultTimeout, maxTimeout, smartChannelBuffer, fireAndForgetEnforcementTimeout,
+                connectionsRetrieveLimit);
     }
 
     @Override
@@ -103,6 +113,7 @@ public final class DefaultCommandConfig implements CommandConfig {
                 "defaultTimeout=" + defaultTimeout +
                 ", maxTimeout=" + maxTimeout +
                 ", smartChannelBuffer=" + smartChannelBuffer +
+                ", fireAndForgetEnforcementTimeout=" + fireAndForgetEnforcementTimeout +
                 ", connectionsRetrieveLimit=" + connectionsRetrieveLimit +
                 "]";
     }

--- a/gateway/service/src/main/resources/gateway.conf
+++ b/gateway/service/src/main/resources/gateway.conf
@@ -214,6 +214,8 @@ ditto {
       default-timeout = ${ditto.gateway.http.request-timeout}
       max-timeout = 1m
       smart-channel-buffer = 10s
+      fire-and-forget-enforcement-timeout = 3s
+      fire-and-forget-enforcement-timeout = ${?FIRE_AND_FORGET_ENFORCEMENT_TIMEOUT}
       connections-retrieve-limit = 100
     }
 

--- a/gateway/service/src/test/resources/command-test.conf
+++ b/gateway/service/src/test/resources/command-test.conf
@@ -2,5 +2,6 @@ command {
   default-timeout = 33s
   max-timeout = 55s
   smart-channel-buffer = 66s
+  fire-and-forget-enforcement-timeout = 3s
   connections-retrieve-limit = 77
 }


### PR DESCRIPTION
The fire-and-forget enforcement change (PR #2396) waits for enforcement errors before returning HTTP 202. However, it used the full command default timeout (= request-timeout = 60s) as the wait duration. Since things-service does not send a response for fire-and-forget commands on success, the gateway waited the full 60s before responding.

Add a dedicated `fire-and-forget-enforcement-timeout` config option (default: 5s) and use it instead. Enforcement errors arrive within milliseconds, so 5s is sufficient to catch them without delaying successful fire-and-forget responses.