### PR TITLE
Fix Fluency thread leak in connection logger publisher

### DIFF
--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseClientActor.java
@@ -275,7 +275,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
         protocolAdapter = protocolAdapterProvider.getProtocolAdapter(null);
         final var monitoringConfig = connectivityConfig().getMonitoringConfig();
         connectionCounterRegistry = ConnectivityCounterRegistry.newInstance(connectivityConfig);
-        connectionLoggerRegistry = ConnectionLoggerRegistry.fromConfig(monitoringConfig.logger());
+        connectionLoggerRegistry = ConnectionLoggerRegistry.fromConfig(monitoringConfig.logger(), system);
         connectionLoggerRegistry.initForConnection(connection);
         connectionLogger = connectionLoggerRegistry.forConnection(connection.getId());
         connectionCounterRegistry.initForConnection(connection);
@@ -1956,6 +1956,7 @@ public abstract class BaseClientActor extends AbstractFSMWithStash<BaseClientSta
                 outboundMappingProcessorActor,
                 getSelf(),
                 getContext(),
+                getContext().getSystem(),
                 connectivityConfig,
                 dittoHeadersValidator,
                 getResponseValidationFailureConsumer());

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BaseConsumerActor.java
@@ -96,7 +96,7 @@ public abstract class BaseConsumerActor extends AbstractActorWithTimers {
 
         acknowledgementConfig = connectivityConfig.getAcknowledgementConfig();
 
-        final var connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig);
+        final var connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig, getContext().getSystem());
         inboundMonitor = connectionMonitorRegistry.forInboundConsumed(connection, sourceAddress);
         inboundAcknowledgedMonitor = connectionMonitorRegistry.forInboundAcknowledged(connection, sourceAddress);
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BasePublisherActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/BasePublisherActor.java
@@ -130,9 +130,9 @@ public abstract class BasePublisherActor<T extends PublishTarget> extends Abstra
         connectionConfig = connectivityConfig.getConnectionConfig();
         final MonitoringConfig monitoringConfig = connectivityConfig.getMonitoringConfig();
         final MonitoringLoggerConfig loggerConfig = monitoringConfig.logger();
-        connectionLogger = ConnectionLogger.getInstance(connection.getId(), loggerConfig);
+        connectionLogger = ConnectionLogger.getInstance(connection.getId(), loggerConfig, getContext().getSystem());
         this.connectivityStatusResolver = checkNotNull(connectivityStatusResolver, "connectivityStatusResolver");
-        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig);
+        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig, getContext().getSystem());
         responseDroppedMonitor = connectionMonitorRegistry.forResponseDropped(connection);
         responsePublishedMonitor = connectionMonitorRegistry.forResponsePublished(connection);
         responseAcknowledgedMonitor = connectionMonitorRegistry.forResponseAcknowledged(connection);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundDispatchingSink.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/InboundDispatchingSink.java
@@ -106,6 +106,7 @@ import org.eclipse.ditto.thingsearch.model.signals.commands.subscription.CreateS
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorRef;
 import org.apache.pekko.actor.ActorRefFactory;
+import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ActorSelection;
 import org.apache.pekko.japi.pf.PFBuilder;
 import org.apache.pekko.pattern.Patterns;
@@ -156,6 +157,7 @@ public final class InboundDispatchingSink
             final ActorRef clientActor,
             final ConnectivityConfig connectivityConfig,
             final ActorRefFactory actorRefFactory,
+            final ActorSystem actorSystem,
             final DittoHeadersValidator dittoHeadersValidator,
             @Nullable final Consumer<MatchingValidationResult.Failure> responseValidationFailureConsumer) {
 
@@ -177,7 +179,7 @@ public final class InboundDispatchingSink
                 ConnectivityPlaceholders.newConnectionIdPlaceholder(),
                 connection.getId());
 
-        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig);
+        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig, actorSystem);
         responseMappedMonitor = connectionMonitorRegistry.forResponseMapped(connection);
         toErrorResponseFunction = DittoRuntimeExceptionToErrorResponseFunction.of(dittoHeadersValidator);
         acknowledgementConfig = connectivityConfig.getConnectionConfig().getAcknowledgementConfig();
@@ -207,6 +209,7 @@ public final class InboundDispatchingSink
      * @param outboundMessageMappingProcessorActor used to publish errors.
      * @param clientActor the client actor ref to forward commands to.
      * @param actorRefFactory the ActorRefFactory to use in order to create new actors in.
+     * @param actorSystem the ActorSystem to use for looking up extensions.
      * @param connectivityConfig the connectivity configuration including potential overwrites.
      * @param responseValidationFailureConsumer optional handler for response validation failures.
      * @return the Sink.
@@ -219,6 +222,7 @@ public final class InboundDispatchingSink
             final ActorRef outboundMessageMappingProcessorActor,
             final ActorRef clientActor,
             final ActorRefFactory actorRefFactory,
+            final ActorSystem actorSystem,
             final ConnectivityConfig connectivityConfig,
             final DittoHeadersValidator dittoHeadersValidator,
             @Nullable final Consumer<MatchingValidationResult.Failure> responseValidationFailureConsumer) {
@@ -232,6 +236,7 @@ public final class InboundDispatchingSink
                 clientActor,
                 connectivityConfig,
                 actorRefFactory,
+                actorSystem,
                 dittoHeadersValidator,
                 responseValidationFailureConsumer
         );

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingProcessorActor.java
@@ -185,7 +185,7 @@ public final class OutboundMappingProcessorActor
 
 
         final var dittoExtensionConfig = ScopedConfig.dittoExtension(system.settings().config());
-        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig);
+        connectionMonitorRegistry = DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig, system);
         responseDispatchedMonitor = connectionMonitorRegistry.forResponseDispatched(this.connection);
         responseDroppedMonitor = connectionMonitorRegistry.forResponseDropped(this.connection);
         responseMappedMonitor = connectionMonitorRegistry.forResponseMapped(this.connection);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingSettings.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/OutboundMappingSettings.java
@@ -109,7 +109,7 @@ final class OutboundMappingSettings {
                 messageMapperFactory.registryOf(DittoMessageMapper.CONTEXT, mappingDefinition);
 
         final ConnectionMonitorRegistry<ConnectionMonitor> connectionMonitorRegistry =
-                DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig);
+                DefaultConnectionMonitorRegistry.fromConfig(connectivityConfig, actorSystem);
         final SignalFilter signalFilter = SignalFilter.of(connection, connectionMonitorRegistry);
 
         final AcknowledgementConfig acknowledgementConfig = connectivityConfig.getAcknowledgementConfig();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/DefaultConnectionMonitorRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/DefaultConnectionMonitorRegistry.java
@@ -28,6 +28,8 @@ import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.logs.ConnectionLoggerRegistry;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.metrics.ConnectivityCounterRegistry;
 
+import org.apache.pekko.actor.ActorSystem;
+
 /**
  * Default implementation of {@link ConnectionMonitorRegistry}.
  */
@@ -45,15 +47,19 @@ public final class DefaultConnectionMonitorRegistry implements ConnectionMonitor
     /**
      * Builds a new {@code DefaultConnectionMonitorRegistry} from a configuration.
      *
-     * @param connectivityConfig the configuration to  use.
+     * @param connectivityConfig the configuration to use.
+     * @param actorSystem the actor system used to look up the Fluency provider extension.
      * @return a new instance of {@code DefaultConnectionMonitorRegistry}.
-     * @throws java.lang.NullPointerException if {@code connectivityConfig} is null.
+     * @throws java.lang.NullPointerException if any argument is {@code null}.
      */
-    public static DefaultConnectionMonitorRegistry fromConfig(final ConnectivityConfig connectivityConfig) {
+    public static DefaultConnectionMonitorRegistry fromConfig(final ConnectivityConfig connectivityConfig,
+            final ActorSystem actorSystem) {
+
         checkNotNull(connectivityConfig);
+        checkNotNull(actorSystem);
 
         final ConnectionLoggerRegistry loggerRegistry =
-                ConnectionLoggerRegistry.fromConfig(connectivityConfig.getMonitoringConfig().logger());
+                ConnectionLoggerRegistry.fromConfig(connectivityConfig.getMonitoringConfig().logger(), actorSystem);
         final ConnectivityCounterRegistry counterRegistry = ConnectivityCounterRegistry.newInstance(connectivityConfig);
 
         return new DefaultConnectionMonitorRegistry(loggerRegistry, counterRegistry);

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLogger.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLogger.java
@@ -24,6 +24,8 @@ import org.eclipse.ditto.connectivity.model.LogEntry;
 import org.eclipse.ditto.connectivity.service.config.MonitoringLoggerConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
 
+import org.apache.pekko.actor.ActorSystem;
+
 /**
  * Logger for connections that provides log messages for end users.
  */
@@ -34,10 +36,13 @@ public interface ConnectionLogger extends Closeable {
      *
      * @param connectionId the ID of the connection.
      * @param config the logger config.
+     * @param actorSystem the actor system used to look up the {@link FluencyProvider} extension.
      * @return the logger.
      */
-    static ConnectionLogger getInstance(final ConnectionId connectionId, final MonitoringLoggerConfig config) {
-        final ConnectionLoggerRegistry connectionLoggerRegistry = ConnectionLoggerRegistry.fromConfig(config);
+    static ConnectionLogger getInstance(final ConnectionId connectionId, final MonitoringLoggerConfig config,
+            final ActorSystem actorSystem) {
+        final ConnectionLoggerRegistry connectionLoggerRegistry =
+                ConnectionLoggerRegistry.fromConfig(config, actorSystem);
         return connectionLoggerRegistry.forConnection(connectionId);
     }
 

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistry.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistry.java
@@ -44,14 +44,12 @@ import org.eclipse.ditto.connectivity.model.LogEntry;
 import org.eclipse.ditto.connectivity.model.LogType;
 import org.eclipse.ditto.connectivity.model.Source;
 import org.eclipse.ditto.connectivity.model.Target;
-import org.eclipse.ditto.connectivity.service.config.FluencyLoggerPublisherConfig;
-import org.eclipse.ditto.connectivity.service.config.LoggerPublisherConfig;
 import org.eclipse.ditto.connectivity.service.config.MonitoringLoggerConfig;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitorRegistry;
 import org.eclipse.ditto.connectivity.service.util.ConnectivityMdcEntryKey;
 import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
 import org.eclipse.ditto.internal.utils.pekko.logging.ThreadSafeDittoLogger;
-import org.komamitsu.fluency.Fluency;
+import org.apache.pekko.actor.ActorSystem;
 import org.slf4j.Logger;
 
 /**
@@ -82,38 +80,44 @@ public final class ConnectionLoggerRegistry implements ConnectionMonitorRegistry
             final int failureCapacity,
             final long maximumLogSizeInByte,
             final Duration loggingDuration,
-            final LoggerPublisherConfig loggerPublisherConfig) {
+            @Nullable final FluentPublishingConnectionLoggerContext fluentPublishingConnectionLoggerContext) {
 
         this.successCapacity = successCapacity;
         this.failureCapacity = failureCapacity;
         this.maximumLogSizeInByte = maximumLogSizeInByte;
         this.loggingDuration = checkNotNull(loggingDuration);
-
-        if (loggerPublisherConfig.isEnabled()) {
-            final FluencyLoggerPublisherConfig fluencyConfig = loggerPublisherConfig.getFluencyLoggerPublisherConfig();
-            final Fluency fluency = fluencyConfig.buildFluencyLoggerPublisher();
-            fluentPublishingConnectionLoggerContext = ConnectionLoggerFactory.newPublishingLoggerContext(fluency,
-                    fluencyConfig.getWaitUntilAllBufferFlushedDurationOnClose(),
-                    loggerPublisherConfig.getLogLevels(),
-                    loggerPublisherConfig.isLogHeadersAndPayload(),
-                    loggerPublisherConfig.getLogTag().orElse(null),
-                    loggerPublisherConfig.getAdditionalLogContext()
-            );
-        } else {
-            fluentPublishingConnectionLoggerContext = null;
-        }
+        this.fluentPublishingConnectionLoggerContext = fluentPublishingConnectionLoggerContext;
     }
 
     /**
      * Build a new {@code ConnectionLoggerRegistry} from configuration.
+     * The Fluency forwarder context is obtained from {@link FluencyProvider} which manages the singleton
+     * Fluency instance and its lifecycle via {@link org.apache.pekko.actor.CoordinatedShutdown}.
      *
      * @param config the configuration to use.
+     * @param actorSystem the actor system used to look up the {@link FluencyProvider} extension.
      * @return a new instance of {@code ConnectionLoggerRegistry}.
      */
-    public static ConnectionLoggerRegistry fromConfig(final MonitoringLoggerConfig config) {
+    public static ConnectionLoggerRegistry fromConfig(final MonitoringLoggerConfig config,
+            final ActorSystem actorSystem) {
+
+        checkNotNull(config);
+        checkNotNull(actorSystem);
+        final FluentPublishingConnectionLoggerContext context =
+                FluencyProvider.get(actorSystem).getContext().orElse(null);
+        return new ConnectionLoggerRegistry(config.successCapacity(), config.failureCapacity(),
+                config.maxLogSizeInBytes(), config.logDuration(), context);
+    }
+
+    static ConnectionLoggerRegistry fromConfig(final MonitoringLoggerConfig config) {
         checkNotNull(config);
         return new ConnectionLoggerRegistry(config.successCapacity(), config.failureCapacity(),
-                config.maxLogSizeInBytes(), config.logDuration(), config.getLoggerPublisherConfig());
+                config.maxLogSizeInBytes(), config.logDuration(), null);
+    }
+
+    static void resetForTests() {
+        LOGGERS.clear();
+        METADATA.clear();
     }
 
     /**

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluencyProvider.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluencyProvider.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.ditto.connectivity.service.messaging.monitoring.logs;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+import javax.annotation.Nullable;
+
+import org.eclipse.ditto.connectivity.service.config.ConnectivityConfig;
+import org.eclipse.ditto.connectivity.service.config.FluencyLoggerPublisherConfig;
+import org.eclipse.ditto.connectivity.service.config.LoggerPublisherConfig;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLogger;
+import org.eclipse.ditto.internal.utils.pekko.logging.DittoLoggerFactory;
+
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.AbstractExtensionId;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.CoordinatedShutdown;
+import org.apache.pekko.actor.ExtendedActorSystem;
+import org.apache.pekko.actor.Extension;
+import org.komamitsu.fluency.Fluency;
+
+/**
+ * Pekko Extension that provides a shared {@link Fluency} instance for publishing connection logs to Fluentd/FluentBit.
+ * <p>
+ * The Fluency client is designed to have one instance per application. This extension ensures exactly one instance
+ * per ActorSystem and registers a {@link CoordinatedShutdown} task to flush and close the forwarder on graceful
+ * shutdown.
+ *
+ * @see org.eclipse.ditto.connectivity.service.messaging.tunnel.SshClientProvider
+ */
+final class FluencyProvider implements Extension {
+
+    private static final DittoLogger LOGGER = DittoLoggerFactory.getLogger(FluencyProvider.class);
+
+    @Nullable private final Fluency fluency;
+    @Nullable private final FluentPublishingConnectionLoggerContext context;
+
+    private FluencyProvider(final ActorSystem actorSystem) {
+        final ConnectivityConfig connectivityConfig =
+                ConnectivityConfig.of(actorSystem.settings().config());
+        final LoggerPublisherConfig publisherConfig =
+                connectivityConfig.getMonitoringConfig().logger().getLoggerPublisherConfig();
+
+        if (publisherConfig.isEnabled()) {
+            final FluencyLoggerPublisherConfig fluencyConfig = publisherConfig.getFluencyLoggerPublisherConfig();
+            fluency = fluencyConfig.buildFluencyLoggerPublisher();
+            context = ConnectionLoggerFactory.newPublishingLoggerContext(fluency,
+                    fluencyConfig.getWaitUntilAllBufferFlushedDurationOnClose(),
+                    publisherConfig.getLogLevels(),
+                    publisherConfig.isLogHeadersAndPayload(),
+                    publisherConfig.getLogTag().orElse(null),
+                    publisherConfig.getAdditionalLogContext()
+            );
+
+            LOGGER.info("Fluency connection log publisher enabled.");
+
+            CoordinatedShutdown.get(actorSystem)
+                    .addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate(),
+                            "close_fluency_forwarder",
+                            () -> {
+                                LOGGER.info("Flushing and closing Fluency forwarder before shutdown.");
+                                try {
+                                    fluency.waitUntilAllBufferFlushed(
+                                            (int) fluencyConfig
+                                                    .getWaitUntilAllBufferFlushedDurationOnClose()
+                                                    .getSeconds());
+                                } catch (final InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                } catch (final Exception e) {
+                                    LOGGER.warn("Error flushing Fluency forwarder: <{}>: {}",
+                                            e.getClass().getSimpleName(), e.getMessage());
+                                }
+                                try {
+                                    fluency.close();
+                                } catch (final Exception e) {
+                                    LOGGER.warn("Error closing Fluency forwarder: <{}>: {}",
+                                            e.getClass().getSimpleName(), e.getMessage());
+                                }
+                                return CompletableFuture.completedFuture(Done.getInstance());
+                            });
+        } else {
+            fluency = null;
+            context = null;
+            LOGGER.info("Fluency connection log publisher is disabled.");
+        }
+    }
+
+    /**
+     * @return the {@link FluentPublishingConnectionLoggerContext} if the publisher is enabled, empty otherwise.
+     */
+    Optional<FluentPublishingConnectionLoggerContext> getContext() {
+        return Optional.ofNullable(context);
+    }
+
+    /**
+     * Load the {@code FluencyProvider} extension.
+     *
+     * @param actorSystem the actor system in which to load the provider.
+     * @return the {@link FluencyProvider}.
+     */
+    static FluencyProvider get(final ActorSystem actorSystem) {
+        return ExtensionId.INSTANCE.get(actorSystem);
+    }
+
+    private static final class ExtensionId extends AbstractExtensionId<FluencyProvider> {
+
+        private static final ExtensionId INSTANCE = new ExtensionId();
+
+        @Override
+        public FluencyProvider createExtension(final ExtendedActorSystem system) {
+            return new FluencyProvider(system);
+        }
+    }
+
+}

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLogger.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLogger.java
@@ -114,21 +114,8 @@ final class FluentPublishingConnectionLogger
     }
 
     @Override
-    public void close() throws IOException {
-        LOGGER.info("Flushing and closing Fluency forwarder, waiting <{}> for buffers being flushed...",
-                waitUntilAllBufferFlushedDurationOnClose);
-
-        // fluencyForwarder.close also flushes:
-        fluencyForwarder.close();
-
-        if (!waitUntilAllBufferFlushedDurationOnClose.isZero() &&
-                !waitUntilAllBufferFlushedDurationOnClose.isNegative()) {
-            try {
-                fluencyForwarder.waitUntilAllBufferFlushed((int) waitUntilAllBufferFlushedDurationOnClose.getSeconds());
-            } catch (final InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
-        }
+    public void close() {
+        // no-op: the shared Fluency forwarder is owned by FluencyProvider
     }
 
     @Override

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/persistence/ConnectionPersistenceActor.java
@@ -224,7 +224,7 @@ public final class ConnectionPersistenceActor
                 .newProvider(self(), log);
         clientActorAskTimeout = connectionConfig.getClientActorAskTimeout();
         final MonitoringConfig monitoringConfig = connectivityConfig.getMonitoringConfig();
-        connectionLoggerRegistry = ConnectionLoggerRegistry.fromConfig(monitoringConfig.logger());
+        connectionLoggerRegistry = ConnectionLoggerRegistry.fromConfig(monitoringConfig.logger(), actorSystem);
         connectionLogger = connectionLoggerRegistry.forConnection(connectionId);
 
         loggingEnabledDuration = monitoringConfig.logger().logDuration();

--- a/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
+++ b/connectivity/service/src/main/java/org/eclipse/ditto/connectivity/service/messaging/validation/ConnectionValidator.java
@@ -195,7 +195,7 @@ public final class ConnectionValidator {
 
         // validate configured certificate
         final ConnectionLogger connectionLogger = ConnectionLogger.getInstance(connection.getId(),
-                connectivityConfig.getMonitoringConfig().logger());
+                connectivityConfig.getMonitoringConfig().logger(), actorSystem);
         validateFormatOfCertificates(connection, dittoHeaders, connectionLogger);
         final ConnectionType connectionType = connection.getConnectionType();
         // validate configured host

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractConsumerActorTest.java
@@ -274,6 +274,7 @@ public abstract class AbstractConsumerActorTest<M> {
                 outboundProcessorActor,
                 TestProbe.apply(actorSystem).ref(),
                 actorSystem,
+                actorSystem,
                 ConnectivityConfig.of(config),
                 DittoHeadersValidator.get(actorSystem, ScopedConfig.dittoExtension(config)),
                 null);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractMessageMappingProcessorActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/AbstractMessageMappingProcessorActorTest.java
@@ -372,6 +372,7 @@ public abstract class AbstractMessageMappingProcessorActorTest {
                 outboundMappingProcessorActor,
                 testKit.getRef(),
                 actorSystem,
+                actorSystem,
                 ConnectivityConfig.of(config),
                 DittoHeadersValidator.get(actorSystem, ScopedConfig.dittoExtension(config)),
                 null);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/amqp/AmqpConsumerActorTest.java
@@ -384,6 +384,7 @@ public final class AmqpConsumerActorTest extends AbstractConsumerActorWithAcknow
                 testRef,
                 TestProbe.apply(actorSystem).ref(),
                 actorSystem,
+                actorSystem,
                 ConnectivityConfig.of(config),
                 DittoHeadersValidator.get(actorSystem, ScopedConfig.dittoExtension(config)),
                 null);

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/DefaultConnectionMonitorRegistryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/DefaultConnectionMonitorRegistryTest.java
@@ -16,9 +16,15 @@ package org.eclipse.ditto.connectivity.service.messaging.monitoring;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.fluentd.FluencyBuilderForFluentd;
+
+import org.apache.pekko.actor.ActorSystem;
+
+import com.typesafe.config.ConfigFactory;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -27,9 +33,23 @@ import nl.jqno.equalsverifier.EqualsVerifier;
  */
 public class DefaultConnectionMonitorRegistryTest {
 
+    private static ActorSystem actorSystem;
+
+    @BeforeClass
+    public static void setUp() {
+        actorSystem = ActorSystem.create("test", ConfigFactory.load("test"));
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        if (actorSystem != null) {
+            actorSystem.terminate();
+        }
+    }
+
     @Test
     public void fromConfig() {
-        assertThat(DefaultConnectionMonitorRegistry.fromConfig(TestConstants.CONNECTIVITY_CONFIG))
+        assertThat(DefaultConnectionMonitorRegistry.fromConfig(TestConstants.CONNECTIVITY_CONFIG, actorSystem))
                 .isNotNull();
     }
 

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistryTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/ConnectionLoggerRegistryTest.java
@@ -47,6 +47,7 @@ import org.eclipse.ditto.connectivity.service.config.DefaultMonitoringLoggerConf
 import org.eclipse.ditto.connectivity.service.config.MonitoringLoggerConfig;
 import org.eclipse.ditto.connectivity.service.messaging.TestConstants;
 import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
+import org.junit.After;
 import org.junit.Test;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.fluentd.FluencyBuilderForFluentd;
@@ -66,6 +67,11 @@ public final class ConnectionLoggerRegistryTest {
     private final Duration moreThanLoggingDuration =
             TestConstants.MONITORING_CONFIG.logger().logDuration()
                     .plusMinutes(1);
+
+    @After
+    public void tearDown() {
+        ConnectionLoggerRegistry.resetForTests();
+    }
 
     @Test
     public void addsLoggerToRegistryOnRetrieve() {
@@ -405,7 +411,9 @@ public final class ConnectionLoggerRegistryTest {
         final Fluency red = new FluencyBuilderForFluentd().build();
         final Fluency black = new FluencyBuilderForFluentd().build("localhost", 9999);
 
-        forClass(ConnectionLoggerRegistry.class).withPrefabValues(Fluency.class, red, black).verify();
+        forClass(ConnectionLoggerRegistry.class)
+                .withPrefabValues(Fluency.class, red, black)
+                .verify();
     }
 
     private ConnectionId connectionId() {

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLoggerTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/monitoring/logs/FluentPublishingConnectionLoggerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.ditto.connectivity.service.messaging.monitoring.logs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import org.eclipse.ditto.connectivity.model.ConnectionId;
+import org.eclipse.ditto.connectivity.model.LogCategory;
+import org.eclipse.ditto.connectivity.model.LogLevel;
+import org.eclipse.ditto.connectivity.model.LogType;
+import org.eclipse.ditto.connectivity.service.messaging.monitoring.ConnectionMonitor;
+import org.junit.Test;
+import org.komamitsu.fluency.Fluency;
+
+/**
+ * Unit test for {@link FluentPublishingConnectionLogger}.
+ */
+public final class FluentPublishingConnectionLoggerTest {
+
+    @Test
+    public void closeDoesNotCloseSharedFluencyForwarder() throws IOException {
+        final Fluency fluency = mock(Fluency.class);
+        final FluentPublishingConnectionLogger underTest = buildLogger(fluency);
+
+        underTest.close();
+
+        verifyNoInteractions(fluency);
+    }
+
+    @Test
+    public void loggerStillEmitsAfterCloseIsCalledOnSibling() throws IOException {
+        final Fluency fluency = mock(Fluency.class);
+
+        // Simulate two loggers sharing the same Fluency (as in production)
+        final FluentPublishingConnectionLogger loggerA = buildLogger(fluency);
+        final FluentPublishingConnectionLogger loggerB = buildLogger(fluency);
+
+        // Close logger A (e.g., connection invalidated)
+        loggerA.close();
+
+        // Logger B should still be able to emit
+        final ConnectionMonitor.InfoProvider info = mock(ConnectionMonitor.InfoProvider.class);
+        when(info.getCorrelationId()).thenReturn("test-correlation");
+        when(info.getTimestamp()).thenReturn(Instant.now());
+
+        loggerB.success(info, "test message after sibling close");
+
+        verify(fluency).emit(anyString(), any(), anyMap());
+    }
+
+    private static FluentPublishingConnectionLogger buildLogger(final Fluency fluency) {
+        return FluentPublishingConnectionLogger
+                .newBuilder(ConnectionId.of("test-connection"), LogCategory.CONNECTION, LogType.OTHER,
+                        fluency, Duration.ofSeconds(5))
+                .withLogLevels(List.of(LogLevel.SUCCESS, LogLevel.FAILURE))
+                .build();
+    }
+}

--- a/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttConsumerActorTest.java
+++ b/connectivity/service/src/test/java/org/eclipse/ditto/connectivity/service/messaging/mqtt/hivemq/consuming/MqttConsumerActorTest.java
@@ -64,6 +64,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import com.hivemq.client.mqtt.datatypes.MqttQos;
 import com.hivemq.client.mqtt.datatypes.MqttTopic;
 import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import com.typesafe.config.ConfigFactory;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorRef;
@@ -81,7 +82,8 @@ public final class MqttConsumerActorTest {
             DittoTracingInitResource.disableDittoTracing();
 
     @ClassRule
-    public static final ActorSystemResource ACTOR_SYSTEM_RESOURCE = ActorSystemResource.newInstance();
+    public static final ActorSystemResource ACTOR_SYSTEM_RESOURCE =
+            ActorSystemResource.newInstance(ConfigFactory.load("test"));
 
     private static final ConnectionId CONNECTION_ID = ConnectionId.generateRandom();
     private static final Set<String> SOURCE_ADDRESSES = Set.of("source/telemetry", "source/status");


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                      
                                                                                                                                                                                                                                  
  Enabling the Fluency-based connection log publisher                                                                                                                                                                             
  (`CONNECTIVITY_LOGGER_PUBLISHER_ENABLED=true`) causes an unbounded thread leak in the connectivity service. On our dev cluster with 37 connections,
  ~2,100 orphaned `Flusher.runLoop` threads accumulated within 17 hours,  with pool IDs climbing past 24,000.                       
                                                                                                                                                                                                                                  
  Two root causes:                                                                                                                                                                                                                
                                                                                                                                                                                                                                  
  1. **Orphaned Fluency instances.** `ConnectionLogger.getInstance()` and `ConnectionLoggerRegistry.fromConfig()` created a new                                                                                                                                                                        
     `ConnectionLoggerRegistry` on every call, each constructing a new Fluency client with its own flusher thread pool. Because the logger                                                                                                                                                          
     cache (`LOGGERS`) is static, `computeIfAbsent` returned already-cached loggers — the newly created Fluency instance was immediately orphaned with no owner to close it, but its flusher thread kept running.
                                              
  2. **Shared Fluency closed by individual loggers.** `FluentPublishingConnectionLogger.close()` called `fluencyForwarder.close()` on the shared Fluency instance. When `invalidateLoggers()` closed one connection's loggers, it shut down the Fluency forwarder for all other connections. The Fluency library then spawned new internal sender threads trying to recover, amplifying the leak.                                
                                                                                                                                                                                                                                  
  ## Solution                                                                                                                                                                                                                     
                                                                                                                                                                                                                                  
  - **Cache registries by config.** `ConnectionLoggerRegistry.fromConfig()` now uses a static `INSTANCES` map with `computeIfAbsent`, so only one registry — and one Fluency client — exists per configuration for the lifetime of the JVM.                                                                                                                                                                                                          
  - **No-op logger close.** `FluentPublishingConnectionLogger.close()` no longer closes the shared Fluency instance. The forwarder is owned by the registry, not by individual loggers.                      